### PR TITLE
The validator currently treats value sets that contain exclude elemen…

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
@@ -235,8 +235,6 @@ public class ValueSetCheckerSimple implements ValueSetChecker {
   private String getValueSetSystem() throws FHIRException {
     if (valueset == null)
       throw new FHIRException(context.formatMessage(I18nConstants.UNABLE_TO_RESOLVE_SYSTEM__NO_VALUE_SET));
-    if (valueset.getCompose().hasExclude())
-      throw new FHIRException(context.formatMessage(I18nConstants.UNABLE_TO_RESOLVE_SYSTEM__VALUE_SET_HAS_EXCLUDES));
     if (valueset.getCompose().getInclude().size() == 0) {
       if (!valueset.hasExpansion() || valueset.getExpansion().getContains().size() == 0)
         throw new FHIRException(context.formatMessage(I18nConstants.UNABLE_TO_RESOLVE_SYSTEM__VALUE_SET_HAS_NO_INCLUDES_OR_EXPANSION));


### PR DESCRIPTION
…ts as ones where a code system cannot be determined.  However, that's not appropriate.  So long as there's only one *include* for the value set, the presence of excludes are irrelevant.  For example, I have a value set that includes all specializations of code X, then explicitly excludes code X.  There's only one include and only one system, so it's a perfectly appropriate value set to be bound to a 'code' extension.  Stripping out the test that checks for excludes as irrelevant.