### PR TITLE
XmlParser: serialize xsi:type

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -262,7 +262,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
   }
 
   public void loadFromFile(InputStream stream, String name, IContextResourceLoader loader) throws IOException, FHIRException {
-    loadFromFile(stream, name, null);
+    loadFromFile(stream, name, loader, null);
   }
   
 	public void loadFromFile(InputStream stream, String name, IContextResourceLoader loader, ILoadFilter filter) throws IOException, FHIRException {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -550,6 +550,16 @@ public class XmlParser extends ParserBase {
     composeElement(xml, e, e.getType(), true);
     xml.end();
   }
+  
+  private void setXsiTypeIfIsTypeAttr(IXMLWriter xml, Element element) throws IOException, FHIRException {
+    if (isTypeAttr(element.getProperty()) && !Utilities.noString(element.getType())) {
+      String type = element.getType();
+      if (Utilities.isAbsoluteUrl(type)) {
+        type = type.substring(type.lastIndexOf("/")+1);
+      }
+      xml.attribute("xsi:type",type);    
+    }
+  }
 
   private void composeElement(IXMLWriter xml, Element element, String elementName, boolean root) throws IOException, FHIRException {
     if (showDecorations) {
@@ -586,9 +596,7 @@ public class XmlParser extends ParserBase {
           xml.link(linkResolver.resolveProperty(element.getProperty()));
         xml.text(element.getValue());
       } else {
-        if (isTypeAttr(element.getProperty()) && !Utilities.noString(element.getType())) {
-          xml.attribute("xsi:type", element.getType());
-        }
+        setXsiTypeIfIsTypeAttr(xml, element);
         if (element.hasValue()) {
           if (linkResolver != null)
             xml.link(linkResolver.resolveType(element.getType()));
@@ -605,9 +613,7 @@ public class XmlParser extends ParserBase {
           xml.element(elementName);
       }
     } else {
-      if (isTypeAttr(element.getProperty()) && !Utilities.noString(element.getType())) {
-        xml.attribute("xsi:type", element.getType());
-      }
+      setXsiTypeIfIsTypeAttr(xml, element);
       for (Element child : element.getChildren()) {
         if (isAttr(child.getProperty())) {
           if (linkResolver != null)

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
@@ -174,22 +174,21 @@ public class CDARoundTripTests {
 
 
   @Test
-  @Disabled
   public void testSimple() throws IOException {
     PackageCacheManager pcm = new PackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
     SimpleWorkerContext context = SimpleWorkerContext.fromPackage(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
-    context.loadFromFile(TestingUtilities.loadTestResourceStream("r5", "cda", "any.xml"), "any.xml", null);
-    context.loadFromFile(TestingUtilities.loadTestResourceStream("r5", "cda", "ii.xml"), "ii.xml", null);
-    context.loadFromFile(TestingUtilities.loadTestResourceStream("r5", "cda", "cd.xml"), "cd.xml", null);
-    context.loadFromFile(TestingUtilities.loadTestResourceStream("r5", "cda", "ce.xml"), "ce.xml", null);
-    context.loadFromFile(TestingUtilities.loadTestResourceStream("r5", "cda", "cda.xml"), "cda.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "any.xml"), "any.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "ii.xml"), "ii.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "cd.xml"), "cd.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "ce.xml"), "ce.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "cda.xml"), "cda.xml", null);
     for (StructureDefinition sd : context.getStructures()) {
       if (!sd.hasSnapshot()) {
         System.out.println("generate snapshot for " + sd.getUrl());
         context.generateSnapshot(sd, true);
       }
     }
-    Element cda = Manager.parse(context, TestingUtilities.loadTestResourceStream("r5", "cda", "example.xml"), FhirFormat.XML);
+    Element cda = Manager.parse(context, TestingUtilities.loadTestResourceStream("validator", "cda", "example.xml"), FhirFormat.XML);
     FHIRPathEngine fp = new FHIRPathEngine(context);
     Assertions.assertEquals("2.16.840.1.113883.3.27.1776", fp.evaluateToString(null, cda, cda, cda, fp.parse("ClinicalDocument.templateId.root")));
   }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/XmlParserTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/XmlParserTests.java
@@ -1,0 +1,65 @@
+package org.hl7.fhir.r5.test;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.elementmodel.Element;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r5.formats.IParser.OutputStyle;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
+import org.hl7.fhir.utilities.cache.PackageCacheManager;
+import org.hl7.fhir.utilities.cache.ToolsVersion;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class XmlParserTests {
+
+  private static SimpleWorkerContext context;
+  private static FHIRPathEngine fp;
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    PackageCacheManager pcm = new PackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+    context = SimpleWorkerContext.fromPackage(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
+    fp = new FHIRPathEngine(context);
+
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "any.xml"), "any.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "ii.xml"), "ii.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "cd.xml"), "cd.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "ce.xml"), "ce.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "ed.xml"), "ed.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "st.xml"), "st.xml", null);
+    context.loadFromFile(TestingUtilities.loadTestResourceStream("validator", "cda", "cda.xml"), "cda.xml", null);
+    for (StructureDefinition sd : context.getStructures()) {
+      if (!sd.hasSnapshot()) {
+        System.out.println("generate snapshot for " + sd.getUrl());
+        context.generateSnapshot(sd, true);
+      }
+    }
+  }
+
+  @Test
+  /**
+   * Deserializes a simplified CDA example into the logical model and checks that
+   * xml deserialization works for the xsi:type 
+   * 
+   * @throws IOException
+   */
+  public void testXsiDeserialiserXmlParser() throws IOException {
+    Element cda = Manager.parse(context, TestingUtilities.loadTestResourceStream("validator", "cda", "example-xsi.xml"),
+        FhirFormat.XML);
+    
+    ByteArrayOutputStream baosXml = new  ByteArrayOutputStream();
+    Manager.compose(context, cda, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);  
+    
+    String cdaSerialised = baosXml.toString();
+    assertTrue(cdaSerialised.indexOf("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"")>0);
+    assertTrue(cdaSerialised.indexOf("xsi:type=\"CD\"")>0); 
+  }
+}


### PR DESCRIPTION
Current xml serialization adds for the xsi:type the complete canoncial url of the datatype, 
e.g. http://hl7.org/fhir/cda/StructureDefinition/CD instead of just CD. This pull requests adjusts the serialization.

```xml
    <translation xsi:type="CD" code="X-34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />

```
 A test-case has been added to check the correct behaviour, requires additional test-data which is added with this pr: https://github.com/FHIR/fhir-test-cases/pull/27

