### PR TITLE
XmlWriter for UTF-8 should not encode umlaut in attributes (elementmodel)

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ResourceRoundTripTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ResourceRoundTripTests.java
@@ -75,8 +75,8 @@ public class ResourceRoundTripTests {
     code.get(0).setValue("ö");
     ByteArrayOutputStream baosXml = new  ByteArrayOutputStream();
     Manager.compose(TestingUtilities.context(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
-    String cdaSerialised = baosXml.toString();
-    assertTrue(cdaSerialised.indexOf("<code value=\"ö\"")>0); 
+    String cdaSerialised = baosXml.toString("UTF-8");
+    assertTrue(cdaSerialised.indexOf("ö")>0); 
   }
 
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
@@ -246,7 +246,7 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 					write(element[0]);
 					write("=\"");
 					if (element[1] != null)
-						write(xmlEscape(element[1]));
+						write(XMLUtil.escapeXML(element[1], charset, false));
 					write("\"");
 				}
 			}
@@ -254,18 +254,6 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 		return col;
 	}
 
-	 protected String xmlEscape(String s) {
-     StringBuilder b = new StringBuilder();
-     for (char c : s.toCharArray()) {
-       if (c < ' ' || c > '~') {
-         b.append("&#x");
-         b.append(Integer.toHexString(c).toUpperCase());
-         b.append(";");
-       } else
-         b.append(c);
-     }
-     return b.toString();
-   }
 	/* (non-Javadoc)
 	 * @see org.eclipse.ohf.utilities.xml.IXMLWriter#attribute(java.lang.String, java.lang.String, java.lang.String, boolean)
 	 */

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
@@ -246,7 +246,7 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 					write(element[0]);
 					write("=\"");
 					if (element[1] != null)
-						write(XMLUtil.escapeXML(element[1], charset, false));
+						write(xmlEscape(element[1]));
 					write("\"");
 				}
 			}
@@ -254,7 +254,20 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 		return col;
 	}
 
-	/* (non-Javadoc)
+	 protected String xmlEscape(String s) {
+     StringBuilder b = new StringBuilder();
+     for (char c : s.toCharArray()) {
+       if (c < ' ') {
+         b.append("&#x");
+         b.append(Integer.toHexString(c).toUpperCase());
+         b.append(";");
+       } else
+         b.append(c);
+     }
+     return b.toString();
+   }
+
+	 /* (non-Javadoc)
 	 * @see org.eclipse.ohf.utilities.xml.IXMLWriter#attribute(java.lang.String, java.lang.String, java.lang.String, boolean)
 	 */
 	@Override


### PR DESCRIPTION
XmlWriter is used in the serialisation of the Element in r5.elementmodel (e.g. after a FHIR Mapping Language transform) and XmlWriter does currently encode umlaute in attributes if we have an UTF-8 encoding.

We get  

```xml
<family value="Br&#xF6;nnimann-Bertholet"/>
```
instead of
```xml
<family value="Brönnimann-Bertholet"/>
```

XmlWriter uses already in other places XMLUtil.escapeXML which encodes depending on the specified encoding of the output. This PR adds this function also for the attribute and provides a unittest to illustrate the behaviour.