### PR TITLE
unit test conversions r3r4 

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/context/SimpleWorkerContext.java
@@ -289,6 +289,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 	      }
 	    }
 	  }
+	  this.version = pi.version();
 	}
 
   public void loadFromFile(String file, IContextResourceLoader loader) throws IOException, FHIRException {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/XhtmlType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/XhtmlType.java
@@ -73,8 +73,13 @@ public class XhtmlType extends Element {
   @Override
   public Base setProperty(int hash, String name, Base value) throws FHIRException {
     if ("value".equals(name)) {
-      place.setDiv(castToXhtml(value));
-      return value;
+      if (value instanceof StringType) {
+        // div is already generated with getValue, we cannot just overwrite it
+        place.getDiv().setValueAsString(((StringType) value).asStringValue());
+      } else {
+        place.setDiv(castToXhtml(value));
+      }
+    	return value;
     } else
       return super.setProperty(hash, name, value);
   }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/FHIRPathEngine.java
@@ -2889,7 +2889,7 @@ public class FHIRPathEngine {
 
       if (!Utilities.noString(f)) {
 
-        if (exp.getParameters().size() != 2) {
+        if (exp.getParameters().size() == 2) {
 
           String t = convertToString(execute(context, focus, exp.getParameters().get(0), true));
           String r = convertToString(execute(context, focus, exp.getParameters().get(1), true));

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -1402,7 +1402,7 @@ public class StructureMapUtilities {
 					}
 				} else if (rule.getSource().size() == 1 && rule.getSourceFirstRep().hasVariable() && rule.getTarget().size() == 1 && rule.getTargetFirstRep().hasVariable() && rule.getTargetFirstRep().getTransform() == StructureMapTransform.CREATE && !rule.getTargetFirstRep().hasParameter()) {
 				  // simple inferred, map by type
-				  System.out.println(v.summary());
+				  log(v.summary());
 				  Base src = v.get(VariableMode.INPUT, rule.getSourceFirstRep().getVariable());
 				  Base tgt = v.get(VariableMode.OUTPUT, rule.getTargetFirstRep().getVariable());
 				  String srcType = src.fhirType();
@@ -1493,7 +1493,9 @@ public class StructureMapUtilities {
     if (value.contains("*")) {
       for (StructureMap sm : worker.listTransforms()) {
         if (urlMatches(value, sm.getUrl())) {
-          res.add(sm); 
+          if (!res.contains(sm)) {
+            res.add(sm); 
+          }
         }
       }
     } else {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/XhtmlType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/XhtmlType.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
@@ -72,7 +73,12 @@ public class XhtmlType extends Element {
   @Override
   public Base setProperty(int hash, String name, Base value) throws FHIRException {
     if ("value".equals(name)) {
-      place.setDiv(castToXhtml(value));
+      if (value instanceof StringType) {
+        // div is already generated with getValue, we cannot just overwrite it
+        place.getDiv().setValueAsString(((StringType) value).asStringValue());
+      } else {
+        place.setDiv(castToXhtml(value));
+      }
       return value;
     } else
       return super.setProperty(hash, name, value);

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
@@ -2896,7 +2896,7 @@ public class FHIRPathEngine {
 
       if (!Utilities.noString(f)) {
 
-        if (exp.getParameters().size() != 2) {
+        if (exp.getParameters().size() == 2) {
 
           String t = convertToString(execute(context, focus, exp.getParameters().get(0), true));
           String r = convertToString(execute(context, focus, exp.getParameters().get(1), true));


### PR DESCRIPTION
When on running the conversion maps between r3 and r4 back I needed to adjust fhir.core for the following points to perform the tests which are summarized in this pull request:

- R3R4ConversionTests using the npm packages of the releases
- FHIRPathEngine fix for replace function
- XHtmlType adjustment: There is an StringType provided during the mapping (why not xhtml?), however the conversion gets lost, because the div was already generated with getValue, it cannot just be overwritten

The updated maps will follow in a pull request on the fhir rep. 

With this pull request the JUnit test can be run without errors during the transforms (not that all the R3R4 conversions are now done ...)
