### PR TITLE
Fix incorrect appending of <br/> tag causing it to be escaped.

### DIFF
--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/NarrativeGenerator.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/NarrativeGenerator.java
@@ -2727,20 +2727,28 @@ public class NarrativeGenerator implements INarrativeGenerator {
   @SuppressWarnings("rawtypes")
   private void generateVersionNotice(XhtmlNode x, ValueSetExpansionComponent expansion) {
     Map<String, String> versions = new HashMap<String, String>();
-    StringBuilder b = new StringBuilder();
+    boolean firstVersion = true;
     for (ValueSetExpansionParameterComponent p : expansion.getParameter()) {
       if (p.getName().equals("version")) {
         String[] parts = ((PrimitiveType) p.getValue()).asStringValue().split("\\|");
-        if (b.length() > 0)
-          b.append("<br>");
         if (parts.length == 2)
           versions.put(parts[0], parts[1]);
         if (!versions.isEmpty()) {
+          StringBuilder b = new StringBuilder();
+          if (firstVersion) {
+            // the first version
+            // set the <p> tag and style attribute
+            x.para().setAttribute("style", "border: black 1px dotted; background-color: #EEEEEE; padding: 8px");
+        	  firstVersion = false;
+          } else {
+            // the second (or greater) version
+            x.br(); // add line break before the version text
+          }
           b.append("Expansion based on ");
-          boolean first = true;
+          boolean firstPart = true;
           for (String s : versions.keySet()) {
-            if (first)
-              first = false;
+            if (firstPart)
+              firstPart = false;
             else
               b.append(", ");
             if (!s.equals("http://snomed.info/sct"))
@@ -2757,11 +2765,10 @@ public class NarrativeGenerator implements INarrativeGenerator {
                 b.append(describeSystem(s)+" version "+versions.get(s));
             }
           }
+          x.addText(b.toString()); // add the version text
         }
       }
     }
-    if (b.length() > 0)
-      x.para().setAttribute("style", "border: black 1px dotted; background-color: #EEEEEE; padding: 8px").addText(b.toString());
   }
 
   private String formatSCTDate(String ds) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/NarrativeGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/NarrativeGenerator.java
@@ -3213,20 +3213,28 @@ public class NarrativeGenerator implements INarrativeGenerator {
   @SuppressWarnings("rawtypes")
   private void generateVersionNotice(XhtmlNode x, ValueSetExpansionComponent expansion) {
     Map<String, String> versions = new HashMap<String, String>();
-    StringBuilder b = new StringBuilder();
+    boolean firstVersion = true;
     for (ValueSetExpansionParameterComponent p : expansion.getParameter()) {
       if (p.getName().equals("version")) {
         String[] parts = ((PrimitiveType) p.getValue()).asStringValue().split("\\|");
-        if (b.length() > 0)
-          b.append("<br>");
         if (parts.length == 2)
           versions.put(parts[0], parts[1]);
         if (!versions.isEmpty()) {
+          StringBuilder b = new StringBuilder();
+          if (firstVersion) {
+            // the first version
+            // set the <p> tag and style attribute
+            x.para().setAttribute("style", "border: black 1px dotted; background-color: #EEEEEE; padding: 8px");
+        	  firstVersion = false;
+          } else {
+            // the second (or greater) version
+            x.br(); // add line break before the version text
+          }
           b.append("Expansion based on ");
-          boolean first = true;
+          boolean firstPart = true;
           for (String s : versions.keySet()) {
-            if (first)
-              first = false;
+            if (firstPart)
+              firstPart = false;
             else
               b.append(", ");
             if (!s.equals("http://snomed.info/sct"))
@@ -3243,11 +3251,10 @@ public class NarrativeGenerator implements INarrativeGenerator {
                 b.append(describeSystem(s)+" version "+versions.get(s));
             }
           }
+          x.addText(b.toString()); // add the version text
         }
       }
     }
-    if (b.length() > 0)
-      x.para().setAttribute("style", "border: black 1px dotted; background-color: #EEEEEE; padding: 8px").addText(b.toString());
   }
 
   private String formatSCTDate(String ds) {


### PR DESCRIPTION
The \<br\/\> tag was not correctly inserted using append(), causing it to be escaped in the html and rendered as characters in the displayed text rather than generating a line break.  Reworked the generateVersionNotice() function so that the tag is inserted correctly.