### PR TITLE
Snapshot generation: handle lack of 'path'

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
@@ -1162,12 +1162,13 @@ public class Utilities {
   }
 
   public static String extractBaseUrl(String url) {
-    if (url.contains("/"))
+	if (url == null)
+		return null;
+	else if (url.contains("/"))
       return url.substring(0,  url.lastIndexOf("/"));
     else
       return url;
-          
-  }
+	}
 
   public static String listCanonicalUrls(Set<String> keys) {
     return keys.toString();


### PR DESCRIPTION
Snapshot generation was failing because there was no userdata named `path` as expected by `extractBaseUrl()` ([code](https://github.com/hapifhir/org.hl7.fhir.core/blob/master/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java#L590)) - I am guessing because my profile isn't intended for specification in the HL7 publication. 

Adjust `extractBaseUrl()` to simply pass the `null` parameter over to `ProfileUtilities.generateSnapshot()` which deals with the webUrl being null just fine.