### PR TITLE
add patch wildcard for ig dependencies

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
@@ -193,6 +193,16 @@ public class VersionUtilities {
     }
   }
 
+  public static String getPatch(String version) {
+    if (version == null)
+      return null;
+    if (Utilities.charCount(version, '.') == 2) {
+      String[] p = version.split("\\.");
+      return p[2];  
+    }
+    return null;
+  }
+
   public static boolean isSemVer(String version) {
     if (Utilities.charCount(version, '.') != 2) {
       return false;
@@ -202,7 +212,7 @@ public class VersionUtilities {
   }
 
   /** 
-   * return true if the current vresion equals test, or later 
+   * return true if the current version equals test, or later 
    * 
    * so if a feature is defined in 4.0, if (VersionUtilities.isThisOrLater("4.0", version))...
    *  
@@ -213,8 +223,34 @@ public class VersionUtilities {
   public static boolean isThisOrLater(String test, String current) {
     String t = getMajMin(test);
     String c = getMajMin(current);
+    if (c.compareTo(t) == 0) {
+      return isMajMinOrLaterPatch(test, current);
+    }
     boolean ok = c.compareTo(t) >= 0;
     return ok;
+  }
+
+  /** 
+   * return true if the current version equals test for major and min, or later patch 
+   * 
+   * @param test
+   * @param current
+   * @return
+   */
+  public static boolean isMajMinOrLaterPatch(String test, String current) {
+    String t = getMajMin(test);
+    String c = getMajMin(current);
+    if (c.compareTo(t) == 0) {
+      String pt = getPatch(test);
+      String pc = getPatch(current);
+      if (pt==null || "x".equals(pt)) {
+        return true;
+      }
+      if (pc!=null) {
+        return pc.compareTo(pt) >= 0;
+      }
+    }
+    return false;
   }
 
   public static String incMajorVersion(String v) {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/BasePackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/BasePackageCacheManager.java
@@ -69,6 +69,9 @@ public abstract class BasePackageCacheManager implements IPackageCacheManager {
         if (Utilities.noString(version)) {
           version = packageClient.getLatestVersion(id);
         }
+        if (version.endsWith(".x")) {
+          version = packageClient.getLatestVersion(id, version);
+        }
         InputStream stream = packageClient.fetch(id, version);
         String url = packageClient.url(id, version);
         return new InputStreamWithSrc(stream, url, version);

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/FilesystemPackageCacheManager.java
@@ -39,6 +39,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.utilities.IniFile;
 import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.cache.NpmPackage.NpmPackageFolder;
 import org.hl7.fhir.utilities.json.JSONUtil;
 import org.slf4j.Logger;
@@ -283,7 +284,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   }
 
   /**
-   * Load the identified package from the cache - it it exists
+   * Load the identified package from the cache - if it exists
    * <p>
    * This is for special purpose only (testing, control over speed of loading).
    * Generally, use the loadPackage method
@@ -307,10 +308,22 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
         return p;
       }
     }
+    String foundPackage = null;
+    String foundVersion = null;
     for (String f : sorted(new File(cacheFolder).list())) {
       if (f.equals(id + "#" + version) || (Utilities.noString(version) && f.startsWith(id + "#"))) {
         return loadPackageInfo(Utilities.path(cacheFolder, f));
       }
+      if (version!=null && version.endsWith(".x") && f.contains("#")) {
+        String[] parts = f.split("#");
+        if (parts[0].equals(id) && VersionUtilities.isMajMinOrLaterPatch((foundVersion!=null ? foundVersion : version),parts[1])) {
+          foundVersion = parts[1];
+          foundPackage = f;
+        }
+      }
+    }
+    if (foundPackage!=null) {
+      return loadPackageInfo(Utilities.path(cacheFolder, foundPackage));
     }
     if ("dev".equals(version))
       return loadPackageFromCacheOnly(id, "current");

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/PackageClient.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/cache/PackageClient.java
@@ -208,5 +208,19 @@ public class PackageClient {
     }
   }
   
+  public String getLatestVersion(String id, String majMinVersion) throws IOException {
+    List<PackageInfo> list = getVersions(id);
+    if (list.isEmpty()) {
+      throw new IOException("Package not found: "+id);
+    } else {
+      String v = majMinVersion;
+      for (PackageInfo p : list) {
+        if (VersionUtilities.isMajMinOrLaterPatch(v, p.version)) {
+          v = p.version;
+        }
+      }
+      return v;
+    }
+  }
 
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -762,6 +762,18 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
     context.getLoadedPackages().add(pi.name()+"#"+pi.version());
     Map<String, byte[]> res = new HashMap<String, byte[]>();
     for (String s : pi.dependencies()) {
+      if (s.endsWith(".x") && s.length()>2) {
+        String packageMajorMinor = s.substring(0, s.length()-2);
+        boolean found = false;
+        for (int i=0; i<context.getLoadedPackages().size() && !found; ++i) {
+          String loadedPackage = context.getLoadedPackages().get(i);
+          if (loadedPackage.startsWith(packageMajorMinor)) {
+            found = true;
+          }
+        }
+        if (found)
+          continue ;
+      }
       if (! context.getLoadedPackages().contains(s)) {
         if (!VersionUtilities.isCorePackage(s)) {
           System.out.println("+  .. load IG from "+s);


### PR DESCRIPTION
The [NPM fhir specification](https://confluence.hl7.org/pages/viewpage.action?pageId=35718629#NPMPackageSpecification-Versionreferences) says:

> When packages point to dependencies they should refer to the whole package version number and not use wildcards, except for the patch version in a semver version reference:
> 
>  "hl7.fhir.core" : "3.0.x"
> This x here means that it should a package resolver should accept the package with the highest found patch number.

This PR adds supports for the following use cases:
- if an ig dependency is defined as .x the latest patch version will used from the file package cache or installed from the package server
- if the ValidationEngine is called and a patched version is already specified before the dependency, the patched version will be used.

e.g.:
ch-core is depending on ch-epr-term 2.0.x, see [ig](https://github.com/hl7ch/ch-core/blob/oe_dependsonigversion/input/ch.fhir.ig.ch-core.xml)

```
java -jar org.hl7.fhir.validator_cli.jar -version 4.0.1 -ig ch.fhir.ig.ch-core#current HPWengerRole.xml 
```
will download ch-epr-term 2.0.4 (latest published version) into the package cache and will be used for validation

```
java -jar org.hl7.fhir.validator_cli.jar -version 4.0.1 -ig ch.fhir.ig.ch-epr-term#2.0.3 -ig ch.fhir.ig.ch-core#current HPWengerRole.xml 
```
will download ch-epr-term 2.0.3 into the package cache and will be used for validation, ch-epr-term 2.0.4 will not be used

```
java -jar org.hl7.fhir.validator_cli.jar -version 4.0.1 -ig ch.fhir.ig.ch-epr-term#2.0.4 -ig ch.fhir.ig.ch-core#current HPWengerRole.xml 
java -jar org.hl7.fhir.validator_cli.jar -version 4.0.1 -ig ch.fhir.ig.ch-core#current HPWengerRole.xml 
```
ch-epr-term 2.0.4 will be used for validation

This PR is depending on a PR for the IG Publisher to support building implementation guide, will follow after this one, since the IG Publisher is depending on this project. 




