### PR TITLE
Full disclosure: this isn't really a 'bug' per say, it's more of a be…

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/ExpressionNode.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/ExpressionNode.java
@@ -646,7 +646,7 @@ public class ExpressionNode {
 	}
 
 	private String location() {
-		return Integer.toString(start.line)+", "+Integer.toString(start.column);
+		return Integer.toString(start.getLine())+", "+Integer.toString(start.getColumn());
 	}
 
 	public TypeDetails getTypes() {

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/ExpressionNode.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/ExpressionNode.java
@@ -630,7 +630,7 @@ public class ExpressionNode {
 	}
 
 	private String location() {
-		return Integer.toString(start.line)+", "+Integer.toString(start.column);
+		return Integer.toString(start.getLine())+", "+Integer.toString(start.getColumn());
 	}
 
 	public TypeDetails getTypes() {

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/ExpressionNode.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/ExpressionNode.java
@@ -554,7 +554,7 @@ public class ExpressionNode {
 	}
 
 	private String location() {
-		return Integer.toString(start.line)+", "+Integer.toString(start.column);
+		return Integer.toString(start.getLine())+", "+Integer.toString(start.getColumn());
 	}
 
 	public TypeDetails getTypes() {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ExpressionNode.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ExpressionNode.java
@@ -633,7 +633,7 @@ public class ExpressionNode {
 	}
 
 	private String location() {
-		return Integer.toString(start.line)+", "+Integer.toString(start.column);
+		return Integer.toString(start.getLine())+", "+Integer.toString(start.getColumn());
 	}
 
 	public TypeDetails getTypes() {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExpressionNode.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExpressionNode.java
@@ -634,7 +634,7 @@ public class ExpressionNode {
 	}
 
 	private String location() {
-		return Integer.toString(start.line)+", "+Integer.toString(start.column);
+		return Integer.toString(start.getLine())+", "+Integer.toString(start.getColumn());
 	}
 
 	public TypeDetails getTypes() {


### PR DESCRIPTION
…st practice thing. The only reason I'm making this change is because I'm working on a parser in my spare time that will most likely never see the light of day, and these accessors are causing me problems because both the line and column fields are private and need to be accessed through the appropriate accessor when I blow the class apart with my parser. 

It's just easier to change it here for this one case, rather than write an exception in my parser.

I mean, it is technically the 'right' way to do it...fwiw