### PR TITLE
[gf#21240]: org.hl7.fhir.core: Validation support for pattern[x] 

### DIFF
--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -482,6 +482,13 @@
       "observation-cholesterol-bad-wrongcode.xml" : {
         "errorCount": 2,
         "errors": ["ERROR: Observation.code.coding.code: Value is '13457-7' but must be '35200-5'","ERROR: Observation.code.coding.display: Value is 'Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation' but must be 'Cholesterol [Moles/?volume] in Serum or Plasma'"]
+      },
+      "observation-triglyceride-good.xml" : {
+        "errorCount": 0
+      }, 
+      "observation-triglyceride-bad-wrongcode.xml" : {
+        "errorCount": 1,
+        "errors": ["ERROR: "]
       }
 		}
 	}

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -484,11 +484,18 @@
         "errors": ["ERROR: Observation.code.coding.code: Value is '13457-7' but must be '35200-5'","ERROR: Observation.code.coding.display: Value is 'Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation' but must be 'Cholesterol [Moles/?volume] in Serum or Plasma'"]
       },
       "observation-triglyceride-good.xml" : {
-        "errorCount": 0
+        "warningCount": 1,
+        "errorCount": 0,
+        "warnings": ["WARNING: Observation.code.coding[1]: The display \"Triglyceride [Moles/​volume] in Serum or Plasma\" is not a valid display for the code {http://loinc.org}35217-9 - should be one of [\"Triglyceride [Mass or Moles/volume] in Serum or Plasma\",\"Trigl SerPl-msCnc\""]
       }, 
+      "observation-triglyceride-good2.xml" : {
+        "warningCount": 1,
+        "errorCount": 0,
+        "warnings": ["WARNING: Observation.code.coding[2]: The display \"Triglyceride [Moles/​volume] in Serum or Plasma\" is not a valid display for the code {http://loinc.org}35217-9 - should be one of [\"Triglyceride [Mass or Moles/volume] in Serum or Plasma\",\"Trigl SerPl-msCnc\""]
+      },       
       "observation-triglyceride-bad-wrongcode.xml" : {
         "errorCount": 1,
-        "errors": ["ERROR: "]
+        "errors": ["ERROR: Observation.code: Expected patternCodeableConcept not found for system: http://loinc.org code: 35217-9 display: Triglyceride [Moles/​volume] in Serum or Plasma"]
       }
 		}
 	}

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-bad-wrongcode.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-bad-wrongcode.xml
@@ -1,0 +1,103 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://hl7.org/fhir/triglyceride-examples.html, changed 
+		id from triglyceride and added explivit profile reference to http://hl7.org/fhir/StructureDefinition/triglyceride 
+		and added snomed ct code for triglyceride -->
+	<id value="observation-triglyceride-bad-wrongcode" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/triglyceride" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: triglyceride
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Triglyceride
+				<span> (Details : {LOINC code '35217-9' = 'Triglyceride [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Triglyceride
+					[Moles/Ã¢â‚¬â€¹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 1.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						2.0 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="35200-5" />
+			<display
+				value="Cholest SerPl-msCnc" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="85600001" />
+			<display value="Triacylglycerol" />
+		</coding>
+		<text value="Cholesterol" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="1.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+	<referenceRange>
+		<high>
+			<value value="2.0" />
+			<unit value="mmol/L" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mmol/L" />
+		</high>
+	</referenceRange>
+</Observation>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good.xml
@@ -1,0 +1,103 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from http://hl7.org/fhir/triglyceride-examples.html, changed 
+		id from triglyceride and added explicit profile reference to http://hl7.org/fhir/StructureDefinition/triglyceride 
+		and added snomed ct code for triglyceride -->
+	<id value="observation-triglyceride-good" />
+	<meta>
+		<profile
+			value="http://hl7.org/fhir/StructureDefinition/triglyceride" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b> Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b> id</b>
+				: triglyceride
+			</p>
+			<p>
+				<b> status</b>
+				: final
+			</p>
+			<p>
+				<b> code</b>
+				: Triglyceride
+				<span> (Details : {LOINC code '35217-9' = 'Triglyceride [Mass or
+					Moles/volume] in Serum or Plasma',
+					given as 'Triglyceride
+					[Moles/Ã¢â‚¬â€¹volume] in Serum or Plasma'})
+				</span>
+			</p>
+			<p>
+				<b> subject</b>
+				:
+				<a> Patient/pat2</a>
+			</p>
+			<p>
+				<b> performer</b>
+				:
+				<a> Acme Laboratory, Inc</a>
+			</p>
+			<p>
+				<b> value</b>
+				: 1.3 mmol/L
+				<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+			</p>
+			<h3> ReferenceRanges</h3>
+			<table>
+				<tr>
+					<td> -</td>
+					<td>
+						<b> High</b>
+					</td>
+				</tr>
+				<tr>
+					<td> *</td>
+					<td>
+						2.0 mmol/L
+						<span> (Details: UCUM code mmol/L = 'mmol/L')</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</text>
+	<status value="final" />
+	<code>
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="35217-9" />
+			<display
+				value="Triglyceride [Moles/Ã¢â‚¬â€¹volume] in Serum or Plasma" />
+		</coding>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="85600001" />
+			<display value="Triacylglycerol" />
+		</coding>
+		<text value="Triglyceride" />
+	</code>
+	<subject>
+		<reference value="Patient/pat2" />
+	</subject>
+	<performer>
+		<reference
+			value="Organization/1832473e-2fe0-452d-abe9-3cdb9879522f" />
+		<display value="Acme Laboratory, Inc" />
+	</performer>
+	<valueQuantity>
+		<value value="1.3" />
+		<unit value="mmol/L" />
+		<system value="http://unitsofmeasure.org" />
+		<code value="mmol/L" />
+	</valueQuantity>
+	<referenceRange>
+		<high>
+			<value value="2.0" />
+			<unit value="mmol/L" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mmol/L" />
+		</high>
+	</referenceRange>
+</Observation>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good2.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good2.xml
@@ -2,7 +2,7 @@
 	<!-- extract from http://hl7.org/fhir/triglyceride-examples.html, changed 
 		id from triglyceride and added explicit profile reference to http://hl7.org/fhir/StructureDefinition/triglyceride 
 		and added snomed ct code for triglyceride -->
-	<id value="observation-triglyceride-good" />
+	<id value="observation-triglyceride-good2" />
 	<meta>
 		<profile
 			value="http://hl7.org/fhir/StructureDefinition/triglyceride" />
@@ -65,17 +65,22 @@
 	</text>
 	<status value="final" />
 	<code>
+    <coding>
+      <system value="http://snomed.info/sct" />
+      <code value="85600001" />
+      <display value="Triacylglycerol" />
+    </coding>
 		<coding>
 			<system value="http://loinc.org" />
 			<code value="35217-9" />
 			<display
 				value="Triglyceride [Moles/&#x200B;volume] in Serum or Plasma" />
 		</coding>
-		<coding>
-			<system value="http://snomed.info/sct" />
-			<code value="85600001" />
-			<display value="Triacylglycerol" />
-		</coding>
+    <coding>
+      <system value="http://snomed.info/sct" />
+      <code value="85600001" />
+      <display value="Triacylglycerol" />
+    </coding>
 		<text value="Triglyceride" />
 	</code>
 	<subject>


### PR DESCRIPTION
The Triglyceride profile (http://hl7.org/fhir/StructureDefinition/triglyceride) has a pattern[x] definition for the Observation.code:

    <patternCodeableConcept> 
        <coding> 
          <system value="http://loinc.org"/> 
          <code value="35217-9"/> 
          <display value="Triglyceride [Moles/Ã¢â‚¬â€¹volume] in Serum or Plasma"/> 
        </coding> 
      </patternCodeableConcept> 

With the current java validator this pattern[x] constraints ist not enforced. 

There are three test cases:
/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good2.xml
/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-good.xml
/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-triglyceride-bad-wrongcode.xml

with this pull request for primitive types and CodeableConcept the pattern[x] is supported.