### PR TITLE
Fix snapshot generation crash when a mapping doesn't have a uri

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
@@ -370,7 +370,7 @@ public class ProfileUtilities extends TranslatingUtilities {
     for (StructureDefinitionMappingComponent baseMap : base.getMapping()) {
       boolean found = false;
       for (StructureDefinitionMappingComponent derivedMap : derived.getMapping()) {
-        if (derivedMap.getUri().equals(baseMap.getUri())) {
+        if (derivedMap.getUri() != null && derivedMap.getUri().equals(baseMap.getUri())) {
           found = true;
           break;
         }


### PR DESCRIPTION
Mapping code was assuming that a mapping would have a `uri`, when [the rule](https://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.mapping.uri) in FHIR is to have a `uri` _or_ a `name`.

Skip mappings that only go by name since names don't have to be unique.