### PR TITLE
Comparison test fix

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/HierarchicalTableGenerator.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/HierarchicalTableGenerator.java
@@ -863,6 +863,9 @@ public class HierarchicalTableGenerator extends TranslatingUtilities {
       b.append(".png");
       String file = Utilities.path(dest, b.toString());
       if (!new File(file).exists()) {
+        File newFile = new File(file);
+        newFile.getParentFile().mkdirs();
+        newFile.createNewFile();
         FileOutputStream stream = new FileOutputStream(file);
         genImage(indents, hasChildren, lineColor, stream);
         if (outputTracker!=null)


### PR DESCRIPTION
tmp directory doesn't exist on unix based machines by default. I modified the ComparisonTests to create the test file and contained directories if that file doesn't already exist so that tests will now pass again