### PR TITLE
Fix validator's directory scanning ignore filter

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -502,7 +502,7 @@ public class ValidationEngine {
 
 
   private boolean isIgnoreFile(File ff) {
-    return Utilities.existsInList(ff.getName(), ".DS_Store") || Utilities.existsInList(Utilities.getFileExtension(ff.getName()), ".md", ".css", ".js", ".png", ".gif", ".jpg", ".html", ".tgz", ".pack", ".zip");
+    return Utilities.existsInList(ff.getName(), ".DS_Store") || Utilities.existsInList(Utilities.getFileExtension(ff.getName()).toLowerCase(), "md", "css", "js", "png", "gif", "jpg", "html", "tgz", "pack", "zip");
     
   }
 


### PR DESCRIPTION
The ignore filter didn't work previously because the file extension is returned without the period.

Improve it to ignore uppercase ("image.PNG") variants as well.