### PR TITLE
ArrayIndexOutOfBoundsException on versioned invalid reference

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -4768,8 +4768,12 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       case 2:
         return checkResourceType(parts[0]);
       default:
-        if (parts[parts.length - 2].equals("_history"))
+        if (parts[parts.length - 2].equals("_history")) {
+          if (parts.length < 4) {
+            return null;
+          }
           return checkResourceType(parts[parts.length - 4]);
+        }
         else
           return checkResourceType(parts[parts.length - 2]);
     }


### PR DESCRIPTION
ArrayIndexOutOfBoundsException when creating a resource with a versioned invalid reference, ex: new Reference("Media/_history/1");

I have created the below test to show the issue, but not sure where to place it in this repo.

@Test
    public void ensureArrayIndexOutOfBoundsExceptionDoesntHappenOnInvalidReference() {
        Reference invalidReference = new Reference("XXX/_history/1");

        AuditEvent auditEvent = new AuditEvent()
            .setRecorded(new Date())
            .setType(new Coding().setSystem(AuditEventType.REST.getSystem()).setCode(AuditEventType.REST.toCode()).setDisplay(AuditEventType.REST.getDisplay()))
            .setSource(new AuditEvent.AuditEventSourceComponent()
                .setIdentifier(new Identifier().setValue("http://foo.dk")))
            .addAgent(new AuditEvent.AuditEventAgentComponent().setRequestor(true));

        AuditEvent.AuditEventEntityComponent auditEventEntityComponent = auditEvent.addEntity();
        auditEventEntityComponent.setReference(invalidReference);

        FhirValidator fhirValidator = createFhirValidator();
        ValidationResult validationResult = fhirValidator.validateWithResult(auditEvent);
    }

    private FhirValidator createFhirValidator() {
        FhirContext fhirContext = new FhirContext(FhirVersionEnum.DSTU3);
        fhirContext.getParserOptions().setDontStripVersionsFromReferencesAtPaths("AuditEvent.entity.reference");

        FhirInstanceValidator fhirInstanceValidator = new FhirInstanceValidator(fhirContext);
        fhirInstanceValidator.setValidationSupport(new ValidationSupportChain(new DefaultProfileValidationSupport(fhirContext)));

        FhirValidator fhirValidator = fhirContext.newValidator();
        fhirValidator.registerValidatorModule(fhirInstanceValidator);
        return fhirValidator;
    }