### PR TITLE
FHIR Mapping Language reference function should return string

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
@@ -1922,7 +1922,7 @@ public class StructureMapUtilities {
 	          id = UUID.randomUUID().toString().toLowerCase();
 	          b.setIdBase(id);
 	        }
-	        return new Reference().setReference(b.fhirType()+"/"+id);
+          return new StringType(b.fhirType()+"/"+id);
 	      }
 	    case DATEOP :
 	      throw new Error("Rule \""+ruleId+"\": Transform "+tgt.getTransform().toCode()+" not supported yet");


### PR DESCRIPTION
the reference function in the [FHIR Mapping Language](https://www.hl7.org/fhir/mapping-language.html) is defined as:

return a string that references the provided tree properly

currently the function returns a Reference Type. The pull request changes this to a string, see also corresponding testcase [pull request](https://github.com/FHIR/fhir-test-cases/pull/2) 