### PR TITLE
allow absolute url for type.code, take 2

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -2354,7 +2354,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       long t = System.nanoTime();
       StructureDefinition sd = context.fetchResource(StructureDefinition.class, url);
       sdTime = sdTime + (System.nanoTime() - t);
-      if (sd != null && (sd.getType().equals(type) || sd.getUrl().equals(url)) && sd.hasSnapshot())
+      if (sd != null && (sd.getType().equals(type) || sd.getUrl().equals(type)) && sd.hasSnapshot())
         return sd;
     }
     return null;


### PR DESCRIPTION
my previous [pull request](https://github.com/hapifhir/org.hl7.fhir.core/pull/95) had an error, which I only noticed now. The effect was that the first absolute url got returned. correction attached, a now also the SubstanceAdministration with multiple effectiveTime types validates. Please apologize the inconvenience for the 2nd pull request.