### PR TITLE
Fix dosage converter

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -1421,7 +1421,7 @@ public class VersionConvertor_30_40 {
     if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose()) {
       // We need to manually make sure that the convertSimpleQuantity method is
       // called. Otherwise (if we would simply forward to the convertType method), this would lead
-      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource, 
+      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource. 
       if (src.getDoseAndRate().get(0).getDose() instanceof org.hl7.fhir.r4.model.Quantity) {
         tgt.setDose(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getDose()));
       } else {
@@ -1437,7 +1437,7 @@ public class VersionConvertor_30_40 {
     if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate()) {
       // We need to manually make sure that the convertSimpleQuantity method is
       // called. Otherwise (if we would simply forward to the convertType method), this would lead
-      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource,
+      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource.
       if (src.getDoseAndRate().get(0).getRate() instanceof org.hl7.fhir.r4.model.Quantity) {
         tgt.setRate(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getRate()));
       } else {

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -1418,16 +1418,32 @@ public class VersionConvertor_30_40 {
       tgt.setRoute(convertCodeableConcept(src.getRoute()));
     if (src.hasMethod())
       tgt.setMethod(convertCodeableConcept(src.getMethod()));
-    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
-      tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose()) {
+      // We need to manually make sure that the convertSimpleQuantity method is
+      // called. Otherwise (if we would simply forward to the convertType method), this would lead
+      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource, 
+      if (src.getDoseAndRate().get(0).getDose() instanceof org.hl7.fhir.r4.model.Quantity) {
+        tgt.setDose(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getDose()));
+      } else {
+        tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+      }
+    }
     if (src.hasMaxDosePerPeriod())
       tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
     if (src.hasMaxDosePerAdministration())
       tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
     if (src.hasMaxDosePerLifetime())
       tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
-      tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate()) {
+      // We need to manually make sure that the convertSimpleQuantity method is
+      // called. Otherwise (if we would simply forward to the convertType method), this would lead
+      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource,
+      if (src.getDoseAndRate().get(0).getRate() instanceof org.hl7.fhir.r4.model.Quantity) {
+        tgt.setRate(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getRate()));
+      } else {
+        tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+      }
+    }
     return tgt;
   }
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -1421,7 +1421,7 @@ public class VersionConvertor_30_40 {
     if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose()) {
       // We need to manually make sure that the convertSimpleQuantity method is
       // called. Otherwise (if we would simply forward to the convertType method), this would lead
-      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource. 
+      // to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource.
       if (src.getDoseAndRate().get(0).getDose() instanceof org.hl7.fhir.r4.model.Quantity) {
         tgt.setDose(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getDose()));
       } else {


### PR DESCRIPTION
We need to manually make sure that the convertSimpleQuantity method is called. Otherwise (if we would simply forward to the convertType method), this would lead to a conversion to another Quantity object, that would be invalid for the DSTU3 Dosage resource.