### PR TITLE
Don't validate against base profile if custom profile is present

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -3496,12 +3496,15 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     if (BUNDLE.equals(element.fhirType())) {
       resolveBundleReferences(element, new ArrayList<Element>());
     }
-    startInner(hostContext, errors, resource, element, defn, stack, hostContext.isCheckSpecials());
 
+    List<Element> profiles = new ArrayList<Element>();
     Element meta = element.getNamedChild(META);
     if (meta != null) {
-      List<Element> profiles = new ArrayList<Element>();
       meta.getNamedChildren("profile", profiles);
+    }
+    if (profiles.isEmpty()) {
+      startInner(hostContext, errors, resource, element, defn, stack, hostContext.isCheckSpecials());
+    } else {
       int i = 0;
       for (Element profile : profiles) {
         StructureDefinition sd = context.fetchResource(StructureDefinition.class, profile.primitiveValue());
@@ -3520,7 +3523,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
           } else if (warning(errors, IssueType.STRUCTURE, element.line(), element.col(), stack.getLiteralPath() + ".meta.profile[" + i + "]", sd != null, I18nConstants.VALIDATION_VAL_PROFILE_UNKNOWN, profile.primitiveValue())) {
             signpost(errors, IssueType.INFORMATIONAL, element.line(), element.col(), stack.getLiteralPath(), !crumbTrails, I18nConstants.VALIDATION_VAL_PROFILE_SIGNPOST_META, sd.getUrl());
             stack.resetIds();
-            startInner(hostContext, errors, resource, element, sd, stack, false);
+            startInner(hostContext, errors, resource, element, sd, stack, hostContext.isCheckSpecials());
           }
         }
         i++;


### PR DESCRIPTION
In 3.8.0 validating against the default profile was skipped when a custom profile was present. Taken from 3.8.0 code InstanceValidator.start():
"// Don't need to validate against the resource if there's a profile because the profile snapshot will include the relevant parts of the resources"

In the 5.0.0 code there is already a similar check in InstanceValidator.validate().676

It works as expected when resource with custom profile is NOT nested inside ex Bundle or Parameter.

I have created the test below to show the problem. I didn't know where to put the test in this project. The test will fail without the change in this pull request.

****I can't get the code to look correct in preview and it cuts away the end of the profile. When I edit the comment it looks fine and everything is there****

@Test
  public void validationResultDiffersWhenResourceIsEmbedded_preferredBinding() {
    String taskProfileWithNewPerformerTypeBinding = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
      + "<StructureDefinition xmlns=\"http://hl7.org/fhir\">\n"
      + "  <url value=\"http://example.org/fhir/StructureDefinition/MyTask\" />\n"
      + "  <name value=\"MyTask\" />\n"
      + "  <status value=\"draft\" />\n"
      + "  <fhirVersion value=\"3.0.2\" />\n"
      + "  <mapping>\n"
      + "    <identity value=\"workflow\" />\n"
      + "    <uri value=\"http://hl7.org/fhir/workflow\" />\n"
      + "    <name value=\"Workflow Mapping\" />\n"
      + "  </mapping>\n"
      + "  <mapping>\n"
      + "    <identity value=\"rim\" />\n"
      + "    <uri value=\"http://hl7.org/v3\" />\n"
      + "    <name value=\"RIM Mapping\" />\n"
      + "  </mapping>\n"
      + "  <mapping>\n"
      + "    <identity value=\"w5\" />\n"
      + "    <uri value=\"http://hl7.org/fhir/w5\" />\n"
      + "    <name value=\"W5 Mapping\" />\n"
      + "  </mapping>\n"
      + "  <kind value=\"resource\" />\n"
      + "  <abstract value=\"false\" />\n"
      + "  <type value=\"Task\" />\n"
      + "  <baseDefinition value=\"http://hl7.org/fhir/StructureDefinition/Task\" />\n"
      + "  <derivation value=\"constraint\" />\n"
      + "  <differential>\n"
      + "    <element id=\"Task.performerType\">\n"
      + "      <path value=\"Task.performerType\" />\n"
      + "      <binding>\n"
      + "        <strength value=\"required\" />\n"
      + "        <valueSetReference>\n"
      + "          <reference value=\"http://hl7.org/fhir/ValueSet/identifier-type\" />\n"
      + "        </valueSetReference>\n"
      + "      </binding>\n"
      + "    </element>\n"
      + "  </differential>\n"
      + "</StructureDefinition>";

    CodeableConcept codeableConcept = new CodeableConcept();
    Coding codingCode = codeableConcept.addCoding();
    codingCode.setCode("NIIP");
    codingCode.setSystem("http://hl7.org/fhir/v2/0203");

    Task task = new Task();
    task.getMeta().addProfile("http://example.org/fhir/StructureDefinition/MyTask");
    task.setStatus(Task.TaskStatus.DRAFT);
    task.setIntent(Task.TaskIntent.FILLERORDER);
    task.setPerformerType(Arrays.asList(codeableConcept)); // The base profile for Task.performerType has a preferred binding

    // Raw resource
    FhirValidator fhirValidator = createFhirValidator(taskProfileWithNewPerformerTypeBinding);
    ValidationResult validationResultRawResource = fhirValidator.validateWithResult(task);

    // Resource embedded in Parameters and Bundle
    Bundle bundle = new Bundle();
    bundle.setType(Bundle.BundleType.TRANSACTION);
    bundle.addEntry()
      .setResource(task)
      .setFullUrl(UUID.randomUUID().toString())
      .getRequest()
      .setUrl(task.getResourceType().name())
      .setMethod(Bundle.HTTPVerb.POST);

    Parameters inParams = new Parameters();
    inParams.addParameter().setName("bundle").setResource(bundle);

    ValidationResult validationResultEmbeddedResource = fhirValidator.validateWithResult(inParams);
    assertEquals(validationResultRawResource.getMessages().size(), validationResultEmbeddedResource.getMessages().size());
  }

private FhirValidator createFhirValidator(String differentialActivityDefinitionReferenced) {
    FhirContext fhirContext = new FhirContext(FhirVersionEnum.DSTU3);
    IValidationSupport defaultProfileValidationSupport = new DefaultProfileValidationSupport(fhirContext);

    PrePopulatedValidationSupport customValidationSupport = new PrePopulatedValidationSupport(fhirContext);
    customValidationSupport.addStructureDefinition(createSnapshot(fhirContext, defaultProfileValidationSupport, differentialActivityDefinitionReferenced));

    FhirInstanceValidator fhirInstanceValidator = new FhirInstanceValidator(fhirContext);
    fhirInstanceValidator.setNoTerminologyChecks(false);
    fhirInstanceValidator.setBestPracticeWarningLevel(IResourceValidator.BestPracticeWarningLevel.Error);
    fhirInstanceValidator.setValidationSupport(new ValidationSupportChain(
      defaultProfileValidationSupport,
      new InMemoryTerminologyServerValidationSupport(fhirContext),
      customValidationSupport));

    FhirValidator fhirValidator = fhirContext.newValidator();
    fhirValidator.registerValidatorModule(fhirInstanceValidator);
    return fhirValidator;
  }

  private StructureDefinition createSnapshot(FhirContext fhirContext, IValidationSupport defaultProfileValidationSupport, String differential) {
    StructureDefinition structureDefinition = fhirContext.newXmlParser().parseResource(StructureDefinition.class, differential);
    StructureDefinition baseStructureDefinition = (StructureDefinition) defaultProfileValidationSupport.fetchStructureDefinition(structureDefinition.getBaseDefinition());

    IWorkerContext workerContext = new HapiWorkerContext(fhirContext, defaultProfileValidationSupport);
    ProfileUtilities profileUtilities = new ProfileUtilities(workerContext, new ArrayList<>(), null);
    profileUtilities.generateSnapshot(baseStructureDefinition, structureDefinition, "", "");

    return structureDefinition;
  }