### PR TITLE
[GF#20482] FHIRPath conformsTo Validation of Warnings/Error handling

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_40_50.java
@@ -2977,10 +2977,10 @@ public class VersionConvertor_40_50 {
       return convertTime((org.hl7.fhir.r4.model.TimeType) src);
     if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
       return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
-    if (src instanceof org.hl7.fhir.r4.model.UriType)
-      return convertUri((org.hl7.fhir.r4.model.UriType) src);
     if (src instanceof org.hl7.fhir.r4.model.UrlType)
       return convertUrl((org.hl7.fhir.r4.model.UrlType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UriType)
+      return convertUri((org.hl7.fhir.r4.model.UriType) src);
     if (src instanceof org.hl7.fhir.r4.model.UuidType)
       return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
     if (src instanceof org.hl7.fhir.r4.model.Extension)
@@ -3103,10 +3103,10 @@ public class VersionConvertor_40_50 {
       return convertTime((org.hl7.fhir.r5.model.TimeType) src);
     if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
       return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
-    if (src instanceof org.hl7.fhir.r5.model.UriType)
-      return convertUri((org.hl7.fhir.r5.model.UriType) src);
     if (src instanceof org.hl7.fhir.r5.model.UrlType)
       return convertUrl((org.hl7.fhir.r5.model.UrlType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UriType)
+      return convertUri((org.hl7.fhir.r5.model.UriType) src);
     if (src instanceof org.hl7.fhir.r5.model.UuidType)
       return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
     if (src instanceof org.hl7.fhir.r5.model.Extension)

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -237,7 +237,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
         throw new NotImplementedException("Not done yet (ValidatorHostServices.conformsToProfile), when item is element");
       boolean ok = true;
       for (ValidationMessage v : valerrors)
-        ok = ok && v.getLevel().isError();
+        ok = ok && !v.getLevel().isError();
       return ok;
     }
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTestSuite.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTestSuite.java
@@ -125,25 +125,24 @@ public class ValidationTestSuite implements IEvaluationContext, IValidatorResour
         val.getContext().cacheResource(sd);
       }
     }
+    List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
+    if (name.startsWith("Json."))
+      val.validate(null, errors, new FileInputStream(path), FhirFormat.JSON);
+    else
+      val.validate(null, errors, new FileInputStream(path), FhirFormat.XML);
+    checkOutcomes(errors, content);
     if (content.has("profile")) {
-      List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
+      List<ValidationMessage> errorsProfile = new ArrayList<ValidationMessage>();
       JsonObject profile = content.getAsJsonObject("profile");
       String filename = TestUtilities.resourceNameToFile("validation-examples", profile.get("source").getAsString());
       String v = content.has("version") ? content.get("version").getAsString() : Constants.VERSION;
       StructureDefinition sd = loadProfile(filename, v);
       if (name.startsWith("Json."))
-        val.validate(null, errors, new FileInputStream(path), FhirFormat.JSON, sd);
+        val.validate(null, errorsProfile, new FileInputStream(path), FhirFormat.JSON, sd);
       else
-         val.validate(null, errors, new FileInputStream(path), FhirFormat.XML, sd);
-      checkOutcomes(errors, profile);
-    } else {
-      List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
-      if (name.startsWith("Json."))
-        val.validate(null, errors, new FileInputStream(path), FhirFormat.JSON);
-      else
-        val.validate(null, errors, new FileInputStream(path), FhirFormat.XML);
-      checkOutcomes(errors, content);
-    }
+         val.validate(null, errorsProfile, new FileInputStream(path), FhirFormat.XML, sd);
+      checkOutcomes(errorsProfile, profile);
+    } 
   }
 
   public StructureDefinition loadProfile(String filename, String v)

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -388,6 +388,28 @@
         "errorCount": 0,
         "warningCount": 1
       },
+      "patient-conform-profile.xml" : {
+        "errorCount": 0,
+        "warningCount": 1
+      },
+      "patient-bad-gender.xml" : {
+        "errorCount": 1,
+        "warningCount": 0,
+        "profile" : {
+          "source" : "patient-conform-profile.xml", 
+          "errorCount": 2,
+          "warningCount": 0
+        }
+      },
+      "patient-warning-maritalstatus.xml" : {
+        "errorCount": 0,
+        "warningCount": 1,
+        "profile" : {
+          "source" : "patient-conform-profile.xml", 
+          "errorCount": 0,
+          "warningCount": 1
+        }
+      },
       "document-good.xml" : {
         "errorCount": 0,
         "profiles" : ["document-section-library.xml"],

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-bad-gender.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-bad-gender.xml
@@ -1,0 +1,11 @@
+<Patient xmlns="http://hl7.org/fhir">
+    <id value="patient-error-gender"/>
+      <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+*FAILURE* validating ./examplesNonValid/patient/patient-error-gender.xml:  error:1 warn:1 info:0
+  Error @ Patient.gender (line 3, col34) : The value provided ('asdfafafafd') is not in the value set http://hl7.org/fhir/ValueSet/administrative-gender|4.0.0 (http://hl7.org/fhir/ValueSet/administrative-gender, and a code is required from this value set) (error message = Unknown Code org.hl7.fhir.r4.model.Coding@5ee34b1b in http://hl7.org/fhir/administrative-gender)
+    </div>
+  </text>
+    <gender value="asdfafafafd"/>
+</Patient>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-conform-profile.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-conform-profile.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<id value="patient-conform-profile" />
+	<url
+		value="http://hl7.org/fhir/StructureDefinition/patient-conform-profile" />
+	<name value="PatientConformProfile" />
+	<status value="draft" />
+	<description
+		value="Test profile to test if a patient with warning or errors in valdidation is conformant to a profile" />
+	<kind value="resource" />
+	<abstract value="false" />
+	<type value="Patient" />
+	<baseDefinition
+		value="http://hl7.org/fhir/StructureDefinition/Patient" />
+	<derivation value="constraint" />
+	<differential>
+		<element id="Patient">
+			<path value="Patient" />
+			<constraint>
+				<key value="conformsToCheck" />
+				<severity value="error" />
+				<human value="conformsToCheck" />
+				<expression
+					value="conformsTo('http://hl7.org/fhir/StructureDefinition/Patient')" />
+			</constraint>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-warning-maritalstatus.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/patient-warning-maritalstatus.xml
@@ -1,0 +1,17 @@
+<Patient xmlns="http://hl7.org/fhir">
+    <id value="patient-warning-maritalstatus"/>
+    <text>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+Success...validating ./examplesNonValid/patient/patient-warning-maritalstatus.xml:  error:0 warn:1 info:0
+  Warning @ Patient.maritalStatus (line 9, col20) : None of the codes provided are in the value set http://hl7.org/fhir/ValueSet/marital-status (http://hl7.org/fhir/ValueSet/marital-status, and a code should come from this value set unless it has no suitable code) (codes = http://fhir.ch/whateversysstem#adfasfdf)
+        </div>
+    </text>
+    <maritalStatus>
+        <coding>
+            <system value="http://fhir.ch/whateversysstem"/>
+            <code value="adfasfdf"/>
+            <display value="I dont know what this value means"/>
+        </coding>
+    </maritalStatus>
+</Patient>


### PR DESCRIPTION
See also https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=20482

If a resource is evaluated with the FHIRPath conforms function against a profile, the function is returning false when there are warnings.

FHIRPath specifies for the conformTo function that:

_Returns true if the single input element conforms to the profile specified by the structure argument, and false otherwise._ 

In the conformance section it is stated about warning constraints:

_Warning Report this as a warning that there may be a problem with the resource, but it is considered valid and can be processed normally_

From the specification I would assume that a Warning Validation Message would still return true for the conformsTo function.

The current Validator/Java Reference Implementation handles the error like this:

```
         boolean ok = true;        
        for (ValidationMessage v : valerrors)          
               ok = ok && v.getLevel().isError();
        return ok;
 
```

As soon as there is a Validation Message and it is not an error, false is returned, i think it should be the inverse:

```
        boolean ok = true;         
       for (ValidationMessage v : valerrors)          
              ok = ok && !v.getLevel().isError();
       return ok; 

```
I will create a pull request which includes

    fix that tests can run:   org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_40_50.java

    change to above mentioned behavior:   org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java

    extendenting TestSuite:   org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTestSuite.java

    modified:   org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json

    patient with an error:   org.hl7.fhir.validation/src/test/resources/validation-examples/patient-bad-gender.xml

    a profile with a constraint that contains the conformTo function:   org.hl7.fhir.validation/src/test/resources/validation-examples/patient-conform-profile.xml

    patient with just a warning:   org.hl7.fhir.validation/src/test/resources/validation-examples/patient-warning-maritalstatus.xml

There are multiple occurences of this evaluation pattern for the conformsTo function in the code, if the pull request is accepted, they would need to be changed to probably. 