### PR TITLE
add indexOf function to FHIRPath

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ExpressionNode.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ExpressionNode.java
@@ -60,7 +60,7 @@ public class ExpressionNode {
     Custom, 
     
     Empty, Not, Exists, SubsetOf, SupersetOf, IsDistinct, Distinct, Count, Where, Select, All, Repeat, Aggregate, Item /*implicit from name[]*/, As, Is, Single,
-    First, Last, Tail, Skip, Take, Union, Combine, Intersect, Exclude, Iif, Upper, Lower, ToChars, Substring, StartsWith, EndsWith, Matches, ReplaceMatches, Contains, Replace, Length,  
+    First, Last, Tail, Skip, Take, Union, Combine, Intersect, Exclude, Iif, Upper, Lower, ToChars, IndexOf, Substring, StartsWith, EndsWith, Matches, ReplaceMatches, Contains, Replace, Length,  
     Children, Descendants, MemberOf, Trace, Check, Today, Now, Resolve, Extension, AllFalse, AnyFalse, AllTrue, AnyTrue,
     HasValue, AliasAs, Alias, HtmlChecks, OfType, Type,
     ConvertsToBoolean, ConvertsToInteger, ConvertsToString, ConvertsToDecimal, ConvertsToQuantity, ConvertsToDateTime, ConvertsToTime, ToBoolean, ToInteger, ToString, ToDecimal, ToQuantity, ToDateTime, ToTime, ConformsTo;
@@ -96,6 +96,7 @@ public class ExpressionNode {
       if (name.equals("lower")) return Function.Lower;
       if (name.equals("upper")) return Function.Upper;
       if (name.equals("toChars")) return Function.ToChars;
+      if (name.equals("indexOf")) return Function.IndexOf;
       if (name.equals("substring")) return Function.Substring;
       if (name.equals("startsWith")) return Function.StartsWith;
       if (name.equals("endsWith")) return Function.EndsWith;
@@ -172,6 +173,7 @@ public class ExpressionNode {
       case ToChars : return "toChars";
       case Lower : return "lower";
       case Upper : return "upper";
+      case IndexOf : return "indexOf";
       case Substring : return "substring";
       case StartsWith : return "startsWith";
       case EndsWith : return "endsWith";

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/FHIRPathEngine.java
@@ -2486,6 +2486,11 @@ public class FHIRPathEngine {
       checkContextString(focus, "toChars");
       return new TypeDetails(CollectionStatus.ORDERED, TypeDetails.FP_String); 
     }
+    case IndexOf : {
+      checkContextString(focus, "indexOf");
+      checkParamTypes(exp.getFunction().toCode(), paramTypes, new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_String)); 
+      return new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer); 
+    }
     case Substring : {
       checkContextString(focus, "subString");
       checkParamTypes(exp.getFunction().toCode(), paramTypes, new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer), new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer)); 
@@ -2722,6 +2727,7 @@ public class FHIRPathEngine {
     case Lower : return funcLower(context, focus, exp);
     case Upper : return funcUpper(context, focus, exp);
     case ToChars : return funcToChars(context, focus, exp);
+    case IndexOf : return funcIndexOf(context, focus, exp);
     case Substring : return funcSubstring(context, focus, exp);
     case StartsWith : return funcStartsWith(context, focus, exp);
     case EndsWith : return funcEndsWith(context, focus, exp);
@@ -3608,6 +3614,24 @@ public class FHIRPathEngine {
       String s = convertToString(focus.get(0));
       for (char c : s.toCharArray())  
         result.add(new StringType(String.valueOf(c)).noExtensions());
+    }
+    return result;
+  }
+  
+  private List<Base> funcIndexOf(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
+    List<Base> result = new ArrayList<Base>();
+    
+    String sw = convertToString(execute(context, focus, exp.getParameters().get(0), true));
+    if (focus.size() == 0) {
+      result.add(new IntegerType(0).noExtensions());
+    } else if (Utilities.noString(sw)) {
+      result.add(new IntegerType(0).noExtensions());
+    } else {
+      String s = convertToString(focus.get(0));
+      if (s == null)
+        result.add(new IntegerType(0).noExtensions());
+      else
+        result.add(new IntegerType(s.indexOf(sw)).noExtensions());
     }
     return result;
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExpressionNode.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExpressionNode.java
@@ -60,7 +60,7 @@ public class ExpressionNode {
     Custom, 
     
     Empty, Not, Exists, SubsetOf, SupersetOf, IsDistinct, Distinct, Count, Where, Select, All, Repeat, Aggregate, Item /*implicit from name[]*/, As, Is, Single,
-    First, Last, Tail, Skip, Take, Union, Combine, Intersect, Exclude, Iif, Upper, Lower, ToChars, Substring, StartsWith, EndsWith, Matches, ReplaceMatches, Contains, Replace, Length,  
+    First, Last, Tail, Skip, Take, Union, Combine, Intersect, Exclude, Iif, Upper, Lower, ToChars, IndexOf, Substring, StartsWith, EndsWith, Matches, ReplaceMatches, Contains, Replace, Length,  
     Children, Descendants, MemberOf, Trace, Check, Today, Now, Resolve, Extension, AllFalse, AnyFalse, AllTrue, AnyTrue,
     HasValue, AliasAs, Alias, HtmlChecks, OfType, Type,
     ConvertsToBoolean, ConvertsToInteger, ConvertsToString, ConvertsToDecimal, ConvertsToQuantity, ConvertsToDateTime, ConvertsToTime, ToBoolean, ToInteger, ToString, ToDecimal, ToQuantity, ToDateTime, ToTime, ConformsTo;
@@ -96,6 +96,7 @@ public class ExpressionNode {
       if (name.equals("lower")) return Function.Lower;
       if (name.equals("upper")) return Function.Upper;
       if (name.equals("toChars")) return Function.ToChars;
+      if (name.equals("indexOf")) return Function.IndexOf;
       if (name.equals("substring")) return Function.Substring;
       if (name.equals("startsWith")) return Function.StartsWith;
       if (name.equals("endsWith")) return Function.EndsWith;
@@ -173,6 +174,7 @@ public class ExpressionNode {
       case ToChars : return "toChars";
       case Lower : return "lower";
       case Upper : return "upper";
+      case IndexOf : return "indexOf";
       case Substring : return "substring";
       case StartsWith : return "startsWith";
       case EndsWith : return "endsWith";

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
@@ -9,6 +9,9 @@ import org.fhir.ucum.UcumException;
 import org.hl7.fhir.exceptions.DefinitionException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.PathEngineException;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.ExpressionNode;
+import org.hl7.fhir.r5.model.IntegerType;
 import org.hl7.fhir.r5.conformance.ProfileUtilities;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.*;
@@ -1078,6 +1081,7 @@ public class FHIRPathEngine {
     case Lower: return checkParamCount(lexer, location, exp, 0);
     case Upper: return checkParamCount(lexer, location, exp, 0);
     case ToChars: return checkParamCount(lexer, location, exp, 0);
+    case IndexOf : return checkParamCount(lexer, location, exp, 1);
     case Substring: return checkParamCount(lexer, location, exp, 1, 2);
     case StartsWith: return checkParamCount(lexer, location, exp, 1);
     case EndsWith: return checkParamCount(lexer, location, exp, 1);
@@ -2486,6 +2490,11 @@ public class FHIRPathEngine {
       checkContextString(focus, "toChars");
       return new TypeDetails(CollectionStatus.ORDERED, TypeDetails.FP_String); 
     }
+    case IndexOf : {
+      checkContextString(focus, "indexOf");
+      checkParamTypes(exp.getFunction().toCode(), paramTypes, new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_String)); 
+      return new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer); 
+    }
     case Substring : {
       checkContextString(focus, "subString");
       checkParamTypes(exp.getFunction().toCode(), paramTypes, new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer), new TypeDetails(CollectionStatus.SINGLETON, TypeDetails.FP_Integer)); 
@@ -2722,6 +2731,7 @@ public class FHIRPathEngine {
     case Lower : return funcLower(context, focus, exp);
     case Upper : return funcUpper(context, focus, exp);
     case ToChars : return funcToChars(context, focus, exp);
+    case IndexOf : return funcIndexOf(context, focus, exp);
     case Substring : return funcSubstring(context, focus, exp);
     case StartsWith : return funcStartsWith(context, focus, exp);
     case EndsWith : return funcEndsWith(context, focus, exp);
@@ -3608,6 +3618,24 @@ public class FHIRPathEngine {
       String s = convertToString(focus.get(0));
       for (char c : s.toCharArray())  
         result.add(new StringType(String.valueOf(c)).noExtensions());
+    }
+    return result;
+  }
+  
+  private List<Base> funcIndexOf(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
+    List<Base> result = new ArrayList<Base>();
+    
+    String sw = convertToString(execute(context, focus, exp.getParameters().get(0), true));
+    if (focus.size() == 0) {
+      result.add(new IntegerType(0).noExtensions());
+    } else if (Utilities.noString(sw)) {
+      result.add(new IntegerType(0).noExtensions());
+    } else {
+      String s = convertToString(focus.get(0));
+      if (s == null)
+        result.add(new IntegerType(0).noExtensions());
+      else
+        result.add(new IntegerType(s.indexOf(sw)).noExtensions());
     }
     return result;
   }


### PR DESCRIPTION
this pull requests adds support for the [indexOf function](http://hl7.org/fhirpath/2018Sep/index.html#indexofsubstring-string-integer) in FHIRPath

e.g.:
```
java -jar org.hl7.fhir.validation.cli-4.1.12-SNAPSHOT.jar -version 4.0.1 -fhirpath "Condition.text.div.indexOf('Severe')" ../fhir-test-cases/r5/condition-example.xml
  .. FHIR Version 4.0, definitions from hl7.fhir.r4.core#4.0.1
  .. connect to tx server @ http://tx.fhir.org
    (v4.0.1)
 ...evaluating Condition.text.div.indexOf('Severe')
42
```