### PR TITLE
CDA Narrative conversion from FHIR, Nullpointer exception fix

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -595,7 +595,7 @@ public class XmlParser extends ParserBase {
       if (element.getType().equals("xhtml")) {
         String rawXhtml = element.getValue();
         if (isCdaText(element.getProperty())) {
-          new CDANarrativeFormat().convert(xml, element.getXhtml());
+          new CDANarrativeFormat().convert(xml, new XhtmlParser().parseFragment(rawXhtml));
         } else {
           xml.escapedText(rawXhtml);
           xml.anchor("end-xhtml");


### PR DESCRIPTION
when mapping from FHIR to CDA a NP exception is thrown:

```
Caused by: java.lang.NullPointerException: null
 	at org.hl7.fhir.utilities.xhtml.CDANarrativeFormat.processAttributes(CDANarrativeFormat.java:556) ~[classes/:na]
 	at org.hl7.fhir.utilities.xhtml.CDANarrativeFormat.convert(CDANarrativeFormat.java:338) ~[classes/:na]
 	at org.hl7.fhir.r5.elementmodel.XmlParser.composeElement(XmlParser.java:622) ~[classes/:na]
````
due that element.getXHtml() returns null for element.getXhtml. The raw Xhtml is available via element.getValue(). Attached PR parses this fragment for conversion to CDA NarrativeFormat.