### PR TITLE
Fix for array index out of bounds exception on adding profile for val…

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/Params.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/Params.java
@@ -92,18 +92,19 @@ public class Params {
         i++; // ignore next parameter
       } else if (args[i].equals(PROFILE)) {
         String p = null;
-        if (i + 1 == args.length)
+        if (i + 1 == args.length) {
           throw new Error("Specified -profile without indicating profile source");
-        else {
+        } else {
           p = args[++i];
-          cliContext.addProfile(args[++i]);
+          cliContext.addProfile(args[i++]);
         }
         if (p != null && i + 1 < args.length && args[i + 1].equals("@")) {
           i++;
-          if (i + 1 == args.length)
+          if (i + 1 == args.length) {
             throw new Error("Specified -profile with @ without indicating profile location");
-          else
+          } else {
             cliContext.addLocation(p, args[++i]);
+          }
         }
       } else if (args[i].equals(QUESTIONNAIRE)) {
         if (i + 1 == args.length)


### PR DESCRIPTION
…idation.

Adding a profile to the validator cli would cause an Array OOB because we increment the index before we pull the value out. (++i vs i++)