### PR TITLE
Exempt package.json from being parsed as a FHIR resource

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -747,7 +747,7 @@ public class ValidationEngine {
 	}
 
   private boolean exemptFile(String fn) {
-    return Utilities.existsInList(fn, "spec.internals", "version.info", "schematron.zip");
+    return Utilities.existsInList(fn, "spec.internals", "version.info", "schematron.zip", "package.json");
   }
 
   private String readInfoVersion(byte[] bs) throws IOException {


### PR DESCRIPTION
Validation of a directory that includes a `package.json` crashes otherwise.