### PR TITLE
StructureMap rendering  has np when RelationShip is not set

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -789,8 +789,7 @@ public class StructureMapUtilities {
       if (e.getCode().startsWith("\""))
         e.setCode(lexer.processConstant(e.getCode()));
 			TargetElementComponent tgt = e.addTarget();
-			if (eq != ConceptMapEquivalence.EQUIVALENT)
-			  tgt.setEquivalence(eq);
+			tgt.setEquivalence(eq);
 			if (tgt.getEquivalence() != ConceptMapEquivalence.UNMATCHED) {
 				lexer.token(":");
 				tgt.setCode(lexer.take());

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
@@ -796,8 +796,7 @@ public class StructureMapUtilities {
       if (e.getCode().startsWith("\""))
         e.setCode(lexer.processConstant(e.getCode()));
 			TargetElementComponent tgt = e.addTarget();
-			if (rel != ConceptMapRelationship.EQUIVALENT)
-			  tgt.setRelationship(rel);
+			tgt.setRelationship(rel);
 			lexer.token(":");
 			tgt.setCode(lexer.take());
 			if (tgt.getCode().startsWith("\""))


### PR DESCRIPTION
when a concept map with an equivalence entry is added the rendering generates a null pointer exception because the relationship is not set. it was explicitly not set during parsing, this behaviour has been now changed that there is no more Nullpointer Exception.

```
at org.hl7.fhir.r5.utils.StructureMapUtilities.getChar(StructureMapUtilities.java:373) ~[classes/:na]
	at org.hl7.fhir.r5.utils.StructureMapUtilities.produceConceptMap(StructureMapUtilities.java:355) ~[classes/:na]
	at org.hl7.fhir.r5.utils.StructureMapUtilities.renderConceptMaps(StructureMapUtilities.java:299) ~[classes/:na]
	at org.hl7.fhir.r5.utils.StructureMapUtilities.render(StructureMapUtilities.java:288) ~[classes/:na]
```