### PR TITLE
org.hl7.fhir.core: Validation support for fixed[x] Complextypes like Coding, Quantity 

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -3817,6 +3817,9 @@ private boolean isAnswerRequirementFulfilled(QuestionnaireItemComponent qItem, L
             checkPrimitive(hostContext, errors, ei.path, type, ei.definition, ei.element, profile);
           } else {
 //            checkNonPrimitive(appContext, errors, ei.path, type, ei.definition, ei.element, profile);
+            if (ei.definition.hasFixed()) {
+              checkFixedValue(errors,ei.path, ei.element, ei.definition.getFixed(), ei.definition.getSliceName(), null);
+            }
           }
           if (type.equals("Identifier")) {
             checkIdentifier(errors, ei.path, ei.element, ei.definition);
@@ -3833,7 +3836,7 @@ private boolean isAnswerRequirementFulfilled(QuestionnaireItemComponent qItem, L
           } else if (type.equals("Resource")) {
             validateContains(hostContext, errors, ei.path, ei.definition, definition, resource, ei.element, localStack, idStatusForEntry(element, ei)); // if
           // (str.matches(".*([.,/])work\\1$"))
-          }
+          } 
         } else {
           if (rule(errors, IssueType.STRUCTURE, ei.line(), ei.col(), stack.getLiteralPath(), ei.definition != null, "Unrecognised Content " + ei.name))
             validateElement(hostContext, errors, profile, ei.definition, null, null, resource, ei.element, type, localStack, false);

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -467,6 +467,21 @@
           "source" : "extension-slice-profile.xml", 
           "errorCount": 0          
         }
+      }, 
+      "observation-cholesterol-good.xml" : {
+        "errorCount": 0
+      }, 
+      "observation-cholesterol-bad-referencerangemissing.xml" : {
+        "errorCount": 1,
+        "errors": ["ERROR: Observation: Profile http://hl7.org/fhir/StructureDefinition/cholesterol, Element 'Observation.referenceRange': minimum required = 1, but only found 0"]
+      }, 
+      "observation-cholesterol-bad-referencerangehighfixedquantitywrong.xml" : {
+        "errorCount": 1,
+        "errors": ["ERROR: Observation.referenceRange.high.value: Value is '0' but must be '4.5'"]
+      }, 
+      "observation-cholesterol-bad-wrongcode.xml" : {
+        "errorCount": 2,
+        "errors": ["ERROR: Observation.code.coding.code: Value is '13457-7' but must be '35200-5'","ERROR: Observation.code.coding.display: Value is 'Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation' but must be 'Cholesterol [Moles/​volume] in Serum or Plasma'"]
       }
 		}
 	}

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-referencerangehighfixedquantitywrong.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-referencerangehighfixedquantitywrong.xml
@@ -1,0 +1,98 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://www.hl7.org/fhir/diagnosticreport-example-lipids.xml.html, 
+		changed id from cholesterol and added explizit profile reference to http://hl7.org/fhir/StructureDefinition/cholesterol -->
+	<id
+		value="observation-cholesterol-bad-referencerangehighfixedquantitywrong" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/cholesterol" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: cholesterol
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Cholesterol
+				<span> (Details : {LOINC code '35200-5' = 'Cholesterol [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Cholesterol
+					[Moles/â€‹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 6.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						4.5 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="35200-5" />
+			<display
+				value="Cholesterol [Moles/​volume] in Serum or Plasma" />
+		</coding>
+		<text value="Cholesterol" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="6.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+	<referenceRange>
+		<high>
+			<value value="0" />
+			<unit value="mmol/L" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mmol/L" />
+		</high>
+	</referenceRange>
+</Observation> 

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-referencerangemissing.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-referencerangemissing.xml
@@ -1,0 +1,92 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://www.hl7.org/fhir/diagnosticreport-example-lipids.xml.html, 
+		changed id from cholesterol and added explizit profile reference to http://hl7.org/fhir/StructureDefinition/cholesterol-->
+	<id value="observation-cholesterol-good" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/cholesterol" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: cholesterol
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Cholesterol
+				<span> (Details : {LOINC code '35200-5' = 'Cholesterol [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Cholesterol
+					[Moles/â€‹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 6.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						4.5 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="35200-5" />
+			<display
+				value="Cholesterol [Moles/​volume] in Serum or Plasma" />
+		</coding>
+		<text value="Cholesterol" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="6.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+  <!-- <referenceRange> <high> <value value="0" /> <unit value="mmol/L" /> 
+    <system value="http://unitsofmeasure.org" /> <code value="mmol/L" /> </high> 
+    </referenceRange> -->
+</Observation> 

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-wrongcode.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-bad-wrongcode.xml
@@ -1,0 +1,100 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://www.hl7.org/fhir/diagnosticreport-example-lipids.xml.html, 
+		changed id from cholesterol and added explizit profile reference to http://hl7.org/fhir/StructureDefinition/cholesterol -->
+	<id value="observation-cholesterol-bad-wrongcode" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/cholesterol" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: cholesterol
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Cholesterol
+				<span> (Details : {LOINC code '35200-5' = 'Cholesterol [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Cholesterol
+					[Moles/â€‹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 6.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						4.5 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<!-- <coding> <system value="http://loinc.org" /> <code value="35200-5" 
+			/> <display value="Cholesterol [Mass or Moles/volume] in Serum or Plasma" 
+			/> </coding> -->
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="13457-7" />
+			<display
+				value="Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation" />
+		</coding>
+		<text value="Cholesterol" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="6.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+	<referenceRange>
+		<high>
+			<value value="4.5" />
+			<unit value="mmol/L" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mmol/L" />
+		</high>
+	</referenceRange>
+</Observation> 

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-good.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-cholesterol-good.xml
@@ -1,0 +1,97 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://www.hl7.org/fhir/diagnosticreport-example-lipids.xml.html, 
+		changed id from cholesterol and added explizit profile reference to http://hl7.org/fhir/StructureDefinition/cholesterol-->
+	<id value="observation-cholesterol-bad-referencerangemissing" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/cholesterol" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: cholesterol
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Cholesterol
+				<span> (Details : {LOINC code '35200-5' = 'Cholesterol [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Cholesterol
+					[Moles/â€‹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 6.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						4.5 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="35200-5" />
+			<display
+				value="Cholesterol [Moles/​volume] in Serum or Plasma" />
+		</coding>
+		<text value="Cholesterol" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="6.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+  <referenceRange>
+    <high>
+      <value value="4.5" />
+      <unit value="mmol/L" />
+      <system value="http://unitsofmeasure.org" />
+      <code value="mmol/L" />
+    </high>
+  </referenceRange>
+</Observation> 


### PR DESCRIPTION
https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=21004&start=0

The Cholesterol profile (http://hl7.org/fhir/StructureDefinition/cholesterol) has a fixed Coding for the Observation.code and a fixed SimpleQuantity for the referenceRange high. However with the current java validator fixed[x] constraints are only enfored on primitive dataypes not on complex ones like above. 

This is the pull request.