### PR TITLE
1. Cleaned up test cases to work after version changes in R5 (not sur…

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -1864,7 +1864,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
             if (!type.hasTargetProfile() || type.hasTargetProfile("http://hl7.org/fhir/StructureDefinition/Resource"))
               ok = true;
             else {
-              List<StructureDefinition> candidateProfiles = new ArrayList<StructureDefinition>();
+              List<String> candidateProfiles = new ArrayList<String>();
               for (UriType u : type.getTargetProfile()) {              
                 String pr = u.getValue();
   
@@ -1875,7 +1875,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
                   if (bt.equals(ft)) {
                     ok = true;
                     if (we!=null && pol.checkValid())
-                      candidateProfiles.add(sd);
+                      candidateProfiles.add(pr);
                   }
                 }
               }
@@ -1883,15 +1883,15 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
               List<List<ValidationMessage>> badProfiles = new ArrayList<List<ValidationMessage>>();
               List<String> profiles = new ArrayList<String>();
               if (!candidateProfiles.isEmpty()) {
-                for (StructureDefinition sd: candidateProfiles) {
-                  profiles.add(sd.getUrl());
+                for (String pr: candidateProfiles) {
+                  profiles.add(pr);
                   List<ValidationMessage> profileErrors = new ArrayList<ValidationMessage>();
-                  doResourceProfile(hostContext, we, sd.getUrl(), profileErrors, stack.push(we, -1, null, null), path, element, profile);
+                  doResourceProfile(hostContext, we, pr, profileErrors, stack.push(we, -1, null, null), path, element, profile);
   
                   if (hasErrors(profileErrors))
                     badProfiles.add(profileErrors);
                   else
-                    goodProfiles.put(sd.getUrl(), profileErrors);
+                    goodProfiles.put(pr, profileErrors);
                     if (type.hasAggregation()) {
                       boolean modeOk = false;
                       for (Enumeration<AggregationMode> mode : type.getAggregation()) {
@@ -1908,7 +1908,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
                 if (goodProfiles.size()==1) {
                   errors.addAll(goodProfiles.values().iterator().next());
                 } else if (goodProfiles.size()==0) {
-                  rule(errors, IssueType.STRUCTURE, element.line(), element.col(), path, false, "Unable to find matching profile among choices: " + StringUtils.join("; ", profiles));
+                  rule(errors, IssueType.STRUCTURE, element.line(), element.col(), path, profiles.size()==1, "Unable to find matching profile among choices: " + StringUtils.join("; ", profiles));
                   for (List<ValidationMessage> messages : badProfiles) {
                     errors.addAll(messages);
                   }

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/manifest.json
@@ -360,6 +360,7 @@
 				]
 			},
 			"slice-by-polymorphic-type.xml": {
+			  "version": "4.0",
 				"errorCount": 0,
 				"profile": {
 					"source": "slice-by-polymorphic-type-profile.xml",
@@ -411,6 +412,7 @@
 				}
 			},
 			"slicing-types-by-string.xml": {
+			  "version": "4.0",
 				"errorCount": 0,
 				"profile": {
 					"source": "slicing-types-by-string-profile.xml",
@@ -729,13 +731,20 @@
 					"source": "patient-translated-codes.profile.xml",
 					"errorCount": 0,
 					"warningCount": 0
-				},
-				"patient-contained-org.xml": {
-					"errorCount": 0,
-					"profile": {
-						"source": "patient-contained-org-profile.xml",
-						"errorCount": 1
-					}
+				}
+      },
+      "patient-contained-org.xml": {
+        "errorCount": 0,
+        "profile": {
+          "source": "patient-contained-org-profile.xml",
+          "errorCount": 1
+        }
+			},
+			"multi-profile-same-resource.xml": {
+				"errorCount": 0,
+				"profile": {
+					"source": "multi-profile-same-resource-profile.xml",
+					"errorCount": 0
 				}
 			}
 		}

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/multi-profile-same-resource-profile.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/multi-profile-same-resource-profile.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<id value="multi-profile-same-resource-profile"/>
+	<contained>
+    <StructureDefinition>
+      <id value="pract1"/>
+      <url value="http://hl7.org/fhir/StructureDefinition/multi-profile-same-resource-profile-pract1"/>
+      <name value="MultiProfileSameResourceProfilePract1"/>
+      <status value="draft"/>
+      <kind value="resource"/>
+      <abstract value="false"/>
+      <type value="Practitioner"/>
+      <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
+      <derivation value="constraint"/>
+      <differential>
+        <element id="Practitioner">
+          <path value="Practitioner"/>
+        </element>
+        <element id="Practitioner.name">
+          <path value="Practitioner.name"/>
+          <min value="1"/>
+        </element>
+        <element id="Practitioner.gender">
+          <path value="Practitioner.gender"/>
+          <max value="0"/>
+        </element>
+      </differential>
+    </StructureDefinition>
+  </contained>
+	<contained>
+    <StructureDefinition>
+      <id value="pract2"/>
+      <url value="http://hl7.org/fhir/StructureDefinition/multi-profile-same-resource-profile-pract2"/>
+      <name value="MultiProfileSameResourceProfilePract2"/>
+      <status value="draft"/>
+      <kind value="resource"/>
+      <abstract value="false"/>
+      <type value="Practitioner"/>
+      <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
+      <derivation value="constraint"/>
+      <differential>
+        <element id="Practitioner">
+          <path value="Practitioner"/>
+        </element>
+        <element id="Practitioner.name">
+          <path value="Practitioner.name"/>
+          <max value="0"/>
+        </element>
+        <element id="Practitioner.gender">
+          <path value="Practitioner.gender"/>
+          <min value="1"/>
+        </element>
+      </differential>
+    </StructureDefinition>
+  </contained>
+	<url value="http://hl7.org/fhir/StructureDefinition/multi-profile-same-resource-profile"/>
+	<name value="MultiProfileSameResourceProfile"/>
+	<status value="draft"/>
+	<description value="Profile with multiple profiles allowed for teh same resource"/>
+	<kind value="resource"/>
+	<abstract value="false"/>
+	<type value="Patient"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Patient">
+			<path value="Patient"/>
+		</element>
+		<element id="Patient.generalPractitioner">
+			<path value="Patient.generalPractitioner"/>
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="#pract1"/>
+				<targetProfile value="#pract2"/>
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/multi-profile-same-resource.xml
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/multi-profile-same-resource.xml
@@ -1,0 +1,17 @@
+<Patient xmlns="http://hl7.org/fhir">
+	<id value="multi-profile-same-resource"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">
+    </div>
+	</text>
+	<contained>
+    <Practitioner>
+      <id value="practitioner"/>
+      <gender value="other"/>
+    </Practitioner>
+  </contained>
+	<generalPractitioner>
+    <reference value="#practitioner"/>
+	</generalPractitioner>
+</Patient>

--- a/org.hl7.fhir.validation/src/test/resources/validation-examples/synthea.json
+++ b/org.hl7.fhir.validation/src/test/resources/validation-examples/synthea.json
@@ -2,7 +2,7 @@
   "resourceType": "Encounter",
   "id": "f003",
   "class" : {
-    "system" : "http://hl7.org/fhir/v3/ActCode",
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
     "code" : "AMB"
   },
   "text": {
@@ -22,7 +22,7 @@
     "reference": "Patient/f001",
     "display": "P. van de Heuvel"
   },
-  "reason": {
+  "reasonCode": {
     "extension": [
       {
         "url": "http://hl7.org/fhir/StructureDefinition/iso21090-nullFlavor",


### PR DESCRIPTION
…e what to do with uk one and patient-contained-org I'll work on next)

2. Added new test case for (and fixed issue with) validation problems when there are multiple target profiles declared that have the same resource type.  (Previously, the validator was always choosing the first profile, even if it was invalid.)
3. Fixed problems where certain profiles were triggering silent NPEs in the validator and improved console messaging so you can tell what warnings and errors are being generated for what.