### PR TITLE
ConceptMap updates for changed relationship types

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_50/ConceptMap10_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_50/ConceptMap10_50.java
@@ -134,10 +134,10 @@ public class ConceptMap10_50 {
                 case EQUIVALENT:
                     tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConceptMapEquivalence.EQUIVALENT);
                     break;
-                case BROADER:
+                case SOURCENARROWERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConceptMapEquivalence.WIDER);
                     break;
-                case NARROWER:
+                case SOURCEBROADERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConceptMapEquivalence.NARROWER);
                     break;
                 case NOTRELATEDTO:
@@ -165,16 +165,16 @@ public class ConceptMap10_50 {
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.EQUIVALENT);
                 break;
             case WIDER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case SUBSUMES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case NARROWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case SPECIALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case INEXACT:
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.RELATEDTO);

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv14_50/ConceptMap14_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv14_50/ConceptMap14_50.java
@@ -142,10 +142,10 @@ public class ConceptMap14_50 {
                 case EQUIVALENT:
                     tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConceptMapEquivalence.EQUIVALENT);
                     break;
-                case BROADER:
+                case SOURCENARROWERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConceptMapEquivalence.WIDER);
                     break;
-                case NARROWER:
+                case SOURCEBROADERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConceptMapEquivalence.NARROWER);
                     break;
                 case NOTRELATEDTO:
@@ -173,16 +173,16 @@ public class ConceptMap14_50 {
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.EQUIVALENT);
                 break;
             case WIDER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case SUBSUMES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case NARROWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case SPECIALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case INEXACT:
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.RELATEDTO);

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_50/ConceptMap30_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_50/ConceptMap30_50.java
@@ -221,10 +221,10 @@ public class ConceptMap30_50 {
                 case EQUIVALENT:
                     tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.ConceptMapEquivalence.EQUIVALENT);
                     break;
-                case BROADER:
+                case SOURCENARROWERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.ConceptMapEquivalence.WIDER);
                     break;
-                case NARROWER:
+                case SOURCEBROADERTARGET:
                     tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.ConceptMapEquivalence.NARROWER);
                     break;
                 case NOTRELATEDTO:
@@ -252,16 +252,16 @@ public class ConceptMap30_50 {
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.EQUIVALENT);
                 break;
             case WIDER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case SUBSUMES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case NARROWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case SPECIALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case INEXACT:
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.RELATEDTO);

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/ConceptMap40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/ConceptMap40_50.java
@@ -262,10 +262,10 @@ public class ConceptMap40_50 extends VersionConvertor_40_50 {
                 case EQUIVALENT:
                     tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.EQUIVALENT);
                     break;
-                case BROADER:
+                case SOURCENARROWERTARGET:
                     tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.WIDER);
                     break;
-                case NARROWER:
+                case SOURCEBROADERTARGET:
                     tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.NARROWER);
                     break;
                 case NOTRELATEDTO:
@@ -293,16 +293,16 @@ public class ConceptMap40_50 extends VersionConvertor_40_50 {
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.EQUIVALENT);
                 break;
             case WIDER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case SUBSUMES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case NARROWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case SPECIALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case RELATEDTO:
               tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.RELATEDTO);

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/Enumerations40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/Enumerations40_50.java
@@ -457,16 +457,16 @@ public class Enumerations40_50 extends VersionConvertor_40_50 {
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.EQUIVALENT);
                 break;
             case WIDER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case SUBSUMES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.BROADER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCENARROWERTARGET);
                 break;
             case NARROWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case SPECIALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.NARROWER);
+                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.SOURCEBROADERTARGET);
                 break;
             case INEXACT:
                 tgt.setValue(org.hl7.fhir.r5.model.Enumerations.ConceptMapRelationship.RELATEDTO);
@@ -496,10 +496,10 @@ public class Enumerations40_50 extends VersionConvertor_40_50 {
             case EQUIVALENT:
                 tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.EQUIVALENT);
                 break;
-            case BROADER:
+            case SOURCENARROWERTARGET:
                 tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.WIDER);
                 break;
-            case NARROWER:
+            case SOURCEBROADERTARGET:
                 tgt.setValue(org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence.NARROWER);
                 break;
             case NOTRELATEDTO:

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConceptMap.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConceptMap.java
@@ -1119,10 +1119,10 @@ public class ConceptMap extends CanonicalResource {
         protected StringType display;
 
         /**
-         * The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).
+         * The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).
          */
         @Child(name = "relationship", type = {CodeType.class}, order=3, min=1, max=1, modifier=true, summary=false)
-        @Description(shortDefinition="related-to | equivalent | broader | narrower | not-related-to", formalDefinition="The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source)." )
+        @Description(shortDefinition="related-to | equivalent | source-is-narrower-than-target | source-is-broader-than-target | not-related-to", formalDefinition="The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target)." )
         @ca.uhn.fhir.model.api.annotation.Binding(valueSet="http://hl7.org/fhir/ValueSet/concept-map-relationship")
         protected Enumeration<ConceptMapRelationship> relationship;
 
@@ -1263,7 +1263,7 @@ public class ConceptMap extends CanonicalResource {
         }
 
         /**
-         * @return {@link #relationship} (The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).). This is the underlying object with id, value and extensions. The accessor "getRelationship" gives direct access to the value
+         * @return {@link #relationship} (The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).). This is the underlying object with id, value and extensions. The accessor "getRelationship" gives direct access to the value
          */
         public Enumeration<ConceptMapRelationship> getRelationshipElement() { 
           if (this.relationship == null)
@@ -1283,7 +1283,7 @@ public class ConceptMap extends CanonicalResource {
         }
 
         /**
-         * @param value {@link #relationship} (The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).). This is the underlying object with id, value and extensions. The accessor "getRelationship" gives direct access to the value
+         * @param value {@link #relationship} (The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).). This is the underlying object with id, value and extensions. The accessor "getRelationship" gives direct access to the value
          */
         public TargetElementComponent setRelationshipElement(Enumeration<ConceptMapRelationship> value) { 
           this.relationship = value;
@@ -1291,14 +1291,14 @@ public class ConceptMap extends CanonicalResource {
         }
 
         /**
-         * @return The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).
+         * @return The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).
          */
         public ConceptMapRelationship getRelationship() { 
           return this.relationship == null ? null : this.relationship.getValue();
         }
 
         /**
-         * @param value The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).
+         * @param value The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).
          */
         public TargetElementComponent setRelationship(ConceptMapRelationship value) { 
             if (this.relationship == null)
@@ -1466,7 +1466,7 @@ public class ConceptMap extends CanonicalResource {
           super.listChildren(children);
           children.add(new Property("code", "code", "Identity (code or path) or the element/item that the map refers to.", 0, 1, code));
           children.add(new Property("display", "string", "The display for the code. The display is only provided to help editors when editing the concept map.", 0, 1, display));
-          children.add(new Property("relationship", "code", "The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).", 0, 1, relationship));
+          children.add(new Property("relationship", "code", "The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).", 0, 1, relationship));
           children.add(new Property("comment", "string", "A description of status/issues in mapping that conveys additional information not represented in  the structured data.", 0, 1, comment));
           children.add(new Property("dependsOn", "", "A set of additional dependencies for this mapping to hold. This mapping is only applicable if the specified element can be resolved, and it has the specified value.", 0, java.lang.Integer.MAX_VALUE, dependsOn));
           children.add(new Property("product", "@ConceptMap.group.element.target.dependsOn", "A set of additional outcomes from this mapping to other elements. To properly execute this mapping, the specified element must be mapped to some data element or source that is in context. The mapping may still be useful without a place for the additional data elements, but the relationship (e.g., equivalent) cannot be relied on.", 0, java.lang.Integer.MAX_VALUE, product));
@@ -1477,7 +1477,7 @@ public class ConceptMap extends CanonicalResource {
           switch (_hash) {
           case 3059181: /*code*/  return new Property("code", "code", "Identity (code or path) or the element/item that the map refers to.", 0, 1, code);
           case 1671764162: /*display*/  return new Property("display", "string", "The display for the code. The display is only provided to help editors when editing the concept map.", 0, 1, display);
-          case -261851592: /*relationship*/  return new Property("relationship", "code", "The relationship between the source and target concepts. The relationship is read from target to source (e.g. the target is 'broader' than the source).", 0, 1, relationship);
+          case -261851592: /*relationship*/  return new Property("relationship", "code", "The relationship between the source and target concepts. The relationship is read from source to target (e.g. source-is-narrower-than-target).", 0, 1, relationship);
           case 950398559: /*comment*/  return new Property("comment", "string", "A description of status/issues in mapping that conveys additional information not represented in  the structured data.", 0, 1, comment);
           case -1109214266: /*dependsOn*/  return new Property("dependsOn", "", "A set of additional dependencies for this mapping to hold. This mapping is only applicable if the specified element can be resolved, and it has the specified value.", 0, java.lang.Integer.MAX_VALUE, dependsOn);
           case -309474065: /*product*/  return new Property("product", "@ConceptMap.group.element.target.dependsOn", "A set of additional outcomes from this mapping to other elements. To properly execute this mapping, the specified element must be mapped to some data element or source that is in context. The mapping may still be useful without a place for the additional data elements, but the relationship (e.g., equivalent) cannot be relied on.", 0, java.lang.Integer.MAX_VALUE, product);

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Enumerations.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Enumerations.java
@@ -1805,13 +1805,13 @@ public class Enumerations {
          */
         EQUIVALENT, 
         /**
-         * The target concept is broader in meaning than the source concept.
+         * The source concept is narrower in meaning than the target concept.
          */
-        BROADER, 
+        SOURCENARROWERTARGET, 
         /**
-         * The target concept is narrower in meaning than the source concept.
+         * The source concept is broader in meaning than the target concept.
          */
-        NARROWER, 
+        SOURCEBROADERTARGET, 
         /**
          * This is an explicit assertion that the target concept is not related to the source concept.
          */
@@ -1827,10 +1827,10 @@ public class Enumerations {
           return RELATEDTO;
         if ("equivalent".equals(codeString))
           return EQUIVALENT;
-        if ("broader".equals(codeString))
-          return BROADER;
-        if ("narrower".equals(codeString))
-          return NARROWER;
+        if ("source-is-narrower-than-target".equals(codeString))
+          return SOURCENARROWERTARGET;
+        if ("source-is-broader-than-target".equals(codeString))
+          return SOURCEBROADERTARGET;
         if ("not-related-to".equals(codeString))
           return NOTRELATEDTO;
         throw new FHIRException("Unknown ConceptMapRelationship code '"+codeString+"'");
@@ -1839,8 +1839,8 @@ public class Enumerations {
           switch (this) {
             case RELATEDTO: return "related-to";
             case EQUIVALENT: return "equivalent";
-            case BROADER: return "broader";
-            case NARROWER: return "narrower";
+            case SOURCENARROWERTARGET: return "source-is-narrower-than-target";
+            case SOURCEBROADERTARGET: return "source-is-broader-than-target";
             case NOTRELATEDTO: return "not-related-to";
             default: return "?";
           }
@@ -1849,8 +1849,8 @@ public class Enumerations {
           switch (this) {
             case RELATEDTO: return "http://hl7.org/fhir/concept-map-relationship";
             case EQUIVALENT: return "http://hl7.org/fhir/concept-map-relationship";
-            case BROADER: return "http://hl7.org/fhir/concept-map-relationship";
-            case NARROWER: return "http://hl7.org/fhir/concept-map-relationship";
+            case SOURCENARROWERTARGET: return "http://hl7.org/fhir/concept-map-relationship";
+            case SOURCEBROADERTARGET: return "http://hl7.org/fhir/concept-map-relationship";
             case NOTRELATEDTO: return "http://hl7.org/fhir/concept-map-relationship";
             default: return "?";
           }
@@ -1859,8 +1859,8 @@ public class Enumerations {
           switch (this) {
             case RELATEDTO: return "The concepts are related to each other, but the exact relationship is not known.";
             case EQUIVALENT: return "The definitions of the concepts mean the same thing.";
-            case BROADER: return "The target concept is broader in meaning than the source concept.";
-            case NARROWER: return "The target concept is narrower in meaning than the source concept.";
+            case SOURCENARROWERTARGET: return "The source concept is narrower in meaning than the target concept.";
+            case SOURCEBROADERTARGET: return "The source concept is broader in meaning than the target concept.";
             case NOTRELATEDTO: return "This is an explicit assertion that the target concept is not related to the source concept.";
             default: return "?";
           }
@@ -1869,8 +1869,8 @@ public class Enumerations {
           switch (this) {
             case RELATEDTO: return "Related To";
             case EQUIVALENT: return "Equivalent";
-            case BROADER: return "Broader";
-            case NARROWER: return "Narrower";
+            case SOURCENARROWERTARGET: return "Source Is Narrower Than Target";
+            case SOURCEBROADERTARGET: return "Source Is Broader Than Target";
             case NOTRELATEDTO: return "Not Related To";
             default: return "?";
           }
@@ -1886,10 +1886,10 @@ public class Enumerations {
           return ConceptMapRelationship.RELATEDTO;
         if ("equivalent".equals(codeString))
           return ConceptMapRelationship.EQUIVALENT;
-        if ("broader".equals(codeString))
-          return ConceptMapRelationship.BROADER;
-        if ("narrower".equals(codeString))
-          return ConceptMapRelationship.NARROWER;
+        if ("source-is-narrower-than-target".equals(codeString))
+          return ConceptMapRelationship.SOURCENARROWERTARGET;
+        if ("source-is-broader-than-target".equals(codeString))
+          return ConceptMapRelationship.SOURCEBROADERTARGET;
         if ("not-related-to".equals(codeString))
           return ConceptMapRelationship.NOTRELATEDTO;
         throw new IllegalArgumentException("Unknown ConceptMapRelationship code '"+codeString+"'");
@@ -1906,10 +1906,10 @@ public class Enumerations {
           return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.RELATEDTO);
         if ("equivalent".equals(codeString))
           return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.EQUIVALENT);
-        if ("broader".equals(codeString))
-          return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.BROADER);
-        if ("narrower".equals(codeString))
-          return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.NARROWER);
+        if ("source-is-narrower-than-target".equals(codeString))
+          return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.SOURCENARROWERTARGET);
+        if ("source-is-broader-than-target".equals(codeString))
+          return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.SOURCEBROADERTARGET);
         if ("not-related-to".equals(codeString))
           return new Enumeration<ConceptMapRelationship>(this, ConceptMapRelationship.NOTRELATEDTO);
         throw new FHIRException("Unknown ConceptMapRelationship code '"+codeString+"'");
@@ -1919,10 +1919,10 @@ public class Enumerations {
         return "related-to";
       if (code == ConceptMapRelationship.EQUIVALENT)
         return "equivalent";
-      if (code == ConceptMapRelationship.BROADER)
-        return "broader";
-      if (code == ConceptMapRelationship.NARROWER)
-        return "narrower";
+      if (code == ConceptMapRelationship.SOURCENARROWERTARGET)
+        return "source-is-narrower-than-target";
+      if (code == ConceptMapRelationship.SOURCEBROADERTARGET)
+        return "source-is-broader-than-target";
       if (code == ConceptMapRelationship.NOTRELATEDTO)
         return "not-related-to";
       return "?";

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ConceptMapRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ConceptMapRenderer.java
@@ -304,10 +304,10 @@ public class ConceptMapRenderer extends TerminologyRenderer {
       return "is related to";
     } else if ("equivalent".equals(code)) {
       return "is equivalent to";
-    } else if ("broader".equals(code)) {
+    } else if ("source-is-narrower-than-target".equals(code)) {
       return "maps to wider concept";
-    } else if ("narrower".equals(code)) {
-      return "maps to narrower concept";
+    } else if ("source-is-broader-than-target".equals(code)) {
+      return "maps to source-is-broader-than-target concept";
     } else if ("not-related-to".equals(code)) {
       return "is not related to";
     } else {
@@ -326,8 +326,8 @@ public class ConceptMapRenderer extends TerminologyRenderer {
       return "maps to wider concept";
     } else if ("subsumes".equals(code)) {
       return "is subsumed by";
-    } else if ("narrower".equals(code)) {
-      return "maps to narrower concept";
+    } else if ("source-is-broader-than-target".equals(code)) {
+      return "maps to source-is-broader-than-target concept";
     } else if ("specializes".equals(code)) {
       return "has specialization";
     } else if ("inexact".equals(code)) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/TerminologyRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/TerminologyRenderer.java
@@ -283,8 +283,8 @@ public class TerminologyRenderer {
       return "";
     switch (mapping.getRelationship()) {
     case EQUIVALENT : return "~";
-    case BROADER : return "<";
-    case NARROWER : return ">";
+    case SOURCENARROWERTARGET : return "<";
+    case SOURCEBROADERTARGET : return ">";
     case NOTRELATEDTO : return "!=";
     default: return "?";
     }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
@@ -358,8 +358,8 @@ public class StructureMapUtilities {
     case RELATEDTO: return "-";
     case EQUIVALENT: return "==";
     case NOTRELATEDTO: return "!=";
-    case BROADER: return "<=";
-    case NARROWER: return ">=";
+    case SOURCENARROWERTARGET: return "<=";
+    case SOURCEBROADERTARGET: return ">=";
     default: return "??";
     }
   }
@@ -826,9 +826,9 @@ public class StructureMapUtilities {
 		if (token.equals("!="))
 			return ConceptMapRelationship.NOTRELATEDTO;
 		if (token.equals("<="))
-			return ConceptMapRelationship.BROADER;
+			return ConceptMapRelationship.SOURCENARROWERTARGET;
 		if (token.equals(">="))
-			return ConceptMapRelationship.NARROWER;
+			return ConceptMapRelationship.SOURCEBROADERTARGET;
 		throw lexer.error("Unknown relationship token '"+token+"'");
 	}
 
@@ -2121,7 +2121,7 @@ public class StructureMapUtilities {
 					message = "Concept map "+su+" found no translation for "+src.getCode();
 				else {
 					for (TargetElementComponent tgt : list.get(0).comp.getTarget()) {
-						if (tgt.getRelationship() == null || EnumSet.of( ConceptMapRelationship.RELATEDTO , ConceptMapRelationship.EQUIVALENT, ConceptMapRelationship.BROADER).contains(tgt.getRelationship())) {
+						if (tgt.getRelationship() == null || EnumSet.of( ConceptMapRelationship.RELATEDTO , ConceptMapRelationship.EQUIVALENT, ConceptMapRelationship.SOURCENARROWERTARGET).contains(tgt.getRelationship())) {
 							if (done) {
 								message = "Concept map "+su+" found multiple matches for "+src.getCode();
 								done = false;


### PR DESCRIPTION
ConceptMap updates for 'source-is-narrower-than-target' (formerly 'broader') and 'source-is-broader-than-target' (formerly 'narrower') relationships.