### PR TITLE
allow conformsTo on Element for InstanceValidator

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -279,11 +279,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
         }
       } else if (item instanceof Element) {
         Element e = (Element) item;
-        if (e.isResource()) {
-          self.validateResource(new ValidatorHostContext(ctxt.getAppContext(), e), valerrors, e, e, sd, IdStatus.OPTIONAL, new NodeStack(context, e, validationLanguage));
-        } else {
-          throw new FHIRException(context.formatMessage(I18nConstants.NOT_SUPPORTED_YET));
-        }
+        self.validateResource(new ValidatorHostContext(ctxt.getAppContext(), e), valerrors, e, e, sd, IdStatus.OPTIONAL, new NodeStack(context, e, validationLanguage));
       } else
         throw new NotImplementedException(context.formatMessage(I18nConstants.NOT_DONE_YET_VALIDATORHOSTSERVICESCONFORMSTOPROFILE_WHEN_ITEM_IS_NOT_AN_ELEMENT));
       boolean ok = true;


### PR DESCRIPTION
The InstanceValidator which is used by the IG Publisher raises an error in the conformsTo implementation when it is called with a profile on an Element (example see [here](http://build.fhir.org/ig/hl7ch/ch-emed/branches/master/qa.html#_scratch_ig-build-temp-720POU_repo_input_examples_bundle_1-1-MedicationTreatmentPlan) when you click on reasoning: ... Not supported yet). 

The conformsTo on Element has been already enabled in the  
PR [FHIR Mapping Language support for conformsTo function](https://github.com/hapifhir/org.hl7.fhir.core/pull/218). [pr details](https://github.com/hapifhir/org.hl7.fhir.core/pull/218/commits/e6e4515777c04bdd62daae124bd6fc3aa9b50c3f). This PR adds the same functionality to the InstanceValidator.