### PR TITLE
XmlWriter for UTF-8 should not encode umlaut in elements (elementmodel)

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
@@ -1,8 +1,11 @@
 package org.hl7.fhir.r5.test;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
@@ -237,6 +240,28 @@ public class CDARoundTripTests {
 		
 		assertsExample(cdaJsonRoundtrip);
 
+	}
+	
+	@Test
+	/**
+	 * verify that umlaut like äö etc are not encoded in UTF-8 in attributes
+	 */
+	public void testSerializeUmlaut() throws IOException {
+	  Element xml = Manager.parse(context,
+		  TestingUtilities.loadTestResourceStream("validator", "cda", "example.xml"), FhirFormat.XML);
+	  
+	  List<Element> title = xml.getChildrenByName("title");
+	  assertTrue(title != null && title.size() == 1);
+	  
+	  
+	  Element value = title.get(0).getChildren().get(0);
+	  Assertions.assertEquals("Episode Note", value.getValue());
+	  value.setValue("öé");
+	  
+	  ByteArrayOutputStream baosXml = new ByteArrayOutputStream();
+	  Manager.compose(TestingUtilities.context(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
+	  String cdaSerialised = baosXml.toString("UTF-8");
+	  assertTrue(cdaSerialised.indexOf("öé") > 0);
 	}
 
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
@@ -726,7 +726,7 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 			if (dontEscape)
 				write(content);
 			else
-				write(XMLUtil.escapeXML(content, "US-ASCII", false));
+				write(XMLUtil.escapeXML(content, charset, false));
 		}
 	}
 


### PR DESCRIPTION
Similiar to the PR https://github.com/hapifhir/org.hl7.fhir.core/pull/236 umlaute like öé should not be encoded in the xml text elements if the encoding is UTF-8. For the XmlWriter the charset can be specified and is now added to as a parameter to XMLUtil.escapeXML. A test illustrates the intended behaviour.