### PR TITLE
Utilities test cases

### DIFF
--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -80,6 +80,13 @@
             <version>${junit_jupiter_version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hl7.fhir.testcases</groupId>
+            <artifactId>fhir-test-cases</artifactId>
+            <version>${validator_test_case_version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
@@ -14,6 +14,11 @@ public class BaseTestingUtilities {
   static public boolean silent;
 
   public static String loadTestResource(String... paths) throws IOException {
+    System.out.println("=====================================");
+    System.out.println("new File(\"../../fhir-test-cases\").exists() == " + new File("../../fhir-test-cases").exists());
+    System.out.println("isTryToLoadFromFileSystem() == " + isTryToLoadFromFileSystem());
+    System.out.println("=====================================");
+
     if (new File("../../fhir-test-cases").exists() && isTryToLoadFromFileSystem()) {
       String n = Utilities.path(System.getProperty("user.dir"), "..", "..", "fhir-test-cases", Utilities.path(paths));
       // ok, we'll resolve this locally
@@ -22,6 +27,11 @@ public class BaseTestingUtilities {
       // resolve from the package 
       String contents;
       String classpath = ("/org/hl7/fhir/testcases/" + Utilities.pathURL(paths));
+
+      System.out.println("=====================================");
+      System.out.println("classpath == " + classpath);
+      System.out.println("=====================================");
+
       try (InputStream inputStream = BaseTestingUtilities.class.getResourceAsStream(classpath)) {
         if (inputStream == null) {
           throw new IOException("Can't find file on classpath: " + classpath);

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
@@ -1,45 +1,30 @@
 package org.hl7.fhir.utilities.tests;
 
+import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.utilities.TextFile;
+import org.hl7.fhir.utilities.Utilities;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.utilities.TextFile;
-import org.hl7.fhir.utilities.Utilities;
 
 public class BaseTestingUtilities {
 
   static public boolean silent;
 
   public static String loadTestResource(String... paths) throws IOException {
-    System.out.println("=====================================");
-    System.out.println("new File(\"../../fhir-test-cases\").exists() == " + new File("../../fhir-test-cases").exists());
-    System.out.println("isTryToLoadFromFileSystem() == " + isTryToLoadFromFileSystem());
-    System.out.println("=====================================");
+    // resolve from the package
+    String contents;
+    String classpath = ("/org/hl7/fhir/testcases/" + Utilities.pathURL(paths));
 
-    if (new File("../../fhir-test-cases").exists() && isTryToLoadFromFileSystem()) {
-      String n = Utilities.path(System.getProperty("user.dir"), "..", "..", "fhir-test-cases", Utilities.path(paths));
-      // ok, we'll resolve this locally
-      return TextFile.fileToString(new File(n));
-    } else {
-      // resolve from the package 
-      String contents;
-      String classpath = ("/org/hl7/fhir/testcases/" + Utilities.pathURL(paths));
-
-      System.out.println("=====================================");
-      System.out.println("classpath == " + classpath);
-      System.out.println("=====================================");
-
-      try (InputStream inputStream = BaseTestingUtilities.class.getResourceAsStream(classpath)) {
-        if (inputStream == null) {
-          throw new IOException("Can't find file on classpath: " + classpath);
-        }
-        contents = IOUtils.toString(inputStream, java.nio.charset.StandardCharsets.UTF_8);
+    try (InputStream inputStream = BaseTestingUtilities.class.getResourceAsStream(classpath)) {
+      if (inputStream == null) {
+        throw new IOException("Can't find file on classpath: " + classpath);
       }
-      return contents;
+      contents = IOUtils.toString(inputStream, java.nio.charset.StandardCharsets.UTF_8);
     }
+    return contents;
   }
 
   public static InputStream loadTestResourceStream(String... paths) throws IOException {


### PR DESCRIPTION
* Removed condition where test cases were read in locally from the local fhir-test-cases project. This approach will not result in deterministic test run results. 

* Added fhir-test-cases dependency to the utilities modules so turtle test cases can be read in.