### PR TITLE
Fix for the issue 1740 (https://github.com/jamesagnew/hapi-fhir/issues/1740)

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/elementmodel/JsonParser.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/elementmodel/JsonParser.java
@@ -241,14 +241,18 @@ public class JsonParser extends ParserBase {
 		JsonElement main = object.has(name) ? object.get(name) : null; 
 		JsonElement fork = object.has("_"+name) ? object.get("_"+name) : null;
 		if (main != null || fork != null) {
-			if (property.isList() && ((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray)) ) {
-				JsonArray arr1 = (JsonArray) main;
-				JsonArray arr2 = (JsonArray) fork;
-				for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
-					JsonElement m = arrI(arr1, i);
-					JsonElement f = arrI(arr2, i);
-					parseChildPrimitiveInstance(context, property, name, npath, m, f);
-				}
+			if (property.isList() ) {
+			  if( ((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray))) {
+          JsonArray arr1 = (JsonArray) main;
+          JsonArray arr2 = (JsonArray) fork;
+          for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
+            JsonElement m = arrI(arr1, i);
+            JsonElement f = arrI(arr2, i);
+            parseChildPrimitiveInstance(context, property, name, npath, m, f);
+          }
+        }else {
+          logError(line(object), col(object), npath, IssueType.INVALID, "This property must be an Array, not "+describeType(object), IssueSeverity.ERROR);
+        }
 			} else
 				parseChildPrimitiveInstance(context, property, name, npath, main, fork);
 		}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
@@ -253,18 +253,14 @@ public class JsonParser extends ParserBase {
 		JsonElement main = object.has(name) ? object.get(name) : null; 
 		JsonElement fork = object.has("_"+name) ? object.get("_"+name) : null;
 		if (main != null || fork != null) {
-			if (property.isList()) {
-			  if(((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray)) ) {
-          JsonArray arr1 = (JsonArray) main;
-          JsonArray arr2 = (JsonArray) fork;
-          for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
-            JsonElement m = arrI(arr1, i);
-            JsonElement f = arrI(arr2, i);
-            parseChildPrimitiveInstance(context, property, name, npath, m, f);
-          }
-        }else {
-			    logError(line(object), col(object), npath, IssueType.INVALID, "This property must be an Array, not "+describeType(object), IssueSeverity.ERROR);
-        }
+			if (property.isList() && ((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray)) ) {
+				JsonArray arr1 = (JsonArray) main;
+				JsonArray arr2 = (JsonArray) fork;
+				for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
+					JsonElement m = arrI(arr1, i);
+					JsonElement f = arrI(arr2, i);
+					parseChildPrimitiveInstance(context, property, name, npath, m, f);
+				}
 			} else
 				parseChildPrimitiveInstance(context, property, name, npath, main, fork);
 		}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
@@ -253,14 +253,18 @@ public class JsonParser extends ParserBase {
 		JsonElement main = object.has(name) ? object.get(name) : null; 
 		JsonElement fork = object.has("_"+name) ? object.get("_"+name) : null;
 		if (main != null || fork != null) {
-			if (property.isList() && ((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray)) ) {
-				JsonArray arr1 = (JsonArray) main;
-				JsonArray arr2 = (JsonArray) fork;
-				for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
-					JsonElement m = arrI(arr1, i);
-					JsonElement f = arrI(arr2, i);
-					parseChildPrimitiveInstance(context, property, name, npath, m, f);
-				}
+			if (property.isList()) {
+			  if(((main == null) || (main instanceof JsonArray)) &&((fork == null) || (fork instanceof JsonArray)) ) {
+          JsonArray arr1 = (JsonArray) main;
+          JsonArray arr2 = (JsonArray) fork;
+          for (int i = 0; i < Math.max(arrC(arr1), arrC(arr2)); i++) {
+            JsonElement m = arrI(arr1, i);
+            JsonElement f = arrI(arr2, i);
+            parseChildPrimitiveInstance(context, property, name, npath, m, f);
+          }
+        }else {
+			    logError(line(object), col(object), npath, IssueType.INVALID, "This property must be an Array, not "+describeType(object), IssueSeverity.ERROR);
+        }
 			} else
 				parseChildPrimitiveInstance(context, property, name, npath, main, fork);
 		}


### PR DESCRIPTION
Describe the bug
=============
OperationDefinition has a field called resource. Which has a cardinality of 0..*.
anything otherthan array should be validation failure.
But if we try passing string as an input the validation is passing.
Tested with Some other resource as well, where the field is List<?> (where ? can be code,string etc) all or showing the same behaviour.

Posted a question in Google HAPI group but couldn't get the satisfactory answer. https://groups.google.com/forum/#!topic/hapi-fhir/locCV7PicNw

So raised a bug in hapi-fhir project.
https://github.com/jamesagnew/hapi-fhir/issues/1740


Soultion
======
In JsonParser, conditions was merged in one if ccondition. i think its better to split it.
Made corresponding changes for R4 FHIR versions.

But for DSTU3 , DSTU2016MAY and R5 corresponding changes has to be done.

