### PR TITLE
add xhtml namespace to div for CDA section narrative

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -43,6 +43,7 @@ public class CDANarrativeFormat {
    */
   public XhtmlNode convert(Element ed) throws FHIRException {
     XhtmlNode div = new XhtmlNode(NodeType.Element, "div");
+    div.setAttribute("xmlns", XhtmlNode.XMLNS);
     processAttributes(ed, div, "ID", "language", "styleCode");
     processChildren(ed, div);
     return div;

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlNode.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlNode.java
@@ -88,8 +88,8 @@ public class XhtmlNode implements IBaseXhtml {
   }
 
   public static final String NBSP = Character.toString((char)0xa0);
-  private static final String DECL_XMLNS = " xmlns=\"http://www.w3.org/1999/xhtml\"";
-
+  public static final String XMLNS = "http://www.w3.org/1999/xhtml";
+  private static final String DECL_XMLNS = " xmlns=\""+XMLNS+"\"";
 
   private Location location;
   private NodeType nodeType;


### PR DESCRIPTION
When validating a CDA document an error is raised: ClinicalDocument.component.structuredBody.component[0].section.text (line 130, col12) : Wrong namespace on the XHTML ('null', should be 'http://www.w3.org/1999/xhtml’) is generated. 

This pull requests adds to the CDANarrativeFormat converter the xhtml namespace to the div element which allows the validation to pass afterwards.

JSON representation before:   "text": "<div><ul><li><span id=\"a1\">...
JSON representation after:   "text": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li><span id=\"a1\">...