### PR TITLE
CDA xsi:type serialization when using fhir mapping language

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
@@ -206,7 +206,7 @@ public class Property {
 	  if (definition.getType().size() > 0)
 	    return definition.getType().size() == 1 && ("Resource".equals(definition.getType().get(0).getCode()) || "DomainResource".equals(definition.getType().get(0).getCode()));
 	  else
-	    return !definition.getPath().contains(".") && (structure.getKind() == StructureDefinitionKind.RESOURCE || structure.getKind() == StructureDefinitionKind.LOGICAL);
+	    return !definition.getPath().contains(".") && (structure.getKind() == StructureDefinitionKind.RESOURCE);
 	}
 
 	public boolean isList() {


### PR DESCRIPTION
Current serialization of elements with xsi:type create an element instead of an xsi:type attribute.

```xml
<ClinicalDocument xmlns="urn:hl7-org:v3">
  <code code="1">
    <translation code="1">
      <CD/>
    </translation>
  </code>
</ClinicalDocument>
```

see [testcase PR]( https://github.com/FHIR/fhir-test-cases/pull/42), output should be

```xml
<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <code code="1">
    <translation xsi:type="CD" code="1" />
  </code>
</ClinicalDocument>  
````

This PR enhances the FHIRMappingLanguate Testsuite that I can produce also xml (e.g. CDA) documents by switching to the ValidationEngine and changes the serialization behaviour that the translation element has the xsi:type attribute set.