### PR TITLE
adding case for when c:\temp does not exist on windows machine

### DIFF
--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/UtilitiesTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/UtilitiesTests.java
@@ -81,7 +81,12 @@ public class UtilitiesTests {
     } else if (os.contains(LINUX)) {
       return LINUX_TEMP_DIR;
     } else if (os.toUpperCase().contains(WINDOWS)) {
-      return WIN_TEMP_DIR;
+      File tmp = new File("c:\\temp");
+      if(tmp.exists()) {
+    	  return WIN_TEMP_DIR;
+      } else {
+    	  return System.getProperty("java.io.tmpdir");
+      }
     } else {
       throw new IllegalStateException("OS not recognized...cannot verify created directories.");
     }


### PR DESCRIPTION
Adding a case for the test to assert against the JVM's temp directory when `c:\temp` is not already present on a Windows machine