### PR TITLE
fml: validator change transform to elementmodel

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -1210,12 +1210,12 @@ public class ValidationEngine implements IValidatorResourceFetcher {
     return issue.getSeverity().toString()+" @ "+issue.getLocation() + " " +issue.getDetails().getText() +(source != null ? " (src = "+source+")" : "");    
   }
 
-  public Resource transform(String source, String map) throws Exception {
+  public org.hl7.fhir.r5.elementmodel.Element transform(String source, String map) throws Exception {
     Content cnt = loadContent(source, "validate");
     return transform(cnt.focus, cnt.cntType, map);
   }
   
-  public Resource transform(byte[] source, FhirFormat cntType, String mapUri) throws Exception {
+  public org.hl7.fhir.r5.elementmodel.Element transform(byte[] source, FhirFormat cntType, String mapUri) throws Exception {
     List<Resource> outputs = new ArrayList<Resource>();
     
     StructureMapUtilities scu = new StructureMapUtilities(context, new TransformSupportServices(outputs));
@@ -1224,13 +1224,12 @@ public class ValidationEngine implements IValidatorResourceFetcher {
     if (map == null)
       throw new Error("Unable to find map "+mapUri+" (Known Maps = "+context.listMapUrls()+")");
     
-    Resource resource = getTargetResourceFromStructureMap(map);
-
+    org.hl7.fhir.r5.elementmodel.Element resource = getTargetResourceFromStructureMap(map);
     scu.transform(null, src, map, resource);
     return resource;
   }
 
-  private Resource getTargetResourceFromStructureMap(StructureMap map) {
+  private org.hl7.fhir.r5.elementmodel.Element getTargetResourceFromStructureMap(StructureMap map) {
     String targetTypeUrl = null;
     for(StructureMap.StructureMapStructureComponent component: map.getStructure()) {
       if(component.getMode() == StructureMap.StructureMapModelMode.TARGET) {
@@ -1252,8 +1251,8 @@ public class ValidationEngine implements IValidatorResourceFetcher {
 
     if(structureDefinition == null)
       throw new FHIRException("Unable to determine StructureDefinition for target type");
-
-    return ResourceFactory.createResource(structureDefinition.getName());
+    
+    return Manager.build(getContext(), structureDefinition);
   }
 
   public DomainResource generate(String source, String version) throws Exception {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/ValidationEngine.java
@@ -250,9 +250,9 @@ public class ValidationEngine implements IValidatorResourceFetcher {
 
   public class TransformSupportServices implements ITransformerServices {
 
-    private List<Resource> outputs;
+    private List<Base> outputs;
 
-    public TransformSupportServices(List<Resource> outputs) {
+    public TransformSupportServices(List<Base> outputs) {
       this.outputs = outputs;
     }
 
@@ -266,19 +266,13 @@ public class ValidationEngine implements IValidatorResourceFetcher {
     @Override
     public Base createType(Object appInfo, String name) throws FHIRException {
       StructureDefinition sd = context.fetchResource(StructureDefinition.class, name);
-      if (sd != null && sd.getKind() == StructureDefinitionKind.LOGICAL) {
-        return Manager.build(context, sd); 
-      } else {
-        if (name.startsWith("http://hl7.org/fhir/StructureDefinition/"))
-          name = name.substring("http://hl7.org/fhir/StructureDefinition/".length());
-        return ResourceFactory.createResourceOrType(name);
-      }
+      return Manager.build(context, sd); 
     }
 
     @Override
     public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
       if (atRootofTransform)
-        outputs.add((Resource) res);
+        outputs.add(res);
       return res;
     }
 
@@ -1216,7 +1210,7 @@ public class ValidationEngine implements IValidatorResourceFetcher {
   }
   
   public org.hl7.fhir.r5.elementmodel.Element transform(byte[] source, FhirFormat cntType, String mapUri) throws Exception {
-    List<Resource> outputs = new ArrayList<Resource>();
+    List<Base> outputs = new ArrayList<Base>();
     
     StructureMapUtilities scu = new StructureMapUtilities(context, new TransformSupportServices(outputs));
     org.hl7.fhir.r5.elementmodel.Element src = Manager.parse(context, new ByteArrayInputStream(source), cntType); 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/r5/validation/Validator.java
@@ -537,11 +537,14 @@ public class Validator {
           throw new Exception("Must provide a map when doing a transform");
         try {
           validator.setMapLog(mapLog);
-          Resource r = validator.transform(sources.get(0), map);
+          org.hl7.fhir.r5.elementmodel.Element r = validator.transform(sources.get(0), map);
           System.out.println(" ...success");
           if (output != null) {
             FileOutputStream s = new FileOutputStream(output);
-            x.compose(s, r);
+            if (output != null && output.endsWith(".json"))
+              new org.hl7.fhir.r5.elementmodel.JsonParser(validator.getContext()).compose(r, s, OutputStyle.PRETTY, null);
+            else
+              new org.hl7.fhir.r5.elementmodel.XmlParser(validator.getContext()).compose(r, s, OutputStyle.PRETTY, null);
             s.close();
           }
         } catch (Exception e) {


### PR DESCRIPTION
the validator cannot transform to R4 resources. an exception is raised (see below). Attached pull request changes the code that the validator is using elementmodel and building the resource structure to elementmodel (same way as in org.hl7.fhir.validation/src/test/java/org/hl7/fhir/conversion/tests/R3R4ConversionTests.java).

> FHIR Validation tool Version 4.1.1 - Built 2019-11-13T07:58:28.102+01:00 - Git 2dd39bb269e9
> Detected Java version: 1.8.0_25 from /Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home/jre on x86_64 (64bit). 3641MB available
> Arguments: /Users/oliveregger/Documents/github/chmed16af/resources/bundle/chmed16af-mp-bundle-s01.xml -transform http://chmed16af.emediplan.ch/fhir/StructureMap/Bundle0.2.0to0.1.0 -version 4.0.1 -ig /Users/oliveregger/Documents/github/chmed16af/maps0.2.0to0.1.0 -log test.txt -output /Users/oliveregger/Documents/github/chmed16af/resources/bundle/chmed16af-mp-bundle-s01-0.1.0.xml
> Directories: Current = /Users/oliveregger/Documents/github/org.hl7.fhir.core/org.hl7.fhir.validation, Package Cache = /Users/oliveregger/.fhir/packages
>   .. FHIR Version 4.0, definitions from hl7.fhir.r4.core#4.0.1
>   .. connect to tx server @ http://tx.fhir.org
>     (v4.0.1)
> +  .. load IG from /Users/oliveregger/Documents/github/chmed16af/maps0.2.0to0.1.0
> Start Transform http://chmed16af.emediplan.ch/fhir/StructureMap/Bundle0.2.0to0.1.0
> Group : Bundle; vars = source variables [src: (Bundle)], target variables [tgt: (Bundle)], shared variables []
>  Group : Resource; vars = source variables [src: (Bundle)], target variables [tgt: (Bundle)], shared variables >    rule : Resource-id; vars = source variables [src: (Bundle)], target variables [tgt: (Bundle)], shared variables []
>  ...Failure: Unable to convert a org.hl7.fhir.r5.elementmodel.Element to a Id
> org.hl7.fhir.exceptions.FHIRException: Unable to convert a org.hl7.fhir.r5.elementmodel.Element to a Id
> 	at org.hl7.fhir.r5.model.Base.castToId(Base.java:439)
> 	at org.hl7.fhir.r5.model.Resource.setProperty(Resource.java:319)
> 	at org.hl7.fhir.r5.model.Bundle.setProperty(Bundle.java:3005)
> 	at org.hl7.fhir.r5.utils.StructureMapUtilities.processTarget(StructureMapUtilities.java:1820)
> 	at org.hl7.fhir.r5.utils.StructureMapUtilities.executeRule(StructureMapUtilities.java:1405)
