### PR TITLE
allow absolute url for type.code

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -2354,7 +2354,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       long t = System.nanoTime();
       StructureDefinition sd = context.fetchResource(StructureDefinition.class, url);
       sdTime = sdTime + (System.nanoTime() - t);
-      if (sd != null && (sd.getType().equals(type) || sd.getUrl().equals("http://hl7.org/fhir/StructureDefinition/" + type)) && sd.hasSnapshot())
+      if (sd != null && (sd.getType().equals(type) || sd.getUrl().equals(url)) && sd.hasSnapshot())
         return sd;
     }
     return null;


### PR DESCRIPTION
Validation the cda.xml in r5 tests gives the following error:

Error @ ClinicalDocument.code (line 15, col114) : Unknown type http://hl7.org/fhir/cda/StructureDefinition/CE
Error @ ClinicalDocument.title (line 16, col9) : Unknown type http://hl7.org/fhir/cda/StructureDefinition/ST
Error @ ClinicalDocument.effectiveTime (line 17, col35) : Unknown type http://hl7.org/fhir/cda/StructureDefinition/TS

This errors are due to the fact, that the ElementDefintion.type.code have an absolut url, which is correct according to the specification: [ElementDefinition.type.code](http://hl7.org/fhir/elementdefinition-definitions.html):

> Definition | URL of Data type or Resource that is a(or the) type used for this element. References are URLs that are relative to http://hl7.org/fhir/StructureDefinition e.g. "string" is a reference to http://hl7.org/fhir/StructureDefinition/string. Absolute URLs are only allowed in logical models.

This pullrequest changes the getProfileForType function, that a profile is also returned if an absolute url has been specified.
