### PR TITLE
nullpointer exception when depending on specific ig version

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/PackageHacker.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/PackageHacker.java
@@ -116,6 +116,9 @@ public class PackageHacker {
 
   public static String fixPackageUrl(String webref) {
     // workaround for past publishing problems
+    if (webref==null) {
+      return null;
+    }
     if (webref.equals("file://C:\\GitHub\\hl7.fhir.us.qicore#4.0.0\\output")) {
       return "http://hl7.org/fhir/us/qicore/STU4";
     }


### PR DESCRIPTION
Our swiss ch-core ig version is depending on the ch-epr-term ig. Till now we used the version "current" to depend on. When specifying a specific version (https://github.com/hl7ch/ch-core/commit/f1d31ff8540518350e4ba283a10b954de04e5bbb) we get now a nullpointer exception, see http://build.fhir.org/ig/hl7ch/ch-core/branches/oe_dependsonigversion/build.log. 


java.lang.NullPointerException
	at org.hl7.fhir.utilities.cache.PackageHacker.fixPackageUrl(PackageHacker.java:119)
	at org.hl7.fhir.igtools.publisher.Publisher.loadIg(Publisher.java:2686)
	at org.hl7.fhir.igtools.publisher.Publisher.initializeFromIg(Publisher.java:1842)
	at org.hl7.fhir.igtools.publisher.Publisher.initialize(Publisher.java:1418)
	at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:709)
	at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:7946)

This happens because pi.url() is null which is set for Base2. Suggested fix for this PR is to return null if the reference provided is already null. 
