### PR TITLE
handling xml without namespace in logical models

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
@@ -450,7 +450,7 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 		if ("http://www.w3.org/XML/1998/namespace".equals(namespace))
 			return "xml:";
 		
-		if (namespace == null || "".equals(namespace))
+		if (namespace == null || "".equals(namespace) || "default".equals(namespace))
 			return "";
 		
 		XMLNamespace ns = findByNamespace(namespace);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTestSuite.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTestSuite.java
@@ -212,14 +212,16 @@ public class ValidationTestSuite implements IEvaluationContext, IValidatorResour
     if (content.has("security-checks")) {
       val.setSecurityChecks(content.get("security-checks").getAsBoolean());
     }
-    val.setAssumeValidRestReferences(content.has("assumeValidRestReferences") ? content.get("assumeValidRestReferences").getAsBoolean() : false);
-    System.out.println(String.format("Start Validating (%d to set up)", (System.nanoTime() - setup) / 1000000));
-    if (name.endsWith(".json"))
-      val.validate(null, errors, IOUtils.toInputStream(testCaseContent, Charsets.UTF_8), FhirFormat.JSON);
-    else
-      val.validate(null, errors, IOUtils.toInputStream(testCaseContent, Charsets.UTF_8), FhirFormat.XML);
-    System.out.println(val.reportTimes());
-    checkOutcomes(errors, content, null);
+    if (content.has("logical")==false) {
+      val.setAssumeValidRestReferences(content.has("assumeValidRestReferences") ? content.get("assumeValidRestReferences").getAsBoolean() : false);
+      System.out.println(String.format("Start Validating (%d to set up)", (System.nanoTime() - setup) / 1000000));
+      if (name.endsWith(".json"))
+        val.validate(null, errors, IOUtils.toInputStream(testCaseContent, Charsets.UTF_8), FhirFormat.JSON);
+      else
+        val.validate(null, errors, IOUtils.toInputStream(testCaseContent, Charsets.UTF_8), FhirFormat.XML);
+      System.out.println(val.reportTimes());
+      checkOutcomes(errors, content, null);
+    }
     if (content.has("profile")) {
       System.out.print("** Profile: ");
       JsonObject profile = content.getAsJsonObject("profile");


### PR DESCRIPTION
We have to handle xml files which have no xml namespace (pre 2000 area ) for a logical model. XmlParsing for a logical model has been extended for that. Suggestion is to indicate this in the logical model with the extension elementdefinition-namespace and "default" as a value:

```
	<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
		<valueUri value="default"/>
	</extension>
```   

A TestCase has been added to the [ValidationSuite](https://github.com/FHIR/fhir-test-cases/pull/69/files), the ValidationSuite Test has in addition be slightly updated, that a logical model is not going through the first standard resource validation step.