### PR TITLE
Fix ordering issue in converter

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
@@ -1822,24 +1822,24 @@ public class VersionConvertor_10_30 {
             return convertId((org.hl7.fhir.dstu2.model.IdType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
             return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
+          return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
+          return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.IntegerType)
             return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
             return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.OidType)
             return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.StringType)
             return convertString((org.hl7.fhir.dstu2.model.StringType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
             return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
+          return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.UriType)
             return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Extension)
             return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
@@ -1856,6 +1856,18 @@ public class VersionConvertor_10_30 {
             return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Period)
             return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.Age)
+          return convertAge((org.hl7.fhir.dstu2.model.Age) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.Count)
+          return convertCount((org.hl7.fhir.dstu2.model.Count) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.Distance)
+          return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.Duration)
+          return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.Money)
+          return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
+        if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
+          return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
             return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Range)
@@ -1880,18 +1892,6 @@ public class VersionConvertor_10_30 {
             return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
         if (src instanceof org.hl7.fhir.dstu2.model.Timing)
             return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Age)
-            return convertAge((org.hl7.fhir.dstu2.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Count)
-            return convertCount((org.hl7.fhir.dstu2.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
         throw new FHIRException("Unknown type " + src.fhirType());
     }
 
@@ -1914,24 +1914,24 @@ public class VersionConvertor_10_30 {
             return convertId((org.hl7.fhir.dstu3.model.IdType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
             return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
+          return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
+          return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
             return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
             return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.OidType)
             return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.StringType)
             return convertString((org.hl7.fhir.dstu3.model.StringType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.TimeType)
             return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
+          return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.UriType)
             return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Extension)
             return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
@@ -1948,6 +1948,18 @@ public class VersionConvertor_10_30 {
             return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Period)
             return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.Age)
+          return convertAge((org.hl7.fhir.dstu3.model.Age) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.Count)
+          return convertCount((org.hl7.fhir.dstu3.model.Count) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.Distance)
+          return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.Duration)
+          return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.Money)
+          return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
+        if (src instanceof org.hl7.fhir.dstu3.model.SimpleQuantity)
+          return convertSimpleQuantity((org.hl7.fhir.dstu3.model.SimpleQuantity) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
             return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Range)
@@ -1972,18 +1984,6 @@ public class VersionConvertor_10_30 {
             return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
         if (src instanceof org.hl7.fhir.dstu3.model.Timing)
             return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Age)
-            return convertAge((org.hl7.fhir.dstu3.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Count)
-            return convertCount((org.hl7.fhir.dstu3.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Money)
-            return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.dstu3.model.SimpleQuantity) src);
         throw new FHIRException("Unknown type " + src.fhirType());
     }
 

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/VersionConvertor_10_30Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/VersionConvertor_10_30Test.java
@@ -1,0 +1,18 @@
+package org.hl7.fhir.convertors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionConvertor_10_30Test {
+
+  @Test
+  public void testConvertUnsignedInt() {
+
+    org.hl7.fhir.dstu3.model.UnsignedIntType output;
+    output = (org.hl7.fhir.dstu3.model.UnsignedIntType)VersionConvertor_10_30.convertType(new org.hl7.fhir.dstu2.model.UnsignedIntType(33));
+    assertEquals(33, output.getValue().intValue());
+
+  }
+
+}


### PR DESCRIPTION
@markiantorno - The convertType method appears to be doing the types alphabetically, but this doesn't always work as there is a hierarchy. E.g. you have to test for UnsignedIntType before testing for IntegerType since the former is a subclass of the latter.

This PR fixes this for the 10/30 converters but I'm not sure if these are generated or not (i.e. what's the best strategy for fixing it for the other versions?)