### PR TITLE
validator support for absolute type definitions

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/InstanceValidator.java
@@ -3989,7 +3989,11 @@ private boolean isAnswerRequirementFulfilled(QuestionnaireItemComponent qItem, L
     if (childDefinitions.isEmpty()) {
       if (actualType == null)
         return; // there'll be an error elsewhere in this case, and we're going to stop.
-      StructureDefinition dt = this.context.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/" + actualType);
+      StructureDefinition dt = null;
+      if (isAbsolute(actualType)) 
+        dt = this.context.fetchResource(StructureDefinition.class, actualType);
+      else
+        dt = this.context.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/" + actualType);
       if (dt == null)
         throw new DefinitionException("Unable to resolve actual type " + actualType);
 


### PR DESCRIPTION
The validator raises an error message for child definitions which have an absolute type, this occurs for example in the cda-core-2.0 logical model where we have in the address (AD type) entries with type of http://hl7.org/fhir/cda/StructureDefinition/ADXP. This pull request enhances that for absolute type url's they get directly resolved.
