### PR TITLE
Update help page of validator CLI in structure and format

### DIFF
--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -1,0 +1,161 @@
+% VALIDATOR\_CLI(1) validator\_cli.jar 5.1.18+b7661db8
+% Grahame Grieve, James Agnew and the FHIR community
+% November 2020
+
+# NAME
+validator\_cli.jar - validate or transform FHIR resources or bundles
+
+# SYNOPSIS
+java -jar validator\_cli.jar [SOURCE] [OPTION]...
+
+# DESCRIPTION
+The validator compares a resource against the base definitions and any profiles
+declared in the resource (Resource.meta.profile) or specified on the command
+line.
+
+Schema and schematron checking is performed, depending on the FHIR version
+as followed:
+
+- XML and JSON Schema: FHIR versions 1.0, 1.4, 3.0, 4.0, 4.5
+- Turtle: FHIR versions 3.0, 4.0, 4.5
+
+# OPTIONS
+
+**SOURCE**
+: A file, URL, directory or pattern for resources to validate. At least one
+  source must be declared. If there is more than one source or if the source 
+  is other than a single file or URL and the output parameter is used, results
+  will be provided as a *Bundle*. Patterns are limited to a directory 
+  followed by a filename with an embedded asterisk.
+
+**-assumeValidRestReferences**
+: If present, assume that URLs that reference resources follow the RESTful
+  URI pattern and it is safe to infer the type from the URL.
+  Default: *disabled*
+
+**-convert**
+: Convert a resource or logical model. This parameter requires the parameters
+  **SOURCE** and **-output**. The parameter **-ig** may be used to provide
+  a logical model.
+  Default: *disabled*
+
+**-debug**
+: Produce additional information about the loading and validation process.
+  Default: *disabled*
+
+**-fhirpath [expression]**
+: Evaluate a FHIRPath expression on a resource or logical model. This requires
+  the parameter **SOURCE**. The parameter **-ig** may be used to provide a
+  logical model.
+
+**-hintAboutNonMustSupport**
+: If present, raise hints if the instance contains data elements that are not
+  marked as *mustSupport=true*. Useful to identify elements included that may
+  be ignored by recipients.
+  Default: *disabled*
+
+**-ig [package|file|folder|url]**
+: An implementation guide or profile definition to load. Can be 
+  the URL of an implementation guide or a package ([id]-[ver]) for
+  a built implementation guide or a local folder that contains a
+  set of conformance resources. This parameter can appear any number of times.
+  Default: *none*
+
+**-language: [lang]**
+: Specifies the language to use when validating coding displays (same value as
+  for xml:lang). This option is ignored if the resource specifies a language.
+  Default: *none*
+
+**-locale [locale]**
+: Specifies the locale or language of the validation result messages
+  (e.g.: de-DE).
+  Default: *en*
+
+**-narrative**
+: Generate narrative for a resource. This parameter requires the parameters
+  **-defn**, **-tx**, **SOURCE**, and **-output**. The parameters
+  **-ig** and **-profile** may be used.
+  Default: *disabled*
+
+**-native [true|false]**
+: Use XML schema (W3C XML Schema and schematron), JSON schema and RDP (ShEx)
+  for validation as well.
+  Default: *false*
+
+**-output [file]**
+: A filename for the results (*OperationOutcome*).
+  Default: *stdout*
+
+**-profile [url]**
+: The canonical URL to validate against (same as if it was specified in 
+  Resource.meta.profile). If no profile is specified, the resource is 
+  validated against the base specification. This parameter can appear any 
+  number of times. (Note: The profile and its dependencies have to be made 
+  available through one of the **-ig** parameters. Package dependencies will 
+  automatically be resolved.)
+  Default: *none*
+
+**-proxy [address]:[port]**
+: Specifies the proxy address and port to use.
+  Default: *disabled*
+
+**-questionnaire [file|url]**
+: The location of a questionnaire. If provided, then the validator will
+  validate any *QuestionnaireResponse* that claims to match the *Questionnaire*
+  against it. This parameter can appear any number of times.
+  Default: *none*
+
+**-recurse**
+: Look in subfolders when **-ig** refers to a folder.
+  Default: *disabled*
+
+**-sct [intl|us|uk|au|nl|ca|se|dk|es]**
+: Specify the edition of SNOMED CT to use. The default FHIR terminology
+  service only supports a subset. To add to this list or the default FHIR
+  terminology service ask on https://chat.fhir.org/#narrow/stream/179202-terminology.
+  Default: *disabled*
+
+**-security-checks**
+: If present, check that string content doesn't include any HTML-like tags that
+  might create problems downstream (though all external input must always be
+  sanitized by escaping for either HTML or SQL).
+  Default: *disabled*
+
+**-snapshot**
+: Generate a snapshot for a profile. This requires the parameters **-defn**,
+  **-tx**, **SOURCE**, and **-output**. The parameter **-ig** may be
+  used to provide necessary base profiles.
+  Default: *disabled*
+
+**-strictExtensions**
+: If present, treat extensions not defined within the specified FHIR version
+  and any referenced implementation guides or profiles as *error*.
+  Default: *information*
+
+**-transform [uri]**
+: Execute a transformation as described by a structure map given by its
+  URI the transformation starts with. Any other dependency maps have to be
+  loaded using **-ig** parameters to reference those maps. (Note: This
+  parameter uses the parameters **-defn**, **-tx**, **-ig** and **-output**.
+  Default: *disabled*
+
+**-tx [url]**
+: The base URL of a FHIR terminology service. To run without terminology
+  value, specify *n/a* as URL. This parameter can appear only once.
+  Default: *http://tx.fhir.org*
+
+**-txLog [file]**
+: Produce a log of the terminology server operations in [file].
+  Default: *disabled*
+
+**-version [1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0]**
+: The FHIR version to use. This can only appear once.
+  Default: *4.5*
+
+# BUGS
+
+https://github.com/hapifhir/org.hl7.fhir.core/issues
+
+# COPYRIGHT
+
+https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LICENSE.txt

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -1,6 +1,8 @@
-% VALIDATOR\_CLI(1) validator\_cli.jar 5.1.18+b7661db8
-% Grahame Grieve, James Agnew and the FHIR community
-% November 2020
+% VALIDATOR\_CLI(1) 5.1.18+b7661d | HL7 FHIR Java CLI Validator
+% Grahame Grieve
+  James Agnew
+  FHIR community
+% $date$
 
 # NAME
 validator\_cli.jar - validate or transform FHIR resources or bundles
@@ -158,4 +160,4 @@ https://github.com/hapifhir/org.hl7.fhir.core/issues
 
 # COPYRIGHT
 
-https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LICENSE.txt
+https://github.com/hapifhir/org.hl7.fhir.core/blob/master/LICENSE.txt

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -5,10 +5,10 @@
 % $date$
 
 # NAME
-validator\_cli.jar - validate or transform FHIR resources or bundles
+validator\_cli.jar - validate or transform HL7 FHIR resources or bundles
 
 # SYNOPSIS
-java -jar validator\_cli.jar [SOURCE] [OPTION]...
+java -jar validator\_cli.jar [SOURCE]... [OPTION]...
 
 # DESCRIPTION
 The validator compares a resource against the base definitions and any profiles

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -85,9 +85,12 @@ as followed:
   for validation as well.
   Default: *false*
 
-**-output [file]**
-: A filename for the results (*OperationOutcome*).
-  Default: *stdout*
+**-output \<file>**
+: Write the validation result messages to a XML formatted output file (instead
+  to *stdout*) as *OperationOutcome* resource or *Bundle* of multiple
+  *OperationOutcome* resources, one for each validated FHIR resource. If no
+  output file has been given, an error occurs.
+  Default: -
 
 **-profile [url]**
 : The canonical URL to validate against (same as if it was specified in 
@@ -162,6 +165,22 @@ as followed:
   *Note: Alternatively the version could be set by using the **-defn** or 
   **-ig** parameter to maintain backwards compatibility.*
   Default: *current build version* (3 or 5 letter version string)
+
+# EXAMPLES
+
+*Note: The validator CLI in general is executed in the Java Runtime Environment
+and packaged as executable jar file. To improve readability the **java -jar**
+command (prefix) always has been omitted for the examples presented.*
+
+## OUTPUT FORMATS
+
+**validator\_cli.jar ./patient.xml -output ./results.xml**
+: Write validation result messages to the a file.
+
+Validate patient resource and write result messages to the a file:
+```
+java -jar validator_cli.jar ./patient.xml -output ./results.xml
+```
 
 # BUGS
 

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -101,11 +101,14 @@ as followed:
 : Specifies the proxy address and port to use.
   Default: *disabled*
 
-**-questionnaire [file|url]**
-: The location of a questionnaire. If provided, then the validator will
-  validate any *QuestionnaireResponse* that claims to match the *Questionnaire*
-  against it. This parameter can appear any number of times.
-  Default: *none*
+**-questionnaire <NONE|CHECK|REQUIRED>**
+: Validate any *QuestionnaireResponse* resource against its matching
+  *Questionnaire* resource referenced by the canonical URL in 
+  *QuestionnaireResponse.questionnaire*. Possible arguments are: *NONE* 
+  (do not validate), *CHECK* (validate iff matching questionnaire is provided)
+  and *REQUIRED* (validate and report an error if no matching questionnaire is
+  provided). *Note: Arguments for this parameter must be provided case
+  sensitive.* Default: *NONE*
 
 **-recurse**
 : Look in subfolders when **-ig** refers to a folder.

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -55,12 +55,19 @@ be installed. The latest validator CLI release could be downloaded from Github
   be ignored by recipients.
   Default: *disabled*
 
-**-ig [package|file|folder|url]**
-: An implementation guide or profile definition to load. Can be 
-  the URL of an implementation guide or a package ([id]-[ver]) for
-  a built implementation guide or a local folder that contains a
-  set of conformance resources. This parameter can appear any number of times.
-  Default: *none*
+**-ig <package|file|directory|url|archive>**
+: Validate resources against an implementation guide. To validate against
+  multiple implementation guides at once, each implementation guide must be
+  provided using a separate **-ig** parameter. If the packages required for
+  validation are not already installed to the FHIR package cache, they will
+  be downloaded and installed. Implementation guides could be provided in
+  various ways, such as a package (w/o version literal), an canonical URL
+  or from local filesystem. For examples, see EXAMPLES section.
+  *Note: To validate against the current build version of the implementation
+  guide, use 'current' as version literal. To validate against a custom build
+  implementation guide, use 'dev' as version literal.*
+  *Note: If the **-version** parameter is provided, the underlying FHIR
+  version of a package must match.*
 
 **-language: [lang]**
 : Specifies the language to use when validating coding displays (same value as
@@ -176,10 +183,38 @@ command (prefix) always has been omitted for the examples presented.*
 **validator\_cli.jar ./patient.xml -output ./results.xml**
 : Write validation result messages to the a file.
 
-Validate patient resource and write result messages to the a file:
-```
-java -jar validator_cli.jar ./patient.xml -output ./results.xml
-```
+## VALIDATION AGAINST IMPLEMENTATION GUIDE
+
+**validator\_cli.jar ./patient.xml -ig hl7.fhir.us.core**
+: Validate resource against the *current version* of an implementation guide
+  package.
+
+**validator\_cli.jar ./patient.xml -ig hl7.fhir.us.core\#1.0.1**
+: Validate resource against a *specific version* of an implementation guide
+  package.
+
+**validator\_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core**
+: Validate resource against the *current version* of an implementation guide
+  (resource) loaded from the canonical URL.
+
+**validator\_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core\|1.0.1**
+: Validate resource against a *specific version* of an implementation guide
+  (resource) loaded from the canonical URL.
+
+**validator\_cli.jar ./patient.xml -ig ./profile.xml**
+: Validate resource against an implementation guide (resource) file.
+
+**validator\_cli.jar ./patient.xml -ig ./profiles/**
+: Validate resource against any implementation guide (resource) file found
+  in the profiles directory.
+
+**validator\_cli.jar ./patient.xml -ig ./profiles/\*.json**
+: Validate resource against any implementation guide (resource) JSON file
+  found in the profiles directory.
+
+**validator\_cli.jar ./patient.xml -ig ./profiles.tgz**
+: Validate resource against any implementaion guide (resource) file found
+  in the gzipped tarball profiles archive.
 
 # BUGS
 

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -188,3 +188,8 @@ https://github.com/hapifhir/org.hl7.fhir.core/issues
 # COPYRIGHT
 
 https://github.com/hapifhir/org.hl7.fhir.core/blob/master/LICENSE.txt
+
+# SEE ALSO
+
+For more information regarding the validation process and the validator CLI
+itself, please see the official [HL7 FHIR implementers documentation](https://confluence.hl7.org/display/FHIR/Implementers).

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -68,9 +68,10 @@ as followed:
   for xml:lang). This option is ignored if the resource specifies a language.
   Default: *none*
 
-**-locale [locale]**
-: Specifies the locale or language of the validation result messages
-  (e.g.: de-DE).
+**-locale \<code>**
+: Specifies the locale or language of the validation result messages, e.g. de
+  to display validation result messages in german language. *Note: Locales can
+  only be used if translations have been provided.*
   Default: *en*
 
 **-narrative**

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -11,15 +11,14 @@ validator\_cli.jar - validate or transform HL7 FHIR resources or bundles
 java -jar validator\_cli.jar [SOURCE]... [OPTION]...
 
 # DESCRIPTION
-The validator compares a resource against the base definitions and any profiles
-declared in the resource (Resource.meta.profile) or specified on the command
-line.
 
-Schema and schematron checking is performed, depending on the FHIR version
-as followed:
+The HL7 FHIR validator CLI compares one or more resources against the base
+definitions and any profiles declared in a resource (Resource.meta.profile)
+or specified on the command line.
 
-- XML and JSON Schema: FHIR versions 1.0, 1.4, 3.0, 4.0, 4.5
-- Turtle: FHIR versions 3.0, 4.0, 4.5
+To run the validator the latest version of the Java Runtime Environment must 
+be installed. The latest validator CLI release could be downloaded from Github
+(https://git.io/Jkf9i).
 
 # OPTIONS
 

--- a/org.hl7.fhir.validation/src/main/resources/help.md
+++ b/org.hl7.fhir.validation/src/main/resources/help.md
@@ -153,9 +153,14 @@ as followed:
 : Produce a log of the terminology server operations in [file].
   Default: *disabled*
 
-**-version [1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0]**
-: The FHIR version to use. This can only appear once.
-  Default: *4.5*
+**-version <1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0>**
+: Validate resources against the passed version of the base FHIR specification.
+  It is recommended to set the version parameter at first. Before validation 
+  starts a check for required packages matching the version is performed.
+  Missing packages will be downloaded and installed to the FHIR package cache.
+  *Note: Alternatively the version could be set by using the **-defn** or 
+  **-ig** parameter to maintain backwards compatibility.*
+  Default: *current build version* (3 or 5 letter version string)
 
 # BUGS
 

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -142,9 +142,15 @@ OPTIONS
               Produce a log of the terminology server  operations  in  [file].
               Default: disabled
 
-       -version [1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0]
-              The  FHIR  version to use.  This can only appear once.  Default:
-              4.5
+       -version <1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0>
+              Validate resources against the passed version of the  base  FHIR
+              specification.   It  is recommended to set the version parameter
+              at first.  Before validation starts a check for  required  pack‐
+              ages  matching  the version is performed.  Missing packages will
+              be downloaded and installed to the FHIR  package  cache.   Note:
+              Alternatively the version could be set by using the -defn or -ig
+              parameter to maintain backwards compatibility. Default:  current
+              build version (3 or 5 letter version string)
 
 BUGS
        https://github.com/hapifhir/org.hl7.fhir.core/issues

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -62,9 +62,11 @@ OPTIONS
               (same value as for xml:lang).  This option is ignored if the re‐
               source specifies a language.  Default: none
 
-       -locale [locale]
+       -locale <code>
               Specifies  the  locale or language of the validation result mes‐
-              sages (e.g.: de-DE).  Default: en
+              sages, e.g. de to display validation result messages  in  german
+              language.   Note:  Locales can only be used if translations have
+              been provided. Default: en
 
        -narrative
               Generate narrative for a resource.  This parameter requires  the

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -90,11 +90,14 @@ OPTIONS
        -proxy [address]:[port]
               Specifies the proxy address and port to use.  Default: disabled
 
-       -questionnaire [file|url]
-              The  location of a questionnaire.  If provided, then the valida‐
-              tor will validate any QuestionnaireResponse that claims to match
-              the  Questionnaire  against  it.   This parameter can appear any
-              number of times.  Default: none
+       -questionnaire <NONE|CHECK|REQUIRED>
+              Validate any QuestionnaireResponse resource against its matching
+              Questionnaire resource referenced by the canonical URL in  Ques‐
+              tionnaireResponse.questionnaire.   Possible  arguments are: NONE
+              (do not validate), CHECK (validate iff matching questionnaire is
+              provided)  and  REQUIRED  (validate  and  report  an error if no
+              matching questionnaire is provided).  Note: Arguments  for  this
+              parameter must be provided case sensitive. Default: NONE
 
        -recurse
               Look in subfolders when -ig refers to a folder.   Default:  dis‐

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -77,8 +77,12 @@ OPTIONS
               Use XML schema (W3C XML Schema and schematron), JSON schema  and
               RDP (ShEx) for validation as well.  Default: false
 
-       -output [file]
-              A filename for the results (OperationOutcome).  Default: stdout
+       -output <file>
+              Write the validation result messages to a XML  formatted  output
+              file  (instead to stdout) as OperationOutcome resource or Bundle
+              of multiple OperationOutcome resources, one for  each  validated
+              FHIR  resource.   If no output file has been given, an error oc‐
+              curs.  Default: -
 
        -profile [url]
               The  canonical URL to validate against (same as if it was speci‐
@@ -154,6 +158,16 @@ OPTIONS
               parameter to maintain backwards compatibility. Default:  current
               build version (3 or 5 letter version string)
 
+EXAMPLES
+       Note: The validator CLI in general is executed in the Java Runtime  En‐
+       vironment  and  packaged as executable jar file. To improve readability
+       the java -jar command (prefix) always has been omitted for the examples
+       presented.
+
+   OUTPUT FORMATS
+       validator_cli.jar ./patient.xml -output ./results.xml
+              Write validation result messages to the a file.
+
 BUGS
        https://github.com/hapifhir/org.hl7.fhir.core/issues
 
@@ -163,4 +177,4 @@ COPYRIGHT
 AUTHORS
        Grahame Grieve; James Agnew; FHIR community.
 
-5.1.18+b7661d                      11/07/20                   VALIDATOR_CLI(1)
+5.1.18+b7661d                      11/08/20                   VALIDATOR_CLI(1)

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -1,10 +1,10 @@
 VALIDATOR_CLI(1)          HL7 FHIR Java CLI Validator         VALIDATOR_CLI(1)
 
 NAME
-       validator_cli.jar - validate or transform FHIR resources or bundles
+       validator_cli.jar - validate or transform HL7 FHIR resources or bundles
 
 SYNOPSIS
-       java -jar validator_cli.jar [SOURCE] [OPTION]...
+       java -jar validator_cli.jar [SOURCE]... [OPTION]...
 
 DESCRIPTION
        The  validator compares a resource against the base definitions and any

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -1,121 +1,108 @@
+VALIDATOR_CLI(1)                                                                                                                                                             VALIDATOR_CLI(1)
 
-The FHIR validation tool validates a FHIR resource or bundle.
-The validation tool compares a resource against the base definitions and any
-profiles declared in the resource (Resource.meta.profile) or specified on the 
-command line
+NAME
+       validator_cli.jar - validate or transform FHIR resources or bundles
 
-The FHIR validation tool validates a FHIR resource or bundle.
-Schema and schematron checking is performed, then some additional checks are performed. 
-* XML & Json (FHIR versions 1.0, 1.4, 3.0, 4.0, " + Constants.VERSION_MM + ")
-* Turtle (FHIR versions 3.0, 4.0, " + Constants.VERSION_MM + ")
+SYNOPSIS
+       java -jar validator_cli.jar [SOURCE] [OPTION]...
 
-If requested, instances will also be verified against the appropriate schema
-W3C XML Schema, JSON schema or ShEx, as appropriate
+DESCRIPTION
+       The validator compares a resource against the base definitions and any profiles declared in the resource (Resource.meta.profile) or specified on the command line.
 
-Usage: java -jar [validator].jar (parameters)
+       Schema and schematron checking is performed, depending on the FHIR version as followed:
 
-The following parameters are supported:
-[source]: a file, url, directory or pattern for resources to validate.  At
-    least one source must be declared.  If there is more than one source or if
-    the source is other than a single file or url and the output parameter is
-    used, results will be provided as a Bundle.
-    Patterns are limited to a directory followed by a filename with an embedded
-    asterisk.  E.g. foo*-examples.xml or someresource.*, etc.
--version [ver]: The FHIR version to use. This can only appear once. 
-    valid values 1.0 | 1.4 | 3.0 | " + VersionUtilities.CURRENT_VERSION + " or 1.0.2 | 1.4.0 | 3.0.2 | 4.0.1 | " + VersionUtilities.CURRENT_FULL_VERSION);
-    Default value is  " + VersionUtilities.CURRENT_VERSION);
--ig [package|file|folder|url]: an IG or profile definition to load. Can be 
-     the URL of an implementation guide or a package ([id]-[ver]) for
-     a built implementation guide or a local folder that contains a
-     set of conformance resources.
-     No default value. This parameter can appear any number of times
--tx [url]: the [base] url of a FHIR terminology service
-     Default value is http://tx.fhir.org. This parameter can appear once
-     To run without terminology value, specific n/a as the URL
--txLog [file]: Produce a log of the terminology server operations in [file]
-     Default value is not to produce a log
--profile [url]: the canonical URL to validate against (same as if it was 
-     specified in Resource.meta.profile). If no profile is specified, the 
-     resource is validated against the base specification. This parameter 
-     can appear any number of times.
-     Note: the profile (and it's dependencies) have to be made available 
-     through one of the -ig parameters. Note that package dependencies will 
-     automatically be resolved
--questionnaire [file|url}: the location of a questionnaire. If provided, then the validator will validate
-     any QuestionnaireResponse that claims to match the Questionnaire against it
-     no default value. This parameter can appear any number of times
--output [file]: a filename for the results (OperationOutcome)
-     Default: results are sent to the std out.
--debug
-     Produce additional information about the loading/validation process
--recurse
-     Look in subfolders when -ig refers to a folder
--locale
-     Specifies the locale/language of the validation result messages (eg.: de-DE
--sct
-     Specify the edition of SNOMED CT to use. Valid Choices:
-       intl | us | uk | au | nl | ca | se | dk | es
-     tx.fhir.org only supports a subset. To add to this list or tx.fhir.org
-     ask on https://chat.fhir.org/#narrow/stream/179202-terminology
--native: use schema for validation as well
-     * XML: w3c schema+schematron
-     * JSON: json.schema
-     * RDF: SHEX
-     Default: false
--language: [lang]
-     The language to use when validating coding displays - same value as for xml:lang
-     Not used if the resource specifies language
-     Default: no specified language
--strictExtensions: If present, treat extensions not defined within the specified FHIR version and any
-     referenced implementation guides or profiles as errors.  (Default is to only raise information messages.)
--hintAboutNonMustSupport: If present, raise hints if the instance contains data elements that are not
-     marked as mustSupport=true.  Useful to identify elements included that may be ignored by recipients
--assumeValidRestReferences: If present, assume that URLs that reference resources follow the RESTful URI pattern
-     and it is safe to infer the type from the URL
--security-checks: If present, check that string content doesn't include any html-like tags that might create
-     problems downstream (though all external input must always be santized by escaping for either html or sql)
+       • XML and JSON Schema: FHIR versions 1.0, 1.4, 3.0, 4.0, 4.5
 
-The validator also supports the param -proxy=[address]:[port] for if you use a proxy
+       • Turtle: FHIR versions 3.0, 4.0, 4.5
 
-Parameters can appear in any order
+OPTIONS
+       SOURCE A  file,  URL, directory or pattern for resources to validate.  At least one source must be declared.  If there is more than one source or if the source is other than a single
+              file or URL and the output parameter is used, results will be provided as a Bundle.  Patterns are limited to a directory followed by a filename with an embedded asterisk.
 
-Alternatively, you can use the validator to execute a transformation as described by a structure map.
-To do this, you must provide some additional parameters:
+       -assumeValidRestReferences
+              If present, assume that URLs that reference resources follow the RESTful URI pattern and it is safe to infer the type from the URL.  Default: disabled
 
- -transform [map]
+       -convert
+              Convert a resource or logical model.  This parameter requires the parameters SOURCE and -output.  The parameter -ig may be used to provide a logical model.  Default: disabled
 
-* [map] the URI of the map that the transform starts with
+       -debug Produce additional information about the loading and validation process.  Default: disabled
 
-Any other dependency maps have to be loaded through an -ig reference 
+       -fhirpath [expression]
+              Evaluate a FHIRPath expression on a resource or logical model.  This requires the parameter SOURCE.  The parameter -ig may be used to provide a logical model.
 
--transform uses the parameters -defn, -txserver, -ig (at least one with the map files), and -output
+       -hintAboutNonMustSupport
+              If present, raise hints if the instance contains data elements that are not marked as mustSupport=true.  Useful to identify elements included that may be  ignored  by  recipi‐
+              ents.  Default: disabled
 
-Alternatively, you can use the validator to generate narrative for a resource.
-To do this, you must provide a specific parameter:
+       -ig [package|file|folder|url]
+              An  implementation guide or profile definition to load.  Can be the URL of an implementation guide or a package ([id]-[ver]) for a built implementation guide or a local folder
+              that contains a set of conformance resources.  This parameter can appear any number of times.  Default: none
 
- -narrative
+       -language: [lang]
+              Specifies the language to use when validating coding displays (same value as for xml:lang).  This option is ignored if the resource specifies a language.  Default: none
 
--narrative requires the parameters -defn, -txserver, -source, and -output. ig and profile may be used
+       -locale [locale]
+              Specifies the locale or language of the validation result messages (e.g.: de-DE).  Default: en
 
-Alternatively, you can use the validator to convert a resource or logical model.
-To do this, you must provide a specific parameter:
+       -narrative
+              Generate narrative for a resource.  This parameter requires the parameters -defn, -tx, SOURCE, and -output.  The parameters -ig and -profile may be used.  Default: disabled
 
- -convert
+       -native [true|false]
+              Use XML schema (W3C XML Schema and schematron), JSON schema and RDP (ShEx) for validation as well.  Default: false
 
--convert requires the parameters -source and -output. ig may be used to provide a logical model
+       -output [file]
+              A filename for the results (OperationOutcome).  Default: stdout
 
-Alternatively, you can use the validator to evaluate a FHIRPath expression on a resource or logical model.
-To do this, you must provide a specific parameter:
+       -profile [url]
+              The canonical URL to validate against (same as if it was specified in Resource.meta.profile).  If no profile is specified, the resource is validated against the base  specifi‐
+              cation.   This  parameter can appear any number of times.  (Note: The profile and its dependencies have to be made available through one of the -ig parameters.  Package depen‐
+              dencies will automatically be resolved.) Default: none
 
- -fhirpath [FHIRPath]
+       -proxy [address]:[port]
+              Specifies the proxy address and port to use.  Default: disabled
 
-* [FHIRPath] the FHIRPath expression to evaluate
+       -questionnaire [file|url]
+              The location of a questionnaire.  If provided, then the validator will validate any QuestionnaireResponse that claims to match the Questionnaire against  it.   This  parameter
+              can appear any number of times.  Default: none
 
--fhirpath requires the parameters -source. ig may be used to provide a logical model
+       -recurse
+              Look in subfolders when -ig refers to a folder.  Default: disabled
 
-Finally, you can use the validator to generate a snapshot for a profile.
-To do this, you must provide a specific parameter:
+       -sct [intl|us|uk|au|nl|ca|se|dk|es]
+              Specify  the  edition  of  SNOMED  CT to use.  The default FHIR terminology service only supports a subset.  To add to this list or the default FHIR terminology service ask on
+              https://chat.fhir.org/#narrow/stream/179202-terminology.  Default: disabled
 
- -snapshot
+       -security-checks
+              If present, check that string content doesn't include any HTML-like tags that might create problems downstream (though all external input must always be sanitized by  escaping
+              for either HTML or SQL).  Default: disabled
 
--snapshot requires the parameters -defn, -txserver, -source, and -output. ig may be used to provide necessary base profiles
+       -snapshot
+              Generate  a snapshot for a profile.  This requires the parameters -defn, -tx, SOURCE, and -output.  The parameter -ig may be used to provide necessary base profiles.  Default:
+              disabled
+
+       -strictExtensions
+              If present, treat extensions not defined within the specified FHIR version and any referenced implementation guides or profiles as error.  Default: information
+
+       -transform [uri]
+              Execute a transformation as described by a structure map given by its URI the transformation starts with.  Any other dependency maps have to be loaded using -ig parameters  to
+              reference those maps.  (Note: This parameter uses the parameters -defn, -tx, -ig and -output.  Default: disabled
+
+       -tx [url]
+              The base URL of a FHIR terminology service.  To run without terminology value, specify n/a as URL.  This parameter can appear only once.  Default: http://tx.fhir.org
+
+       -txLog [file]
+              Produce a log of the terminology server operations in [file].  Default: disabled
+
+       -version [1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0]
+              The FHIR version to use.  This can only appear once.  Default: 4.5
+
+BUGS
+       https://github.com/hapifhir/org.hl7.fhir.core/issues
+
+COPYRIGHT
+       https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LICENSE.txt
+
+AUTHORS
+       Grahame Grieve, James Agnew and the FHIR community.
+
+validator_cli.jar 5.1.18+b7661db8                                                       November 2020                                                                        VALIDATOR_CLI(1)

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -1,4 +1,4 @@
-VALIDATOR_CLI(1)                                              VALIDATOR_CLI(1)
+VALIDATOR_CLI(1)          HL7 FHIR Java CLI Validator         VALIDATOR_CLI(1)
 
 NAME
        validator_cli.jar - validate or transform FHIR resources or bundles
@@ -147,10 +147,9 @@ BUGS
        https://github.com/hapifhir/org.hl7.fhir.core/issues
 
 COPYRIGHT
-       https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LI‐
-       CENSE.txt
+       https://github.com/hapifhir/org.hl7.fhir.core/blob/master/LICENSE.txt
 
 AUTHORS
-       Grahame Grieve, James Agnew and the FHIR community.
+       Grahame Grieve; James Agnew; FHIR community.
 
-validator_cli.jar 5.1.18+b7661db8November 2020                VALIDATOR_CLI(1)
+5.1.18+b7661d                      11/07/20                   VALIDATOR_CLI(1)

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -7,16 +7,13 @@ SYNOPSIS
        java -jar validator_cli.jar [SOURCE]... [OPTION]...
 
 DESCRIPTION
-       The  validator compares a resource against the base definitions and any
-       profiles declared in the resource (Resource.meta.profile) or  specified
-       on the command line.
+       The  HL7  FHIR validator CLI compares one or more resources against the
+       base  definitions  and  any  profiles  declared  in  a  resource   (Re‐
+       source.meta.profile) or specified on the command line.
 
-       Schema and schematron checking is performed, depending on the FHIR ver‐
-       sion as followed:
-
-       • XML and JSON Schema: FHIR versions 1.0, 1.4, 3.0, 4.0, 4.5
-
-       • Turtle: FHIR versions 3.0, 4.0, 4.5
+       To run the validator the latest version of the Java Runtime Environment
+       must be installed.  The latest validator CLI release could be download‐
+       ed from Github (https://git.io/Jkf9i).
 
 OPTIONS
        SOURCE A file, URL, directory or pattern for resources to validate.  At

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -1,4 +1,4 @@
-VALIDATOR_CLI(1)                                                                                                                                                             VALIDATOR_CLI(1)
+VALIDATOR_CLI(1)                                              VALIDATOR_CLI(1)
 
 NAME
        validator_cli.jar - validate or transform FHIR resources or bundles
@@ -7,102 +7,150 @@ SYNOPSIS
        java -jar validator_cli.jar [SOURCE] [OPTION]...
 
 DESCRIPTION
-       The validator compares a resource against the base definitions and any profiles declared in the resource (Resource.meta.profile) or specified on the command line.
+       The  validator compares a resource against the base definitions and any
+       profiles declared in the resource (Resource.meta.profile) or  specified
+       on the command line.
 
-       Schema and schematron checking is performed, depending on the FHIR version as followed:
+       Schema and schematron checking is performed, depending on the FHIR ver‐
+       sion as followed:
 
        • XML and JSON Schema: FHIR versions 1.0, 1.4, 3.0, 4.0, 4.5
 
        • Turtle: FHIR versions 3.0, 4.0, 4.5
 
 OPTIONS
-       SOURCE A  file,  URL, directory or pattern for resources to validate.  At least one source must be declared.  If there is more than one source or if the source is other than a single
-              file or URL and the output parameter is used, results will be provided as a Bundle.  Patterns are limited to a directory followed by a filename with an embedded asterisk.
+       SOURCE A file, URL, directory or pattern for resources to validate.  At
+              least  one  source  must be declared.  If there is more than one
+              source or if the source is other than a single file or  URL  and
+              the output parameter is used, results will be provided as a Bun‐
+              dle.  Patterns are limited to a directory followed by a filename
+              with an embedded asterisk.
 
        -assumeValidRestReferences
-              If present, assume that URLs that reference resources follow the RESTful URI pattern and it is safe to infer the type from the URL.  Default: disabled
+              If present, assume that URLs that reference resources follow the
+              RESTful URI pattern and it is safe to infer the  type  from  the
+              URL.  Default: disabled
 
        -convert
-              Convert a resource or logical model.  This parameter requires the parameters SOURCE and -output.  The parameter -ig may be used to provide a logical model.  Default: disabled
+              Convert  a  resource  or logical model.  This parameter requires
+              the parameters SOURCE and -output.  The  parameter  -ig  may  be
+              used to provide a logical model.  Default: disabled
 
-       -debug Produce additional information about the loading and validation process.  Default: disabled
+       -debug Produce  additional information about the loading and validation
+              process.  Default: disabled
 
        -fhirpath [expression]
-              Evaluate a FHIRPath expression on a resource or logical model.  This requires the parameter SOURCE.  The parameter -ig may be used to provide a logical model.
+              Evaluate a FHIRPath expression on a resource or  logical  model.
+              This  requires  the  parameter SOURCE.  The parameter -ig may be
+              used to provide a logical model.
 
        -hintAboutNonMustSupport
-              If present, raise hints if the instance contains data elements that are not marked as mustSupport=true.  Useful to identify elements included that may be  ignored  by  recipi‐
-              ents.  Default: disabled
+              If present, raise hints if the instance contains  data  elements
+              that are not marked as mustSupport=true.  Useful to identify el‐
+              ements included that may be  ignored  by  recipients.   Default:
+              disabled
 
        -ig [package|file|folder|url]
-              An  implementation guide or profile definition to load.  Can be the URL of an implementation guide or a package ([id]-[ver]) for a built implementation guide or a local folder
-              that contains a set of conformance resources.  This parameter can appear any number of times.  Default: none
+              An  implementation  guide or profile definition to load.  Can be
+              the URL of an implementation guide or a package ([id]-[ver]) for
+              a  built  implementation guide or a local folder that contains a
+              set of conformance resources.  This  parameter  can  appear  any
+              number of times.  Default: none
 
        -language: [lang]
-              Specifies the language to use when validating coding displays (same value as for xml:lang).  This option is ignored if the resource specifies a language.  Default: none
+              Specifies  the  language  to use when validating coding displays
+              (same value as for xml:lang).  This option is ignored if the re‐
+              source specifies a language.  Default: none
 
        -locale [locale]
-              Specifies the locale or language of the validation result messages (e.g.: de-DE).  Default: en
+              Specifies  the  locale or language of the validation result mes‐
+              sages (e.g.: de-DE).  Default: en
 
        -narrative
-              Generate narrative for a resource.  This parameter requires the parameters -defn, -tx, SOURCE, and -output.  The parameters -ig and -profile may be used.  Default: disabled
+              Generate narrative for a resource.  This parameter requires  the
+              parameters  -defn, -tx, SOURCE, and -output.  The parameters -ig
+              and -profile may be used.  Default: disabled
 
        -native [true|false]
-              Use XML schema (W3C XML Schema and schematron), JSON schema and RDP (ShEx) for validation as well.  Default: false
+              Use XML schema (W3C XML Schema and schematron), JSON schema  and
+              RDP (ShEx) for validation as well.  Default: false
 
        -output [file]
               A filename for the results (OperationOutcome).  Default: stdout
 
        -profile [url]
-              The canonical URL to validate against (same as if it was specified in Resource.meta.profile).  If no profile is specified, the resource is validated against the base  specifi‐
-              cation.   This  parameter can appear any number of times.  (Note: The profile and its dependencies have to be made available through one of the -ig parameters.  Package depen‐
-              dencies will automatically be resolved.) Default: none
+              The  canonical URL to validate against (same as if it was speci‐
+              fied in Resource.meta.profile).  If no profile is specified, the
+              resource  is validated against the base specification.  This pa‐
+              rameter can appear any number of times.  (Note: The profile  and
+              its  dependencies  have  to be made available through one of the
+              -ig parameters.  Package dependencies will automatically be  re‐
+              solved.) Default: none
 
        -proxy [address]:[port]
               Specifies the proxy address and port to use.  Default: disabled
 
        -questionnaire [file|url]
-              The location of a questionnaire.  If provided, then the validator will validate any QuestionnaireResponse that claims to match the Questionnaire against  it.   This  parameter
-              can appear any number of times.  Default: none
+              The  location of a questionnaire.  If provided, then the valida‐
+              tor will validate any QuestionnaireResponse that claims to match
+              the  Questionnaire  against  it.   This parameter can appear any
+              number of times.  Default: none
 
        -recurse
-              Look in subfolders when -ig refers to a folder.  Default: disabled
+              Look in subfolders when -ig refers to a folder.   Default:  dis‐
+              abled
 
        -sct [intl|us|uk|au|nl|ca|se|dk|es]
-              Specify  the  edition  of  SNOMED  CT to use.  The default FHIR terminology service only supports a subset.  To add to this list or the default FHIR terminology service ask on
-              https://chat.fhir.org/#narrow/stream/179202-terminology.  Default: disabled
+              Specify  the edition of SNOMED CT to use.  The default FHIR ter‐
+              minology service only supports a subset.  To add to this list or
+              the     default     FHIR     terminology    service    ask    on
+              https://chat.fhir.org/#narrow/stream/179202-terminology.     De‐
+              fault: disabled
 
        -security-checks
-              If present, check that string content doesn't include any HTML-like tags that might create problems downstream (though all external input must always be sanitized by  escaping
-              for either HTML or SQL).  Default: disabled
+              If  present,  check  that  string  content  doesn't  include any
+              HTML-like tags that might create problems downstream (though all
+              external  input  must always be sanitized by escaping for either
+              HTML or SQL).  Default: disabled
 
        -snapshot
-              Generate  a snapshot for a profile.  This requires the parameters -defn, -tx, SOURCE, and -output.  The parameter -ig may be used to provide necessary base profiles.  Default:
-              disabled
+              Generate a snapshot for a profile.  This requires the parameters
+              -defn,  -tx, SOURCE, and -output.  The parameter -ig may be used
+              to provide necessary base profiles.  Default: disabled
 
        -strictExtensions
-              If present, treat extensions not defined within the specified FHIR version and any referenced implementation guides or profiles as error.  Default: information
+              If present, treat extensions not defined  within  the  specified
+              FHIR  version  and  any referenced implementation guides or pro‐
+              files as error.  Default: information
 
        -transform [uri]
-              Execute a transformation as described by a structure map given by its URI the transformation starts with.  Any other dependency maps have to be loaded using -ig parameters  to
-              reference those maps.  (Note: This parameter uses the parameters -defn, -tx, -ig and -output.  Default: disabled
+              Execute a transformation as described by a structure  map  given
+              by its URI the transformation starts with.  Any other dependency
+              maps have to be loaded using -ig parameters to  reference  those
+              maps.  (Note: This parameter uses the parameters -defn, -tx, -ig
+              and -output.  Default: disabled
 
        -tx [url]
-              The base URL of a FHIR terminology service.  To run without terminology value, specify n/a as URL.  This parameter can appear only once.  Default: http://tx.fhir.org
+              The base URL of a FHIR terminology service.  To run without ter‐
+              minology  value,  specify n/a as URL.  This parameter can appear
+              only once.  Default: http://tx.fhir.org
 
        -txLog [file]
-              Produce a log of the terminology server operations in [file].  Default: disabled
+              Produce a log of the terminology server  operations  in  [file].
+              Default: disabled
 
        -version [1.0|1.0.2|1.4|1.4.0|3.0|3.0.2|4.0.1|4.5|4.5.0]
-              The FHIR version to use.  This can only appear once.  Default: 4.5
+              The  FHIR  version to use.  This can only appear once.  Default:
+              4.5
 
 BUGS
        https://github.com/hapifhir/org.hl7.fhir.core/issues
 
 COPYRIGHT
-       https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LICENSE.txt
+       https://raw.githubusercontent.com/hapifhir/org.hl7.fhir.core/master/LI‐
+       CENSE.txt
 
 AUTHORS
        Grahame Grieve, James Agnew and the FHIR community.
 
-validator_cli.jar 5.1.18+b7661db8                                                       November 2020                                                                        VALIDATOR_CLI(1)
+validator_cli.jar 5.1.18+b7661db8November 2020                VALIDATOR_CLI(1)

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -47,12 +47,20 @@ OPTIONS
               ements included that may be  ignored  by  recipients.   Default:
               disabled
 
-       -ig [package|file|folder|url]
-              An  implementation  guide or profile definition to load.  Can be
-              the URL of an implementation guide or a package ([id]-[ver]) for
-              a  built  implementation guide or a local folder that contains a
-              set of conformance resources.  This  parameter  can  appear  any
-              number of times.  Default: none
+       -ig <package|file|directory|url|archive>
+              Validate resources against an implementation guide.  To validate
+              against multiple implementation guides at once, each implementa‐
+              tion guide must be provided using a separate -ig parameter.   If
+              the  packages  required for validation are not already installed
+              to the FHIR package cache,  they  will  be  downloaded  and  in‐
+              stalled.   Implementation  guides  could  be provided in various
+              ways, such as a package (w/o version literal), an canonical  URL
+              or  from  local filesystem.  For examples, see EXAMPLES section.
+              Note: To validate against the current build version of  the  im‐
+              plementation  guide,  use `current' as version literal. To vali‐
+              date against a custom build implementation guide, use  `dev'  as
+              version  literal.  Note:  If the -version parameter is provided,
+              the underlying FHIR version of a package must match.
 
        -language: [lang]
               Specifies  the  language  to use when validating coding displays
@@ -167,35 +175,35 @@ EXAMPLES
 
    VALIDATION AGAINST IMPLEMENTATION GUIDE
        validator_cli.jar ./patient.xml -ig hl7.fhir.us.core
-              Validate resource against the current version of an  implementa‐
+              Validate  resource against the current version of an implementa‐
               tion guide package.
 
        validator_cli.jar ./patient.xml -ig hl7.fhir.us.core#1.0.1
-              Validate  resource  against a specific version of an implementa‐
+              Validate resource against a specific version of  an  implementa‐
               tion guide package.
 
        validator_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core
-              Validate resource against the current version of an  implementa‐
+              Validate  resource against the current version of an implementa‐
               tion guide (resource) loaded from the canonical URL.
 
        validator_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core|1.0.1
-              Validate  resource  against a specific version of an implementa‐
+              Validate resource against a specific version of  an  implementa‐
               tion guide (resource) loaded from the canonical URL.
 
        validator_cli.jar ./patient.xml -ig ./profile.xml
-              Validate resource against  an  implementation  guide  (resource)
+              Validate  resource  against  an  implementation guide (resource)
               file.
 
        validator_cli.jar ./patient.xml -ig ./profiles/
-              Validate  resource  against  any implementation guide (resource)
+              Validate resource against any  implementation  guide  (resource)
               file found in the profiles directory.
 
        validator_cli.jar ./patient.xml -ig ./profiles/*.json
-              Validate  resource  against  any   implementation   guide   (re‐
-              source)JSON file found in the profiles directory.
+              Validate  resource  against  any implementation guide (resource)
+              JSON file found in the profiles directory.
 
        validator_cli.jar ./patient.xml -ig ./profiles.tgz
-              Validate  resource  against  any  implementaion guide (resource)
+              Validate resource against  any  implementaion  guide  (resource)
               file found in the gzipped tarball profiles archive.
 
 BUGS

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -165,11 +165,49 @@ EXAMPLES
        validator_cli.jar ./patient.xml -output ./results.xml
               Write validation result messages to the a file.
 
+   VALIDATION AGAINST IMPLEMENTATION GUIDE
+       validator_cli.jar ./patient.xml -ig hl7.fhir.us.core
+              Validate resource against the current version of an  implementa‐
+              tion guide package.
+
+       validator_cli.jar ./patient.xml -ig hl7.fhir.us.core#1.0.1
+              Validate  resource  against a specific version of an implementa‐
+              tion guide package.
+
+       validator_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core
+              Validate resource against the current version of an  implementa‐
+              tion guide (resource) loaded from the canonical URL.
+
+       validator_cli.jar ./patient.xml -ig http://hl7.org/fhir/us/core|1.0.1
+              Validate  resource  against a specific version of an implementa‐
+              tion guide (resource) loaded from the canonical URL.
+
+       validator_cli.jar ./patient.xml -ig ./profile.xml
+              Validate resource against  an  implementation  guide  (resource)
+              file.
+
+       validator_cli.jar ./patient.xml -ig ./profiles/
+              Validate  resource  against  any implementation guide (resource)
+              file found in the profiles directory.
+
+       validator_cli.jar ./patient.xml -ig ./profiles/*.json
+              Validate  resource  against  any   implementation   guide   (re‐
+              source)JSON file found in the profiles directory.
+
+       validator_cli.jar ./patient.xml -ig ./profiles.tgz
+              Validate  resource  against  any  implementaion guide (resource)
+              file found in the gzipped tarball profiles archive.
+
 BUGS
        https://github.com/hapifhir/org.hl7.fhir.core/issues
 
 COPYRIGHT
        https://github.com/hapifhir/org.hl7.fhir.core/blob/master/LICENSE.txt
+
+SEE ALSO
+       For more information regarding the validation process and the validator
+       CLI itself, please see the official HL7 FHIR implementers documentation
+       (https://confluence.hl7.org/display/FHIR/Implementers).
 
 AUTHORS
        Grahame Grieve; James Agnew; FHIR community.


### PR DESCRIPTION
The help page of the validator CLI was difficult to use with regards to readability and navigation. I re-structured and formatted the help.txt file according to man page style:

- added sections and moved content
- sorted parameters lexicographical
- did minor spellchecking
- added some metadata