### PR TITLE
Don't crash on bad files present in IG, ignore & warn instead

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -736,7 +736,7 @@ public class ValidationEngine {
             throw new Exception("Unsupported version "+version);
 
         } catch (Exception e) {
-          throw new Exception("Error parsing "+fn+": "+e.getMessage(), e);
+          System.out.println(" - ignored due to error: "+e.getMessage());
         }
         if (r != null) {
           context.cacheResource(r);


### PR DESCRIPTION
If an invalid file is present in the context folder, the validation will fail. This means that you have to get all your files to be perfect before you can validate the one in question - seems harsh, irrelevant files should be ignored instead. This PR adds a warning instead, so the output now is:

```
+  .. load IG from /home/vadi/Desktop/mirjamstestproject/mirjamstestproject
 ..file: ObservationDefinition-example.xml - ignored due to error: Unknown resource type ObservationDefinition
 ..file: adam-everyman.json  .. validate [/home/vadi/Desktop/mirjamstestproject/mirjamstestproject/adam-everyman.json]
Terminology server: Check for supported code systems for http://www.alpha.alp/use-case
```

Fixes https://github.com/hapifhir/org.hl7.fhir.core/issues/54.

This is just about the #1 complaint in Hammer right now, Java validator giving errors on files that aren't the target of the validation (https://github.com/health-validator/Hammer/issues/81)