### PR TITLE
Improve numeric comparison of package versions

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.utilities.npm.NpmPackage;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -250,14 +249,18 @@ public class VersionUtilities {
       if (testPart.equals(currentPart)) {
         continue;
       }
-      if (StringUtils.isNumeric(testPart) && StringUtils.isNumeric(currentPart)) {
-        return Integer.parseInt(currentPart) - Integer.parseInt(testPart) > 0;
-      } else {
-        return currentPart.compareTo(testPart) >= 0;
-      }
+      return compareVersionPart(testPart, currentPart);
     }
 
     return true;
+  }
+
+  private static boolean compareVersionPart(String theTestPart, String theCurrentPart) {
+    if (StringUtils.isNumeric(theTestPart) && StringUtils.isNumeric(theCurrentPart)) {
+      return Integer.parseInt(theCurrentPart) - Integer.parseInt(theTestPart) >= 0;
+    } else {
+      return theCurrentPart.compareTo(theTestPart) >= 0;
+    }
   }
 
   /** 
@@ -277,7 +280,7 @@ public class VersionUtilities {
         return true;
       }
       if (pc!=null) {
-        return pc.compareTo(pt) >= 0;
+        return compareVersionPart(pt, pc);
       }
     }
     return false;

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/VersionUtilitiesTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/VersionUtilitiesTest.java
@@ -1,0 +1,34 @@
+package org.hl7.fhir.utilities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VersionUtilitiesTest {
+
+  @Test
+  public void isThisOrLater_Simple() {
+    assertTrue(VersionUtilities.isThisOrLater("0.1", "0.2"));
+    assertFalse(VersionUtilities.isThisOrLater("0.2", "0.1"));
+  }
+
+  @Test
+  public void isThisOrLater_NeedNumericComparison() {
+    assertTrue(VersionUtilities.isThisOrLater("0.9", "0.10"));
+    assertFalse(VersionUtilities.isThisOrLater("0.10", "0.9"));
+  }
+
+  @Test
+  public void isThisOrLater_DifferentLengths() {
+    assertTrue(VersionUtilities.isThisOrLater("0.9", "0.9.1"));
+    assertFalse(VersionUtilities.isThisOrLater("0.9.1", "0.9"));
+  }
+
+  @Test
+  public void isThisOrLater_NonNumeric() {
+    assertTrue(VersionUtilities.isThisOrLater("0.A", "0.B"));
+    assertFalse(VersionUtilities.isThisOrLater("0.B", "0.A"));
+  }
+
+
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/VersionUtilitiesTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/VersionUtilitiesTest.java
@@ -31,4 +31,18 @@ public class VersionUtilitiesTest {
   }
 
 
+  @Test
+  public void isMajMinOrLaterPatch_Simple() {
+    assertTrue(VersionUtilities.isMajMinOrLaterPatch("0.9.0", "0.9.0"));
+    assertTrue(VersionUtilities.isMajMinOrLaterPatch("0.9.0", "0.9.1"));
+    assertFalse(VersionUtilities.isThisOrLater("0.9.0", "0.8.1"));
+  }
+
+  @Test
+  public void isMajMinOrLaterPatch_VersionWithX() {
+    assertTrue(VersionUtilities.isMajMinOrLaterPatch("0.9.x", "0.9.0"));
+    assertTrue(VersionUtilities.isMajMinOrLaterPatch("0.9.x", "0.9.1"));
+    assertFalse(VersionUtilities.isThisOrLater("0.9.x", "0.8.1"));
+  }
+
 }


### PR DESCRIPTION
Because of the way versions were compared, the package client would assume that version `1.0.9` was newer than `1.0.10`. This PR adds a smarter version comparison algorithm,