### PR TITLE
Also output JSON if requested for narrative, snapshot generation & transforms

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
@@ -484,6 +484,8 @@ public class Validator {
   private static void handleOutputToStream(Resource r, String output, OutputStream s) throws IOException {
     if (output.endsWith(".html") || output.endsWith(".htm") && r instanceof DomainResource)
       new XhtmlComposer(XhtmlComposer.HTML, true).compose(s, ((DomainResource) r).getText().getDiv());
+    else if (output.endsWith(".json"))
+        new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(s, r);
     else
       new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(s, r);
     s.close();


### PR DESCRIPTION
Previous PR https://github.com/hapifhir/org.hl7.fhir.core/pull/35 serialised only validation results of the output file ended on ".json" - this PR applies it to the other possible scenarios as well (narrative, snapshot generation & transformation output).