### PR TITLE
validator enhancement for logical models (conversion) and FHIRPath expressions

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -1263,6 +1263,12 @@ public class ValidationEngine implements IValidatorResourceFetcher {
     return (DomainResource) res;
   }
   
+  public void convert(String source, String output) throws Exception {
+    Content cnt = loadContent(source, "validate");
+    Element e = Manager.parse(context, new ByteArrayInputStream(cnt.focus), cnt.cntType);
+    Manager.compose(context, e, new FileOutputStream(output), (output.endsWith(".json") ? FhirFormat.JSON : FhirFormat.XML), OutputStyle.PRETTY, null);
+  }
+  
   public StructureDefinition snapshot(String source, String version) throws Exception {
     Content cnt = loadContent(source, "validate");
     Resource res = loadResourceByVersion(version, cnt.focus, Utilities.getFileNameForName(source));

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -1268,7 +1268,14 @@ public class ValidationEngine implements IValidatorResourceFetcher {
     Element e = Manager.parse(context, new ByteArrayInputStream(cnt.focus), cnt.cntType);
     Manager.compose(context, e, new FileOutputStream(output), (output.endsWith(".json") ? FhirFormat.JSON : FhirFormat.XML), OutputStyle.PRETTY, null);
   }
-  
+
+  public String evaluateFhirPath(String source, String expression) throws Exception {
+    Content cnt = loadContent(source, "validate");
+    FHIRPathEngine fpe = new FHIRPathEngine(context);
+    Element e = Manager.parse(context, new ByteArrayInputStream(cnt.focus), cnt.cntType);
+    return fpe.evaluateToString(e, expression);
+  }
+
   public StructureDefinition snapshot(String source, String version) throws Exception {
     Content cnt = loadContent(source, "validate");
     Resource res = loadResourceByVersion(version, cnt.focus, Utilities.getFileNameForName(source));

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
@@ -64,7 +64,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementKind;
 import org.hl7.fhir.r5.conformance.CapabilityStatementUtilities;
 import org.hl7.fhir.r5.conformance.CapabilityStatementUtilities.CapabilityStatementComparisonOutput;
 import org.hl7.fhir.r5.conformance.ProfileComparer;
@@ -79,14 +78,12 @@ import org.hl7.fhir.r5.model.Constants;
 import org.hl7.fhir.r5.model.DomainResource;
 import org.hl7.fhir.r5.model.FhirPublication;
 import org.hl7.fhir.r5.model.ImplementationGuide;
-import org.hl7.fhir.r5.model.IntegerType;
 import org.hl7.fhir.r5.model.MetadataResource;
 import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.utils.KeyGenerator;
-import org.hl7.fhir.r5.utils.NarrativeGenerator;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
 import org.hl7.fhir.r5.validation.ValidationEngine.ScanOutputItem;
 import org.hl7.fhir.utilities.TextFile;
@@ -94,7 +91,6 @@ import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtil;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.cache.PackageCacheManager;
-import org.hl7.fhir.utilities.cache.ToolsVersion;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 
@@ -115,7 +111,7 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 public class Validator {
 
   public enum EngineMode {
-    VALIDATION, TRANSFORM, NARRATIVE, SNAPSHOT, SCAN
+    VALIDATION, TRANSFORM, NARRATIVE, SNAPSHOT, SCAN, CONVERT
   }
 
   private static String getNamedParam(String[] args, String param) {
@@ -239,6 +235,13 @@ public class Validator {
       System.out.println(" -narrative");
       System.out.println("");
       System.out.println("-narrative requires the parameters -defn, -txserver, -source, and -output. ig and profile may be used");
+      System.out.println("");
+      System.out.println("Alternatively, you can use the validator to convert a resource or logical model.");
+      System.out.println("To do this, you must provide a specific parameter:");
+      System.out.println("");
+      System.out.println(" -convert");
+      System.out.println("");
+      System.out.println("-convert requires the parameters -source and -output. ig may be used to provide a logical model");
       System.out.println("");
       System.out.println("Finally, you can use the validator to generate a snapshot for a profile.");
       System.out.println("To do this, you must provide a specific parameter:");
@@ -495,6 +498,8 @@ public class Validator {
           }
         } else if (args[i].startsWith("-x")) {
           i++;
+        } else if (args[i].equals("-convert")) {
+          mode = EngineMode.CONVERT;
         } else {
           sources.add(args[i]);
         }
@@ -560,6 +565,9 @@ public class Validator {
         if (output != null) {
           validator.handleOutput(r, output, sv);
         }
+      } else if (mode == EngineMode.CONVERT) {
+        validator.convert(sources.get(0), output);
+        System.out.println(" ...convert");
       } else {
         if  (definitions == null)
           throw new Exception("Must provide a defn when doing validation");

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
@@ -111,7 +111,7 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 public class Validator {
 
   public enum EngineMode {
-    VALIDATION, TRANSFORM, NARRATIVE, SNAPSHOT, SCAN, CONVERT
+    VALIDATION, TRANSFORM, NARRATIVE, SNAPSHOT, SCAN, CONVERT, FHIRPATH
   }
 
   private static String getNamedParam(String[] args, String param) {
@@ -242,6 +242,15 @@ public class Validator {
       System.out.println(" -convert");
       System.out.println("");
       System.out.println("-convert requires the parameters -source and -output. ig may be used to provide a logical model");
+      System.out.println("");
+      System.out.println("Alternatively, you can use the validator to evaluate a FHIRPath expression on a resource or logical model.");
+      System.out.println("To do this, you must provide a specific parameter:");
+      System.out.println("");
+      System.out.println(" -fhirpath [FHIRPath]");
+      System.out.println("");
+      System.out.println("* [FHIRPath] the FHIRPath expression to evaluate");
+      System.out.println("");
+      System.out.println("-fhirpath requires the parameters -source. ig may be used to provide a logical model");
       System.out.println("");
       System.out.println("Finally, you can use the validator to generate a snapshot for a profile.");
       System.out.println("To do this, you must provide a specific parameter:");
@@ -393,6 +402,7 @@ public class Validator {
       String txLog = null;
       String mapLog = null;
       String lang = null;
+      String fhirpath = null;
       boolean doDebug = false;
 
       // load the parameters - so order doesn't matter
@@ -500,6 +510,15 @@ public class Validator {
           i++;
         } else if (args[i].equals("-convert")) {
           mode = EngineMode.CONVERT;
+        } else if (args[i].equals("-fhirpath")) {
+            mode = EngineMode.FHIRPATH;
+            if (fhirpath == null)
+              if (i+1 == args.length)
+                throw new Error("Specified -fhirpath without indicating a FHIRPath expression");
+              else
+                fhirpath = args[++i];
+            else
+              throw new Exception("Can only nominate a single -fhirpath parameter");
         } else {
           sources.add(args[i]);
         }
@@ -568,6 +587,9 @@ public class Validator {
       } else if (mode == EngineMode.CONVERT) {
         validator.convert(sources.get(0), output);
         System.out.println(" ...convert");
+      } else if (mode == EngineMode.FHIRPATH) {
+        System.out.println(" ...evaluating "+fhirpath);
+        System.out.println(validator.evaluateFhirPath(sources.get(0), fhirpath));
       } else {
         if  (definitions == null)
           throw new Exception("Must provide a defn when doing validation");


### PR DESCRIPTION
This pull requests adds two functionalities already implemented in core to the validator:

1. conversion between formats
2. evaluating a FHIRPath expression against a resource (or logical model)

The **-convert** option allows to convert a source file to the desired output (e.g. xml to json). 

```
 java -jar org.hl7.fhir.validator.jar ./test.xml -version 4.0.0 -convert -output ./test.json 
```
This conversion can also be used for logical models (e.g. the CDA Logical model)  to convert the CDA xml into the json representation.

```
 java -jar org.hl7.fhir.validator.jar-version 4.0.0 ./cda.xml -ig hl7.fhir.cda#dev -convert -output ./cda.json
```

The **-fhirpath** evaluates a FHIRPath expression against a resource/logical model:

```
 java -jar org.hl7.fhir.validator.jar-version 4.0.0 ./patient.xml -version 4.0.0 -fhirpath Patient.name.family
  .. connect to tx server @ http://tx.fhir.org
  .. definitions from hl7.fhir.core#4.0.0
    (v4.0.0)
 ...evaluating Patient.name.family
Muster
```

This can also be used with a logical model:
```
 java -jar org.hl7.fhir.validator.jar-version 4.0.0 ./cda-original.xml -version 4.0.0 -ig hl7.fhir.cda#dev -fhirpath confidentialityCode.codeSystem
  .. connect to tx server @ http://tx.fhir.org
  .. definitions from hl7.fhir.core#4.0.0
    (v4.0.0)
+  .. load IG from hl7.fhir.cda#dev
 ...evaluating confidentialityCode.codeSystem
2.16.840.1.113883.5.25
```
