### PR TITLE
performance: improve speed of comparing UriTypes

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/UriType.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/UriType.java
@@ -152,6 +152,9 @@ public class UriType extends PrimitiveType<String> {
 		if (getValue() == null || other.getValue() == null) {
 			return false;
 		}
+		if (getValue().equals(other.getValue())) {
+			return true;
+		}
 
 		String normalize = normalize(getValue());
 		String normalize2 = normalize(other.getValue());

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/UriType.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/UriType.java
@@ -153,6 +153,9 @@ public class UriType extends PrimitiveType<String> {
 		if (getValue() == null || other.getValue() == null) {
 			return false;
 		}
+		if (getValue().equals(other.getValue())) {
+			return true;
+		}
 
 		String normalize = normalize(getValue());
 		String normalize2 = normalize(other.getValue());

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/UriType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/UriType.java
@@ -153,6 +153,9 @@ public class UriType extends PrimitiveType<String> {
 		if (getValue() == null || other.getValue() == null) {
 			return false;
 		}
+		if (getValue().equals(other.getValue())) {
+			return true;
+		}
 
 		String normalize = normalize(getValue());
 		String normalize2 = normalize(other.getValue());

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/UriType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/UriType.java
@@ -155,6 +155,9 @@ public class UriType extends PrimitiveType<String> {
 		if (getValue() == null || other.getValue() == null) {
 			return false;
 		}
+		if (getValue().equals(other.getValue())) {
+			return true;
+		}
 
 		String normalize = normalize(getValue());
 		String normalize2 = normalize(other.getValue());

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/UriType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/UriType.java
@@ -124,7 +124,7 @@ public class UriType extends PrimitiveType<String> {
 	/**
 	 * Creates a new OidType instance which uses the given OID as the content (and prepends "urn:oid:" to the OID string
 	 * in the value of the newly created OidType, per the FHIR specification).
-	 * 
+	 *
 	 * @param theOid
 	 *            The OID to use (<code>null</code> is acceptable and will result in a UriDt instance with a
 	 *            <code>null</code> value)
@@ -155,6 +155,9 @@ public class UriType extends PrimitiveType<String> {
 		if (getValue() == null || other.getValue() == null) {
 			return false;
 		}
+		if (getValue().equals(other.getValue())) {
+			return true;
+		}
 
 		String normalize = normalize(getValue());
 		String normalize2 = normalize(other.getValue());
@@ -162,7 +165,7 @@ public class UriType extends PrimitiveType<String> {
    }
 
 		public String fhirType() {
-			return "uri";			
+			return "uri";
 		}
 
 }


### PR DESCRIPTION
While searching for performance bottlenecks in HAPI FHIR, we noticed that comparing FHIR resources was unnecessarily expensive: `equalsDeep()` calls `normalize()` even in case of string equality, which leeds to tons of unneeded URI objects; creation of these URI objects is in turn very expensive because it involves parsing the string constructor argument.

This very simple fix reduced our CPU load very significantly. There is probably more tuning potential in `normalize()`, but that's another story.