### PR TITLE
cda narrative support tfoot

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -152,7 +152,9 @@ public class CDANarrativeFormat {
   }
 
   private void processFootNote(Element e, XhtmlNode xn) {
-    throw new Error("element "+e.getNodeName()+" not handled yet");
+    XhtmlNode xc = xn.addTag("tfoot");
+    processAttributes(e, xc, "ID", "language", "styleCode", "align", "char", "charoff", "valign");
+    processChildren(e, xc);
   }
 
   private void processFootNodeRef(Element e, XhtmlNode xn) {
@@ -221,7 +223,9 @@ public class CDANarrativeFormat {
   }
 
   private void processTFoot(Element e, XhtmlNode xn) {
-    throw new Error("element "+e.getNodeName()+" not handled yet");
+    XhtmlNode xc = xn.addTag("tfoot");
+    processAttributes(e, xc, "ID", "language", "styleCode", "align", "char", "charoff", "valign");
+    processChildren(e, xc);
   }
 
   private void processTh(Element e, XhtmlNode xn) throws FHIRException {
@@ -450,8 +454,11 @@ public class CDANarrativeFormat {
     xml.exit("td");
   }
 
-  private void processTFoot(IXMLWriter xml, XhtmlNode n) {
-    throw new Error("element "+n.getName()+" not handled yet");
+  private void processTFoot(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+    processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
+    xml.enter("tfoot");
+    processChildren(xml, n);
+    xml.exit("tfoot");
   }
 
   private void processTh(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {


### PR DESCRIPTION
added support for tfoot according to narrative-block schema:

```xml
<xs:complexType name="StrucDoc.Tfoot">
		<xs:sequence maxOccurs="unbounded">
			<xs:element name="tr" type="hl7v3:StrucDoc.Tr"/>
		</xs:sequence>
		<xs:attribute name="ID" type="xs:ID"/>
		<xs:attribute name="language" type="xs:NMTOKEN"/>
		<xs:attribute name="styleCode" type="xs:NMTOKENS"/>
		<xs:attribute name="align">
			<xs:simpleType>
				<xs:restriction base="xs:NMTOKEN">
					<xs:enumeration value="left"/>
					<xs:enumeration value="center"/>
					<xs:enumeration value="right"/>
					<xs:enumeration value="justify"/>
					<xs:enumeration value="char"/>
				</xs:restriction>
			</xs:simpleType>
		</xs:attribute>
		<xs:attribute name="char" type="xs:string"/>
		<xs:attribute name="charoff" type="xs:string"/>
		<xs:attribute name="valign">
			<xs:simpleType>
				<xs:restriction base="xs:NMTOKEN">
					<xs:enumeration value="top"/>
					<xs:enumeration value="middle"/>
					<xs:enumeration value="bottom"/>
					<xs:enumeration value="baseline"/>
				</xs:restriction>
			</xs:simpleType>
		</xs:attribute>
	</xs:complexType>
```