### PR TITLE
structure maps: line comments and fhir path expression

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/StructureMapUtilities.java
@@ -914,6 +914,9 @@ public class StructureMapUtilities {
 	  String comment = null;
     if (lexer.hasComment()) {
       comment = getMultiLineComments(lexer);
+      if (lexer.done()) {
+        return ;
+      }
     }
 		lexer.token("group");
 		StructureMapGroupComponent group = result.addGroup();
@@ -1010,7 +1013,6 @@ public class StructureMapUtilities {
 
 	private void parseRule(StructureMap map, List<StructureMapGroupRuleComponent> list, FHIRLexer lexer, boolean newFmt) throws FHIRException {
 		StructureMapGroupRuleComponent rule = new StructureMapGroupRuleComponent(); 
-		list.add(rule);
 		if (!newFmt) {
 		  rule.setName(lexer.takeDottedToken());
 		  lexer.token(":");
@@ -1018,8 +1020,12 @@ public class StructureMapUtilities {
     } else {
       if (lexer.hasComment()) {
         rule.setDocumentation(this.getMultiLineComments(lexer));
+        if (lexer.hasToken("}")) {
+          return ; // catched a comment at the end
+        }
       }
     }
+    list.add(rule);
 		boolean done = false;
 		while (!done) {
 			parseSource(rule, lexer);

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -15,18 +15,17 @@ import org.hl7.fhir.r5.utils.StructureMapUtilities;
 import org.hl7.fhir.r5.utils.StructureMapUtilities.ITransformerServices;
 import org.hl7.fhir.utilities.cache.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.cache.ToolsVersion;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@Disabled // org.hl7.fhir.exceptions.FHIRException: Unable to resolve package id hl7.fhir.core#4.0.0
 public class StructureMapUtilitiesTest implements ITransformerServices {
 
   static private SimpleWorkerContext context;
-
-  //  @BeforeAll
+  
+  @BeforeAll
   static public void setUp() throws Exception {
     FilesystemPackageCacheManager pcm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
-    context = SimpleWorkerContext.fromPackage(pcm.loadPackage("hl7.fhir.core", "4.0.0"));
+    context = SimpleWorkerContext.fromPackage(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
   }
 
   @Test
@@ -38,6 +37,26 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     // StructureMap/ActivityDefinition3to4: StructureMap.group[3].rule[2].name error id value '"expression"' is not valid
     assertEquals("expression", structureMap.getGroup().get(2).getRule().get(1).getName());
   }
+  
+  @Test
+  public void testSyntax() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(context, this);
+    String fileMap = TestingUtilities.loadTestResource("r5", "fml", "syntax.map");
+    StructureMap structureMap = scu.parse(fileMap, "Syntax");
+
+    assertEquals("syntax", structureMap.getName());
+    assertEquals("http://github.com/FHIR/fhir-test-cases/r5/fml/syntax", structureMap.getUrl());
+    assertEquals("Patient", structureMap.getStructure().get(0).getAlias());
+    assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", structureMap.getStructure().get(0).getUrl());
+    assertEquals("Source Documentation", structureMap.getStructure().get(0).getDocumentation());
+    assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", structureMap.getStructure().get(0).getUrl());
+    assertEquals("http://hl7.org/fhir/StructureDefinition/Basic", structureMap.getStructure().get(1).getUrl());
+    assertEquals("Target Documentation", structureMap.getStructure().get(1).getDocumentation());
+        
+    System.out.println(StructureMapUtilities.render(structureMap));
+
+  }
+
 
   @Override
   public void log(String message) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.StructureMap;
+import org.hl7.fhir.r5.model.StructureMap.StructureMapGroupRuleTargetComponent;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.r5.utils.StructureMapUtilities;
 import org.hl7.fhir.r5.utils.StructureMapUtilities.ITransformerServices;
@@ -38,13 +39,12 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     assertEquals("expression", structureMap.getGroup().get(2).getRule().get(1).getName());
   }
   
-  @Test
-  public void testSyntax() throws IOException, FHIRException {
-    StructureMapUtilities scu = new StructureMapUtilities(context, this);
-    String fileMap = TestingUtilities.loadTestResource("r5", "fml", "syntax.map");
-    StructureMap structureMap = scu.parse(fileMap, "Syntax");
 
+  
+  
+  private void assertSerializeDeserialize(StructureMap structureMap) {
     assertEquals("syntax", structureMap.getName());
+    assertEquals("Title of this map\r\nAuthor", structureMap.getDescription());
     assertEquals("http://github.com/FHIR/fhir-test-cases/r5/fml/syntax", structureMap.getUrl());
     assertEquals("Patient", structureMap.getStructure().get(0).getAlias());
     assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", structureMap.getStructure().get(0).getUrl());
@@ -52,12 +52,29 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", structureMap.getStructure().get(0).getUrl());
     assertEquals("http://hl7.org/fhir/StructureDefinition/Basic", structureMap.getStructure().get(1).getUrl());
     assertEquals("Target Documentation", structureMap.getStructure().get(1).getDocumentation());
-        
-    System.out.println(StructureMapUtilities.render(structureMap));
-
+    assertEquals("Groups\r\nrule for patient group", structureMap.getGroup().get(0).getDocumentation());
+    assertEquals("Comment to rule", structureMap.getGroup().get(0).getRule().get(0).getDocumentation());
+    assertEquals("Copy identifier short syntax", structureMap.getGroup().get(0).getRule().get(1).getDocumentation());
+    
+    StructureMapGroupRuleTargetComponent target = structureMap.getGroup().get(0).getRule().get(2).getTarget().get(1);
+    assertEquals("'urn:uuid:' + r.lower()", target.getParameter().get(0).toString());
   }
 
+  @Test
+  public void testSyntax() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(context, this);
+    String fileMap = TestingUtilities.loadTestResource("r5", "fml", "syntax.map");
+    System.out.println(fileMap);
 
+    StructureMap structureMap = scu.parse(fileMap, "Syntax");
+    assertSerializeDeserialize(structureMap);
+        
+    String renderedMap = StructureMapUtilities.render(structureMap);
+    StructureMap map = scu.parse(renderedMap, "Syntax");
+    System.out.println(map);
+    assertSerializeDeserialize(map);
+  }
+  
   @Override
   public void log(String message) {
   }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <hapi_fhir_version>5.1.0</hapi_fhir_version>
-        <validator_test_case_version>1.1.33</validator_test_case_version>
+        <validator_test_case_version>1.1.34-SNAPSHOT</validator_test_case_version>
         <junit_jupiter_version>5.6.2</junit_jupiter_version>
         <maven_surefire_version>3.0.0-M4</maven_surefire_version>
         <jacoco_version>0.8.5</jacoco_version>


### PR DESCRIPTION
1. The FHIR Mapping language spec [General syntax notes](https://www.hl7.org/fhir/mapping-language.html#syntax) says: 

> Comments are started by the characters "//" and can be found anywhere.

Line comment support has been extended, that (multiple) lines can be added for the header, group, and rules. A test has been provided to verify that serializing and deserializing works correctly (see [PR](https://github.com/FHIR/fhir-test-cases/pull/68)). 

e.g.
```
map "http://github.com/FHIR/fhir-test-cases/r5/fml/syntax" = "syntax"

// Title of this map
// Author

uses "http://hl7.org/fhir/StructureDefinition/Patient" alias Patient as source // Source Documentation
uses "http://hl7.org/fhir/StructureDefinition/Basic" alias Basic as target // Target Documentation

// Groups
// rule for patient group
group Patient(source src : Patient, target tgt : Basic) {
  // Comment to rule
  src -> tgt.extension as ext, ext.value = create('Reference') as reference, reference.reference = reference(src) "value";
``` 

2. The render quoted the shorthand FHIRPath expression with a double quote, e.g. ("'urn:uuid:' + r.lower()") instead of ('urn:uuid:' + r.lower())

A new test testSyntax has been to org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java.