### PR TITLE
Condition Convertor: Fix convertCondition*Status

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8253,19 +8253,19 @@ public class VersionConvertor_30_40 {
     org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
     switch (src) {
       case ACTIVE: 
-        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("active");
+        cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_CLINICAL_URL).setCode("active");
         return cc;
       case RECURRENCE: 
-        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("recurrence");
+        cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_CLINICAL_URL).setCode("recurrence");
         return cc;
       case INACTIVE: 
-        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("inactive");
+        cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_CLINICAL_URL).setCode("inactive");
         return cc;
       case REMISSION: 
-        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("remission");
+        cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_CLINICAL_URL).setCode("remission");
         return cc;
       case RESOLVED:
-        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("resolved");
+        cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_CLINICAL_URL).setCode("resolved");
         return cc;
       default: return null;
       }
@@ -8302,19 +8302,19 @@ public class VersionConvertor_30_40 {
     org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
     switch (src) {
     case PROVISIONAL: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("provisional");
+      cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL).setCode("provisional");
       return cc;
     case DIFFERENTIAL: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("differential");
+      cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL).setCode("differential");
       return cc;
     case CONFIRMED: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("confirmed");
+      cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL).setCode("confirmed");
       return cc;
     case REFUTED: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("refuted");
+      cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL).setCode("refuted");
       return cc;
     case ENTEREDINERROR:
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("entered-in-error");
+      cc.addCoding().setSystem(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL).setCode("entered-in-error");
       return cc;
     default: return null;
     }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8244,6 +8244,7 @@ public class VersionConvertor_30_40 {
   }
   
   private static final String VALUE_SET_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-clinical";
+  private static final String CODE_SYSTEM_CONDITION_CLINICAL_URL = "https://terminology.hl7.org/CodeSystem/condition-clinical";
 
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionClinicalStatus(org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus src) throws FHIRException {
     if (src == null)
@@ -8272,15 +8273,21 @@ public class VersionConvertor_30_40 {
   private static org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus convertConditionClinicalStatus(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
     if (src == null)
       return null;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "active")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.ACTIVE;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "recurrence")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RECURRENCE;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "inactive")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.INACTIVE;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "remission")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.REMISSION;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "resolved")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RESOLVED;
+    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "active")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "active")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.ACTIVE;
+    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "recurrence")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "recurrence")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RECURRENCE;
+    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "inactive")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "inactive")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.INACTIVE;
+    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "remission")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "remission")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.REMISSION;
+    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "resolved")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "resolved")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RESOLVED;
     return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.NULL;
   }
 
-  private static final String VALUE_SET_CONDITION_VER_CLINICAL = "http://hl7.org/fhir/ValueSet/condition-ver-status";
+  private static final String VALUE_SET_CONDITION_VER_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-ver-status";
+  private static final String CODE_SYSTEM_CONDITION_VER_CLINICAL_URL = "http://terminology.hl7.org/CodeSystem/condition-ver-status";
   
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionVerificationStatus(org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus src) throws FHIRException {
     if (src == null)
@@ -8288,19 +8295,19 @@ public class VersionConvertor_30_40 {
     org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
     switch (src) {
     case PROVISIONAL: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("provisional");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("provisional");
       return cc;
     case DIFFERENTIAL: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("differential");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("differential");
       return cc;
     case CONFIRMED: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("confirmed");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("confirmed");
       return cc;
     case REFUTED: 
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("refuted");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("refuted");
       return cc;
     case ENTEREDINERROR:
-      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("entered-in-error");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL_URL).setCode("entered-in-error");
       return cc;
     default: return null;
     }
@@ -8309,11 +8316,16 @@ public class VersionConvertor_30_40 {
   private static org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus convertConditionVerificationStatus(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
     if (src == null)
       return null;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "provisional")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.PROVISIONAL;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "differential")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.DIFFERENTIAL;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "confirmed")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.CONFIRMED;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "refuted")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.REFUTED;
-    if (src.hasCoding("http://hl7.org/fhir/condition-clinical", "entered-in-error")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.ENTEREDINERROR;
+    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "provisional")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "provisional")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.PROVISIONAL;
+    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "differential")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "differential")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.DIFFERENTIAL;
+    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "confirmed")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "confirmed")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.CONFIRMED;
+    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "refuted")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "refuted")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.REFUTED;
+    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "entered-in-error")
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "entered-in-error")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.ENTEREDINERROR;
     return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.NULL;
   }
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8243,7 +8243,6 @@ public class VersionConvertor_30_40 {
     return tgt;
   }
   
-  private static final String VALUE_SET_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-clinical";
   private static final String CODE_SYSTEM_CONDITION_CLINICAL_URL = "http://terminology.hl7.org/CodeSystem/condition-clinical";
   private static final String VALUE_SET_LEGACY_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/condition-clinical";
 
@@ -8274,25 +8273,19 @@ public class VersionConvertor_30_40 {
   private static org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus convertConditionClinicalStatus(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
     if (src == null)
       return null;
-    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "active")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "active")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "active")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "active")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.ACTIVE;
-    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "recurrence")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "recurrence")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "recurrence")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "recurrence")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RECURRENCE;
-    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "inactive")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "inactive")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "inactive")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "inactive")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.INACTIVE;
-    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "remission")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "remission")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "remission")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "remission")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.REMISSION;
-    if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "resolved")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "resolved")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "resolved")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "resolved")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RESOLVED;
     return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.NULL;
   }
 
-  private static final String VALUE_SET_CONDITION_VER_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-ver-status";
   private static final String CODE_SYSTEM_CONDITION_VER_CLINICAL_URL = "http://terminology.hl7.org/CodeSystem/condition-ver-status";
   private static final String VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL = "http://hl7.org/fhir/condition-ver-status";
   
@@ -8323,20 +8316,15 @@ public class VersionConvertor_30_40 {
   private static org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus convertConditionVerificationStatus(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
     if (src == null)
       return null;
-    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "provisional")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "provisional")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "provisional")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "provisional")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.PROVISIONAL;
-    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "differential")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "differential")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "differential")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "differential")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.DIFFERENTIAL;
-    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "confirmed")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "confirmed")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "confirmed")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "confirmed")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.CONFIRMED;
-    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "refuted")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "refuted")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "refuted")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "refuted")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.REFUTED;
-    if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "entered-in-error")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "entered-in-error")
+    if (src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "entered-in-error")
         ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "entered-in-error")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.ENTEREDINERROR;
     return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.NULL;
   }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8242,6 +8242,8 @@ public class VersionConvertor_30_40 {
       tgt.addNote(convertAnnotation(t));
     return tgt;
   }
+  
+  private static final String VALUE_SET_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-clinical";
 
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionClinicalStatus(org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus src) throws FHIRException {
     if (src == null)
@@ -8249,19 +8251,19 @@ public class VersionConvertor_30_40 {
     org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
     switch (src) {
       case ACTIVE: 
-        cc.addCoding().setSystem("http://hl7.org/fhir/condition-clinical").setCode("active");
+        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("active");
         return cc;
       case RECURRENCE: 
-        cc.addCoding().setSystem("http://hl7.org/fhir/condition-clinical").setCode("recurrence");
+        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("recurrence");
         return cc;
       case INACTIVE: 
-        cc.addCoding().setSystem("http://hl7.org/fhir/condition-clinical").setCode("inactive");
+        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("inactive");
         return cc;
       case REMISSION: 
-        cc.addCoding().setSystem("http://hl7.org/fhir/condition-clinical").setCode("remission");
+        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("remission");
         return cc;
       case RESOLVED:
-        cc.addCoding().setSystem("http://hl7.org/fhir/condition-clinical").setCode("resolved");
+        cc.addCoding().setSystem(VALUE_SET_CONDITION_CLINICAL_URL).setCode("resolved");
         return cc;
       default: return null;
       }
@@ -8278,25 +8280,27 @@ public class VersionConvertor_30_40 {
     return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.NULL;
   }
 
+  private static final String VALUE_SET_CONDITION_VER_CLINICAL = "http://hl7.org/fhir/ValueSet/condition-ver-status";
+  
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionVerificationStatus(org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus src) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
     switch (src) {
     case PROVISIONAL: 
-      cc.addCoding().setSystem("http://hl7.org/fhir/condition-ver-status").setCode("provisional");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("provisional");
       return cc;
     case DIFFERENTIAL: 
-      cc.addCoding().setSystem("http://hl7.org/fhir/condition-ver-status").setCode("differential");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("differential");
       return cc;
     case CONFIRMED: 
-      cc.addCoding().setSystem("http://hl7.org/fhir/condition-ver-status").setCode("confirmed");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("confirmed");
       return cc;
     case REFUTED: 
-      cc.addCoding().setSystem("http://hl7.org/fhir/condition-ver-status").setCode("refuted");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("refuted");
       return cc;
     case ENTEREDINERROR:
-      cc.addCoding().setSystem("http://hl7.org/fhir/condition-ver-status").setCode("entered-in-error");
+      cc.addCoding().setSystem(VALUE_SET_CONDITION_VER_CLINICAL).setCode("entered-in-error");
       return cc;
     default: return null;
     }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8244,7 +8244,8 @@ public class VersionConvertor_30_40 {
   }
   
   private static final String VALUE_SET_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-clinical";
-  private static final String CODE_SYSTEM_CONDITION_CLINICAL_URL = "https://terminology.hl7.org/CodeSystem/condition-clinical";
+  private static final String CODE_SYSTEM_CONDITION_CLINICAL_URL = "http://terminology.hl7.org/CodeSystem/condition-clinical";
+  private static final String VALUE_SET_LEGACY_CONDITION_CLINICAL_URL = "http://hl7.org/fhir/condition-clinical";
 
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionClinicalStatus(org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus src) throws FHIRException {
     if (src == null)
@@ -8274,20 +8275,26 @@ public class VersionConvertor_30_40 {
     if (src == null)
       return null;
     if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "active")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "active")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.ACTIVE;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "active")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "active")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.ACTIVE;
     if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "recurrence")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "recurrence")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RECURRENCE;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "recurrence")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "recurrence")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RECURRENCE;
     if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "inactive")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "inactive")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.INACTIVE;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "inactive")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "inactive")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.INACTIVE;
     if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "remission")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "remission")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.REMISSION;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "remission")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "remission")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.REMISSION;
     if (src.hasCoding(VALUE_SET_CONDITION_CLINICAL_URL, "resolved")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "resolved")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RESOLVED;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_CLINICAL_URL, "resolved")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_CLINICAL_URL, "resolved")) return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.RESOLVED;
     return org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus.NULL;
   }
 
   private static final String VALUE_SET_CONDITION_VER_CLINICAL_URL = "http://hl7.org/fhir/ValueSet/condition-ver-status";
   private static final String CODE_SYSTEM_CONDITION_VER_CLINICAL_URL = "http://terminology.hl7.org/CodeSystem/condition-ver-status";
+  private static final String VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL = "http://hl7.org/fhir/condition-ver-status";
   
   private static org.hl7.fhir.r4.model.CodeableConcept convertConditionVerificationStatus(org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus src) throws FHIRException {
     if (src == null)
@@ -8317,15 +8324,20 @@ public class VersionConvertor_30_40 {
     if (src == null)
       return null;
     if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "provisional")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "provisional")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.PROVISIONAL;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "provisional")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "provisional")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.PROVISIONAL;
     if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "differential")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "differential")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.DIFFERENTIAL;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "differential")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "differential")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.DIFFERENTIAL;
     if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "confirmed")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "confirmed")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.CONFIRMED;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "confirmed")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "confirmed")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.CONFIRMED;
     if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "refuted")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "refuted")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.REFUTED;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "refuted")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "refuted")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.REFUTED;
     if (src.hasCoding(VALUE_SET_CONDITION_VER_CLINICAL_URL, "entered-in-error")
-        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "entered-in-error")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.ENTEREDINERROR;
+        ||src.hasCoding(CODE_SYSTEM_CONDITION_VER_CLINICAL_URL, "entered-in-error")
+        ||src.hasCoding(VALUE_SET_LEGACY_CONDITION_VER_CLINICAL_URL, "entered-in-error")) return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.ENTEREDINERROR;
     return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.NULL;
   }
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -8329,7 +8329,6 @@ public class VersionConvertor_30_40 {
     return org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus.NULL;
   }
 
-
   public static org.hl7.fhir.r4.model.Condition.ConditionStageComponent convertConditionStageComponent(org.hl7.fhir.dstu3.model.Condition.ConditionStageComponent src) throws FHIRException {
     if (src == null)
       return null;


### PR DESCRIPTION
FHIR specifies the defining URL for the condition's clinical status value set to be [0]:

`http://hl7.org/fhir/ValueSet/condition-clinical`

However, is seems that the converter contains a typo as the code currently uses this URL:

`http://hl7.org/fhir/condition-clinical`

This PR addresses this issue and makes sure that the converter creates valid FHIR Condition resources.


But, since a lot of FHIR resources in the real world don't use the correct URL, this PR also makes the converter a little bit more robust by accepting the following URLs as well:

`http://terminology.hl7.org/CodeSystem/condition-clinical`
(which is actually the HL7 code system that the values set for this status is based upon)
`http://hl7.org/fhir/condition-clinical`
(the formally solely used URL)


The same issues mentioned here also apply to the condition's verification status, which is fixed in this PR as well.

[0] http://hl7.org/fhir/valueset-condition-clinical.html