### PR TITLE
StructureMap ruleName not quoted after parsing #48

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
@@ -1016,7 +1016,11 @@ public class StructureMapUtilities {
 		}
 		if (newFmt) {
 		  if (lexer.isConstant()) {
-		    rule.setName(lexer.take());
+		    if (lexer.isStringConstant()) {
+		      rule.setName(lexer.readConstant("ruleName"));
+		    } else {
+		      rule.setName(lexer.take());
+		    }
 		  } else {
 		    if (rule.getSource().size() != 1 || !rule.getSourceFirstRep().hasElement())
 		      throw lexer.error("Complex rules must have an explicit name");

--- a/org.hl7.fhir.r5/src/main/resources/fml/ActivityDefinition.map
+++ b/org.hl7.fhir.r5/src/main/resources/fml/ActivityDefinition.map
@@ -1,0 +1,64 @@
+map "http://hl7.org/fhir/StructureMap/ActivityDefinition3to4" = "R3 to R4 Conversions for ActivityDefinition"
+
+uses "http://hl7.org/fhir/3.0/StructureDefinition/ActivityDefinition" alias ActivityDefinitionR3 as source
+uses "http://hl7.org/fhir/StructureDefinition/ActivityDefinition" alias ActivityDefinition as target
+
+imports "http://hl7.org/fhir/StructureMap/*3to4"
+
+group ActivityDefinition(source src : ActivityDefinitionR3, target tgt : ActivityDefinition) extends DomainResource <<type+>> {
+  src.url -> tgt.url;
+  src.identifier -> tgt.identifier;
+  src.version -> tgt.version;
+  src.name -> tgt.name;
+  src.title -> tgt.title;
+  src.subtitle -> tgt.subtitle;
+  src.status -> tgt.status;
+  src.experimental -> tgt.experimental;
+  src.subject -> tgt.subject;
+  src.date -> tgt.date;
+  src.publisher -> tgt.publisher;
+  src.contact -> tgt.contact;
+  src.description -> tgt.description;
+  src.useContext -> tgt.useContext;
+  src.jurisdiction -> tgt.jurisdiction;
+  src.purpose -> tgt.purpose;
+  src.usage -> tgt.usage;
+  src.copyright -> tgt.copyright;
+  src.approvalDate -> tgt.approvalDate;
+  src.lastReviewDate -> tgt.lastReviewDate;
+  src.effectivePeriod -> tgt.effectivePeriod;
+  src.topic -> tgt.topic;
+  src.contributor as vs where type = 'author' -> tgt.author as vt then Contributor(vs, vt);
+  src.contributor as vs where type = 'editor' -> tgt.editor as vt then Contributor(vs, vt);
+  src.contributor as vs where type = 'reviewer' -> tgt.reviewer as vt then Contributor(vs, vt);
+  src.contributor as vs where type = 'endorser' -> tgt.endorser as vt then Contributor(vs, vt);
+  src.relatedArtifact -> tgt.relatedArtifact;
+  src.library -> tgt.library;
+  src.kind as v -> tgt.kind = translate(v, 'http://hl7.org/fhir/StructureMap/ConceptMaps3to4#ResourceTypeMap', 'code');
+  src.code -> tgt.code;
+  src.doNotPerform -> tgt.doNotPerform;
+  src.timing -> tgt.timing;
+  src.location -> tgt.location;
+  src.participant as s -> tgt.participant as t then ActivityDefinitionParticipant(s, t);
+  src.product -> tgt.product;
+  src.quantity -> tgt.quantity;
+  src.dosage -> tgt.dosage;
+  src.bodySite -> tgt.bodySite;
+  src.specimenRequirement -> tgt.specimenRequirement;
+  src.transform -> tgt.transform;
+  src.dynamicValue as s -> tgt.dynamicValue as t then ActivityDefinitionDynamicValue(s, t);
+}
+
+group ActivityDefinitionParticipant(source src, target tgt) extends BackboneElement {
+  src.type -> tgt.type;
+  src.role -> tgt.role;
+}
+
+group ActivityDefinitionDynamicValue(source src, target tgt) extends BackboneElement {
+  src.path -> tgt.path;
+  src as vs where vs.type.exists().not() -> tgt.expression = create('Expression') as vt then {
+    vs.description -> vt.description;
+    vs.language -> vt.language;
+    vs.expression -> vt.expression;
+  } "expression";
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -1,0 +1,79 @@
+package org.hl7.fhir.r5.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.StructureMap;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.EOperationOutcome;
+import org.hl7.fhir.r5.utils.StructureMapUtilities;
+import org.hl7.fhir.r5.utils.StructureMapUtilities.ITransformerServices;
+import org.hl7.fhir.utilities.TextFile;
+import org.hl7.fhir.utilities.cache.PackageCacheManager;
+import org.hl7.fhir.utilities.cache.ToolsVersion;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xmlpull.v1.XmlPullParserException;
+
+public class StructureMapUtilitiesTest implements ITransformerServices{
+
+  static private SimpleWorkerContext context;
+
+  @BeforeClass
+  static public void setUp() throws Exception {
+    if (context == null) {
+      PackageCacheManager pcm = new PackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+      context = SimpleWorkerContext.fromPackage(pcm.loadPackage("hl7.fhir.core", "4.0.0"));
+    }
+  }
+
+  @Test
+  public void testParseRuleName()
+      throws FileNotFoundException, IOException, XmlPullParserException, EOperationOutcome, FHIRException {
+
+    StructureMapUtilities scu = new StructureMapUtilities(context, this);
+    String fileMap = TestingUtilities.resourceNameToFile("fml", "ActivityDefinition.map");
+    StructureMap structureMap = scu.parse(TextFile.fileToString(fileMap), "ActivityDefinition3To4");
+    
+    // StructureMap/ActivityDefinition3to4: StructureMap.group[3].rule[2].name error id value '"expression"' is not valid
+    assertEquals("expression",structureMap.getGroup().get(2).getRule().get(1).getName());
+  }
+  
+  @Override
+  public void log(String message) {
+  }
+
+  @Override
+  public Base createType(Object appInfo, String name) throws FHIRException {
+    return null;
+  }
+
+  @Override
+  public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+    return null;
+  }
+
+  @Override
+  public Coding translate(Object appInfo, Coding source, String conceptMapUrl) throws FHIRException {
+    return null;
+  }
+
+  @Override
+  public Base resolveReference(Object appContext, String url) throws FHIRException {
+    return null;
+  }
+
+  @Override
+  public List<Base> performSearch(Object appContext, String url) throws FHIRException {
+    return null;
+  }
+
+}


### PR DESCRIPTION
see https://github.com/hapifhir/org.hl7.fhir.core/issues/48

- adjusting parser that if a string constant is available it is used
- JUnit test to verify the behavior 