### PR TITLE
logical model support for defaulttype/typeAttr

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
@@ -106,8 +106,11 @@ public class Property {
       if (tail.endsWith("[x]") && elementName != null && elementName.startsWith(tail.substring(0, tail.length()-3))) {
 				String name = elementName.substring(tail.length()-3);
         return isPrimitive(lowFirst(name)) ? lowFirst(name) : name;        
-			} else
+			} else {
+	      if (ToolingExtensions.hasExtension(ed, "http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype"))
+	        return ToolingExtensions.readStringExtension(ed, "http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype");
         throw new Error("logic error, gettype when types > 1, name mismatch for "+elementName+" on at "+ed.getPath());
+			}
     } else if (ed.getType().get(0).getCode() == null) {
       if (Utilities.existsInList(ed.getId(), "Element.id", "Extension.url"))
         return "string";

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -309,8 +309,13 @@ public class XmlParser extends ParserBase {
     					if (property.getDefinition().hasRepresentation(PropertyRepresentation.TYPEATTR)) {
     						String xsiType = ((org.w3c.dom.Element) child).getAttributeNS(FormatUtilities.NS_XSI, "type");
     						if (Utilities.noString(xsiType)) {
-    		          logError(line(child), col(child), path, IssueType.STRUCTURE, "No type found on '"+child.getLocalName()+'"', IssueSeverity.ERROR);
-    		          ok = false;
+                  if (ToolingExtensions.hasExtension(property.getDefinition(), "http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype")) {
+                    xsiType = ToolingExtensions.readStringExtension(property.getDefinition(), "http://hl7.org/fhir/StructureDefinition/elementdefinition-defaulttype");
+                    n.setType(xsiType);
+                  } else {
+      		          logError(line(child), col(child), path, IssueType.STRUCTURE, "No type found on '"+child.getLocalName()+'"', IssueSeverity.ERROR);
+      		          ok = false;
+                  }
     						} else {
     							if (xsiType.contains(":"))
     								xsiType = xsiType.substring(xsiType.indexOf(":")+1);


### PR DESCRIPTION
In CDA substanceAdministration.effectiveTime has a defaultType of SXCM_TS. The type can be further specialized with a typeAttr (xsi:type) to IVL_TS etc, however the typeAttr is optional.

This pull request adds the default type behaviour in validation and parsing.

