### PR TITLE
[GF#21472]: org.hl7.fhir.core: Validator cannot validate BP Profile

### DIFF
--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -468,6 +468,32 @@
           "errorCount": 0          
         }
       }, 
+      "observation-bp-validationfails.xml" : {
+        "errorCount": 4,
+        "errors": [
+        "ERROR: Observation.component[1]: Error in discriminator at Observation.component:SystolicBP.code.coding: slicing found",
+        "ERROR: Observation.component[2]: Error in discriminator at Observation.component:SystolicBP.code.coding: slicing found",
+        "ERROR: Observation.component[1]: Error in discriminator at Observation.component:DiastolicBP.code.coding: slicing found",
+        "ERROR: Observation.component[2]: Error in discriminator at Observation.component:DiastolicBP.code.coding: slicing found"
+        ]        
+      },
+      "observation-bp.xml" : {
+        "errorCount": 0,
+        "profile" : {
+          "source" : "observation-bp-profile.xml", 
+          "errorCount": 0
+        }
+      }, 
+      "observation-bp-bad-onlydiastolic.xml" : {
+        "errorCount": 0,
+        "profile" : {
+          "source" : "observation-bp-profile.xml", 
+          "errorCount": 1,
+          "errors": [
+           "ERROR: Observation: Profile http://hl7.org/fhir/StructureDefinition/observation-bp-profile, Element 'Observation.component[SystolicBP]': minimum required = 1, but only found 0"
+          ] 
+        }
+      },      
       "observation-cholesterol-good.xml" : {
         "errorCount": 0
       }, 

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-bad-onlydiastolic.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-bad-onlydiastolic.xml
@@ -1,0 +1,250 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from https://www.hl7.org/fhir/observation-example-bloodpressure.xml, 
+		changed id from blood-pressure to observation-bp and removed systolic loinc coide that observation fails -->
+	<id value="observation-bp-bad-onlydiastolic" />
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b>Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b>id</b>
+				: blood-pressure
+			</p>
+			<p>
+				<b>meta</b>
+				:
+			</p>
+			<p>
+				<b>identifier</b>
+				: urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281
+			</p>
+			<p>
+				<b>basedOn</b>
+				:
+			</p>
+			<p>
+				<b>status</b>
+				: final
+			</p>
+			<p>
+				<b>category</b>
+				: Vital Signs
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/observation-category code
+					&#39;vital-signs&#39; = &#39;Vital Signs&#39;, given as &#39;Vital
+					Signs&#39;})</span>
+			</p>
+			<p>
+				<b>code</b>:
+				Blood pressure systolic &amp; diastolic
+				<span>(Details : {LOINC code &#39;85354-9&#39; = &#39;Blood pressure
+					panel with all children optional&#39;, given as &#39;Blood pressure
+					panel with all children optional&#39;})</span>
+			</p>
+			<p>
+				<b>subject</b>
+				:
+				<a>Patient/example</a>
+			</p>
+			<p>
+				<b>effective</b>
+				: 17/09/2012
+			</p>
+			<p>
+				<b>performer</b>
+				:
+				<a>Practitioner/example</a>
+			</p>
+			<p>
+				<b>interpretation</b>
+				: Below low normal
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+					code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+			</p>
+			<p>
+				<b>bodySite</b>
+				: Right arm
+				<span>(Details : {SNOMED CT code &#39;368209003&#39; = &#39;Right
+					upper arm&#39;, given as &#39;Right arm&#39;})</span>
+			</p>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Systolic blood pressure
+					<span>(Details : {LOINC code &#39;8480-6&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{SNOMED CT code &#39;271649006&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{http://acme.org/devices/clinical-codes code &#39;bp-s&#39; =
+						&#39;bp-s&#39;, given as &#39;Systolic Blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 107 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;N&#39; = &#39;Normal&#39;, given as &#39;normal&#39;})
+					</span>
+				</p>
+			</blockquote>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Diastolic blood pressure
+					<span>(Details : {LOINC code &#39;8462-4&#39; = &#39;Diastolic
+						blood pressure&#39;, given as &#39;Diastolic blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 60 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Below low normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+				</p>
+			</blockquote>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281" />
+	</identifier><!-- demonstrating the use of the baseOn element with a fictive 
+		identifier -->
+	<basedOn>
+		<identifier>
+			<system value="https://acme.org/identifiers" />
+			<value value="1234" />
+		</identifier>
+	</basedOn>
+	<status value="final" />
+	<category>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code><!-- replaced by 85354-9 <coding> <system value="http://loinc.org"/> 
+			<code value="85354-9"/> <display value="Blood pressure systolic &amp; diastolic"/> 
+			</coding> -->
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display
+				value="Blood pressure panel with all children optional" />
+		</coding>
+		<text value="Blood pressure systolic &amp; diastolic" />
+	</code>
+	<subject>
+		<reference value="Patient/example" />
+	</subject>
+	<effectiveDateTime value="2012-09-17" />
+	<performer>
+		<reference value="Practitioner/example" />
+	</performer><!-- an interpretation offered to the combination observation 
+		generally, it would only be appropriate to offer an interpretation of an 
+		observation that has no value if it has "COMP" (component) observations -->
+	<interpretation>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+			<code value="L" />
+			<display value="low" />
+		</coding>
+		<text value="Below low normal" />
+	</interpretation><!-- The BodySite can be captured in a LOINC code but am 
+		showing it here to demonstrate populating the element -->
+	<bodySite>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="368209003" />
+			<display value="Right arm" />
+		</coding>
+	</bodySite>
+	<component><!-- Observations are often coded in multiple code systems. - 
+			LOINC provides a very specific code (though not more specific in this particular 
+			case) - snomed provides a clinically relevant code that is usually less granular 
+			than LOINC - the source system provides its own code, which may be less or 
+			more granular than LOINC this is shown here to demonstrate the concept of 
+			translations within the codeableConcept datatype. The diastolic code below 
+			only has a LOINC code -->
+		<code><!-- LOINC -code -->
+<!-- removed systolic loinc coide that observation fails 		<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding>
+-->			<!-- SNOMED CT Codes -->
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="271649006" />
+				<display value="Systolic blood pressure" />
+			</coding><!-- Also, a local code specific to the source system -->
+			<coding>
+				<system value="http://acme.org/devices/clinical-codes" />
+				<code value="bp-s" />
+				<display value="Systolic Blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="107" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="N" />
+				<display value="normal" />
+			</coding>
+			<text value="Normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+	<component><!-- this codes only has a LOINC code -->
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="60" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="L" />
+				<display value="low" />
+			</coding>
+			<text value="Below low normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+</Observation>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-profile.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-profile.xml
@@ -1,0 +1,243 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<id value="observation-bp-profile" />
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">reworked official bp profile to use patternCodeableConcept</div>
+	</text>
+	<url value="http://hl7.org/fhir/StructureDefinition/observation-bp-profile" />
+	<version value="4.0.0" />
+	<name value="observation-bp" />
+	<title value="Observation Blood Pressure Profile" />
+	<status value="draft" />
+	<experimental value="false" />
+	<date value="2019-05-06" />
+	<publisher
+		value="Health Level Seven International (Orders and Observations Workgroup)" />
+	<contact>
+		<telecom>
+			<system value="url" />
+			<value
+				value="http://www.hl7.org/Special/committees/orders/index.cfm Orders and Observations" />
+		</telecom>
+	</contact>
+	<description value="FHIR Blood Pressure Profile" />
+	<fhirVersion value="4.0.0" />
+	<mapping>
+		<identity value="workflow" />
+		<uri value="http://hl7.org/fhir/workflow" />
+		<name value="Workflow Pattern" />
+	</mapping>
+	<mapping>
+		<identity value="sct-concept" />
+		<uri value="http://snomed.info/conceptdomain" />
+		<name value="SNOMED CT Concept Domain Binding" />
+	</mapping>
+	<mapping>
+		<identity value="v2" />
+		<uri value="http://hl7.org/v2" />
+		<name value="HL7 v2 Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="rim" />
+		<uri value="http://hl7.org/v3" />
+		<name value="RIM Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="w5" />
+		<uri value="http://hl7.org/fhir/fivews" />
+		<name value="FiveWs Pattern Mapping" />
+	</mapping>
+	<mapping>
+		<identity value="sct-attr" />
+		<uri value="http://snomed.org/attributebinding" />
+		<name value="SNOMED CT Attribute Binding" />
+	</mapping>
+	<kind value="resource" />
+	<abstract value="false" />
+	<type value="Observation" />
+	<baseDefinition
+		value="http://hl7.org/fhir/StructureDefinition/vitalsigns" />
+	<derivation value="constraint" />
+	<differential>
+		<element id="Observation">
+			<path value="Observation" />
+			<short value="FHIR Blood Pressure Profile" />
+			<definition
+				value="This profile defines  how to represent Blood Pressure observations in FHIR using a standard LOINC code and UCUM units of measure.  This is a grouping structure. It has no value in Observation.valueQuantity but contains at least one component (systolic and/or diastolic)." />
+			<min value="0" />
+			<max value="*" />
+		</element>
+		<element id="Observation.code">
+			<path value="Observation.code" />
+			<short value="Blood Pressure" />
+			<definition value="Blood Pressure" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="CodeableConcept" />
+			</type>
+			<patternCodeableConcept>
+				<coding>
+					<system value="http://loinc.org" />
+					<code value="85354-9" />
+				</coding>
+			</patternCodeableConcept>
+			<mustSupport value="true" />
+		</element>
+		<element id="Observation.valueQuantity">
+			<path value="Observation.valueQuantity" />
+			<min value="0" />
+			<max value="0" />
+		</element>
+		<element id="Observation.component">
+			<path value="Observation.component" />
+			<slicing>
+				<discriminator>
+					<type value="pattern" />
+					<path value="code" />
+				</discriminator>
+				<rules value="open" />
+			</slicing>
+			<min value="2" />
+			<max value="*" />
+		</element>
+		<element id="Observation.component:SystolicBP">
+			<path value="Observation.component" />
+			<sliceName value="SystolicBP" />
+			<short value="SystolicBP" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Observation.component:SystolicBP.code">
+			<path value="Observation.component.code" />
+			<min value="1" />
+			<patternCodeableConcept>
+				<coding>
+					<system value="http://loinc.org" />
+					<code value="8480-6" />
+				</coding>
+			</patternCodeableConcept>
+		</element>
+		<element id="Observation.component:SystolicBP.valueQuantity">
+			<path value="Observation.component.valueQuantity" />
+			<type>
+				<code value="Quantity" />
+			</type>
+		</element>
+		<element
+			id="Observation.component:SystolicBP.valueQuantity.value">
+			<path value="Observation.component.valueQuantity.value" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="decimal" />
+			</type>
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:SystolicBP.valueQuantity.unit">
+			<path value="Observation.component.valueQuantity.unit" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="string" />
+			</type>
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:SystolicBP.valueQuantity.system">
+			<path value="Observation.component.valueQuantity.system" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://unitsofmeasure.org" />
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:SystolicBP.valueQuantity.code">
+			<path value="Observation.component.valueQuantity.code" />
+			<short
+				value="Coded responses from the common UCUM units for vital signs value set." />
+			<definition
+				value="Coded responses from the common UCUM units for vital signs value set." />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mm[Hg]" />
+			<mustSupport value="true" />
+		</element>
+		<element id="Observation.component:DiastolicBP">
+			<path value="Observation.component" />
+			<sliceName value="DiastolicBP" />
+			<short value="DiastolicBP" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Observation.component:DiastolicBP">
+			<path value="Observation.component.code" />
+			<min value="1" />
+			<patternCodeableConcept>
+				<coding>
+					<system value="http://loinc.org" />
+					<code value="8462-4" />
+				</coding>
+			</patternCodeableConcept>
+		</element>
+		<element id="Observation.component:DiastolicBP.valueQuantity">
+			<path value="Observation.component.valueQuantity" />
+			<type>
+				<code value="Quantity" />
+			</type>
+		</element>
+		<element
+			id="Observation.component:DiastolicBP.valueQuantity.value">
+			<path value="Observation.component.valueQuantity.value" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="decimal" />
+			</type>
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:DiastolicBP.valueQuantity.unit">
+			<path value="Observation.component.valueQuantity.unit" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="string" />
+			</type>
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:DiastolicBP.valueQuantity.system">
+			<path value="Observation.component.valueQuantity.system" />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="uri" />
+			</type>
+			<fixedUri value="http://unitsofmeasure.org" />
+			<mustSupport value="true" />
+		</element>
+		<element
+			id="Observation.component:DiastolicBP.valueQuantity.code">
+			<path value="Observation.component.valueQuantity.code" />
+			<short
+				value="Coded responses from the common UCUM units for vital signs value set." />
+			<definition
+				value="Coded responses from the common UCUM units for vital signs value set." />
+			<min value="1" />
+			<max value="1" />
+			<type>
+				<code value="code" />
+			</type>
+			<fixedCode value="mm[Hg]" />
+			<mustSupport value="true" />
+		</element>
+	</differential>
+</StructureDefinition>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-validationfails.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp-validationfails.xml
@@ -1,0 +1,253 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from https://www.hl7.org/fhir/observation-example-bloodpressure.xml, 
+		changed id from blood-pressure to observation-bp-validationfails and added explicit profile 
+		reference to http://hl7.org/fhir/StructureDefinition/bp -->
+	<id value="observation-bp-validationfails" />
+	<meta>
+		<profile value="http://hl7.org/fhir/StructureDefinition/bp" />
+	</meta>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b>Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b>id</b>
+				: blood-pressure
+			</p>
+			<p>
+				<b>meta</b>
+				:
+			</p>
+			<p>
+				<b>identifier</b>
+				: urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281
+			</p>
+			<p>
+				<b>basedOn</b>
+				:
+			</p>
+			<p>
+				<b>status</b>
+				: final
+			</p>
+			<p>
+				<b>category</b>
+				: Vital Signs
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/observation-category code
+					&#39;vital-signs&#39; = &#39;Vital Signs&#39;, given as &#39;Vital
+					Signs&#39;})</span>
+			</p>
+			<p>
+				<b>code</b>:
+				Blood pressure systolic &amp; diastolic
+				<span>(Details : {LOINC code &#39;85354-9&#39; = &#39;Blood pressure
+					panel with all children optional&#39;, given as &#39;Blood pressure
+					panel with all children optional&#39;})</span>
+			</p>
+			<p>
+				<b>subject</b>
+				:
+				<a>Patient/example</a>
+			</p>
+			<p>
+				<b>effective</b>
+				: 17/09/2012
+			</p>
+			<p>
+				<b>performer</b>
+				:
+				<a>Practitioner/example</a>
+			</p>
+			<p>
+				<b>interpretation</b>
+				: Below low normal
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+					code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+			</p>
+			<p>
+				<b>bodySite</b>
+				: Right arm
+				<span>(Details : {SNOMED CT code &#39;368209003&#39; = &#39;Right
+					upper arm&#39;, given as &#39;Right arm&#39;})</span>
+			</p>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Systolic blood pressure
+					<span>(Details : {LOINC code &#39;8480-6&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{SNOMED CT code &#39;271649006&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{http://acme.org/devices/clinical-codes code &#39;bp-s&#39; =
+						&#39;bp-s&#39;, given as &#39;Systolic Blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 107 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;N&#39; = &#39;Normal&#39;, given as &#39;normal&#39;})
+					</span>
+				</p>
+			</blockquote>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Diastolic blood pressure
+					<span>(Details : {LOINC code &#39;8462-4&#39; = &#39;Diastolic
+						blood pressure&#39;, given as &#39;Diastolic blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 60 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Below low normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+				</p>
+			</blockquote>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281" />
+	</identifier><!-- demonstrating the use of the baseOn element with a fictive 
+		identifier -->
+	<basedOn>
+		<identifier>
+			<system value="https://acme.org/identifiers" />
+			<value value="1234" />
+		</identifier>
+	</basedOn>
+	<status value="final" />
+	<category>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code><!-- replaced by 85354-9 <coding> <system value="http://loinc.org"/> 
+			<code value="85354-9"/> <display value="Blood pressure systolic &amp; diastolic"/> 
+			</coding> -->
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display
+				value="Blood pressure panel with all children optional" />
+		</coding>
+		<text value="Blood pressure systolic &amp; diastolic" />
+	</code>
+	<subject>
+		<reference value="Patient/example" />
+	</subject>
+	<effectiveDateTime value="2012-09-17" />
+	<performer>
+		<reference value="Practitioner/example" />
+	</performer><!-- an interpretation offered to the combination observation 
+		generally, it would only be appropriate to offer an interpretation of an 
+		observation that has no value if it has "COMP" (component) observations -->
+	<interpretation>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+			<code value="L" />
+			<display value="low" />
+		</coding>
+		<text value="Below low normal" />
+	</interpretation><!-- The BodySite can be captured in a LOINC code but am 
+		showing it here to demonstrate populating the element -->
+	<bodySite>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="368209003" />
+			<display value="Right arm" />
+		</coding>
+	</bodySite>
+	<component><!-- Observations are often coded in multiple code systems. - 
+			LOINC provides a very specific code (though not more specific in this particular 
+			case) - snomed provides a clinically relevant code that is usually less granular 
+			than LOINC - the source system provides its own code, which may be less or 
+			more granular than LOINC this is shown here to demonstrate the concept of 
+			translations within the codeableConcept datatype. The diastolic code below 
+			only has a LOINC code -->
+		<code><!-- LOINC -code -->
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding><!-- SNOMED CT Codes -->
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="271649006" />
+				<display value="Systolic blood pressure" />
+			</coding><!-- Also, a local code specific to the source system -->
+			<coding>
+				<system value="http://acme.org/devices/clinical-codes" />
+				<code value="bp-s" />
+				<display value="Systolic Blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="107" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="N" />
+				<display value="normal" />
+			</coding>
+			<text value="Normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+	<component><!-- this codes only has a LOINC code -->
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="60" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="L" />
+				<display value="low" />
+			</coding>
+			<text value="Below low normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+</Observation>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/observation-bp.xml
@@ -1,0 +1,249 @@
+<Observation xmlns="http://hl7.org/fhir">
+	<!-- extract from https://www.hl7.org/fhir/observation-example-bloodpressure.xml, 
+		changed id from blood-pressure to observation-bp -->
+	<id value="observation-bp" />
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<p>
+				<b>Generated Narrative with Details</b>
+			</p>
+			<p>
+				<b>id</b>
+				: blood-pressure
+			</p>
+			<p>
+				<b>meta</b>
+				:
+			</p>
+			<p>
+				<b>identifier</b>
+				: urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281
+			</p>
+			<p>
+				<b>basedOn</b>
+				:
+			</p>
+			<p>
+				<b>status</b>
+				: final
+			</p>
+			<p>
+				<b>category</b>
+				: Vital Signs
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/observation-category code
+					&#39;vital-signs&#39; = &#39;Vital Signs&#39;, given as &#39;Vital
+					Signs&#39;})</span>
+			</p>
+			<p>
+				<b>code</b>:
+				Blood pressure systolic &amp; diastolic
+				<span>(Details : {LOINC code &#39;85354-9&#39; = &#39;Blood pressure
+					panel with all children optional&#39;, given as &#39;Blood pressure
+					panel with all children optional&#39;})</span>
+			</p>
+			<p>
+				<b>subject</b>
+				:
+				<a>Patient/example</a>
+			</p>
+			<p>
+				<b>effective</b>
+				: 17/09/2012
+			</p>
+			<p>
+				<b>performer</b>
+				:
+				<a>Practitioner/example</a>
+			</p>
+			<p>
+				<b>interpretation</b>
+				: Below low normal
+				<span>(Details :
+					{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+					code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+			</p>
+			<p>
+				<b>bodySite</b>
+				: Right arm
+				<span>(Details : {SNOMED CT code &#39;368209003&#39; = &#39;Right
+					upper arm&#39;, given as &#39;Right arm&#39;})</span>
+			</p>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Systolic blood pressure
+					<span>(Details : {LOINC code &#39;8480-6&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{SNOMED CT code &#39;271649006&#39; = &#39;Systolic blood
+						pressure&#39;, given as &#39;Systolic blood pressure&#39;};
+						{http://acme.org/devices/clinical-codes code &#39;bp-s&#39; =
+						&#39;bp-s&#39;, given as &#39;Systolic Blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 107 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;N&#39; = &#39;Normal&#39;, given as &#39;normal&#39;})
+					</span>
+				</p>
+			</blockquote>
+			<blockquote>
+				<p>
+					<b>component</b>
+				</p>
+				<p>
+					<b>code</b>
+					: Diastolic blood pressure
+					<span>(Details : {LOINC code &#39;8462-4&#39; = &#39;Diastolic
+						blood pressure&#39;, given as &#39;Diastolic blood pressure&#39;})
+					</span>
+				</p>
+				<p>
+					<b>value</b>
+					: 60 mmHg
+					<span> (Details: UCUM code mm[Hg] = &#39;mmHg&#39;)</span>
+				</p>
+				<p>
+					<b>interpretation</b>
+					: Below low normal
+					<span>(Details :
+						{http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation
+						code &#39;L&#39; = &#39;Low&#39;, given as &#39;low&#39;})</span>
+				</p>
+			</blockquote>
+		</div>
+	</text>
+	<identifier>
+		<system value="urn:ietf:rfc:3986" />
+		<value value="urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281" />
+	</identifier><!-- demonstrating the use of the baseOn element with a fictive 
+		identifier -->
+	<basedOn>
+		<identifier>
+			<system value="https://acme.org/identifiers" />
+			<value value="1234" />
+		</identifier>
+	</basedOn>
+	<status value="final" />
+	<category>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/observation-category" />
+			<code value="vital-signs" />
+			<display value="Vital Signs" />
+		</coding>
+	</category>
+	<code><!-- replaced by 85354-9 <coding> <system value="http://loinc.org"/> 
+			<code value="85354-9"/> <display value="Blood pressure systolic &amp; diastolic"/> 
+			</coding> -->
+		<coding>
+			<system value="http://loinc.org" />
+			<code value="85354-9" />
+			<display
+				value="Blood pressure panel with all children optional" />
+		</coding>
+		<text value="Blood pressure systolic &amp; diastolic" />
+	</code>
+	<subject>
+		<reference value="Patient/example" />
+	</subject>
+	<effectiveDateTime value="2012-09-17" />
+	<performer>
+		<reference value="Practitioner/example" />
+	</performer><!-- an interpretation offered to the combination observation 
+		generally, it would only be appropriate to offer an interpretation of an 
+		observation that has no value if it has "COMP" (component) observations -->
+	<interpretation>
+		<coding>
+			<system
+				value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+			<code value="L" />
+			<display value="low" />
+		</coding>
+		<text value="Below low normal" />
+	</interpretation><!-- The BodySite can be captured in a LOINC code but am 
+		showing it here to demonstrate populating the element -->
+	<bodySite>
+		<coding>
+			<system value="http://snomed.info/sct" />
+			<code value="368209003" />
+			<display value="Right arm" />
+		</coding>
+	</bodySite>
+	<component><!-- Observations are often coded in multiple code systems. - 
+			LOINC provides a very specific code (though not more specific in this particular 
+			case) - snomed provides a clinically relevant code that is usually less granular 
+			than LOINC - the source system provides its own code, which may be less or 
+			more granular than LOINC this is shown here to demonstrate the concept of 
+			translations within the codeableConcept datatype. The diastolic code below 
+			only has a LOINC code -->
+		<code><!-- LOINC -code -->
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8480-6" />
+				<display value="Systolic blood pressure" />
+			</coding><!-- SNOMED CT Codes -->
+			<coding>
+				<system value="http://snomed.info/sct" />
+				<code value="271649006" />
+				<display value="Systolic blood pressure" />
+			</coding><!-- Also, a local code specific to the source system -->
+			<coding>
+				<system value="http://acme.org/devices/clinical-codes" />
+				<code value="bp-s" />
+				<display value="Systolic Blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="107" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="N" />
+				<display value="normal" />
+			</coding>
+			<text value="Normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+	<component><!-- this codes only has a LOINC code -->
+		<code>
+			<coding>
+				<system value="http://loinc.org" />
+				<code value="8462-4" />
+				<display value="Diastolic blood pressure" />
+			</coding>
+		</code>
+		<valueQuantity>
+			<value value="60" />
+			<unit value="mmHg" />
+			<system value="http://unitsofmeasure.org" />
+			<code value="mm[Hg]" />
+		</valueQuantity><!-- an interpretation for the individual composite observation -->
+		<interpretation>
+			<coding>
+				<system
+					value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation" />
+				<code value="L" />
+				<display value="low" />
+			</coding>
+			<text value="Below low normal" />
+		</interpretation><!-- Should have a refrange as well -->
+	</component>
+</Observation>


### PR DESCRIPTION
The example https://www.hl7.org/fhir/observation-example-bloodpressure.xml does not validate with the current validator against the profile http://hl7.org/fhir/StructureDefinition/bp.

The following error messages are generated: 

"ERROR: Observation.component[1]: Error in discriminator at Observation.component:SystolicBP.code.coding: slicing found", "ERROR: Observation.component[2]: Error in discriminator at Observation.component:SystolicBP.code.coding: slicing found", "ERROR: Observation.component[1]: Error in discriminator at Observation.component:DiastolicBP.code.coding: slicing found", "ERROR: Observation.component[2]: Error in discriminator at Observation.component:DiastolicBP.code.coding: slicing found"

This pull request shows the behaviour int the ValidationTestSuite to illustrate the problem (observation-bp-validationfails.xml).

One possible fix it is to simplify the slicing and use patternCodeableConcept for the components.code in the slicing for the Blood Pressure profile as illustrated in (see observation-bp-profile.xml), but that would need an update to http://hl7.org/fhir/StructureDefinition/bp.

 