### PR TITLE
snapshot for logical model and enxp parsing

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
@@ -463,7 +463,11 @@ public class ProfileUtilities extends TranslatingUtilities {
       StructureDefinitionDifferentialComponent diff = cloneDiff(derived.getDifferential()); // we make a copy here because we're sometimes going to hack the differential while processing it. Have to migrate user data back afterwards
       StructureDefinitionSnapshotComponent baseSnapshot  = base.getSnapshot(); 
       if (derived.getDerivation().equals(TypeDerivationRule.SPECIALIZATION)) {
-        baseSnapshot = cloneSnapshot(baseSnapshot, base.getType(), derived.getType());
+        String derivedType = derived.getType();
+        if (StructureDefinitionKind.LOGICAL.equals(derived.getKind()) && derived.getType().contains("/")) {
+          derivedType = derivedType.substring(derivedType.lastIndexOf("/")+1);
+        }
+        baseSnapshot = cloneSnapshot(baseSnapshot, base.getType(), derivedType);
       }
       processPaths("", derived.getSnapshot(), baseSnapshot, diff, baseCursor, diffCursor, baseSnapshot.getElement().size()-1, 
           derived.getDifferential().hasElement() ? derived.getDifferential().getElement().size()-1 : -1, url, webUrl, derived.present(), null, null, false, base.getUrl(), null, false, new ArrayList<ElementRedirection>(), base);

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -245,7 +245,7 @@ public class XmlParser extends ParserBase {
     if (!Utilities.noString(text)) {
     	Property property = getTextProp(properties);
     	if (property != null) {
-        if ("ED.data[x]".equals(property.getDefinition().getId())) {
+        if ("ED.data[x]".equals(property.getDefinition().getId()) || (property.getDefinition()!=null && property.getDefinition().getBase()!=null && "ED.data[x]".equals(property.getDefinition().getBase().getPath()))) {
           if ("B64".equals(node.getAttribute("representation"))) {
             context.getChildren().add(new Element("dataBase64Binary", property, "base64Binary", text).markLocation(line(node), col(node)));
           } else {


### PR DESCRIPTION
additional two refinements for logical model snapshot generation:

1. a logical model can have a type with an absolute url (e.g. http://hl7.org/fhir/cda/StructureDefinition/RecordTarget), for the element id, path just the tail has to be used, this has been adjusted. [For logical models, where the type is a URL, the type name SHOULD start with the tail of the type URL where required.](http://hl7.org/fhir/structuredefinition-definitions.html)

and for parsing:
2. ED.data[x] can also be specialised and parsing has been adjusted to support ENXP