### PR TITLE
validation of bundles: allow multiple authors in section

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
@@ -140,7 +140,7 @@ public class BundleValidator extends BaseValidator{
       NodeStack localStack = stack.push(section, i, null, null);
 
       // technically R4+, but there won't be matches from before that
-      validateDocumentReference(errors, entries, section, stack, fullUrl, id, false, "author", "Section");
+      validateDocumentReference(errors, entries, section, stack, fullUrl, id, true, "author", "Section");
       validateDocumentReference(errors, entries, section, stack, fullUrl, id, false, "focus", "Section");
 
       List<Element> sectionEntries = new ArrayList<Element>();


### PR DESCRIPTION
when validating a bundle which has two authors in a section we get the following exception:

```
Exception in thread "main" java.lang.Error: Attempt to read a single element when there is more than one present (author)
	at org.hl7.fhir.r5.elementmodel.Element.getNamedChild(Element.java:549)
	at org.hl7.fhir.validation.instance.type.BundleValidator.validateDocumentReference(BundleValidator.java:182)
	at org.hl7.fhir.validation.instance.type.BundleValidator.validateSections(BundleValidator.java:143)
	at org.hl7.fhir.validation.instance.type.BundleValidator.validateDocument(BundleValidator.java:131)
	at org.hl7.fhir.validation.instance.type.BundleValidator.validateBundle(BundleValidator.java:60)
	at org.hl7.fhir.validation.instance.InstanceValidator.checkSpecials(InstanceValidator.java:3688)
	at org.hl7.fhir.validation.instance.InstanceValidator.startInner(InstanceValidator.java:3680)
	at org.hl7.fhir.validation.instance.InstanceValidator.start(InstanceValidator.java:3558)
```

section authors can be 0..* [link](http://hl7.org/fhir/composition.html), if validateDocumentReference is called with repeat to true as in this PR the check runs without an exception.  

bundle example with two authors (but second author comment out currently in github) is [here](https://github.com/hl7ch/ch-emed/blob/master/input/examples/bundle/MedicationCard-DifferentAuthors.xml)