### PR TITLE
Fix for issue #373

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
@@ -18,8 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
-
 /*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
@@ -46,10 +44,9 @@ import java.util.stream.Collectors;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
-public class VersionConvertor_10_30 {
 
+public class VersionConvertor_10_30 {
   public static void copyElement(org.hl7.fhir.dstu2.model.Element src, org.hl7.fhir.dstu3.model.Element tgt) throws FHIRException {
     tgt.setId(src.getId());
     for (org.hl7.fhir.dstu2.model.Extension e : src.getExtension()) {
@@ -300,1539 +297,1335 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.dstu2.model.Extension src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
     copyElement(src, tgt);
-    if (src.hasUrlElement())
-      tgt.setUrlElement(convertUri(src.getUrlElement()));
-    if (src.hasValue())
-      tgt.setValue(convertType(src.getValue()));
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Extension tgt = new org.hl7.fhir.dstu2.model.Extension();
     copyElement(src, tgt);
-    if (src.hasUrlElement())
-      tgt.setUrlElement(convertUri(src.getUrlElement()));
-    if (src.hasValue())
-      tgt.setValue(convertType(src.getValue()));
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.dstu2.model.Narrative src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
     copyElement(src, tgt);
-    if (src.hasStatus())
-      tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-    if (src.hasDiv())
-      tgt.setDiv(src.getDiv());
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Narrative tgt = new org.hl7.fhir.dstu2.model.Narrative();
     copyElement(src, tgt);
-    if (src.hasStatus())
-      tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
     tgt.setDiv(src.getDiv());
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case GENERATED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
-        break;
-      case EXTENSIONS:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
-        break;
-      case ADDITIONAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
-        break;
-      case EMPTY:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Narrative.NarrativeStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case GENERATED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
-        break;
-      case EXTENSIONS:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
-        break;
-      case ADDITIONAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
-        break;
-      case EMPTY:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.dstu2.model.Annotation src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
     copyElement(src, tgt);
-    if (src.hasAuthor())
-      tgt.setAuthor(convertType(src.getAuthor()));
-    if (src.hasTimeElement())
-      tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Annotation tgt = new org.hl7.fhir.dstu2.model.Annotation();
     copyElement(src, tgt);
-    if (src.hasAuthor())
-      tgt.setAuthor(convertType(src.getAuthor()));
-    if (src.hasTimeElement())
-      tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.dstu2.model.Attachment src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
     copyElement(src, tgt);
-    if (src.hasContentTypeElement())
-      tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-    if (src.hasLanguageElement())
-      tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    if (src.hasDataElement())
-      tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-    if (src.hasUrlElement())
-      tgt.setUrlElement(convertUri(src.getUrlElement()));
-    if (src.hasSizeElement())
-      tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-    if (src.hasHashElement())
-      tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-    if (src.hasTitleElement())
-      tgt.setTitleElement(convertString(src.getTitleElement()));
-    if (src.hasCreationElement())
-      tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasSizeElement()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Attachment tgt = new org.hl7.fhir.dstu2.model.Attachment();
     copyElement(src, tgt);
-    if (src.hasContentTypeElement())
-      tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-    if (src.hasLanguageElement())
-      tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    if (src.hasDataElement())
-      tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-    if (src.hasUrlElement())
-      tgt.setUrlElement(convertUri(src.getUrlElement()));
-    if (src.hasSizeElement())
-      tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-    if (src.hasHashElement())
-      tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-    if (src.hasTitleElement())
-      tgt.setTitleElement(convertString(src.getTitleElement()));
-    if (src.hasCreationElement())
-      tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasSizeElement()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2.model.CodeableConcept src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu2.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.CodeableConcept tgt = new org.hl7.fhir.dstu2.model.CodeableConcept();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.dstu2.model.Coding src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
     copyElement(src, tgt);
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasVersionElement())
-      tgt.setVersionElement(convertString(src.getVersionElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
-    if (src.hasDisplayElement())
-      tgt.setDisplayElement(convertString(src.getDisplayElement()));
-    if (src.hasUserSelectedElement())
-      tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Coding tgt = new org.hl7.fhir.dstu2.model.Coding();
     copyElement(src, tgt);
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasVersionElement())
-      tgt.setVersionElement(convertString(src.getVersionElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
-    if (src.hasDisplayElement())
-      tgt.setDisplayElement(convertString(src.getDisplayElement()));
-    if (src.hasUserSelectedElement())
-      tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.dstu2.model.Identifier src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-    if (src.hasType())
-      tgt.setType(convertCodeableConcept(src.getType()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasValueElement())
-      tgt.setValueElement(convertString(src.getValueElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
-    if (src.hasAssigner())
-      tgt.setAssigner(convertReference(src.getAssigner()));
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Identifier tgt = new org.hl7.fhir.dstu2.model.Identifier();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-    if (src.hasType())
-      tgt.setType(convertCodeableConcept(src.getType()));
-    if (src.hasSystem())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasValue())
-      tgt.setValueElement(convertString(src.getValueElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
-    if (src.hasAssigner())
-      tgt.setAssigner(convertReference(src.getAssigner()));
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case USUAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
-        break;
-      case OFFICIAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
-        break;
-      case SECONDARY:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Identifier.IdentifierUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case USUAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
-        break;
-      case OFFICIAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
-        break;
-      case SECONDARY:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.dstu2.model.Period src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
     copyElement(src, tgt);
-    if (src.hasStartElement())
-      tgt.setStartElement(convertDateTime(src.getStartElement()));
-    if (src.hasEndElement())
-      tgt.setEndElement(convertDateTime(src.getEndElement()));
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Period tgt = new org.hl7.fhir.dstu2.model.Period();
     copyElement(src, tgt);
-    if (src.hasStartElement())
-      tgt.setStartElement(convertDateTime(src.getStartElement()));
-    if (src.hasEndElement())
-      tgt.setEndElement(convertDateTime(src.getEndElement()));
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.dstu2.model.Quantity src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Quantity tgt = new org.hl7.fhir.dstu2.model.Quantity();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case LESS_THAN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
-        break;
-      case LESS_OR_EQUAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-        break;
-      case GREATER_OR_EQUAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-        break;
-      case GREATER_THAN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Quantity.QuantityComparatorEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case LESS_THAN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
-        break;
-      case LESS_OR_EQUAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-        break;
-      case GREATER_OR_EQUAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-        break;
-      case GREATER_THAN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.dstu2.model.Range src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
     copyElement(src, tgt);
-    if (src.hasLow())
-      tgt.setLow(convertSimpleQuantity(src.getLow()));
-    if (src.hasHigh())
-      tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Range tgt = new org.hl7.fhir.dstu2.model.Range();
     copyElement(src, tgt);
-    if (src.hasLow())
-      tgt.setLow(convertSimpleQuantity(src.getLow()));
-    if (src.hasHigh())
-      tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.dstu2.model.Ratio src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
     copyElement(src, tgt);
-    if (src.hasNumerator())
-      tgt.setNumerator(convertQuantity(src.getNumerator()));
-    if (src.hasDenominator())
-      tgt.setDenominator(convertQuantity(src.getDenominator()));
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Ratio tgt = new org.hl7.fhir.dstu2.model.Ratio();
     copyElement(src, tgt);
-    if (src.hasNumerator())
-      tgt.setNumerator(convertQuantity(src.getNumerator()));
-    if (src.hasDenominator())
-      tgt.setDenominator(convertQuantity(src.getDenominator()));
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.dstu2.model.Reference src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
     copyElement(src, tgt);
-    if (src.hasReference())
-      tgt.setReference(src.getReference());
-    if (src.hasDisplayElement())
-      tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Reference tgt = new org.hl7.fhir.dstu2.model.Reference();
     copyElement(src, tgt);
-    if (src.hasReference())
-      tgt.setReference(src.getReference());
-    if (src.hasDisplayElement())
-      tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.dstu2.model.SampledData src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
     copyElement(src, tgt);
-    if (src.hasOrigin())
-      tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-    if (src.hasPeriodElement())
-      tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-    if (src.hasFactorElement())
-      tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-    if (src.hasLowerLimitElement())
-      tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-    if (src.hasUpperLimitElement())
-      tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-    if (src.hasDimensionsElement())
-      tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-    if (src.hasDataElement())
-      tgt.setDataElement(convertString(src.getDataElement()));
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.SampledData tgt = new org.hl7.fhir.dstu2.model.SampledData();
     copyElement(src, tgt);
-    if (src.hasOrigin())
-      tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-    if (src.hasPeriodElement())
-      tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-    if (src.hasFactorElement())
-      tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-    if (src.hasLowerLimitElement())
-      tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-    if (src.hasUpperLimitElement())
-      tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-    if (src.hasDimensionsElement())
-      tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-    if (src.hasDataElement())
-      tgt.setDataElement(convertString(src.getDataElement()));
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.dstu2.model.Signature src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu2.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-    if (src.hasWhenElement())
-      tgt.setWhenElement(convertInstant(src.getWhenElement()));
-    if (src.hasWho())
-      tgt.setWho(convertType(src.getWho()));
-    if (src.hasContentTypeElement())
-      tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-    if (src.hasBlobElement())
-      tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlobElement()) tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Signature tgt = new org.hl7.fhir.dstu2.model.Signature();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-    if (src.hasWhenElement())
-      tgt.setWhenElement(convertInstant(src.getWhenElement()));
-    if (src.hasWho())
-      tgt.setWho(convertType(src.getWho()));
-    if (src.hasContentTypeElement())
-      tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-    if (src.hasBlobElement())
-      tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlobElement()) tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.dstu2.model.Address src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertAddressUse(src.getUseElement()));
-    if (src.hasType())
-      tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     for (org.hl7.fhir.dstu2.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-    if (src.hasCityElement())
-      tgt.setCityElement(convertString(src.getCityElement()));
-    if (src.hasDistrictElement())
-      tgt.setDistrictElement(convertString(src.getDistrictElement()));
-    if (src.hasStateElement())
-      tgt.setStateElement(convertString(src.getStateElement()));
-    if (src.hasPostalCodeElement())
-      tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-    if (src.hasCountryElement())
-      tgt.setCountryElement(convertString(src.getCountryElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Address tgt = new org.hl7.fhir.dstu2.model.Address();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertAddressUse(src.getUseElement()));
-    if (src.hasType())
-      tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-    if (src.hasCityElement())
-      tgt.setCityElement(convertString(src.getCityElement()));
-    if (src.hasDistrictElement())
-      tgt.setDistrictElement(convertString(src.getDistrictElement()));
-    if (src.hasStateElement())
-      tgt.setStateElement(convertString(src.getStateElement()));
-    if (src.hasPostalCodeElement())
-      tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-    if (src.hasCountryElement())
-      tgt.setCountryElement(convertString(src.getCountryElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HOME:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
-        break;
-      case WORK:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HOME:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
-        break;
-      case WORK:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case POSTAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
-        break;
-      case PHYSICAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
-        break;
-      case BOTH:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressTypeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case POSTAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
-        break;
-      case PHYSICAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
-        break;
-      case BOTH:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2.model.ContactPoint src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
     copyElement(src, tgt);
-    if (src.hasSystem())
-      tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-    if (src.hasValueElement())
-      tgt.setValueElement(convertString(src.getValueElement()));
-    if (src.hasUse())
-      tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-    if (src.hasRank())
-      tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ContactPoint tgt = new org.hl7.fhir.dstu2.model.ContactPoint();
     copyElement(src, tgt);
-    if (src.hasSystem())
-      tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-    if (src.hasValueElement())
-      tgt.setValueElement(convertString(src.getValueElement()));
-    if (src.hasUse())
-      tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-    if (src.hasRankElement())
-      tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRankElement()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case PHONE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
-        break;
-      case FAX:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
-        break;
-      case EMAIL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
-        break;
-      case PAGER:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
-        break;
-      case OTHER:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystemEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case PHONE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
-        break;
-      case FAX:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
-        break;
-      case EMAIL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
-        break;
-      case PAGER:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
-        break;
-      case OTHER:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-        break;
-      case URL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HOME:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
-        break;
-      case WORK:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
-        break;
-      case MOBILE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HOME:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
-        break;
-      case WORK:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
-        break;
-      case MOBILE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2.model.ElementDefinition src, List<String> slicePaths) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
     copyElement(src, tgt);
-    if (src.hasPathElement())
-      tgt.setPathElement(convertString(src.getPathElement()));
-    tgt.setRepresentation(src.getRepresentation().stream()
-      .map(VersionConvertor_10_30::convertPropertyRepresentation)
-      .collect(Collectors.toList()));
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_30::convertPropertyRepresentation).collect(Collectors.toList()));
     if (src.hasName()) {
-      if (slicePaths.contains(src.getPath()))
-        tgt.setSliceNameElement(convertString(src.getNameElement()));
-      if (src.hasNameElement())
-        tgt.setIdElement(convertString(src.getNameElement()));
+      if (slicePaths.contains(src.getPath())) tgt.setSliceNameElement(convertString(src.getNameElement()));
+      if (src.hasNameElement()) tgt.setIdElement(convertString(src.getNameElement()));
     }
-    if (src.hasLabel())
-      tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
     for (org.hl7.fhir.dstu2.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-    if (src.hasSlicing())
-      tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-    if (src.hasShort())
-      tgt.setShortElement(convertString(src.getShortElement()));
-    if (src.hasDefinition())
-      tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-    if (src.hasComments())
-      tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-    if (src.hasRequirements())
-      tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
     for (org.hl7.fhir.dstu2.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-    if (src.hasMin())
-      tgt.setMin(src.getMin());
-    if (src.hasMax())
-      tgt.setMaxElement(convertString(src.getMaxElement()));
-    if (src.hasBase())
-      tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-    if (src.hasNameReference())
-      tgt.setContentReference("#" + src.getNameReference());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasNameReference()) tgt.setContentReference("#" + src.getNameReference());
     for (org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent t : src.getType())
       tgt.addType(convertElementDefinitionTypeComponent(t));
-    if (src.hasDefaultValue())
-      tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
     if (src.hasMeaningWhenMissing())
       tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-    if (src.hasFixed())
-      tgt.setFixed(convertType(src.getFixed()));
-    if (src.hasPattern())
-      tgt.setPattern(convertType(src.getPattern()));
-    if (src.hasExample())
-      tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-    if (src.hasMinValue())
-      tgt.setMinValue(convertType(src.getMinValue()));
-    if (src.hasMaxValue())
-      tgt.setMaxValue(convertType(src.getMaxValue()));
-    if (src.hasMaxLength())
-      tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
     for (org.hl7.fhir.dstu2.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
     for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
       tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-    if (src.hasMustSupport())
-      tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-    if (src.hasIsModifier())
-      tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-    if (src.hasIsSummary())
-      tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-    if (src.hasBinding())
-      tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
     for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
       tgt.addMapping(convertElementDefinitionMappingComponent(t));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition tgt = new org.hl7.fhir.dstu2.model.ElementDefinition();
     copyElement(src, tgt);
-    if (src.hasPathElement())
-      tgt.setPathElement(convertString(src.getPathElement()));
-    tgt.setRepresentation(src.getRepresentation().stream()
-      .map(VersionConvertor_10_30::convertPropertyRepresentation)
-      .collect(Collectors.toList()));
-    if (src.hasSliceName())
-      tgt.setNameElement(convertString(src.getSliceNameElement()));
-    else
-      tgt.setNameElement(convertString(src.getIdElement()));
-    if (src.hasLabelElement())
-      tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_30::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    else tgt.setNameElement(convertString(src.getIdElement()));
+    if (src.hasLabelElement()) tgt.setLabelElement(convertString(src.getLabelElement()));
     for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-    if (src.hasSlicing())
-      tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-    if (src.hasShortElement())
-      tgt.setShortElement(convertString(src.getShortElement()));
-    if (src.hasDefinitionElement())
-      tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-    if (src.hasCommentElement())
-      tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-    if (src.hasRequirementsElement())
-      tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShortElement()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinitionElement()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasCommentElement()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
     for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
     tgt.setMin(src.getMin());
-    if (src.hasMaxElement())
-      tgt.setMaxElement(convertString(src.getMaxElement()));
-    if (src.hasBase())
-      tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-    if (src.hasContentReference())
-      tgt.setNameReference(src.getContentReference().substring(1));
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setNameReference(src.getContentReference().substring(1));
     for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType())
       tgt.addType(convertElementDefinitionTypeComponent(t));
-    if (src.hasDefaultValue())
-      tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
     if (src.hasMeaningWhenMissingElement())
       tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-    if (src.hasFixed())
-      tgt.setFixed(convertType(src.getFixed()));
-    if (src.hasPattern())
-      tgt.setPattern(convertType(src.getPattern()));
-    if (src.hasExample())
-      tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
-    if (src.hasMinValue())
-      tgt.setMinValue(convertType(src.getMinValue()));
-    if (src.hasMaxValue())
-      tgt.setMaxValue(convertType(src.getMaxValue()));
-    if (src.hasMaxLengthElement())
-      tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLengthElement()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
     for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
     for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
       tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-    if (src.hasMustSupportElement())
-      tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-    if (src.hasIsModifierElement())
-      tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-    if (src.hasIsSummaryElement())
-      tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-    if (src.hasBinding())
-      tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    if (src.hasMustSupportElement()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifierElement()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsSummaryElement()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
     for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
       tgt.addMapping(convertElementDefinitionMappingComponent(t));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case XMLATTR:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentationEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case XMLATTR:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu2.model.StringType t : src.getDiscriminator())
       tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue()));
-    if (src.hasDescriptionElement())
-      tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-    if (src.hasOrderedElement())
-      tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-    if (src.hasRules())
-      tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent();
     copyElement(src, tgt);
     for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
       tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-    if (src.hasDescriptionElement())
-      tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-    if (src.hasOrderedElement())
-      tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-    if (src.hasRules())
-      tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CLOSED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
-        break;
-      case OPEN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
-        break;
-      case OPENATEND:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRulesEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CLOSED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
-        break;
-      case OPEN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
-        break;
-      case OPENATEND:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
     copyElement(src, tgt);
-    if (src.hasPathElement())
-      tgt.setPathElement(convertString(src.getPathElement()));
-    if (src.hasMin())
-      tgt.setMin(src.getMin());
-    if (src.hasMaxElement())
-      tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent();
     copyElement(src, tgt);
-    if (src.hasPathElement())
-      tgt.setPathElement(convertString(src.getPathElement()));
-    if (src.hasMin())
-      tgt.setMin(src.getMin());
-    if (src.hasMaxElement())
-      tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent convertElementDefinitionTypeComponent(org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
     copyElement(src, tgt);
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCodeToUri(src.getCodeElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCodeToUri(src.getCodeElement()));
     for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile())
-      if (src.hasTarget())
-        tgt.setTargetProfile(t.getValueAsString());
-      else
-        tgt.setProfile(t.getValue());
-    tgt.setAggregation(src.getAggregation().stream()
-      .map(VersionConvertor_10_30::convertAggregationMode)
-      .collect(Collectors.toList()));
+      if (src.hasTarget()) tgt.setTargetProfile(t.getValueAsString());
+      else tgt.setProfile(t.getValue());
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_10_30::convertAggregationMode).collect(Collectors.toList()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent convertElementDefinitionTypeComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent();
     copyElement(src, tgt);
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertUriToCode(src.getCodeElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertUriToCode(src.getCodeElement()));
     if (src.hasTarget()) {
-      if (src.hasTargetProfile())
-        tgt.addProfile(src.getTargetProfile());
-    } else if (src.hasProfile())
-      tgt.addProfile(src.getProfile());
-    tgt.setAggregation(src.getAggregation().stream()
-      .map(VersionConvertor_10_30::convertAggregationMode)
-      .collect(Collectors.toList()));
+      if (src.hasTargetProfile()) tgt.addProfile(src.getTargetProfile());
+    } else if (src.hasProfile()) tgt.addProfile(src.getProfile());
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_10_30::convertAggregationMode).collect(Collectors.toList()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CONTAINED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
-        break;
-      case REFERENCED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
-        break;
-      case BUNDLED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.AggregationModeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CONTAINED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
-        break;
-      case REFERENCED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
-        break;
-      case BUNDLED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
     copyElement(src, tgt);
-    if (src.hasKeyElement())
-      tgt.setKeyElement(convertId(src.getKeyElement()));
-    if (src.hasRequirementsElement())
-      tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-    if (src.hasSeverity())
-      tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-    if (src.hasHumanElement())
-      tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
     tgt.setExpression(ToolingExtensions.readStringExtension(src, ToolingExtensions.EXT_EXPRESSION));
-    if (src.hasXpathElement())
-      tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent();
     copyElement(src, tgt);
-    if (src.hasKeyElement())
-      tgt.setKeyElement(convertId(src.getKeyElement()));
-    if (src.hasRequirementsElement())
-      tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-    if (src.hasSeverity())
-      tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-    if (src.hasHumanElement())
-      tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
     if (src.hasExpression())
       ToolingExtensions.addStringExtension(tgt, ToolingExtensions.EXT_EXPRESSION, src.getExpression());
-    if (src.hasXpathElement())
-      tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case ERROR:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
-        break;
-      case WARNING:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverityEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case ERROR:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
-        break;
-      case WARNING:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
     copyElement(src, tgt);
-    if (src.hasStrength())
-      tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-    if (src.hasDescriptionElement())
-      tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-    if (src.hasValueSet())
-      tgt.setValueSet(convertType(src.getValueSet()));
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSet(convertType(src.getValueSet()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent();
     copyElement(src, tgt);
-    if (src.hasStrength())
-      tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-    if (src.hasDescriptionElement())
-      tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-    if (src.hasValueSet())
-      tgt.setValueSet(convertType(src.getValueSet()));
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSet(convertType(src.getValueSet()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case REQUIRED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
-        break;
-      case EXTENSIBLE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
-        break;
-      case PREFERRED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
-        break;
-      case EXAMPLE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.BindingStrengthEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case REQUIRED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
-        break;
-      case EXTENSIBLE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
-        break;
-      case PREFERRED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
-        break;
-      case EXAMPLE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
     copyElement(src, tgt);
-    if (src.hasIdentityElement())
-      tgt.setIdentityElement(convertId(src.getIdentityElement()));
-    if (src.hasLanguageElement())
-      tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    if (src.hasMapElement())
-      tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent();
     copyElement(src, tgt);
-    if (src.hasIdentityElement())
-      tgt.setIdentityElement(convertId(src.getIdentityElement()));
-    if (src.hasLanguageElement())
-      tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    if (src.hasMapElement())
-      tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.dstu2.model.HumanName src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertNameUse(src.getUseElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
     for (org.hl7.fhir.dstu2.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
     for (org.hl7.fhir.dstu2.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
     for (org.hl7.fhir.dstu2.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
     for (org.hl7.fhir.dstu2.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.HumanName tgt = new org.hl7.fhir.dstu2.model.HumanName();
     copyElement(src, tgt);
-    if (src.hasUse())
-      tgt.setUseElement(convertNameUse(src.getUseElement()));
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
-    if (src.hasFamily())
-      tgt.addFamily(src.getFamily());
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
     for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
     for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
     for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-    if (src.hasPeriod())
-      tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case USUAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
-        break;
-      case OFFICIAL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
-        break;
-      case NICKNAME:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
-        break;
-      case ANONYMOUS:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
-        break;
-      case MAIDEN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.HumanName.NameUseEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case USUAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
-        break;
-      case OFFICIAL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
-        break;
-      case TEMP:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
-        break;
-      case NICKNAME:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
-        break;
-      case ANONYMOUS:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
-        break;
-      case OLD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
-        break;
-      case MAIDEN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.dstu2.model.Meta src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
     copyElement(src, tgt);
-    if (src.hasVersionIdElement())
-      tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-    if (src.hasLastUpdatedElement())
-      tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
     for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
     for (org.hl7.fhir.dstu2.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
     for (org.hl7.fhir.dstu2.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
@@ -1840,14 +1633,11 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu2.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Meta tgt = new org.hl7.fhir.dstu2.model.Meta();
     copyElement(src, tgt);
-    if (src.hasVersionIdElement())
-      tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-    if (src.hasLastUpdatedElement())
-      tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
     for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
     for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
     for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
@@ -1855,487 +1645,397 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.dstu2.model.Timing src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu2.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-    if (src.hasRepeat())
-      tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-    if (src.hasCode())
-      tgt.setCode(convertCodeableConcept(src.getCode()));
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Timing tgt = new org.hl7.fhir.dstu2.model.Timing();
     copyElement(src, tgt);
     for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-    if (src.hasRepeat())
-      tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-    if (src.hasCode())
-      tgt.setCode(convertCodeableConcept(src.getCode()));
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
     copyElement(src, tgt);
-    if (src.hasBounds())
-      tgt.setBounds(convertType(src.getBounds()));
-    if (src.hasCountElement())
-      tgt.setCountElement(convertInteger(src.getCountElement()));
-    if (src.hasDurationElement())
-      tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-    if (src.hasDurationMaxElement())
-      tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-    if (src.hasDurationUnits())
-      tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
-    if (src.hasFrequencyElement())
-      tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
-    if (src.hasFrequencyMaxElement())
-      tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
-    if (src.hasPeriodElement())
-      tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-    if (src.hasPeriodMaxElement())
-      tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-    if (src.hasPeriodUnits())
-      tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCountElement()) tgt.setCountElement(convertInteger(src.getCountElement()));
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnits()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
+    if (src.hasFrequencyElement()) tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
+    if (src.hasFrequencyMaxElement()) tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnits()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
     tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent();
     copyElement(src, tgt);
-    if (src.hasBounds())
-      tgt.setBounds(convertType(src.getBounds()));
-    if (src.hasCountElement())
-      tgt.setCountElement(convertInteger(src.getCountElement()));
-    if (src.hasDurationElement())
-      tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-    if (src.hasDurationMaxElement())
-      tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-    if (src.hasDurationUnit())
-      tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
-    if (src.hasFrequencyElement())
-      tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
-    if (src.hasFrequencyMaxElement())
-      tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
-    if (src.hasPeriodElement())
-      tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-    if (src.hasPeriodMaxElement())
-      tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-    if (src.hasPeriodUnit())
-      tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-    if (src.hasWhen())
-      tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCountElement()) tgt.setCountElement(convertInteger(src.getCountElement()));
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequencyElement()) tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
+    if (src.hasFrequencyMaxElement()) tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case S:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
-        break;
-      case MIN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
-        break;
-      case H:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
-        break;
-      case D:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
-        break;
-      case WK:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
-        break;
-      case MO:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
-        break;
-      case A:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.UnitsOfTimeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case S:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
-        break;
-      case MIN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
-        break;
-      case H:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
-        break;
-      case D:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
-        break;
-      case WK:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
-        break;
-      case MO:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
-        break;
-      case A:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HS:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
-        break;
-      case WAKE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
-        break;
-      case C:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
-        break;
-      case CM:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
-        break;
-      case CD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
-        break;
-      case CV:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
-        break;
-      case AC:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
-        break;
-      case ACM:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
-        break;
-      case ACD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
-        break;
-      case ACV:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
-        break;
-      case PC:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
-        break;
-      case PCM:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
-        break;
-      case PCD:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
-        break;
-      case PCV:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.EventTimingEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case HS:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
-        break;
-      case WAKE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
-        break;
-      case C:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
-        break;
-      case CM:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
-        break;
-      case CD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
-        break;
-      case CV:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
-        break;
-      case AC:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
-        break;
-      case ACM:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
-        break;
-      case ACD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
-        break;
-      case ACV:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
-        break;
-      case PC:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
-        break;
-      case PCM:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
-        break;
-      case PCD:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
-        break;
-      case PCV:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.dstu2.model.Age src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Age tgt = new org.hl7.fhir.dstu2.model.Age();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.dstu2.model.Count src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Count tgt = new org.hl7.fhir.dstu2.model.Count();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.dstu2.model.Distance src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Distance tgt = new org.hl7.fhir.dstu2.model.Distance();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.dstu2.model.Duration src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Duration tgt = new org.hl7.fhir.dstu2.model.Duration();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.dstu2.model.Money src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Money tgt = new org.hl7.fhir.dstu2.model.Money();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu2.model.SimpleQuantity src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2.model.SimpleQuantity();
     copyElement(src, tgt);
-    if (src.hasValueElement())
-      tgt.setValueElement(convertDecimal(src.getValueElement()));
-    if (src.hasComparator())
-      tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-    if (src.hasUnitElement())
-      tgt.setUnitElement(convertString(src.getUnitElement()));
-    if (src.hasSystemElement())
-      tgt.setSystemElement(convertUri(src.getSystemElement()));
-    if (src.hasCodeElement())
-      tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.dstu2.model.Type src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     if (src instanceof org.hl7.fhir.dstu2.model.Base64BinaryType)
       return convertBase64Binary((org.hl7.fhir.dstu2.model.Base64BinaryType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.BooleanType)
@@ -2348,8 +2048,7 @@ public class VersionConvertor_10_30 {
       return convertDateTime((org.hl7.fhir.dstu2.model.DateTimeType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.DecimalType)
       return convertDecimal((org.hl7.fhir.dstu2.model.DecimalType) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.IdType)
-      return convertId((org.hl7.fhir.dstu2.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.IdType) return convertId((org.hl7.fhir.dstu2.model.IdType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
       return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
@@ -2360,16 +2059,14 @@ public class VersionConvertor_10_30 {
       return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
       return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.OidType)
-      return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OidType) return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.StringType)
       return convertString((org.hl7.fhir.dstu2.model.StringType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
       return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
       return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.UriType)
-      return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UriType) return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Extension)
       return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
@@ -2380,30 +2077,23 @@ public class VersionConvertor_10_30 {
       return convertAttachment((org.hl7.fhir.dstu2.model.Attachment) src);
     if (src instanceof org.hl7.fhir.dstu2.model.CodeableConcept)
       return convertCodeableConcept((org.hl7.fhir.dstu2.model.CodeableConcept) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Coding)
-      return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Coding) return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Identifier)
       return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Period)
-      return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Age)
-      return convertAge((org.hl7.fhir.dstu2.model.Age) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Count)
-      return convertCount((org.hl7.fhir.dstu2.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Period) return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Age) return convertAge((org.hl7.fhir.dstu2.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Count) return convertCount((org.hl7.fhir.dstu2.model.Count) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Distance)
       return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Duration)
       return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Money)
-      return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Money) return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
     if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
       return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
       return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Range)
-      return convertRange((org.hl7.fhir.dstu2.model.Range) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Ratio)
-      return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Range) return convertRange((org.hl7.fhir.dstu2.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Ratio) return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Reference)
       return convertReference((org.hl7.fhir.dstu2.model.Reference) src);
     if (src instanceof org.hl7.fhir.dstu2.model.SampledData)
@@ -2418,16 +2108,13 @@ public class VersionConvertor_10_30 {
       return convertElementDefinition((org.hl7.fhir.dstu2.model.ElementDefinition) src, new ArrayList<String>());
     if (src instanceof org.hl7.fhir.dstu2.model.HumanName)
       return convertHumanName((org.hl7.fhir.dstu2.model.HumanName) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Meta)
-      return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
-    if (src instanceof org.hl7.fhir.dstu2.model.Timing)
-      return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Meta) return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Timing) return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
     throw new FHIRException("Unknown type " + src.fhirType());
   }
 
   public static org.hl7.fhir.dstu2.model.Type convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
       return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
@@ -2440,8 +2127,7 @@ public class VersionConvertor_10_30 {
       return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
       return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.IdType)
-      return convertId((org.hl7.fhir.dstu3.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IdType) return convertId((org.hl7.fhir.dstu3.model.IdType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
       return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
@@ -2452,16 +2138,14 @@ public class VersionConvertor_10_30 {
       return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
       return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.OidType)
-      return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OidType) return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.StringType)
       return convertString((org.hl7.fhir.dstu3.model.StringType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.TimeType)
       return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
       return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.UriType)
-      return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UriType) return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Extension)
       return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
@@ -2472,30 +2156,23 @@ public class VersionConvertor_10_30 {
       return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
     if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
       return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Coding)
-      return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Coding) return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
       return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Period)
-      return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Age)
-      return convertAge((org.hl7.fhir.dstu3.model.Age) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Count)
-      return convertCount((org.hl7.fhir.dstu3.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Period) return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Age) return convertAge((org.hl7.fhir.dstu3.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Count) return convertCount((org.hl7.fhir.dstu3.model.Count) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Distance)
       return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Duration)
       return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Money)
-      return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Money) return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
     if (src instanceof org.hl7.fhir.dstu3.model.SimpleQuantity)
       return convertSimpleQuantity((org.hl7.fhir.dstu3.model.SimpleQuantity) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
       return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Range)
-      return convertRange((org.hl7.fhir.dstu3.model.Range) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Ratio)
-      return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Range) return convertRange((org.hl7.fhir.dstu3.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Ratio) return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Reference)
       return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
     if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
@@ -2510,10 +2187,8 @@ public class VersionConvertor_10_30 {
       return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
     if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
       return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Meta)
-      return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
-    if (src instanceof org.hl7.fhir.dstu3.model.Timing)
-      return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Meta) return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Timing) return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
     throw new FHIRException("Unknown type " + src.fhirType());
   }
 
@@ -2544,67 +2219,69 @@ public class VersionConvertor_10_30 {
 
   public static void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.dstu2.model.Resource tgt) throws FHIRException {
     tgt.setId(src.getId());
-    if (src.hasMeta())
-      tgt.setMeta(convertMeta(src.getMeta()));
-    if (src.hasImplicitRules())
-      tgt.setImplicitRules(src.getImplicitRules());
-    if (src.hasLanguage())
-      tgt.setLanguage(src.getLanguage());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGenderEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case MALE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
-        break;
-      case FEMALE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
-        break;
-      case OTHER:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
-        break;
-      case UNKNOWN:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGenderEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case MALE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
-        break;
-      case FEMALE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
-        break;
-      case OTHER:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
-        break;
-      case UNKNOWN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
     tgt.setValue(convertSearchParamType(src.getValue()));
@@ -2635,44 +2312,46 @@ public class VersionConvertor_10_30 {
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.SearchParamTypeEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case NUMBER:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
-        break;
-      case DATE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
-        break;
-      case STRING:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
-        break;
-      case TOKEN:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
-        break;
-      case REFERENCE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
-        break;
-      case COMPOSITE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
-        break;
-      case QUANTITY:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
-        break;
-      case URI:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public class SourceElementComponentWrapper {
-
     public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
       super();
       this.source = source;
@@ -2681,9 +2360,7 @@ public class VersionConvertor_10_30 {
     }
 
     public String source;
-
     public String target;
-
     public org.hl7.fhir.dstu3.model.ConceptMap.SourceElementComponent comp;
   }
 
@@ -2694,214 +2371,209 @@ public class VersionConvertor_10_30 {
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case DRAFT:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
-        break;
-      case ACTIVE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-        break;
-      case RETIRED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case DRAFT:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
-        break;
-      case ACTIVE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-        break;
-      case RETIRED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus> convertDocumentReferenceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CURRENT:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.CURRENT);
-        break;
-      case SUPERSEDED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.SUPERSEDED);
-        break;
-      case ENTEREDINERROR:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.ENTEREDINERROR);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CURRENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.CURRENT);
+          break;
+        case SUPERSEDED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.SUPERSEDED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.ENTEREDINERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus> convertDocumentReferenceStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CURRENT:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.CURRENT);
-        break;
-      case SUPERSEDED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.SUPERSEDED);
-        break;
-      case ENTEREDINERROR:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.ENTEREDINERROR);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CURRENT:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.CURRENT);
+          break;
+        case SUPERSEDED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.SUPERSEDED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.ENTEREDINERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public boolean hasConcept(org.hl7.fhir.dstu3.model.CodeableConcept cc, String system, String code) {
     for (org.hl7.fhir.dstu3.model.Coding c : cc.getCoding()) {
-      if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-        return true;
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
     }
     return false;
   }
 
   static public boolean hasConcept(org.hl7.fhir.dstu2.model.CodeableConcept cc, String system, String code) {
     for (org.hl7.fhir.dstu2.model.Coding c : cc.getCoding()) {
-      if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-        return true;
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
     }
     return false;
   }
 
   public static org.hl7.fhir.dstu3.model.Dosage convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Dosage tgt = new org.hl7.fhir.dstu3.model.Dosage();
     copyElement(src, tgt);
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
-    if (src.hasTiming())
-      tgt.setTiming(convertTiming(src.getTiming()));
-    if (src.hasAsNeeded())
-      tgt.setAsNeeded(convertType(src.getAsNeeded()));
-    if (src.hasSiteCodeableConcept())
-      tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
-    if (src.hasRoute())
-      tgt.setRoute(convertCodeableConcept(src.getRoute()));
-    if (src.hasMethod())
-      tgt.setMethod(convertCodeableConcept(src.getMethod()));
-    if (src.hasDose())
-      tgt.setDose(convertType(src.getDose()));
-    if (src.hasRate())
-      tgt.setRate(convertType(src.getRate()));
-    if (src.hasMaxDosePerPeriod())
-      tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSiteCodeableConcept()) tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose()) tgt.setDose(convertType(src.getDose()));
+    if (src.hasRate()) tgt.setRate(convertType(src.getRate()));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu3.model.Dosage src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent tgt = new org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent();
     copyElement(src, tgt);
-    if (src.hasTextElement())
-      tgt.setTextElement(convertString(src.getTextElement()));
-    if (src.hasTiming())
-      tgt.setTiming(convertTiming(src.getTiming()));
-    if (src.hasAsNeeded())
-      tgt.setAsNeeded(convertType(src.getAsNeeded()));
-    if (src.hasSite())
-      tgt.setSite(convertType(src.getSite()));
-    if (src.hasRoute())
-      tgt.setRoute(convertCodeableConcept(src.getRoute()));
-    if (src.hasMethod())
-      tgt.setMethod(convertCodeableConcept(src.getMethod()));
-    if (src.hasDose())
-      tgt.setDose(convertType(src.getDose()));
-    if (src.hasRate())
-      tgt.setRate(convertType(src.getRate()));
-    if (src.hasMaxDosePerPeriod())
-      tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertType(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose()) tgt.setDose(convertType(src.getDose()));
+    if (src.hasRate()) tgt.setRate(convertType(src.getRate()));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ProcessRequest.ActionList> convertActionList(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ProcessRequest.ActionList> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ProcessRequest.ActionList> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ProcessRequest.ActionListEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CANCEL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.CANCEL);
-        break;
-      case POLL:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.POLL);
-        break;
-      case REPROCESS:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.REPROCESS);
-        break;
-      case STATUS:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.STATUS);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CANCEL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.CANCEL);
+          break;
+        case POLL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.POLL);
+          break;
+        case REPROCESS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.REPROCESS);
+          break;
+        case STATUS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.STATUS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ProcessRequest.ActionList.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ProcessRequest.ActionList> convertActionList(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ProcessRequest.ActionList> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ProcessRequest.ActionList> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ProcessRequest.ActionListEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case CANCEL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.CANCEL);
-        break;
-      case POLL:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.POLL);
-        break;
-      case REPROCESS:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.REPROCESS);
-        break;
-      case STATUS:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.STATUS);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CANCEL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.CANCEL);
+          break;
+        case POLL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.POLL);
+          break;
+        case REPROCESS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.REPROCESS);
+          break;
+        case STATUS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.STATUS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ProcessRequest.ActionList.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.ProcessRequest.ItemsComponent convertItemsComponent(org.hl7.fhir.dstu2.model.ProcessRequest.ItemsComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.ProcessRequest.ItemsComponent tgt = new org.hl7.fhir.dstu3.model.ProcessRequest.ItemsComponent();
     copyElement(src, tgt);
     if (src.hasSequenceLinkIdElement())
@@ -2910,8 +2582,7 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu2.model.ProcessRequest.ItemsComponent convertItemsComponent(org.hl7.fhir.dstu3.model.ProcessRequest.ItemsComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ProcessRequest.ItemsComponent tgt = new org.hl7.fhir.dstu2.model.ProcessRequest.ItemsComponent();
     copyElement(src, tgt);
     if (src.hasSequenceLinkIdElement())
@@ -2920,120 +2591,127 @@ public class VersionConvertor_10_30 {
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Slot.SlotStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case BUSY:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSY);
-        break;
-      case FREE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.FREE);
-        break;
-      case BUSYUNAVAILABLE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-        break;
-      case BUSYTENTATIVE:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSYTENTATIVE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Slot.SlotStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Slot.SlotStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Slot.SlotStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case BUSY:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
-        break;
-      case FREE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
-        break;
-      case BUSYUNAVAILABLE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-        break;
-      case BUSYTENTATIVE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case REQUESTED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
-        break;
-      case COMPLETED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-        break;
-      case FAILED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-        break;
-      case CANCELLED:
-        tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUESTED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case FAILED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatusEnumFactory());
     VersionConvertor_10_30.copyElement(src, tgt);
-    switch (src.getValue()) {
-      case ACTIVE:
-        tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
-        break;
-      case COMPLETED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-        break;
-      case CANCELLED:
-        tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-        break;
-      default:
-        tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
-        break;
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
     }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent convertCodeSystem(org.hl7.fhir.dstu3.model.CodeSystem src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent();
     copyElement(src, tgt);
-    if (src.hasUrlElement())
-      tgt.setSystemElement(convertUri(src.getUrlElement()));
-    if (src.hasVersionElement())
-      tgt.setVersionElement(convertString(src.getVersionElement()));
-    if (src.hasCaseSensitiveElement())
-      tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
+    if (src.hasUrlElement()) tgt.setSystemElement(convertUri(src.getUrlElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCaseSensitiveElement()) tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
     for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(src, cc));
     return tgt;
   }
 
   public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent convertCodeSystemConcept(CodeSystem cs, ConceptDefinitionComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent();
     copyElement(src, tgt);
     tgt.setAbstract(CodeSystemUtilities.isNotSelectable(cs, src));
@@ -3047,8 +2725,7 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent convertCodeSystemDesignation(ConceptDefinitionDesignationComponent src) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent();
     copyElement(src, tgt);
     tgt.setUse(convertCoding(src.getUse()));
@@ -3062,8 +2739,7 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src, VersionConvertorAdvisor30 advisor) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     if (src instanceof org.hl7.fhir.dstu2.model.Parameters)
       return Parameters10_30.convertParameters((org.hl7.fhir.dstu2.model.Parameters) src);
     if (src instanceof org.hl7.fhir.dstu2.model.Account)
@@ -3153,7 +2829,7 @@ public class VersionConvertor_10_30 {
     if (src instanceof org.hl7.fhir.dstu2.model.MedicationDispense)
       return MedicationDispense10_30.convertMedicationDispense((org.hl7.fhir.dstu2.model.MedicationDispense) src);
     if (src instanceof org.hl7.fhir.dstu2.model.MedicationOrder)
-      return MedicationRequest10_30.convertMedicationOrder((org.hl7.fhir.dstu2.model.MedicationOrder)src);
+      return MedicationRequest10_30.convertMedicationOrder((org.hl7.fhir.dstu2.model.MedicationOrder) src);
     if (src instanceof org.hl7.fhir.dstu2.model.MedicationStatement)
       return MedicationStatement10_30.convertMedicationStatement((org.hl7.fhir.dstu2.model.MedicationStatement) src);
     if (src instanceof org.hl7.fhir.dstu2.model.MessageHeader)
@@ -3214,8 +2890,7 @@ public class VersionConvertor_10_30 {
   }
 
   public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src, VersionConvertorAdvisor30 advisor) throws FHIRException {
-    if (src == null || src.isEmpty())
-      return null;
+    if (src == null || src.isEmpty()) return null;
     if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
       return Parameters10_30.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
     if (src instanceof org.hl7.fhir.dstu3.model.Appointment)

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_40.java
@@ -1,67 +1,6 @@
 package org.hl7.fhir.convertors;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.hl7.fhir.convertors.conv10_40.AllergyIntolerance10_40;
-import org.hl7.fhir.convertors.conv10_40.Appointment10_40;
-import org.hl7.fhir.convertors.conv10_40.AppointmentResponse10_40;
-import org.hl7.fhir.convertors.conv10_40.AuditEvent10_40;
-import org.hl7.fhir.convertors.conv10_40.Basic10_40;
-import org.hl7.fhir.convertors.conv10_40.Binary10_40;
-import org.hl7.fhir.convertors.conv10_40.Bundle10_40;
-import org.hl7.fhir.convertors.conv10_40.CarePlan10_40;
-import org.hl7.fhir.convertors.conv10_40.Communication10_40;
-import org.hl7.fhir.convertors.conv10_40.CommunicationRequest10_40;
-import org.hl7.fhir.convertors.conv10_40.Composition10_40;
-import org.hl7.fhir.convertors.conv10_40.ConceptMap10_40;
-import org.hl7.fhir.convertors.conv10_40.Condition10_40;
-import org.hl7.fhir.convertors.conv10_40.Conformance10_40;
-import org.hl7.fhir.convertors.conv10_40.DataElement10_40;
-import org.hl7.fhir.convertors.conv10_40.DetectedIssue10_40;
-import org.hl7.fhir.convertors.conv10_40.DeviceMetric10_40;
-import org.hl7.fhir.convertors.conv10_40.DeviceUseStatement10_40;
-import org.hl7.fhir.convertors.conv10_40.DiagnosticReport10_40;
-import org.hl7.fhir.convertors.conv10_40.DocumentReference10_40;
-import org.hl7.fhir.convertors.conv10_40.Encounter10_40;
-import org.hl7.fhir.convertors.conv10_40.EnrollmentRequest10_40;
-import org.hl7.fhir.convertors.conv10_40.EnrollmentResponse10_40;
-import org.hl7.fhir.convertors.conv10_40.EpisodeOfCare10_40;
-import org.hl7.fhir.convertors.conv10_40.FamilyMemberHistory10_40;
-import org.hl7.fhir.convertors.conv10_40.Flag10_40;
-import org.hl7.fhir.convertors.conv10_40.Group10_40;
-import org.hl7.fhir.convertors.conv10_40.HealthcareService10_40;
-import org.hl7.fhir.convertors.conv10_40.ImplementationGuide10_40;
-import org.hl7.fhir.convertors.conv10_40.List10_40;
-import org.hl7.fhir.convertors.conv10_40.Location10_40;
-import org.hl7.fhir.convertors.conv10_40.MedicationDispense10_40;
-import org.hl7.fhir.convertors.conv10_40.MedicationRequest10_40;
-import org.hl7.fhir.convertors.conv10_40.MedicationStatement10_40;
-import org.hl7.fhir.convertors.conv10_40.MessageHeader10_40;
-import org.hl7.fhir.convertors.conv10_40.NamingSystem10_40;
-import org.hl7.fhir.convertors.conv10_40.Observation10_40;
-import org.hl7.fhir.convertors.conv10_40.OperationDefinition10_40;
-import org.hl7.fhir.convertors.conv10_40.OperationOutcome10_40;
-import org.hl7.fhir.convertors.conv10_40.Organization10_40;
-import org.hl7.fhir.convertors.conv10_40.Parameters10_40;
-import org.hl7.fhir.convertors.conv10_40.Patient10_40;
-import org.hl7.fhir.convertors.conv10_40.Person10_40;
-import org.hl7.fhir.convertors.conv10_40.Practitioner10_40;
-import org.hl7.fhir.convertors.conv10_40.Questionnaire10_40;
-import org.hl7.fhir.convertors.conv10_40.QuestionnaireResponse10_40;
-import org.hl7.fhir.convertors.conv10_40.RiskAssessment10_40;
-import org.hl7.fhir.convertors.conv10_40.Schedule10_40;
-import org.hl7.fhir.convertors.conv10_40.SearchParameter10_40;
-import org.hl7.fhir.convertors.conv10_40.Slot10_40;
-import org.hl7.fhir.convertors.conv10_40.StructureDefinition10_40;
-import org.hl7.fhir.convertors.conv10_40.Subscription10_40;
-import org.hl7.fhir.convertors.conv10_40.Substance10_40;
-import org.hl7.fhir.convertors.conv10_40.SupplyDelivery10_40;
-import org.hl7.fhir.convertors.conv10_40.SupplyRequest10_40;
-import org.hl7.fhir.convertors.conv10_40.TestScript10_40;
-import org.hl7.fhir.convertors.conv10_40.ValueSet10_40;
+import org.hl7.fhir.convertors.conv10_40.*;
 import org.hl7.fhir.dstu2.model.CodeableConcept;
 import org.hl7.fhir.dstu2.model.Parameters;
 import org.hl7.fhir.dstu2.model.Parameters.ParametersParameterComponent;
@@ -70,16 +9,23 @@ import org.hl7.fhir.dstu2.model.Reference;
 import org.hl7.fhir.dstu2.utils.ToolingExtensions;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.conformance.ProfileUtilities;
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.CodeSystem.ConceptDefinitionComponent;
 import org.hl7.fhir.r4.model.CodeSystem.ConceptDefinitionDesignationComponent;
 import org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent;
 import org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent;
 import org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
 import org.hl7.fhir.r4.model.Immunization.ImmunizationPerformerComponent;
-import org.hl7.fhir.r4.model.Timing.EventTiming;
+import org.hl7.fhir.r4.model.TerminologyCapabilities;
+import org.hl7.fhir.r4.model.UnsignedIntType;
 import org.hl7.fhir.r4.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.utilities.Utilities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -107,3333 +53,3017 @@ import org.hl7.fhir.utilities.Utilities;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
+
 public class VersionConvertor_10_40 {
+  static public List<String> CANONICAL_URLS = new ArrayList<String>();
 
-    static public List<String> CANONICAL_URLS = new ArrayList<String>();
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  }
 
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  public static void copyElement(org.hl7.fhir.dstu2.model.Element src, org.hl7.fhir.r4.model.Element tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu2.model.Extension e : src.getExtension()) {
+      tgt.addExtension(convertExtension(e));
     }
+  }
 
-    public static void copyElement(org.hl7.fhir.dstu2.model.Element src, org.hl7.fhir.r4.model.Element tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu2.model.Extension e : src.getExtension()) {
-            tgt.addExtension(convertExtension(e));
+  public static void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu2.model.Element tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      tgt.addExtension(convertExtension(e));
+    }
+  }
+
+  public static void copyElement(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2.model.Element tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      tgt.addExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu2.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu2.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu2.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UriType convertCodeToUri(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeType convertUriToCode(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDateTimeToDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu2.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu2.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu2.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IdType(src.getValue()) : new org.hl7.fhir.dstu2.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu2.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValue()) : new org.hl7.fhir.r4.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.InstantType(src.getValue()) : new org.hl7.fhir.dstu2.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu2.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValue()) : new org.hl7.fhir.r4.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu2.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu2.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu2.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.OidType(src.getValue()) : new org.hl7.fhir.dstu2.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu2.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu2.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu2.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UriType(src.getValue()) : new org.hl7.fhir.dstu2.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu2.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu2.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu2.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Extension tgt = new org.hl7.fhir.dstu2.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
+      else if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu2.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Narrative tgt = new org.hl7.fhir.dstu2.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu2.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Annotation tgt = new org.hl7.fhir.dstu2.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu2.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    tgt.setUrl(src.getUrl());
+    if (src.hasSizeElement()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Attachment tgt = new org.hl7.fhir.dstu2.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    tgt.setUrl(src.getUrl());
+    if (src.hasSizeElement()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.CodeableConcept tgt = new org.hl7.fhir.dstu2.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu2.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Coding tgt = new org.hl7.fhir.dstu2.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu2.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Identifier tgt = new org.hl7.fhir.dstu2.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu2.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Period tgt = new org.hl7.fhir.dstu2.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu2.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Quantity tgt = new org.hl7.fhir.dstu2.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu2.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Range tgt = new org.hl7.fhir.dstu2.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu2.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Ratio tgt = new org.hl7.fhir.dstu2.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu2.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
+    copyElement(src, tgt);
+    tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Reference tgt = new org.hl7.fhir.dstu2.model.Reference();
+    copyElement(src, tgt);
+    tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu2.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.SampledData tgt = new org.hl7.fhir.dstu2.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu2.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
+    else tgt.setWho(convertReference(src.getWhoReference()));
+    if (src.hasContentTypeElement()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlobElement()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Signature tgt = new org.hl7.fhir.dstu2.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasSigFormatElement()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasDataElement()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu2.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Address tgt = new org.hl7.fhir.dstu2.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ContactPoint tgt = new org.hl7.fhir.dstu2.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRankElement()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2.model.ElementDefinition src, List<String> slicePaths, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasName()) {
+      if (slicePaths.contains(src.getPath())) tgt.setSliceNameElement(convertString(src.getNameElement()));
+      if (src.hasNameElement()) tgt.setIdElement(convertString(src.getNameElement()));
+    }
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasNameReference()) tgt.setContentReference("#" + src.getNameReference());
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertElementDefinitionTypeComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu2.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (tgt.getIsModifier()) {
+      String reason = org.hl7.fhir.dstu2.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+      if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+      tgt.setIsModifierReason(reason);
+    }
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    if (!tgt.hasId()) tgt.setId(tgt.getPath());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition tgt = new org.hl7.fhir.dstu2.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    else tgt.setNameElement(convertString(src.getIdElement()));
+    if (src.hasLabelElement()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShortElement()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinitionElement()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasCommentElement()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setNameReference(src.getContentReference().substring(1));
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertElementDefinitionTypeComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissingElement())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLengthElement()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupportElement()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifierElement()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu2.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummaryElement()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    org.hl7.fhir.dstu2.model.ElementDefinition slicingElement = context.get(pos);
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getDiscriminator()) {
+      boolean isExists = false;
+      if (!t.asStringValue().contains("@")) {
+        int slices = 0;
+        boolean existsSlicePresent = false;
+        boolean notExistsSlicePresent = false;
+        String existsPath = slicingElement.getPath() + "." + t.asStringValue();
+        for (int i = pos + 1; i < context.size(); i++) {
+          org.hl7.fhir.dstu2.model.ElementDefinition e = context.get(i);
+          if (e.getPath().equals(slicingElement.getPath())) slices++;
+          else if (!e.getPath().startsWith(slicingElement.getPath() + ".")) break;
+          else if (e.getPath().equals(existsPath)) {
+            if (e.hasMin() && e.getMin() > 0) existsSlicePresent = true;
+            else if (e.hasMax() && e.getMax().equals("0")) notExistsSlicePresent = true;
+          }
         }
-    }
-
-    public static void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu2.model.Element tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            tgt.addExtension(convertExtension(e));
-        }
-    }
-
-    public static void copyElement(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2.model.Element tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            tgt.addExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
-      org.hl7.fhir.dstu2.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu2.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu2.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu2.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UriType convertCodeToUri(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeType convertUriToCode(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDateTimeToDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu2.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu2.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu2.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IdType(src.getValue()) : new org.hl7.fhir.dstu2.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu2.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValue()) : new org.hl7.fhir.r4.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.InstantType(src.getValue()) : new org.hl7.fhir.dstu2.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu2.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValue()) : new org.hl7.fhir.r4.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu2.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu2.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu2.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.OidType(src.getValue()) : new org.hl7.fhir.dstu2.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
-      org.hl7.fhir.dstu2.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu2.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu2.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu2.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UriType(src.getValue()) : new org.hl7.fhir.dstu2.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu2.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu2.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu2.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Extension tgt = new org.hl7.fhir.dstu2.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
-            else if (src.hasValue())
-                tgt.setValue(convertType(src.getValue()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu2.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Narrative tgt = new org.hl7.fhir.dstu2.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu2.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTimeElement())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Annotation tgt = new org.hl7.fhir.dstu2.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTimeElement())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu2.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        tgt.setUrl(src.getUrl());
-        if (src.hasSizeElement())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHashElement())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitleElement())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreationElement())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Attachment tgt = new org.hl7.fhir.dstu2.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        tgt.setUrl(src.getUrl());
-        if (src.hasSizeElement())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHashElement())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitleElement())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreationElement())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.CodeableConcept tgt = new org.hl7.fhir.dstu2.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu2.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelectedElement())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Coding tgt = new org.hl7.fhir.dstu2.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelectedElement())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu2.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Identifier tgt = new org.hl7.fhir.dstu2.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu2.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStartElement())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEndElement())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Period tgt = new org.hl7.fhir.dstu2.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStartElement())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEndElement())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu2.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Quantity tgt = new org.hl7.fhir.dstu2.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu2.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Range tgt = new org.hl7.fhir.dstu2.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu2.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Ratio tgt = new org.hl7.fhir.dstu2.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu2.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
-        copyElement(src, tgt);
-        tgt.setReference(src.getReference());
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Reference tgt = new org.hl7.fhir.dstu2.model.Reference();
-        copyElement(src, tgt);
-        tgt.setReference(src.getReference());
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu2.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactorElement())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimitElement())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimitElement())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.SampledData tgt = new org.hl7.fhir.dstu2.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactorElement())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimitElement())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimitElement())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu2.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWhoUriType())
-            tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
-        else
-            tgt.setWho(convertReference(src.getWhoReference()));
-        if (src.hasContentTypeElement())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlobElement())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Signature tgt = new org.hl7.fhir.dstu2.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasSigFormatElement())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasDataElement())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu2.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCityElement())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrictElement())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasStateElement())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCodeElement())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountryElement())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Address tgt = new org.hl7.fhir.dstu2.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCityElement())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrictElement())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasStateElement())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCodeElement())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountryElement())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ContactPoint tgt = new org.hl7.fhir.dstu2.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRankElement())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2.model.ElementDefinition src, List<String> slicePaths, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_10_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasName()) {
-            if (slicePaths.contains(src.getPath()))
-                tgt.setSliceNameElement(convertString(src.getNameElement()));
-            if (src.hasNameElement())
-                tgt.setIdElement(convertString(src.getNameElement()));
-        }
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComments())
-            tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasNameReference())
-            tgt.setContentReference("#" + src.getNameReference());
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent t : src.getType()) convertElementDefinitionTypeComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu2.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu2.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-                reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
-        }
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        if (!tgt.hasId())
-            tgt.setId(tgt.getPath());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition tgt = new org.hl7.fhir.dstu2.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_10_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setNameElement(convertString(src.getSliceNameElement()));
-        else
-            tgt.setNameElement(convertString(src.getIdElement()));
-        if (src.hasLabelElement())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShortElement())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinitionElement())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasCommentElement())
-            tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setNameReference(src.getContentReference().substring(1));
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType()) convertElementDefinitionTypeComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissingElement())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLengthElement())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupportElement())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifierElement())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu2.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummaryElement())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        org.hl7.fhir.dstu2.model.ElementDefinition slicingElement = context.get(pos);
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getDiscriminator()) {
-            boolean isExists = false;
-            if (!t.asStringValue().contains("@")) {
-                int slices = 0;
-                boolean existsSlicePresent = false;
-                boolean notExistsSlicePresent = false;
-                String existsPath = slicingElement.getPath() + "." + t.asStringValue();
-                for (int i = pos + 1; i < context.size(); i++) {
-                    org.hl7.fhir.dstu2.model.ElementDefinition e = context.get(i);
-                    if (e.getPath().equals(slicingElement.getPath()))
-                        slices++;
-                    else if (!e.getPath().startsWith(slicingElement.getPath() + "."))
-                        break;
-                    else if (e.getPath().equals(existsPath)) {
-                        if (e.hasMin() && e.getMin() > 0)
-                            existsSlicePresent = true;
-                        else if (e.hasMax() && e.getMax().equals("0"))
-                            notExistsSlicePresent = true;
-                    }
-                }
-                isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
-            }
-            tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
-        }
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrderedElement())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrderedElement())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static void convertElementDefinitionTypeComponent(org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list) if (t.getCode().equals(src.getCode()))
-            tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCode(src.getCode());
-        }
-        if (tgt.hasTarget()) {
-            for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addTargetProfile(u.getValue());
-        } else {
-            for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
-        }
-        for (org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregationElement().setValue(a.getValue()));
-        }
-    }
-
-    public static void convertElementDefinitionTypeComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCode(src.getCode());
-        list.add(tgt);
-        if (src.hasTarget()) {
-            for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        } else {
-            for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        }
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        tgt.setExpression(ToolingExtensions.readStringExtension(src, ToolingExtensions.EXT_EXPRESSION));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            ToolingExtensions.addStringExtension(tgt, ToolingExtensions.EXT_EXPRESSION, src.getExpression());
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        org.hl7.fhir.r4.model.Type vs = convertType(src.getValueSet());
-        if (vs != null) {
-            tgt.setValueSet(vs instanceof org.hl7.fhir.r4.model.Reference ? ((org.hl7.fhir.r4.model.Reference) vs).getReference() : vs.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu2.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu2.model.Reference(src.getValueSet()));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu2.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.HumanName tgt = new org.hl7.fhir.dstu2.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.addFamily(src.getFamily());
-        for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu2.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionIdElement())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdatedElement())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Meta tgt = new org.hl7.fhir.dstu2.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionIdElement())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdatedElement())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu2.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Timing tgt = new org.hl7.fhir.dstu2.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasDurationElement())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMaxElement())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnits())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMaxElement())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnits())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
-        if (src.hasWhen()) {
-            tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasDurationElement())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMaxElement())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMaxElement())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu2.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Age tgt = new org.hl7.fhir.dstu2.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu2.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Count tgt = new org.hl7.fhir.dstu2.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu2.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Distance tgt = new org.hl7.fhir.dstu2.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu2.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Duration tgt = new org.hl7.fhir.dstu2.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu2.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCodeElement())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Money tgt = new org.hl7.fhir.dstu2.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrencyElement())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu2.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu2.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu2.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu2.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DateType)
-            return convertDate((org.hl7.fhir.dstu2.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu2.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu2.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.IdType)
-            return convertId((org.hl7.fhir.dstu2.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OidType)
-            return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.StringType)
-            return convertString((org.hl7.fhir.dstu2.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UriType)
-            return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu2.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu2.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu2.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu2.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Range)
-            return convertRange((org.hl7.fhir.dstu2.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Reference)
-            return convertReference((org.hl7.fhir.dstu2.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu2.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu2.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Address)
-            return convertAddress((org.hl7.fhir.dstu2.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu2.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu2.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Age)
-            return convertAge((org.hl7.fhir.dstu2.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Count)
-            return convertCount((org.hl7.fhir.dstu2.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r4.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeType)
-            return convertCode((org.hl7.fhir.r4.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateType)
-            return convertDate((org.hl7.fhir.r4.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IdType)
-            return convertId((org.hl7.fhir.r4.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r4.model.InstantType)
-            return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r4.model.OidType)
-            return convertOid((org.hl7.fhir.r4.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.StringType)
-            return convertString((org.hl7.fhir.r4.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r4.model.TimeType)
-            return convertTime((org.hl7.fhir.r4.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IntegerType)
-          return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UriType)
-            return convertUri((org.hl7.fhir.r4.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UuidType)
-            return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.Extension)
-            return convertExtension((org.hl7.fhir.r4.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r4.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r4.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coding)
-            return convertCoding((org.hl7.fhir.r4.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r4.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r4.model.Period)
-            return convertPeriod((org.hl7.fhir.r4.model.Period) src);
-        if (src instanceof org.hl7.fhir.r4.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Range)
-            return convertRange((org.hl7.fhir.r4.model.Range) src);
-        if (src instanceof org.hl7.fhir.r4.model.Ratio)
-            return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r4.model.Reference)
-            return convertReference((org.hl7.fhir.r4.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r4.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r4.model.Signature)
-            return convertSignature((org.hl7.fhir.r4.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r4.model.Address)
-            return convertAddress((org.hl7.fhir.r4.model.Address) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r4.model.Meta)
-            return convertMeta((org.hl7.fhir.r4.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r4.model.Timing)
-            return convertTiming((org.hl7.fhir.r4.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r4.model.Age)
-            return convertAge((org.hl7.fhir.r4.model.Age) src);
-        if (src instanceof org.hl7.fhir.r4.model.Count)
-            return convertCount((org.hl7.fhir.r4.model.Count) src);
-        if (src instanceof org.hl7.fhir.r4.model.Distance)
-            return convertDistance((org.hl7.fhir.r4.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Duration)
-            return convertDuration((org.hl7.fhir.r4.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r4.model.Money)
-            return convertMoney((org.hl7.fhir.r4.model.Money) src);
-        if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    public static void copyDomainResource(org.hl7.fhir.dstu2.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu2.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu2.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu2.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    public static void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    public static void copyResource(org.hl7.fhir.dstu2.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        tgt.setMeta(convertMeta(src.getMeta()));
-        tgt.setImplicitRules(src.getImplicitRules());
-        tgt.setLanguage(src.getLanguage());
-    }
-
-    public static void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu2.model.Resource tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public class SourceElementComponentWrapper {
-
-        public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
-            super();
-            this.source = source;
-            this.target = target;
-            this.comp = comp;
-        }
-
-        public String source;
-
-        public String target;
-
-        public org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent comp;
-    }
-
-    public static org.hl7.fhir.r4.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2.model.CodeableConcept t) throws FHIRException {
-        org.hl7.fhir.r4.model.UsageContext result = new org.hl7.fhir.r4.model.UsageContext();
-        result.setValue(convertCodeableConcept(t));
-        return result;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
-        CanonicalType dst = new CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
-        Reference dst = new Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityModeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Conformance.ConformanceEventModeEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Reference getPerformer(List<ImmunizationPerformerComponent> practitioner) {
-        for (ImmunizationPerformerComponent p : practitioner) {
-            if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "AP"))
-                return p.getActor();
-        }
-        return null;
-    }
-
-    static public org.hl7.fhir.r4.model.Reference getRequester(List<ImmunizationPerformerComponent> practitioner) {
-        for (ImmunizationPerformerComponent p : practitioner) {
-            if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "OP"))
-                return p.getActor();
-        }
-        return null;
-    }
-
-    static public boolean hasConcept(org.hl7.fhir.r4.model.CodeableConcept cc, String system, String code) {
-        for (org.hl7.fhir.r4.model.Coding c : cc.getCoding()) {
-            if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-                return true;
-        }
-        return false;
-    }
-
-    static public boolean hasConcept(org.hl7.fhir.dstu2.model.CodeableConcept cc, String system, String code) {
-        for (org.hl7.fhir.dstu2.model.Coding c : cc.getCoding()) {
-            if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-                return true;
-        }
-        return false;
-    }
-
-    public static org.hl7.fhir.r4.model.Dosage convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSiteCodeableConcept())
-            tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDose() || src.hasRate()) {
-            DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
-            if (src.hasDose())
-                dr.setDose(convertType(src.getDose()));
-            if (src.hasRate())
-                dr.setRate(convertType(src.getRate()));
-        }
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent tgt = new org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent();
-        copyElement(src, tgt);
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertType(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
-            tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
-            tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Slot.SlotStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case BUSY:
-                tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSY);
-                break;
-            case FREE:
-                tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.FREE);
-                break;
-            case BUSYUNAVAILABLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-                break;
-            case BUSYTENTATIVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSYTENTATIVE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Slot.SlotStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case BUSY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
-                break;
-            case FREE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
-                break;
-            case BUSYUNAVAILABLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-                break;
-            case BUSYTENTATIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUESTED:
-                tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
-                break;
-            case COMPLETED:
-                tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-                break;
-            case FAILED:
-                tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            case CANCELLED:
-                tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatusEnumFactory());
-        VersionConvertor_10_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
-                break;
-            case COMPLETED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-                break;
-            case CANCELLED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent convertCodeSystem(org.hl7.fhir.r4.model.CodeSystem src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setSystemElement(convertUri(src.getUrlElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCaseSensitiveElement())
-            tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
-        for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(src, cc));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent convertCodeSystemConcept(CodeSystem cs, ConceptDefinitionComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent();
-        copyElement(src, tgt);
-        tgt.setAbstract(CodeSystemUtilities.isNotSelectable(cs, src));
-        tgt.setCode(src.getCode());
-        tgt.setDefinition(src.getDefinition());
-        tgt.setDisplay(src.getDisplay());
-        for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(cs, cc));
-        for (ConceptDefinitionDesignationComponent cc : src.getDesignation()) tgt.addDesignation(convertCodeSystemDesignation(cc));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent convertCodeSystemDesignation(ConceptDefinitionDesignationComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent();
-        copyElement(src, tgt);
-        tgt.setUse(convertCoding(src.getUse()));
-        tgt.setLanguage(src.getLanguage());
-        tgt.setValue(src.getValue());
-        return tgt;
-    }
-
-    static public boolean isJurisdiction(CodeableConcept t) {
-        return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
-    }
-
-    public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src, VersionConvertorAdvisor40 advisor) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2.model.Parameters)
-            return Parameters10_40.convertParameters((org.hl7.fhir.dstu2.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Appointment)
-            return Appointment10_40.convertAppointment((org.hl7.fhir.dstu2.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.AllergyIntolerance)
-            return AllergyIntolerance10_40.convertAllergyIntolerance((org.hl7.fhir.dstu2.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.AppointmentResponse)
-            return AppointmentResponse10_40.convertAppointmentResponse((org.hl7.fhir.dstu2.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.AuditEvent)
-            return AuditEvent10_40.convertAuditEvent((org.hl7.fhir.dstu2.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Basic)
-            return Basic10_40.convertBasic((org.hl7.fhir.dstu2.model.Basic) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Binary)
-            return Binary10_40.convertBinary((org.hl7.fhir.dstu2.model.Binary) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Bundle)
-            return Bundle10_40.convertBundle((org.hl7.fhir.dstu2.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CarePlan)
-            return CarePlan10_40.convertCarePlan((org.hl7.fhir.dstu2.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Communication)
-            return Communication10_40.convertCommunication((org.hl7.fhir.dstu2.model.Communication) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CommunicationRequest)
-            return CommunicationRequest10_40.convertCommunicationRequest((org.hl7.fhir.dstu2.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Composition)
-            return Composition10_40.convertComposition((org.hl7.fhir.dstu2.model.Composition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ConceptMap)
-            return ConceptMap10_40.convertConceptMap((org.hl7.fhir.dstu2.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Condition)
-            return Condition10_40.convertCondition((org.hl7.fhir.dstu2.model.Condition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Conformance)
-            return Conformance10_40.convertConformance((org.hl7.fhir.dstu2.model.Conformance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DataElement)
-            return DataElement10_40.convertDataElement((org.hl7.fhir.dstu2.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DetectedIssue)
-            return DetectedIssue10_40.convertDetectedIssue((org.hl7.fhir.dstu2.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DeviceMetric)
-            return DeviceMetric10_40.convertDeviceMetric((org.hl7.fhir.dstu2.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DeviceUseStatement)
-            return DeviceUseStatement10_40.convertDeviceUseStatement((org.hl7.fhir.dstu2.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DiagnosticReport)
-            return DiagnosticReport10_40.convertDiagnosticReport((org.hl7.fhir.dstu2.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DocumentReference)
-            return DocumentReference10_40.convertDocumentReference((org.hl7.fhir.dstu2.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Encounter)
-            return Encounter10_40.convertEncounter((org.hl7.fhir.dstu2.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentRequest)
-            return EnrollmentRequest10_40.convertEnrollmentRequest((org.hl7.fhir.dstu2.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentResponse)
-            return EnrollmentResponse10_40.convertEnrollmentResponse((org.hl7.fhir.dstu2.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EpisodeOfCare)
-            return EpisodeOfCare10_40.convertEpisodeOfCare((org.hl7.fhir.dstu2.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.FamilyMemberHistory)
-            return FamilyMemberHistory10_40.convertFamilyMemberHistory((org.hl7.fhir.dstu2.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Flag)
-            return Flag10_40.convertFlag((org.hl7.fhir.dstu2.model.Flag) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Group)
-            return Group10_40.convertGroup((org.hl7.fhir.dstu2.model.Group) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.HealthcareService)
-            return HealthcareService10_40.convertHealthcareService((org.hl7.fhir.dstu2.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ImplementationGuide)
-            return ImplementationGuide10_40.convertImplementationGuide((org.hl7.fhir.dstu2.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.List_)
-            return List10_40.convertList((org.hl7.fhir.dstu2.model.List_) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Location)
-            return Location10_40.convertLocation((org.hl7.fhir.dstu2.model.Location) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MedicationDispense)
-            return MedicationDispense10_40.convertMedicationDispense((org.hl7.fhir.dstu2.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MedicationStatement)
-            return MedicationStatement10_40.convertMedicationStatement((org.hl7.fhir.dstu2.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MedicationOrder)
-            return MedicationRequest10_40.convertMedicationRequest((org.hl7.fhir.dstu2.model.MedicationOrder) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MessageHeader)
-            return MessageHeader10_40.convertMessageHeader((org.hl7.fhir.dstu2.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.NamingSystem)
-            return NamingSystem10_40.convertNamingSystem((org.hl7.fhir.dstu2.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Observation)
-            return Observation10_40.convertObservation((org.hl7.fhir.dstu2.model.Observation) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OperationDefinition)
-            return OperationDefinition10_40.convertOperationDefinition((org.hl7.fhir.dstu2.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OperationOutcome)
-            return OperationOutcome10_40.convertOperationOutcome((org.hl7.fhir.dstu2.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Organization)
-            return Organization10_40.convertOrganization((org.hl7.fhir.dstu2.model.Organization) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Patient)
-            return Patient10_40.convertPatient((org.hl7.fhir.dstu2.model.Patient) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Person)
-            return Person10_40.convertPerson((org.hl7.fhir.dstu2.model.Person) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Practitioner)
-            return Practitioner10_40.convertPractitioner((org.hl7.fhir.dstu2.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Questionnaire)
-            return Questionnaire10_40.convertQuestionnaire((org.hl7.fhir.dstu2.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.QuestionnaireResponse)
-            return QuestionnaireResponse10_40.convertQuestionnaireResponse((org.hl7.fhir.dstu2.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.RiskAssessment)
-            return RiskAssessment10_40.convertRiskAssessment((org.hl7.fhir.dstu2.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Schedule)
-            return Schedule10_40.convertSchedule((org.hl7.fhir.dstu2.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SearchParameter)
-            return SearchParameter10_40.convertSearchParameter((org.hl7.fhir.dstu2.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Slot)
-            return Slot10_40.convertSlot((org.hl7.fhir.dstu2.model.Slot) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.StructureDefinition)
-            return StructureDefinition10_40.convertStructureDefinition((org.hl7.fhir.dstu2.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Subscription)
-            return Subscription10_40.convertSubscription((org.hl7.fhir.dstu2.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Substance)
-            return Substance10_40.convertSubstance((org.hl7.fhir.dstu2.model.Substance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SupplyDelivery)
-            return SupplyDelivery10_40.convertSupplyDelivery((org.hl7.fhir.dstu2.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SupplyRequest)
-            return SupplyRequest10_40.convertSupplyRequest((org.hl7.fhir.dstu2.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.TestScript)
-            return TestScript10_40.convertTestScript((org.hl7.fhir.dstu2.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ValueSet)
-            return ValueSet10_40.convertValueSet((org.hl7.fhir.dstu2.model.ValueSet) src, advisor);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src, VersionConvertorAdvisor40 advisor) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Parameters)
-            return Parameters10_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r4.model.Appointment)
-            return Appointment10_40.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
-            return AppointmentResponse10_40.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
-            return AuditEvent10_40.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r4.model.Basic)
-            return Basic10_40.convertBasic((org.hl7.fhir.r4.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r4.model.Binary)
-            return Binary10_40.convertBinary((org.hl7.fhir.r4.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r4.model.Bundle)
-            return Bundle10_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src, advisor);
-        if (src instanceof org.hl7.fhir.r4.model.CarePlan)
-            return CarePlan10_40.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r4.model.Communication)
-            return Communication10_40.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r4.model.CommunicationRequest)
-            return CommunicationRequest10_40.convertCommunicationRequest((org.hl7.fhir.r4.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.Composition)
-            return Composition10_40.convertComposition((org.hl7.fhir.r4.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
-            return ConceptMap10_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.Condition)
-            return Condition10_40.convertCondition((org.hl7.fhir.r4.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
-            return Conformance10_40.convertConformance((org.hl7.fhir.r4.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
-            return DetectedIssue10_40.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceMetric)
-            return DeviceMetric10_40.convertDeviceMetric((org.hl7.fhir.r4.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
-            return DeviceUseStatement10_40.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
-            return DiagnosticReport10_40.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
-            return DocumentReference10_40.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r4.model.Encounter)
-            return Encounter10_40.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r4.model.EnrollmentRequest)
-            return EnrollmentRequest10_40.convertEnrollmentRequest((org.hl7.fhir.r4.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.EnrollmentResponse)
-            return EnrollmentResponse10_40.convertEnrollmentResponse((org.hl7.fhir.r4.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
-            return EpisodeOfCare10_40.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
-            return FamilyMemberHistory10_40.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r4.model.Flag)
-            return Flag10_40.convertFlag((org.hl7.fhir.r4.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r4.model.Group)
-            return Group10_40.convertGroup((org.hl7.fhir.r4.model.Group) src);
-        if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
-            return HealthcareService10_40.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
-            return ImplementationGuide10_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r4.model.ListResource)
-            return List10_40.convertList((org.hl7.fhir.r4.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r4.model.Location)
-            return Location10_40.convertLocation((org.hl7.fhir.r4.model.Location) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
-            return MedicationDispense10_40.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
-            return MedicationStatement10_40.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
-            return MessageHeader10_40.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
-            return NamingSystem10_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.Observation)
-            return Observation10_40.convertObservation((org.hl7.fhir.r4.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
-            return OperationDefinition10_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
-            return OperationOutcome10_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r4.model.Organization)
-            return Organization10_40.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r4.model.Patient)
-            return Patient10_40.convertPatient((org.hl7.fhir.r4.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r4.model.Person)
-            return Person10_40.convertPerson((org.hl7.fhir.r4.model.Person) src);
-        if (src instanceof org.hl7.fhir.r4.model.Practitioner)
-            return Practitioner10_40.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
-            return Questionnaire10_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
-            return QuestionnaireResponse10_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
-            return RiskAssessment10_40.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r4.model.Schedule)
-            return Schedule10_40.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
-            return SearchParameter10_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r4.model.Slot)
-            return Slot10_40.convertSlot((org.hl7.fhir.r4.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
-            return StructureDefinition10_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Subscription)
-            return Subscription10_40.convertSubscription((org.hl7.fhir.r4.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.r4.model.Substance)
-            return Substance10_40.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
-            return SupplyDelivery10_40.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r4.model.SupplyRequest)
-            return SupplyRequest10_40.convertSupplyRequest((org.hl7.fhir.r4.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.TestScript)
-            return TestScript10_40.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r4.model.ValueSet)
-            return ValueSet10_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src, advisor);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src) {
-        TerminologyCapabilities res = new TerminologyCapabilities();
-        for (ParametersParameterComponent p : src.getParameter()) {
-            if (p.getName().equals("system"))
-                res.addCodeSystem().setUri(p.getValue().primitiveValue());
-        }
-        return res;
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "Bundle", "CarePlan", "Communication", "CommunicationRequest", "Composition", "ConceptMap", "Condition", "CapabilityStatement", "DetectedIssue", "DeviceMetric", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "EnrollmentRequest", "EnrollmentResponse", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Group", "HealthcareService", "ImplementationGuide", "ListResource", "Location", "MedicationDispense", "MedicationStatement", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "Person", "Practitioner", "Questionnaire", "QuestionnaireResponse", "RiskAssessment", "Schedule", "SearchParameter", "Slot", "StructureDefinition", "Subscription", "Substance", "SupplyDelivery", "SupplyRequest", "TestScript", "ValueSet");
-    }
-
-    public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src) throws FHIRException {
-        return convertResource(src, null);
-    }
-
-    public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
-        return convertResource(src, null);
-    }
-
-    public static UnsignedIntType convertUnsignedIntToPositive(PositiveIntType src) {
-      org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+        isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
+      }
+      tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
+    }
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static void convertElementDefinitionTypeComponent(org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
       copyElement(src, tgt);
-      return tgt;
+      tgt.setCode(src.getCode());
     }
+    if (tgt.hasTarget()) {
+      for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addTargetProfile(u.getValue());
+    } else {
+      for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
+    }
+    for (org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregationElement().setValue(a.getValue()));
+    }
+  }
+
+  public static void convertElementDefinitionTypeComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCode(src.getCode());
+    list.add(tgt);
+    if (src.hasTarget()) {
+      for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    }
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    tgt.setExpression(ToolingExtensions.readStringExtension(src, ToolingExtensions.EXT_EXPRESSION));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression())
+      ToolingExtensions.addStringExtension(tgt, ToolingExtensions.EXT_EXPRESSION, src.getExpression());
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    org.hl7.fhir.r4.model.Type vs = convertType(src.getValueSet());
+    if (vs != null) {
+      tgt.setValueSet(vs instanceof org.hl7.fhir.r4.model.Reference ? ((org.hl7.fhir.r4.model.Reference) vs).getReference() : vs.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu2.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu2.model.Reference(src.getValueSet()));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu2.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.HumanName tgt = new org.hl7.fhir.dstu2.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
+    for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu2.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Meta tgt = new org.hl7.fhir.dstu2.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu2.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Timing tgt = new org.hl7.fhir.dstu2.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnits()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnits()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
+    if (src.hasWhen()) {
+      tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu2.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Age tgt = new org.hl7.fhir.dstu2.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu2.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Count tgt = new org.hl7.fhir.dstu2.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu2.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Distance tgt = new org.hl7.fhir.dstu2.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu2.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Duration tgt = new org.hl7.fhir.dstu2.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu2.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCodeElement()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Money tgt = new org.hl7.fhir.dstu2.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrencyElement()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu2.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu2.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu2.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CodeType)
+      return convertCode((org.hl7.fhir.dstu2.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DateType)
+      return convertDate((org.hl7.fhir.dstu2.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu2.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu2.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.IdType) return convertId((org.hl7.fhir.dstu2.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OidType) return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.StringType)
+      return convertString((org.hl7.fhir.dstu2.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
+      return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UriType) return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
+      return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu2.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu2.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu2.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu2.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Coding) return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Period) return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Range) return convertRange((org.hl7.fhir.dstu2.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Ratio) return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Reference)
+      return convertReference((org.hl7.fhir.dstu2.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu2.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu2.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Address)
+      return convertAddress((org.hl7.fhir.dstu2.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu2.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu2.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Meta) return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Timing) return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Age) return convertAge((org.hl7.fhir.dstu2.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Count) return convertCount((org.hl7.fhir.dstu2.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Money) return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r4.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeType) return convertCode((org.hl7.fhir.r4.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateType) return convertDate((org.hl7.fhir.r4.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IdType) return convertId((org.hl7.fhir.r4.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r4.model.InstantType)
+      return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r4.model.OidType) return convertOid((org.hl7.fhir.r4.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.StringType)
+      return convertString((org.hl7.fhir.r4.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r4.model.TimeType) return convertTime((org.hl7.fhir.r4.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UriType) return convertUri((org.hl7.fhir.r4.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UuidType) return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.Extension)
+      return convertExtension((org.hl7.fhir.r4.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r4.model.Narrative)
+      return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r4.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coding) return convertCoding((org.hl7.fhir.r4.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r4.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r4.model.Period) return convertPeriod((org.hl7.fhir.r4.model.Period) src);
+    if (src instanceof org.hl7.fhir.r4.model.Quantity) return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Range) return convertRange((org.hl7.fhir.r4.model.Range) src);
+    if (src instanceof org.hl7.fhir.r4.model.Ratio) return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r4.model.Reference)
+      return convertReference((org.hl7.fhir.r4.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r4.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r4.model.Signature)
+      return convertSignature((org.hl7.fhir.r4.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r4.model.Address) return convertAddress((org.hl7.fhir.r4.model.Address) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.HumanName)
+      return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r4.model.Meta) return convertMeta((org.hl7.fhir.r4.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r4.model.Timing) return convertTiming((org.hl7.fhir.r4.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r4.model.Age) return convertAge((org.hl7.fhir.r4.model.Age) src);
+    if (src instanceof org.hl7.fhir.r4.model.Count) return convertCount((org.hl7.fhir.r4.model.Count) src);
+    if (src instanceof org.hl7.fhir.r4.model.Distance) return convertDistance((org.hl7.fhir.r4.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Duration) return convertDuration((org.hl7.fhir.r4.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r4.model.Money) return convertMoney((org.hl7.fhir.r4.model.Money) src);
+    if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  public static void copyDomainResource(org.hl7.fhir.dstu2.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu2.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu2.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu2.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  public static void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  public static void copyResource(org.hl7.fhir.dstu2.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    tgt.setMeta(convertMeta(src.getMeta()));
+    tgt.setImplicitRules(src.getImplicitRules());
+    tgt.setLanguage(src.getLanguage());
+  }
+
+  public static void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu2.model.Resource tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public class SourceElementComponentWrapper {
+    public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
+      super();
+      this.source = source;
+      this.target = target;
+      this.comp = comp;
+    }
+
+    public String source;
+    public String target;
+    public org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent comp;
+  }
+
+  public static org.hl7.fhir.r4.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2.model.CodeableConcept t) throws FHIRException {
+    org.hl7.fhir.r4.model.UsageContext result = new org.hl7.fhir.r4.model.UsageContext();
+    result.setValue(convertCodeableConcept(t));
+    return result;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
+    CanonicalType dst = new CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
+    Reference dst = new Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Conformance.ConformanceEventModeEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Reference getPerformer(List<ImmunizationPerformerComponent> practitioner) {
+    for (ImmunizationPerformerComponent p : practitioner) {
+      if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "AP")) return p.getActor();
+    }
+    return null;
+  }
+
+  static public org.hl7.fhir.r4.model.Reference getRequester(List<ImmunizationPerformerComponent> practitioner) {
+    for (ImmunizationPerformerComponent p : practitioner) {
+      if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "OP")) return p.getActor();
+    }
+    return null;
+  }
+
+  static public boolean hasConcept(org.hl7.fhir.r4.model.CodeableConcept cc, String system, String code) {
+    for (org.hl7.fhir.r4.model.Coding c : cc.getCoding()) {
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
+    }
+    return false;
+  }
+
+  static public boolean hasConcept(org.hl7.fhir.dstu2.model.CodeableConcept cc, String system, String code) {
+    for (org.hl7.fhir.dstu2.model.Coding c : cc.getCoding()) {
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
+    }
+    return false;
+  }
+
+  public static org.hl7.fhir.r4.model.Dosage convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSiteCodeableConcept()) tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose() || src.hasRate()) {
+      DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
+      if (src.hasDose()) dr.setDose(convertType(src.getDose()));
+      if (src.hasRate()) dr.setRate(convertType(src.getRate()));
+    }
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent tgt = new org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent();
+    copyElement(src, tgt);
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertType(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
+      tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
+      tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Slot.SlotStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Slot.SlotStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Slot.SlotStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Slot.SlotStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUESTED:
+          tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case FAILED:
+          tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatusEnumFactory());
+    VersionConvertor_10_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent convertCodeSystem(org.hl7.fhir.r4.model.CodeSystem src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setSystemElement(convertUri(src.getUrlElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCaseSensitiveElement()) tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
+    for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(src, cc));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent convertCodeSystemConcept(CodeSystem cs, ConceptDefinitionComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent();
+    copyElement(src, tgt);
+    tgt.setAbstract(CodeSystemUtilities.isNotSelectable(cs, src));
+    tgt.setCode(src.getCode());
+    tgt.setDefinition(src.getDefinition());
+    tgt.setDisplay(src.getDisplay());
+    for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(cs, cc));
+    for (ConceptDefinitionDesignationComponent cc : src.getDesignation())
+      tgt.addDesignation(convertCodeSystemDesignation(cc));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent convertCodeSystemDesignation(ConceptDefinitionDesignationComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent();
+    copyElement(src, tgt);
+    tgt.setUse(convertCoding(src.getUse()));
+    tgt.setLanguage(src.getLanguage());
+    tgt.setValue(src.getValue());
+    return tgt;
+  }
+
+  static public boolean isJurisdiction(CodeableConcept t) {
+    return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
+  }
+
+  public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src, VersionConvertorAdvisor40 advisor) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2.model.Parameters)
+      return Parameters10_40.convertParameters((org.hl7.fhir.dstu2.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Appointment)
+      return Appointment10_40.convertAppointment((org.hl7.fhir.dstu2.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.AllergyIntolerance)
+      return AllergyIntolerance10_40.convertAllergyIntolerance((org.hl7.fhir.dstu2.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.AppointmentResponse)
+      return AppointmentResponse10_40.convertAppointmentResponse((org.hl7.fhir.dstu2.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.AuditEvent)
+      return AuditEvent10_40.convertAuditEvent((org.hl7.fhir.dstu2.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Basic)
+      return Basic10_40.convertBasic((org.hl7.fhir.dstu2.model.Basic) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Binary)
+      return Binary10_40.convertBinary((org.hl7.fhir.dstu2.model.Binary) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Bundle)
+      return Bundle10_40.convertBundle((org.hl7.fhir.dstu2.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CarePlan)
+      return CarePlan10_40.convertCarePlan((org.hl7.fhir.dstu2.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Communication)
+      return Communication10_40.convertCommunication((org.hl7.fhir.dstu2.model.Communication) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CommunicationRequest)
+      return CommunicationRequest10_40.convertCommunicationRequest((org.hl7.fhir.dstu2.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Composition)
+      return Composition10_40.convertComposition((org.hl7.fhir.dstu2.model.Composition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ConceptMap)
+      return ConceptMap10_40.convertConceptMap((org.hl7.fhir.dstu2.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Condition)
+      return Condition10_40.convertCondition((org.hl7.fhir.dstu2.model.Condition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Conformance)
+      return Conformance10_40.convertConformance((org.hl7.fhir.dstu2.model.Conformance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DataElement)
+      return DataElement10_40.convertDataElement((org.hl7.fhir.dstu2.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DetectedIssue)
+      return DetectedIssue10_40.convertDetectedIssue((org.hl7.fhir.dstu2.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DeviceMetric)
+      return DeviceMetric10_40.convertDeviceMetric((org.hl7.fhir.dstu2.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DeviceUseStatement)
+      return DeviceUseStatement10_40.convertDeviceUseStatement((org.hl7.fhir.dstu2.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DiagnosticReport)
+      return DiagnosticReport10_40.convertDiagnosticReport((org.hl7.fhir.dstu2.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DocumentReference)
+      return DocumentReference10_40.convertDocumentReference((org.hl7.fhir.dstu2.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Encounter)
+      return Encounter10_40.convertEncounter((org.hl7.fhir.dstu2.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentRequest)
+      return EnrollmentRequest10_40.convertEnrollmentRequest((org.hl7.fhir.dstu2.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentResponse)
+      return EnrollmentResponse10_40.convertEnrollmentResponse((org.hl7.fhir.dstu2.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EpisodeOfCare)
+      return EpisodeOfCare10_40.convertEpisodeOfCare((org.hl7.fhir.dstu2.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.FamilyMemberHistory)
+      return FamilyMemberHistory10_40.convertFamilyMemberHistory((org.hl7.fhir.dstu2.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Flag)
+      return Flag10_40.convertFlag((org.hl7.fhir.dstu2.model.Flag) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Group)
+      return Group10_40.convertGroup((org.hl7.fhir.dstu2.model.Group) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.HealthcareService)
+      return HealthcareService10_40.convertHealthcareService((org.hl7.fhir.dstu2.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ImplementationGuide)
+      return ImplementationGuide10_40.convertImplementationGuide((org.hl7.fhir.dstu2.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.List_)
+      return List10_40.convertList((org.hl7.fhir.dstu2.model.List_) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Location)
+      return Location10_40.convertLocation((org.hl7.fhir.dstu2.model.Location) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MedicationDispense)
+      return MedicationDispense10_40.convertMedicationDispense((org.hl7.fhir.dstu2.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MedicationStatement)
+      return MedicationStatement10_40.convertMedicationStatement((org.hl7.fhir.dstu2.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MedicationOrder)
+      return MedicationRequest10_40.convertMedicationRequest((org.hl7.fhir.dstu2.model.MedicationOrder) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MessageHeader)
+      return MessageHeader10_40.convertMessageHeader((org.hl7.fhir.dstu2.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.NamingSystem)
+      return NamingSystem10_40.convertNamingSystem((org.hl7.fhir.dstu2.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Observation)
+      return Observation10_40.convertObservation((org.hl7.fhir.dstu2.model.Observation) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OperationDefinition)
+      return OperationDefinition10_40.convertOperationDefinition((org.hl7.fhir.dstu2.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OperationOutcome)
+      return OperationOutcome10_40.convertOperationOutcome((org.hl7.fhir.dstu2.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Organization)
+      return Organization10_40.convertOrganization((org.hl7.fhir.dstu2.model.Organization) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Patient)
+      return Patient10_40.convertPatient((org.hl7.fhir.dstu2.model.Patient) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Person)
+      return Person10_40.convertPerson((org.hl7.fhir.dstu2.model.Person) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Practitioner)
+      return Practitioner10_40.convertPractitioner((org.hl7.fhir.dstu2.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Questionnaire)
+      return Questionnaire10_40.convertQuestionnaire((org.hl7.fhir.dstu2.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.QuestionnaireResponse)
+      return QuestionnaireResponse10_40.convertQuestionnaireResponse((org.hl7.fhir.dstu2.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.RiskAssessment)
+      return RiskAssessment10_40.convertRiskAssessment((org.hl7.fhir.dstu2.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Schedule)
+      return Schedule10_40.convertSchedule((org.hl7.fhir.dstu2.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SearchParameter)
+      return SearchParameter10_40.convertSearchParameter((org.hl7.fhir.dstu2.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Slot)
+      return Slot10_40.convertSlot((org.hl7.fhir.dstu2.model.Slot) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.StructureDefinition)
+      return StructureDefinition10_40.convertStructureDefinition((org.hl7.fhir.dstu2.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Subscription)
+      return Subscription10_40.convertSubscription((org.hl7.fhir.dstu2.model.Subscription) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Substance)
+      return Substance10_40.convertSubstance((org.hl7.fhir.dstu2.model.Substance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SupplyDelivery)
+      return SupplyDelivery10_40.convertSupplyDelivery((org.hl7.fhir.dstu2.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SupplyRequest)
+      return SupplyRequest10_40.convertSupplyRequest((org.hl7.fhir.dstu2.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.TestScript)
+      return TestScript10_40.convertTestScript((org.hl7.fhir.dstu2.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ValueSet)
+      return ValueSet10_40.convertValueSet((org.hl7.fhir.dstu2.model.ValueSet) src, advisor);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src, VersionConvertorAdvisor40 advisor) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Parameters)
+      return Parameters10_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r4.model.Appointment)
+      return Appointment10_40.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
+      return AppointmentResponse10_40.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
+      return AuditEvent10_40.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r4.model.Basic)
+      return Basic10_40.convertBasic((org.hl7.fhir.r4.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r4.model.Binary)
+      return Binary10_40.convertBinary((org.hl7.fhir.r4.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r4.model.Bundle)
+      return Bundle10_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src, advisor);
+    if (src instanceof org.hl7.fhir.r4.model.CarePlan)
+      return CarePlan10_40.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r4.model.Communication)
+      return Communication10_40.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r4.model.CommunicationRequest)
+      return CommunicationRequest10_40.convertCommunicationRequest((org.hl7.fhir.r4.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.Composition)
+      return Composition10_40.convertComposition((org.hl7.fhir.r4.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
+      return ConceptMap10_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.Condition)
+      return Condition10_40.convertCondition((org.hl7.fhir.r4.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
+      return Conformance10_40.convertConformance((org.hl7.fhir.r4.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
+      return DetectedIssue10_40.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceMetric)
+      return DeviceMetric10_40.convertDeviceMetric((org.hl7.fhir.r4.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
+      return DeviceUseStatement10_40.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
+      return DiagnosticReport10_40.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
+      return DocumentReference10_40.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r4.model.Encounter)
+      return Encounter10_40.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r4.model.EnrollmentRequest)
+      return EnrollmentRequest10_40.convertEnrollmentRequest((org.hl7.fhir.r4.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.EnrollmentResponse)
+      return EnrollmentResponse10_40.convertEnrollmentResponse((org.hl7.fhir.r4.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
+      return EpisodeOfCare10_40.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
+      return FamilyMemberHistory10_40.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r4.model.Flag) return Flag10_40.convertFlag((org.hl7.fhir.r4.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r4.model.Group)
+      return Group10_40.convertGroup((org.hl7.fhir.r4.model.Group) src);
+    if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
+      return HealthcareService10_40.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
+      return ImplementationGuide10_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r4.model.ListResource)
+      return List10_40.convertList((org.hl7.fhir.r4.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r4.model.Location)
+      return Location10_40.convertLocation((org.hl7.fhir.r4.model.Location) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
+      return MedicationDispense10_40.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
+      return MedicationStatement10_40.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
+      return MessageHeader10_40.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
+      return NamingSystem10_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.Observation)
+      return Observation10_40.convertObservation((org.hl7.fhir.r4.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
+      return OperationDefinition10_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
+      return OperationOutcome10_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r4.model.Organization)
+      return Organization10_40.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r4.model.Patient)
+      return Patient10_40.convertPatient((org.hl7.fhir.r4.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r4.model.Person)
+      return Person10_40.convertPerson((org.hl7.fhir.r4.model.Person) src);
+    if (src instanceof org.hl7.fhir.r4.model.Practitioner)
+      return Practitioner10_40.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
+      return Questionnaire10_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
+      return QuestionnaireResponse10_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
+      return RiskAssessment10_40.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r4.model.Schedule)
+      return Schedule10_40.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
+      return SearchParameter10_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r4.model.Slot) return Slot10_40.convertSlot((org.hl7.fhir.r4.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
+      return StructureDefinition10_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Subscription)
+      return Subscription10_40.convertSubscription((org.hl7.fhir.r4.model.Subscription) src);
+    if (src instanceof org.hl7.fhir.r4.model.Substance)
+      return Substance10_40.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
+      return SupplyDelivery10_40.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r4.model.SupplyRequest)
+      return SupplyRequest10_40.convertSupplyRequest((org.hl7.fhir.r4.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.TestScript)
+      return TestScript10_40.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r4.model.ValueSet)
+      return ValueSet10_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src, advisor);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src) {
+    TerminologyCapabilities res = new TerminologyCapabilities();
+    for (ParametersParameterComponent p : src.getParameter()) {
+      if (p.getName().equals("system")) res.addCodeSystem().setUri(p.getValue().primitiveValue());
+    }
+    return res;
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "Bundle", "CarePlan", "Communication", "CommunicationRequest", "Composition", "ConceptMap", "Condition", "CapabilityStatement", "DetectedIssue", "DeviceMetric", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "EnrollmentRequest", "EnrollmentResponse", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Group", "HealthcareService", "ImplementationGuide", "ListResource", "Location", "MedicationDispense", "MedicationStatement", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "Person", "Practitioner", "Questionnaire", "QuestionnaireResponse", "RiskAssessment", "Schedule", "SearchParameter", "Slot", "StructureDefinition", "Subscription", "Substance", "SupplyDelivery", "SupplyRequest", "TestScript", "ValueSet");
+  }
+
+  public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src) throws FHIRException {
+    return convertResource(src, null);
+  }
+
+  public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
+    return convertResource(src, null);
+  }
+
+  public static UnsignedIntType convertUnsignedIntToPositive(PositiveIntType src) {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_50.java
@@ -1,65 +1,6 @@
 package org.hl7.fhir.convertors;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.hl7.fhir.convertors.conv10_50.Appointment10_50;
-import org.hl7.fhir.convertors.conv10_50.AppointmentResponse10_50;
-import org.hl7.fhir.convertors.conv10_50.AuditEvent10_50;
-import org.hl7.fhir.convertors.conv10_50.Basic10_50;
-import org.hl7.fhir.convertors.conv10_50.Binary10_50;
-import org.hl7.fhir.convertors.conv10_50.Bundle10_50;
-import org.hl7.fhir.convertors.conv10_50.CarePlan10_50;
-import org.hl7.fhir.convertors.conv10_50.Communication10_50;
-import org.hl7.fhir.convertors.conv10_50.CommunicationRequest10_50;
-import org.hl7.fhir.convertors.conv10_50.Composition10_50;
-import org.hl7.fhir.convertors.conv10_50.ConceptMap10_50;
-import org.hl7.fhir.convertors.conv10_50.Condition10_50;
-import org.hl7.fhir.convertors.conv10_50.Conformance10_50;
-import org.hl7.fhir.convertors.conv10_50.DataElement10_50;
-import org.hl7.fhir.convertors.conv10_50.DetectedIssue10_50;
-import org.hl7.fhir.convertors.conv10_50.DeviceMetric10_50;
-import org.hl7.fhir.convertors.conv10_50.DeviceUseStatement10_50;
-import org.hl7.fhir.convertors.conv10_50.DiagnosticReport10_50;
-import org.hl7.fhir.convertors.conv10_50.DocumentReference10_50;
-import org.hl7.fhir.convertors.conv10_50.Encounter10_50;
-import org.hl7.fhir.convertors.conv10_50.EnrollmentRequest10_50;
-import org.hl7.fhir.convertors.conv10_50.EnrollmentResponse10_50;
-import org.hl7.fhir.convertors.conv10_50.EpisodeOfCare10_50;
-import org.hl7.fhir.convertors.conv10_50.FamilyMemberHistory10_50;
-import org.hl7.fhir.convertors.conv10_50.Flag10_50;
-import org.hl7.fhir.convertors.conv10_50.Group10_50;
-import org.hl7.fhir.convertors.conv10_50.HealthcareService10_50;
-import org.hl7.fhir.convertors.conv10_50.ImplementationGuide10_50;
-import org.hl7.fhir.convertors.conv10_50.List10_50;
-import org.hl7.fhir.convertors.conv10_50.Location10_50;
-import org.hl7.fhir.convertors.conv10_50.MedicationDispense10_50;
-import org.hl7.fhir.convertors.conv10_50.MedicationStatement10_50;
-import org.hl7.fhir.convertors.conv10_50.MessageHeader10_50;
-import org.hl7.fhir.convertors.conv10_50.NamingSystem10_50;
-import org.hl7.fhir.convertors.conv10_50.Observation10_50;
-import org.hl7.fhir.convertors.conv10_50.OperationDefinition10_50;
-import org.hl7.fhir.convertors.conv10_50.OperationOutcome10_50;
-import org.hl7.fhir.convertors.conv10_50.Organization10_50;
-import org.hl7.fhir.convertors.conv10_50.Parameters10_50;
-import org.hl7.fhir.convertors.conv10_50.Patient10_50;
-import org.hl7.fhir.convertors.conv10_50.Person10_50;
-import org.hl7.fhir.convertors.conv10_50.Practitioner10_50;
-import org.hl7.fhir.convertors.conv10_50.Provenance10_50;
-import org.hl7.fhir.convertors.conv10_50.Questionnaire10_50;
-import org.hl7.fhir.convertors.conv10_50.QuestionnaireResponse10_50;
-import org.hl7.fhir.convertors.conv10_50.RiskAssessment10_50;
-import org.hl7.fhir.convertors.conv10_50.Schedule10_50;
-import org.hl7.fhir.convertors.conv10_50.SearchParameter10_50;
-import org.hl7.fhir.convertors.conv10_50.Slot10_50;
-import org.hl7.fhir.convertors.conv10_50.StructureDefinition10_50;
-import org.hl7.fhir.convertors.conv10_50.Substance10_50;
-import org.hl7.fhir.convertors.conv10_50.SupplyDelivery10_50;
-import org.hl7.fhir.convertors.conv10_50.SupplyRequest10_50;
-import org.hl7.fhir.convertors.conv10_50.TestScript10_50;
-import org.hl7.fhir.convertors.conv10_50.ValueSet10_50;
+import org.hl7.fhir.convertors.conv10_50.*;
 import org.hl7.fhir.dstu2.model.CodeableConcept;
 import org.hl7.fhir.dstu2.model.Parameters;
 import org.hl7.fhir.dstu2.model.Parameters.ParametersParameterComponent;
@@ -75,12 +16,15 @@ import org.hl7.fhir.r5.model.CodeableReference;
 import org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent;
 import org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent;
 import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
-import org.hl7.fhir.r5.model.Enumeration;
 import org.hl7.fhir.r5.model.Immunization.ImmunizationPerformerComponent;
 import org.hl7.fhir.r5.model.TerminologyCapabilities;
-import org.hl7.fhir.r5.model.Timing.EventTiming;
 import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.utilities.Utilities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -108,3364 +52,3031 @@ import org.hl7.fhir.utilities.Utilities;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
+
 public class VersionConvertor_10_50 {
+  static public List<String> CANONICAL_URLS = new ArrayList<String>();
 
-    static public List<String> CANONICAL_URLS = new ArrayList<String>();
-
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
-    }
-
-    public static void copyElement(org.hl7.fhir.dstu2.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu2.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    public static void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu2.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    public static void copyElement(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu2.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu2.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu2.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UriType convertCodeToUri(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeType convertUriToCode(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDateTimeToDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu2.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu2.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu2.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IdType(src.getValue()) : new org.hl7.fhir.dstu2.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu2.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValue()) : new org.hl7.fhir.r5.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.InstantType(src.getValue()) : new org.hl7.fhir.dstu2.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu2.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValue()) : new org.hl7.fhir.r5.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu2.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu2.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu2.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.OidType(src.getValue()) : new org.hl7.fhir.dstu2.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
-      org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-      copyElement(src, tgt);
-      return tgt;
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
   }
 
-    public static org.hl7.fhir.dstu2.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
+  public static void copyElement(org.hl7.fhir.dstu2.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu2.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
+  }
 
-    public static org.hl7.fhir.dstu2.model.StringType convertMarkdownToString(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
+  public static void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu2.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
-    
-    public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu2.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
+  }
 
-    public static org.hl7.fhir.dstu2.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu2.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
+  public static void copyElement(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
+  }
 
-    public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
+  public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu2.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu2.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu2.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertCodeToUri(org.hl7.fhir.dstu2.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeType convertUriToCode(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu2.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu2.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDateTimeToDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateType convertDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu2.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu2.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu2.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu2.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IdType(src.getValue()) : new org.hl7.fhir.dstu2.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu2.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValue()) : new org.hl7.fhir.r5.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.InstantType(src.getValue()) : new org.hl7.fhir.dstu2.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu2.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValue()) : new org.hl7.fhir.r5.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu2.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu2.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu2.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.OidType(src.getValue()) : new org.hl7.fhir.dstu2.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.dstu2.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.StringType convertMarkdownToString(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.StringType(src.getValue()) : new org.hl7.fhir.dstu2.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu2.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu2.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu2.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UriType(src.getValue()) : new org.hl7.fhir.dstu2.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu2.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu2.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu2.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu2.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Extension tgt = new org.hl7.fhir.dstu2.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
+      else if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu2.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Narrative tgt = new org.hl7.fhir.dstu2.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu2.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu2.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
+  public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu2.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Annotation tgt = new org.hl7.fhir.dstu2.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTimeElement()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu2.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Long.valueOf(src.getSize()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Attachment tgt = new org.hl7.fhir.dstu2.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Math.toIntExact(src.getSize()));
+    if (src.hasHashElement()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitleElement()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreationElement()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.CodeableConcept tgt = new org.hl7.fhir.dstu2.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu2.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Coding tgt = new org.hl7.fhir.dstu2.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelectedElement()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu2.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Identifier tgt = new org.hl7.fhir.dstu2.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UriType(src.getValue()) : new org.hl7.fhir.dstu2.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu2.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
+  public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu2.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Period tgt = new org.hl7.fhir.dstu2.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStartElement()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEndElement()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu2.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Quantity tgt = new org.hl7.fhir.dstu2.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu2.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu2.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu2.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu2.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
+  public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu2.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Range tgt = new org.hl7.fhir.dstu2.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu2.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Ratio tgt = new org.hl7.fhir.dstu2.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu2.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
+    copyElement(src, tgt);
+    tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Reference tgt = new org.hl7.fhir.dstu2.model.Reference();
+    copyElement(src, tgt);
+    tgt.setReference(src.getReference());
+    if (src.hasDisplayElement()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu2.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.SampledData tgt = new org.hl7.fhir.dstu2.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactorElement()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimitElement()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimitElement()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu2.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
+    else tgt.setWho(convertReference(src.getWhoReference()));
+    if (src.hasContentTypeElement()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlobElement()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Signature tgt = new org.hl7.fhir.dstu2.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasSigFormatElement()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasDataElement()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu2.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Address tgt = new org.hl7.fhir.dstu2.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCityElement()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrictElement()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasStateElement()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCodeElement()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountryElement()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Extension tgt = new org.hl7.fhir.dstu2.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
-            else if (src.hasValue())
-                tgt.setValue(convertType(src.getValue()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu2.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Narrative tgt = new org.hl7.fhir.dstu2.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
-                break;
+  public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRankElement()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ContactPoint tgt = new org.hl7.fhir.dstu2.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValueElement()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRankElement()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2.model.ElementDefinition src, List<String> slicePaths, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasName()) {
+      if (slicePaths.contains(src.getPath())) tgt.setSliceNameElement(convertString(src.getNameElement()));
+      if (src.hasNameElement()) tgt.setIdElement(convertString(src.getNameElement()));
+    }
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasNameReference()) tgt.setContentReference("#" + src.getNameReference());
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertElementDefinitionTypeComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu2.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (tgt.getIsModifier()) {
+      String reason = org.hl7.fhir.dstu2.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+      if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+      tgt.setIsModifierReason(reason);
+    }
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    if (!tgt.hasId()) tgt.setId(tgt.getPath());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition tgt = new org.hl7.fhir.dstu2.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_10_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    else tgt.setNameElement(convertString(src.getIdElement()));
+    if (src.hasLabelElement()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShortElement()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinitionElement()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasCommentElement()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setNameReference(src.getContentReference().substring(1));
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertElementDefinitionTypeComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissingElement())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLengthElement()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupportElement()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifierElement()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu2.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummaryElement()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    org.hl7.fhir.dstu2.model.ElementDefinition slicingElement = context.get(pos);
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getDiscriminator()) {
+      boolean isExists = false;
+      if (!t.asStringValue().contains("@")) {
+        int slices = 0;
+        boolean existsSlicePresent = false;
+        boolean notExistsSlicePresent = false;
+        String existsPath = slicingElement.getPath() + "." + t.asStringValue();
+        for (int i = pos + 1; i < context.size(); i++) {
+          org.hl7.fhir.dstu2.model.ElementDefinition e = context.get(i);
+          if (e.getPath().equals(slicingElement.getPath())) slices++;
+          else if (!e.getPath().startsWith(slicingElement.getPath() + ".")) break;
+          else if (e.getPath().equals(existsPath)) {
+            if (e.hasMin() && e.getMin() > 0) existsSlicePresent = true;
+            else if (e.hasMax() && e.getMax().equals("0")) notExistsSlicePresent = true;
+          }
         }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu2.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTimeElement())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Annotation tgt = new org.hl7.fhir.dstu2.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTimeElement())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu2.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Long.valueOf(src.getSize()));
-        if (src.hasHashElement())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitleElement())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreationElement())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Attachment tgt = new org.hl7.fhir.dstu2.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Math.toIntExact(src.getSize()));
-        if (src.hasHashElement())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitleElement())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreationElement())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.CodeableConcept tgt = new org.hl7.fhir.dstu2.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu2.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelectedElement())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Coding tgt = new org.hl7.fhir.dstu2.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelectedElement())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu2.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Identifier tgt = new org.hl7.fhir.dstu2.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu2.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStartElement())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEndElement())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Period tgt = new org.hl7.fhir.dstu2.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStartElement())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEndElement())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu2.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Quantity tgt = new org.hl7.fhir.dstu2.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu2.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Range tgt = new org.hl7.fhir.dstu2.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu2.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Ratio tgt = new org.hl7.fhir.dstu2.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu2.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
-        copyElement(src, tgt);
-        tgt.setReference(src.getReference());
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Reference tgt = new org.hl7.fhir.dstu2.model.Reference();
-        copyElement(src, tgt);
-        tgt.setReference(src.getReference());
-        if (src.hasDisplayElement())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu2.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactorElement())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimitElement())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimitElement())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.SampledData tgt = new org.hl7.fhir.dstu2.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactorElement())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimitElement())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimitElement())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu2.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWhoUriType())
-            tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
-        else
-            tgt.setWho(convertReference(src.getWhoReference()));
-        if (src.hasContentTypeElement())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlobElement())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Signature tgt = new org.hl7.fhir.dstu2.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasSigFormatElement())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasDataElement())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu2.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCityElement())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrictElement())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasStateElement())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCodeElement())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountryElement())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Address tgt = new org.hl7.fhir.dstu2.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCityElement())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrictElement())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasStateElement())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCodeElement())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountryElement())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRankElement())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ContactPoint tgt = new org.hl7.fhir.dstu2.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValueElement())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRankElement())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2.model.ElementDefinition src, List<String> slicePaths, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_10_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasName()) {
-            if (slicePaths.contains(src.getPath()))
-                tgt.setSliceNameElement(convertString(src.getNameElement()));
-            if (src.hasNameElement())
-                tgt.setIdElement(convertString(src.getNameElement()));
-        }
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComments())
-            tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasNameReference())
-            tgt.setContentReference("#" + src.getNameReference());
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent t : src.getType()) convertElementDefinitionTypeComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu2.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu2.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-                reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
-        }
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        if (!tgt.hasId())
-            tgt.setId(tgt.getPath());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition tgt = new org.hl7.fhir.dstu2.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_10_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setNameElement(convertString(src.getSliceNameElement()));
-        else
-            tgt.setNameElement(convertString(src.getIdElement()));
-        if (src.hasLabelElement())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShortElement())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinitionElement())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasCommentElement())
-            tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setNameReference(src.getContentReference().substring(1));
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType()) convertElementDefinitionTypeComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissingElement())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.setExample(convertType(src.getExampleFirstRep().getValue()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLengthElement())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupportElement())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifierElement())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu2.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummaryElement())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        org.hl7.fhir.dstu2.model.ElementDefinition slicingElement = context.get(pos);
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getDiscriminator()) {
-            boolean isExists = false;
-            if (!t.asStringValue().contains("@")) {
-                int slices = 0;
-                boolean existsSlicePresent = false;
-                boolean notExistsSlicePresent = false;
-                String existsPath = slicingElement.getPath() + "." + t.asStringValue();
-                for (int i = pos + 1; i < context.size(); i++) {
-                    org.hl7.fhir.dstu2.model.ElementDefinition e = context.get(i);
-                    if (e.getPath().equals(slicingElement.getPath()))
-                        slices++;
-                    else if (!e.getPath().startsWith(slicingElement.getPath() + "."))
-                        break;
-                    else if (e.getPath().equals(existsPath)) {
-                        if (e.hasMin() && e.getMin() > 0)
-                            existsSlicePresent = true;
-                        else if (e.hasMax() && e.getMax().equals("0"))
-                            notExistsSlicePresent = true;
-                    }
-                }
-                isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
-            }
-            tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
-        }
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrderedElement())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrderedElement())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static void convertElementDefinitionTypeComponent(org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list) if (t.getCode().equals(src.getCode()))
-            tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCode(src.getCode());
-        }
-        if (tgt.hasTarget()) {
-            for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addTargetProfile(u.getValue());
-        } else {
-            for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
-        }
-        for (org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-    }
-
-    public static void convertElementDefinitionTypeComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-        list.add(tgt);
-        if (src.hasTarget()) {
-            for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        } else {
-            for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        }
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        tgt.setExpression(ToolingExtensions.readStringExtension(src, ToolingExtensions.EXT_EXPRESSION));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirementsElement())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            ToolingExtensions.addStringExtension(tgt, ToolingExtensions.EXT_EXPRESSION, src.getExpression());
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        org.hl7.fhir.r5.model.DataType vs = convertType(src.getValueSet());
-        if (vs != null) {
-            tgt.setValueSet(vs instanceof org.hl7.fhir.r5.model.Reference ? ((org.hl7.fhir.r5.model.Reference) vs).getReference() : vs.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescriptionElement())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu2.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu2.model.Reference(src.getValueSet()));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguageElement())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu2.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu2.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.HumanName tgt = new org.hl7.fhir.dstu2.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.addFamily(src.getFamily());
-        for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu2.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionIdElement())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdatedElement())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu2.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Meta tgt = new org.hl7.fhir.dstu2.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionIdElement())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdatedElement())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu2.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Timing tgt = new org.hl7.fhir.dstu2.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasDurationElement())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMaxElement())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnits())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMaxElement())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnits())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
-        tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasDurationElement())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMaxElement())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMaxElement())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu2.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Age tgt = new org.hl7.fhir.dstu2.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu2.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Count tgt = new org.hl7.fhir.dstu2.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu2.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Distance tgt = new org.hl7.fhir.dstu2.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu2.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Duration tgt = new org.hl7.fhir.dstu2.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu2.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCodeElement())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Money tgt = new org.hl7.fhir.dstu2.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrencyElement())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValueElement())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnitElement())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystemElement())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCodeElement())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu2.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu2.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu2.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu2.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DateType)
-            return convertDate((org.hl7.fhir.dstu2.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu2.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu2.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.IdType)
-            return convertId((org.hl7.fhir.dstu2.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OidType)
-            return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.StringType)
-            return convertString((org.hl7.fhir.dstu2.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UriType)
-            return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu2.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu2.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu2.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu2.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Range)
-            return convertRange((org.hl7.fhir.dstu2.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Reference)
-            return convertReference((org.hl7.fhir.dstu2.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu2.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu2.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Address)
-            return convertAddress((org.hl7.fhir.dstu2.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu2.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu2.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Age)
-            return convertAge((org.hl7.fhir.dstu2.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Count)
-            return convertCount((org.hl7.fhir.dstu2.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r5.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeType)
-            return convertCode((org.hl7.fhir.r5.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateType)
-            return convertDate((org.hl7.fhir.r5.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IdType)
-            return convertId((org.hl7.fhir.r5.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r5.model.InstantType)
-            return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r5.model.OidType)
-            return convertOid((org.hl7.fhir.r5.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.StringType)
-            return convertString((org.hl7.fhir.r5.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r5.model.TimeType)
-            return convertTime((org.hl7.fhir.r5.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IntegerType)
-          return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UriType)
-            return convertUri((org.hl7.fhir.r5.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UuidType)
-            return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.Extension)
-            return convertExtension((org.hl7.fhir.r5.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r5.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r5.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r5.model.Coding)
-            return convertCoding((org.hl7.fhir.r5.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r5.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r5.model.Period)
-            return convertPeriod((org.hl7.fhir.r5.model.Period) src);
-        if (src instanceof org.hl7.fhir.r5.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.Range)
-            return convertRange((org.hl7.fhir.r5.model.Range) src);
-        if (src instanceof org.hl7.fhir.r5.model.Ratio)
-            return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r5.model.Reference)
-            return convertReference((org.hl7.fhir.r5.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r5.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r5.model.Signature)
-            return convertSignature((org.hl7.fhir.r5.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r5.model.Address)
-            return convertAddress((org.hl7.fhir.r5.model.Address) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r5.model.Meta)
-            return convertMeta((org.hl7.fhir.r5.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r5.model.Timing)
-            return convertTiming((org.hl7.fhir.r5.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r5.model.Age)
-            return convertAge((org.hl7.fhir.r5.model.Age) src);
-        if (src instanceof org.hl7.fhir.r5.model.Count)
-            return convertCount((org.hl7.fhir.r5.model.Count) src);
-        if (src instanceof org.hl7.fhir.r5.model.Distance)
-            return convertDistance((org.hl7.fhir.r5.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Duration)
-            return convertDuration((org.hl7.fhir.r5.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r5.model.Money)
-            return convertMoney((org.hl7.fhir.r5.model.Money) src);
-        if (src instanceof org.hl7.fhir.r5.model.SimpleQuantity)
-            return convertSimpleQuantity((org.hl7.fhir.r5.model.SimpleQuantity) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    public static void copyDomainResource(org.hl7.fhir.dstu2.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu2.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu2.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu2.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    public static void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    public static void copyResource(org.hl7.fhir.dstu2.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    public static void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu2.model.Resource tgt) throws FHIRException {
-        tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public CodeableReference convertCodeableConceptToCodableReference(CodeableConcept src) {
-        CodeableReference tgt = new CodeableReference();
-        tgt.setConcept(convertCodeableConcept(src));
-        return tgt;
-    }
-
-    static public class SourceElementComponentWrapper {
-
-        public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
-            super();
-            this.source = source;
-            this.target = target;
-            this.comp = comp;
-        }
-
-        public String source;
-
-        public String target;
-
-        public org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent comp;
-    }
-
-    public static org.hl7.fhir.r5.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2.model.CodeableConcept t) throws FHIRException {
-        org.hl7.fhir.r5.model.UsageContext result = new org.hl7.fhir.r5.model.UsageContext();
-        result.setValue(convertCodeableConcept(t));
-        return result;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
-        CanonicalType dst = new CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
-        Reference dst = new Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityModeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Conformance.ConformanceEventModeEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Reference getPerformer(List<ImmunizationPerformerComponent> practitioner) {
-        for (ImmunizationPerformerComponent p : practitioner) {
-            if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "AP"))
-                return p.getActor();
-        }
-        return null;
-    }
-
-    static public org.hl7.fhir.r5.model.Reference getRequester(List<ImmunizationPerformerComponent> practitioner) {
-        for (ImmunizationPerformerComponent p : practitioner) {
-            if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "OP"))
-                return p.getActor();
-        }
-        return null;
-    }
-
-    static public boolean hasConcept(org.hl7.fhir.r5.model.CodeableConcept cc, String system, String code) {
-        for (org.hl7.fhir.r5.model.Coding c : cc.getCoding()) {
-            if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-                return true;
-        }
-        return false;
-    }
-
-    static public boolean hasConcept(org.hl7.fhir.dstu2.model.CodeableConcept cc, String system, String code) {
-        for (org.hl7.fhir.dstu2.model.Coding c : cc.getCoding()) {
-            if (system.equals(c.getSystem()) && code.equals(c.getCode()))
-                return true;
-        }
-        return false;
-    }
-
-    public static org.hl7.fhir.r5.model.Dosage convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSiteCodeableConcept())
-            tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDose() || src.hasRate()) {
-            DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
-            if (src.hasDose())
-                dr.setDose(convertType(src.getDose()));
-            if (src.hasRate())
-                dr.setRate(convertType(src.getRate()));
-        }
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent tgt = new org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent();
-        copyElement(src, tgt);
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertType(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
-            tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
-            tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Slot.SlotStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case BUSY:
-                tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSY);
-                break;
-            case FREE:
-                tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.FREE);
-                break;
-            case BUSYUNAVAILABLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-                break;
-            case BUSYTENTATIVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSYTENTATIVE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Slot.SlotStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case BUSY:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
-                break;
-            case FREE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
-                break;
-            case BUSYUNAVAILABLE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
-                break;
-            case BUSYTENTATIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUESTED:
-                tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
-                break;
-            case COMPLETED:
-                tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-                break;
-            case FAILED:
-                tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            case CANCELLED:
-                tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatusEnumFactory());
-        VersionConvertor_10_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
-                break;
-            case COMPLETED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
-                break;
-            case CANCELLED:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent convertCodeSystem(org.hl7.fhir.r5.model.CodeSystem src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setSystemElement(convertUri(src.getUrlElement()));
-        if (src.hasVersionElement())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCaseSensitiveElement())
-            tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
-        for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(src, cc));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent convertCodeSystemConcept(CodeSystem cs, ConceptDefinitionComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent();
-        copyElement(src, tgt);
-        tgt.setAbstract(CodeSystemUtilities.isNotSelectable(cs, src));
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-        if (src.hasDefinition())
-            tgt.setDefinition(src.getDefinition());
-        if (src.hasDisplay())
-            tgt.setDisplay(src.getDisplay());
-        for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(cs, cc));
-        for (ConceptDefinitionDesignationComponent cc : src.getDesignation()) tgt.addDesignation(convertCodeSystemDesignation(cc));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent convertCodeSystemDesignation(ConceptDefinitionDesignationComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUse(convertCoding(src.getUse()));
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        return tgt;
-    }
-
-    static public boolean isJurisdiction(CodeableConcept t) {
-        return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
-    }
-
-    public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src, VersionConvertorAdvisor50 advisor) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2.model.Parameters)
-            return Parameters10_50.convertParameters((org.hl7.fhir.dstu2.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Appointment)
-            return Appointment10_50.convertAppointment((org.hl7.fhir.dstu2.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.AppointmentResponse)
-            return AppointmentResponse10_50.convertAppointmentResponse((org.hl7.fhir.dstu2.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.AuditEvent)
-            return AuditEvent10_50.convertAuditEvent((org.hl7.fhir.dstu2.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Basic)
-            return Basic10_50.convertBasic((org.hl7.fhir.dstu2.model.Basic) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Binary)
-            return Binary10_50.convertBinary((org.hl7.fhir.dstu2.model.Binary) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Bundle)
-            return Bundle10_50.convertBundle((org.hl7.fhir.dstu2.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CarePlan)
-            return CarePlan10_50.convertCarePlan((org.hl7.fhir.dstu2.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Communication)
-            return Communication10_50.convertCommunication((org.hl7.fhir.dstu2.model.Communication) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.CommunicationRequest)
-            return CommunicationRequest10_50.convertCommunicationRequest((org.hl7.fhir.dstu2.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Composition)
-            return Composition10_50.convertComposition((org.hl7.fhir.dstu2.model.Composition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ConceptMap)
-            return ConceptMap10_50.convertConceptMap((org.hl7.fhir.dstu2.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Condition)
-            return Condition10_50.convertCondition((org.hl7.fhir.dstu2.model.Condition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Conformance)
-            return Conformance10_50.convertConformance((org.hl7.fhir.dstu2.model.Conformance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DataElement)
-            return DataElement10_50.convertDataElement((org.hl7.fhir.dstu2.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DetectedIssue)
-            return DetectedIssue10_50.convertDetectedIssue((org.hl7.fhir.dstu2.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DeviceMetric)
-            return DeviceMetric10_50.convertDeviceMetric((org.hl7.fhir.dstu2.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DeviceUseStatement)
-            return DeviceUseStatement10_50.convertDeviceUseStatement((org.hl7.fhir.dstu2.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DiagnosticReport)
-            return DiagnosticReport10_50.convertDiagnosticReport((org.hl7.fhir.dstu2.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.DocumentReference)
-            return DocumentReference10_50.convertDocumentReference((org.hl7.fhir.dstu2.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Encounter)
-            return Encounter10_50.convertEncounter((org.hl7.fhir.dstu2.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentRequest)
-            return EnrollmentRequest10_50.convertEnrollmentRequest((org.hl7.fhir.dstu2.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentResponse)
-            return EnrollmentResponse10_50.convertEnrollmentResponse((org.hl7.fhir.dstu2.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.EpisodeOfCare)
-            return EpisodeOfCare10_50.convertEpisodeOfCare((org.hl7.fhir.dstu2.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.FamilyMemberHistory)
-            return FamilyMemberHistory10_50.convertFamilyMemberHistory((org.hl7.fhir.dstu2.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Flag)
-            return Flag10_50.convertFlag((org.hl7.fhir.dstu2.model.Flag) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Group)
-            return Group10_50.convertGroup((org.hl7.fhir.dstu2.model.Group) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.HealthcareService)
-            return HealthcareService10_50.convertHealthcareService((org.hl7.fhir.dstu2.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ImplementationGuide)
-            return ImplementationGuide10_50.convertImplementationGuide((org.hl7.fhir.dstu2.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.List_)
-            return List10_50.convertList((org.hl7.fhir.dstu2.model.List_) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Location)
-            return Location10_50.convertLocation((org.hl7.fhir.dstu2.model.Location) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MedicationDispense)
-            return MedicationDispense10_50.convertMedicationDispense((org.hl7.fhir.dstu2.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MedicationStatement)
-            return MedicationStatement10_50.convertMedicationStatement((org.hl7.fhir.dstu2.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.MessageHeader)
-            return MessageHeader10_50.convertMessageHeader((org.hl7.fhir.dstu2.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.NamingSystem)
-            return NamingSystem10_50.convertNamingSystem((org.hl7.fhir.dstu2.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Observation)
-            return Observation10_50.convertObservation((org.hl7.fhir.dstu2.model.Observation) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OperationDefinition)
-            return OperationDefinition10_50.convertOperationDefinition((org.hl7.fhir.dstu2.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.OperationOutcome)
-            return OperationOutcome10_50.convertOperationOutcome((org.hl7.fhir.dstu2.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Organization)
-            return Organization10_50.convertOrganization((org.hl7.fhir.dstu2.model.Organization) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Patient)
-            return Patient10_50.convertPatient((org.hl7.fhir.dstu2.model.Patient) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Person)
-            return Person10_50.convertPerson((org.hl7.fhir.dstu2.model.Person) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Practitioner)
-          return Practitioner10_50.convertPractitioner((org.hl7.fhir.dstu2.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Provenance)
-          return Provenance10_50.convertProvenance((org.hl7.fhir.dstu2.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Questionnaire)
-            return Questionnaire10_50.convertQuestionnaire((org.hl7.fhir.dstu2.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.QuestionnaireResponse)
-            return QuestionnaireResponse10_50.convertQuestionnaireResponse((org.hl7.fhir.dstu2.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.RiskAssessment)
-            return RiskAssessment10_50.convertRiskAssessment((org.hl7.fhir.dstu2.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Schedule)
-            return Schedule10_50.convertSchedule((org.hl7.fhir.dstu2.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SearchParameter)
-            return SearchParameter10_50.convertSearchParameter((org.hl7.fhir.dstu2.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Slot)
-            return Slot10_50.convertSlot((org.hl7.fhir.dstu2.model.Slot) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.StructureDefinition)
-            return StructureDefinition10_50.convertStructureDefinition((org.hl7.fhir.dstu2.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.Substance)
-            return Substance10_50.convertSubstance((org.hl7.fhir.dstu2.model.Substance) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SupplyDelivery)
-            return SupplyDelivery10_50.convertSupplyDelivery((org.hl7.fhir.dstu2.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.SupplyRequest)
-            return SupplyRequest10_50.convertSupplyRequest((org.hl7.fhir.dstu2.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.TestScript)
-            return TestScript10_50.convertTestScript((org.hl7.fhir.dstu2.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu2.model.ValueSet)
-            return ValueSet10_50.convertValueSet((org.hl7.fhir.dstu2.model.ValueSet) src, advisor);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src, VersionConvertorAdvisor50 advisor) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Parameters)
-            return Parameters10_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r5.model.Appointment)
-            return Appointment10_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
-            return AppointmentResponse10_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
-            return AuditEvent10_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r5.model.Basic)
-            return Basic10_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r5.model.Binary)
-            return Binary10_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r5.model.Bundle)
-            return Bundle10_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src, advisor);
-        if (src instanceof org.hl7.fhir.r5.model.CarePlan)
-            return CarePlan10_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r5.model.Communication)
-            return Communication10_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r5.model.CommunicationRequest)
-            return CommunicationRequest10_50.convertCommunicationRequest((org.hl7.fhir.r5.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.Composition)
-            return Composition10_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
-            return ConceptMap10_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.Condition)
-            return Condition10_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
-            return Conformance10_50.convertConformance((org.hl7.fhir.r5.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
-            return DetectedIssue10_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceMetric)
-            return DeviceMetric10_50.convertDeviceMetric((org.hl7.fhir.r5.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
-            return DeviceUseStatement10_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
-            return DiagnosticReport10_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
-            return DocumentReference10_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r5.model.Encounter)
-            return Encounter10_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r5.model.EnrollmentRequest)
-            return EnrollmentRequest10_50.convertEnrollmentRequest((org.hl7.fhir.r5.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.EnrollmentResponse)
-            return EnrollmentResponse10_50.convertEnrollmentResponse((org.hl7.fhir.r5.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
-            return EpisodeOfCare10_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
-            return FamilyMemberHistory10_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r5.model.Flag)
-            return Flag10_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r5.model.Group)
-            return Group10_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
-        if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
-            return HealthcareService10_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-            return ImplementationGuide10_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r5.model.ListResource)
-            return List10_50.convertList((org.hl7.fhir.r5.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r5.model.Location)
-            return Location10_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
-            return MedicationDispense10_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
-            return MedicationStatement10_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
-        if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
-            return MessageHeader10_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
-            return NamingSystem10_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.Observation)
-            return Observation10_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
-            return OperationDefinition10_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
-            return OperationOutcome10_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r5.model.Organization)
-            return Organization10_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r5.model.Patient)
-            return Patient10_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r5.model.Person)
-            return Person10_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
-        if (src instanceof org.hl7.fhir.r5.model.Practitioner)
-            return Practitioner10_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r5.model.Provenance)
-          return Provenance10_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
-            return Questionnaire10_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
-            return QuestionnaireResponse10_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
-            return RiskAssessment10_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r5.model.Schedule)
-            return Schedule10_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
-            return SearchParameter10_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r5.model.Slot)
-            return Slot10_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
-            return StructureDefinition10_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Substance)
-            return Substance10_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
-            return SupplyDelivery10_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r5.model.SupplyRequest)
-            return SupplyRequest10_50.convertSupplyRequest((org.hl7.fhir.r5.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.TestScript)
-            return TestScript10_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r5.model.ValueSet)
-            return ValueSet10_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src, advisor);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src) {
-        TerminologyCapabilities res = new TerminologyCapabilities();
-        for (ParametersParameterComponent p : src.getParameter()) {
-            if (p.getName().equals("system"))
-                res.addCodeSystem().setUri(p.getValue().primitiveValue());
-            if (p.getName().equals("expansion.parameter"))
-              res.getExpansion().addParameter().setName(p.getValue().primitiveValue());
-        }
-        return res;
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "Bundle", "CarePlan", "Communication", "CommunicationRequest", "Composition", "ConceptMap", "Condition", "CapabilityStatement", "DetectedIssue", "DeviceMetric", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "EnrollmentRequest", "EnrollmentResponse", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Group", "HealthcareService", "ImplementationGuide", "ListResource", "Location", "MedicationDispense", "MedicationStatement", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "Person", "Practitioner", "Questionnaire", "QuestionnaireResponse", "RiskAssessment", "Schedule", "SearchParameter", "Slot", "StructureDefinition", "Subscription", "Substance", "SupplyDelivery", "SupplyRequest", "TestScript", "ValueSet");
-    }
-
-    public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src) throws FHIRException {
-        return convertResource(src, null);
-    }
-
-    public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
-        return convertResource(src, null);
-    }
+        isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
+      }
+      tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
+    }
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrderedElement()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static void convertElementDefinitionTypeComponent(org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
+      copyElement(src, tgt);
+      tgt.setCode(src.getCode());
+    }
+    if (tgt.hasTarget()) {
+      for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addTargetProfile(u.getValue());
+    } else {
+      for (org.hl7.fhir.dstu2.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
+    }
+    for (org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+  }
+
+  public static void convertElementDefinitionTypeComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(src.getCode());
+    list.add(tgt);
+    if (src.hasTarget()) {
+      for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    }
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    tgt.setExpression(ToolingExtensions.readStringExtension(src, ToolingExtensions.EXT_EXPRESSION));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirementsElement()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression())
+      ToolingExtensions.addStringExtension(tgt, ToolingExtensions.EXT_EXPRESSION, src.getExpression());
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    org.hl7.fhir.r5.model.DataType vs = convertType(src.getValueSet());
+    if (vs != null) {
+      tgt.setValueSet(vs instanceof org.hl7.fhir.r5.model.Reference ? ((org.hl7.fhir.r5.model.Reference) vs).getReference() : vs.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescriptionElement()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu2.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu2.model.Reference(src.getValueSet()));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguageElement()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu2.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu2.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.HumanName tgt = new org.hl7.fhir.dstu2.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
+    for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu2.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu2.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu2.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Meta tgt = new org.hl7.fhir.dstu2.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionIdElement()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdatedElement()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu2.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Timing tgt = new org.hl7.fhir.dstu2.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnits()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitsElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnits()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitsElement()));
+    tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasDurationElement()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMaxElement()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitsElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMaxElement()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitsElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu2.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Age tgt = new org.hl7.fhir.dstu2.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu2.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Count tgt = new org.hl7.fhir.dstu2.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu2.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Distance tgt = new org.hl7.fhir.dstu2.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu2.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Duration tgt = new org.hl7.fhir.dstu2.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu2.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCodeElement()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Money tgt = new org.hl7.fhir.dstu2.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrencyElement()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValueElement()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnitElement()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystemElement()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCodeElement()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu2.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu2.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu2.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CodeType)
+      return convertCode((org.hl7.fhir.dstu2.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DateType)
+      return convertDate((org.hl7.fhir.dstu2.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu2.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu2.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.IdType) return convertId((org.hl7.fhir.dstu2.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu2.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu2.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OidType) return convertOid((org.hl7.fhir.dstu2.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu2.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.StringType)
+      return convertString((org.hl7.fhir.dstu2.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.TimeType)
+      return convertTime((org.hl7.fhir.dstu2.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu2.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu2.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UriType) return convertUri((org.hl7.fhir.dstu2.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.UuidType)
+      return convertUuid((org.hl7.fhir.dstu2.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu2.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu2.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu2.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu2.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu2.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Coding) return convertCoding((org.hl7.fhir.dstu2.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu2.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Period) return convertPeriod((org.hl7.fhir.dstu2.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu2.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Range) return convertRange((org.hl7.fhir.dstu2.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Ratio) return convertRatio((org.hl7.fhir.dstu2.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Reference)
+      return convertReference((org.hl7.fhir.dstu2.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu2.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu2.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Address)
+      return convertAddress((org.hl7.fhir.dstu2.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu2.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu2.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Meta) return convertMeta((org.hl7.fhir.dstu2.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Timing) return convertTiming((org.hl7.fhir.dstu2.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Age) return convertAge((org.hl7.fhir.dstu2.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Count) return convertCount((org.hl7.fhir.dstu2.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu2.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu2.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Money) return convertMoney((org.hl7.fhir.dstu2.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.dstu2.model.SimpleQuantity) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r5.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeType) return convertCode((org.hl7.fhir.r5.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateType) return convertDate((org.hl7.fhir.r5.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IdType) return convertId((org.hl7.fhir.r5.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r5.model.InstantType)
+      return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r5.model.OidType) return convertOid((org.hl7.fhir.r5.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.StringType)
+      return convertString((org.hl7.fhir.r5.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r5.model.TimeType) return convertTime((org.hl7.fhir.r5.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UriType) return convertUri((org.hl7.fhir.r5.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UuidType) return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.Extension)
+      return convertExtension((org.hl7.fhir.r5.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r5.model.Narrative)
+      return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r5.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r5.model.Coding) return convertCoding((org.hl7.fhir.r5.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r5.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r5.model.Period) return convertPeriod((org.hl7.fhir.r5.model.Period) src);
+    if (src instanceof org.hl7.fhir.r5.model.Quantity) return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.Range) return convertRange((org.hl7.fhir.r5.model.Range) src);
+    if (src instanceof org.hl7.fhir.r5.model.Ratio) return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r5.model.Reference)
+      return convertReference((org.hl7.fhir.r5.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r5.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r5.model.Signature)
+      return convertSignature((org.hl7.fhir.r5.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r5.model.Address) return convertAddress((org.hl7.fhir.r5.model.Address) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.HumanName)
+      return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r5.model.Meta) return convertMeta((org.hl7.fhir.r5.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r5.model.Timing) return convertTiming((org.hl7.fhir.r5.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r5.model.Age) return convertAge((org.hl7.fhir.r5.model.Age) src);
+    if (src instanceof org.hl7.fhir.r5.model.Count) return convertCount((org.hl7.fhir.r5.model.Count) src);
+    if (src instanceof org.hl7.fhir.r5.model.Distance) return convertDistance((org.hl7.fhir.r5.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Duration) return convertDuration((org.hl7.fhir.r5.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r5.model.Money) return convertMoney((org.hl7.fhir.r5.model.Money) src);
+    if (src instanceof org.hl7.fhir.r5.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.r5.model.SimpleQuantity) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  public static void copyDomainResource(org.hl7.fhir.dstu2.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu2.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu2.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu2.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  public static void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  public static void copyResource(org.hl7.fhir.dstu2.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  public static void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu2.model.Resource tgt) throws FHIRException {
+    tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public CodeableReference convertCodeableConceptToCodableReference(CodeableConcept src) {
+    CodeableReference tgt = new CodeableReference();
+    tgt.setConcept(convertCodeableConcept(src));
+    return tgt;
+  }
+
+  static public class SourceElementComponentWrapper {
+    public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
+      super();
+      this.source = source;
+      this.target = target;
+      this.comp = comp;
+    }
+
+    public String source;
+    public String target;
+    public org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent comp;
+  }
+
+  public static org.hl7.fhir.r5.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2.model.CodeableConcept t) throws FHIRException {
+    org.hl7.fhir.r5.model.UsageContext result = new org.hl7.fhir.r5.model.UsageContext();
+    result.setValue(convertCodeableConcept(t));
+    return result;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
+    CanonicalType dst = new CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
+    Reference dst = new Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Conformance.ConformanceEventModeEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Conformance.ConformanceEventMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu2.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Reference getPerformer(List<ImmunizationPerformerComponent> practitioner) {
+    for (ImmunizationPerformerComponent p : practitioner) {
+      if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "AP")) return p.getActor();
+    }
+    return null;
+  }
+
+  static public org.hl7.fhir.r5.model.Reference getRequester(List<ImmunizationPerformerComponent> practitioner) {
+    for (ImmunizationPerformerComponent p : practitioner) {
+      if (hasConcept(p.getFunction(), "http://hl7.org/fhir/v2/0443", "OP")) return p.getActor();
+    }
+    return null;
+  }
+
+  static public boolean hasConcept(org.hl7.fhir.r5.model.CodeableConcept cc, String system, String code) {
+    for (org.hl7.fhir.r5.model.Coding c : cc.getCoding()) {
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
+    }
+    return false;
+  }
+
+  static public boolean hasConcept(org.hl7.fhir.dstu2.model.CodeableConcept cc, String system, String code) {
+    for (org.hl7.fhir.dstu2.model.Coding c : cc.getCoding()) {
+      if (system.equals(c.getSystem()) && code.equals(c.getCode())) return true;
+    }
+    return false;
+  }
+
+  public static org.hl7.fhir.r5.model.Dosage convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSiteCodeableConcept()) tgt.setSite(convertCodeableConcept(src.getSiteCodeableConcept()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose() || src.hasRate()) {
+      DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
+      if (src.hasDose()) dr.setDose(convertType(src.getDose()));
+      if (src.hasRate()) dr.setRate(convertType(src.getRate()));
+    }
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent convertMedicationOrderDosageInstructionComponent(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent tgt = new org.hl7.fhir.dstu2.model.MedicationOrder.MedicationOrderDosageInstructionComponent();
+    copyElement(src, tgt);
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertType(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
+      tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
+      tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Slot.SlotStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Slot.SlotStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> convertSlotStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Slot.SlotStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.Slot.SlotStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.Slot.SlotStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case BUSY:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSY);
+          break;
+        case FREE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.FREE);
+          break;
+        case BUSYUNAVAILABLE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYUNAVAILABLE);
+          break;
+        case BUSYTENTATIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.BUSYTENTATIVE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.Slot.SlotStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUESTED:
+          tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.ACTIVE);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case FAILED:
+          tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> convertSupplyRequestStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.SupplyRequest.SupplyRequestStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.Enumeration<org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus> tgt = new org.hl7.fhir.dstu2.model.Enumeration<>(new org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatusEnumFactory());
+    VersionConvertor_10_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.REQUESTED);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.COMPLETED);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.CANCELLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2.model.SupplyRequest.SupplyRequestStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent convertCodeSystem(org.hl7.fhir.r5.model.CodeSystem src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ValueSetCodeSystemComponent();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setSystemElement(convertUri(src.getUrlElement()));
+    if (src.hasVersionElement()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCaseSensitiveElement()) tgt.setCaseSensitiveElement(convertBoolean(src.getCaseSensitiveElement()));
+    for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(src, cc));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent convertCodeSystemConcept(CodeSystem cs, ConceptDefinitionComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionComponent();
+    copyElement(src, tgt);
+    tgt.setAbstract(CodeSystemUtilities.isNotSelectable(cs, src));
+    if (src.hasCode()) tgt.setCode(src.getCode());
+    if (src.hasDefinition()) tgt.setDefinition(src.getDefinition());
+    if (src.hasDisplay()) tgt.setDisplay(src.getDisplay());
+    for (ConceptDefinitionComponent cc : src.getConcept()) tgt.addConcept(convertCodeSystemConcept(cs, cc));
+    for (ConceptDefinitionDesignationComponent cc : src.getDesignation())
+      tgt.addDesignation(convertCodeSystemDesignation(cc));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent convertCodeSystemDesignation(ConceptDefinitionDesignationComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent tgt = new org.hl7.fhir.dstu2.model.ValueSet.ConceptDefinitionDesignationComponent();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUse(convertCoding(src.getUse()));
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    return tgt;
+  }
+
+  static public boolean isJurisdiction(CodeableConcept t) {
+    return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
+  }
+
+  public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src, VersionConvertorAdvisor50 advisor) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2.model.Parameters)
+      return Parameters10_50.convertParameters((org.hl7.fhir.dstu2.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Appointment)
+      return Appointment10_50.convertAppointment((org.hl7.fhir.dstu2.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.AppointmentResponse)
+      return AppointmentResponse10_50.convertAppointmentResponse((org.hl7.fhir.dstu2.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.AuditEvent)
+      return AuditEvent10_50.convertAuditEvent((org.hl7.fhir.dstu2.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Basic)
+      return Basic10_50.convertBasic((org.hl7.fhir.dstu2.model.Basic) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Binary)
+      return Binary10_50.convertBinary((org.hl7.fhir.dstu2.model.Binary) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Bundle)
+      return Bundle10_50.convertBundle((org.hl7.fhir.dstu2.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CarePlan)
+      return CarePlan10_50.convertCarePlan((org.hl7.fhir.dstu2.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Communication)
+      return Communication10_50.convertCommunication((org.hl7.fhir.dstu2.model.Communication) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.CommunicationRequest)
+      return CommunicationRequest10_50.convertCommunicationRequest((org.hl7.fhir.dstu2.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Composition)
+      return Composition10_50.convertComposition((org.hl7.fhir.dstu2.model.Composition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ConceptMap)
+      return ConceptMap10_50.convertConceptMap((org.hl7.fhir.dstu2.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Condition)
+      return Condition10_50.convertCondition((org.hl7.fhir.dstu2.model.Condition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Conformance)
+      return Conformance10_50.convertConformance((org.hl7.fhir.dstu2.model.Conformance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DataElement)
+      return DataElement10_50.convertDataElement((org.hl7.fhir.dstu2.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DetectedIssue)
+      return DetectedIssue10_50.convertDetectedIssue((org.hl7.fhir.dstu2.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DeviceMetric)
+      return DeviceMetric10_50.convertDeviceMetric((org.hl7.fhir.dstu2.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DeviceUseStatement)
+      return DeviceUseStatement10_50.convertDeviceUseStatement((org.hl7.fhir.dstu2.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DiagnosticReport)
+      return DiagnosticReport10_50.convertDiagnosticReport((org.hl7.fhir.dstu2.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.DocumentReference)
+      return DocumentReference10_50.convertDocumentReference((org.hl7.fhir.dstu2.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Encounter)
+      return Encounter10_50.convertEncounter((org.hl7.fhir.dstu2.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentRequest)
+      return EnrollmentRequest10_50.convertEnrollmentRequest((org.hl7.fhir.dstu2.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EnrollmentResponse)
+      return EnrollmentResponse10_50.convertEnrollmentResponse((org.hl7.fhir.dstu2.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.EpisodeOfCare)
+      return EpisodeOfCare10_50.convertEpisodeOfCare((org.hl7.fhir.dstu2.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.FamilyMemberHistory)
+      return FamilyMemberHistory10_50.convertFamilyMemberHistory((org.hl7.fhir.dstu2.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Flag)
+      return Flag10_50.convertFlag((org.hl7.fhir.dstu2.model.Flag) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Group)
+      return Group10_50.convertGroup((org.hl7.fhir.dstu2.model.Group) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.HealthcareService)
+      return HealthcareService10_50.convertHealthcareService((org.hl7.fhir.dstu2.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ImplementationGuide)
+      return ImplementationGuide10_50.convertImplementationGuide((org.hl7.fhir.dstu2.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.List_)
+      return List10_50.convertList((org.hl7.fhir.dstu2.model.List_) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Location)
+      return Location10_50.convertLocation((org.hl7.fhir.dstu2.model.Location) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MedicationDispense)
+      return MedicationDispense10_50.convertMedicationDispense((org.hl7.fhir.dstu2.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MedicationStatement)
+      return MedicationStatement10_50.convertMedicationStatement((org.hl7.fhir.dstu2.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.MessageHeader)
+      return MessageHeader10_50.convertMessageHeader((org.hl7.fhir.dstu2.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.NamingSystem)
+      return NamingSystem10_50.convertNamingSystem((org.hl7.fhir.dstu2.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Observation)
+      return Observation10_50.convertObservation((org.hl7.fhir.dstu2.model.Observation) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OperationDefinition)
+      return OperationDefinition10_50.convertOperationDefinition((org.hl7.fhir.dstu2.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.OperationOutcome)
+      return OperationOutcome10_50.convertOperationOutcome((org.hl7.fhir.dstu2.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Organization)
+      return Organization10_50.convertOrganization((org.hl7.fhir.dstu2.model.Organization) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Patient)
+      return Patient10_50.convertPatient((org.hl7.fhir.dstu2.model.Patient) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Person)
+      return Person10_50.convertPerson((org.hl7.fhir.dstu2.model.Person) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Practitioner)
+      return Practitioner10_50.convertPractitioner((org.hl7.fhir.dstu2.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Provenance)
+      return Provenance10_50.convertProvenance((org.hl7.fhir.dstu2.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Questionnaire)
+      return Questionnaire10_50.convertQuestionnaire((org.hl7.fhir.dstu2.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.QuestionnaireResponse)
+      return QuestionnaireResponse10_50.convertQuestionnaireResponse((org.hl7.fhir.dstu2.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.RiskAssessment)
+      return RiskAssessment10_50.convertRiskAssessment((org.hl7.fhir.dstu2.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Schedule)
+      return Schedule10_50.convertSchedule((org.hl7.fhir.dstu2.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SearchParameter)
+      return SearchParameter10_50.convertSearchParameter((org.hl7.fhir.dstu2.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Slot)
+      return Slot10_50.convertSlot((org.hl7.fhir.dstu2.model.Slot) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.StructureDefinition)
+      return StructureDefinition10_50.convertStructureDefinition((org.hl7.fhir.dstu2.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.Substance)
+      return Substance10_50.convertSubstance((org.hl7.fhir.dstu2.model.Substance) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SupplyDelivery)
+      return SupplyDelivery10_50.convertSupplyDelivery((org.hl7.fhir.dstu2.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.SupplyRequest)
+      return SupplyRequest10_50.convertSupplyRequest((org.hl7.fhir.dstu2.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.TestScript)
+      return TestScript10_50.convertTestScript((org.hl7.fhir.dstu2.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu2.model.ValueSet)
+      return ValueSet10_50.convertValueSet((org.hl7.fhir.dstu2.model.ValueSet) src, advisor);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src, VersionConvertorAdvisor50 advisor) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Parameters)
+      return Parameters10_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r5.model.Appointment)
+      return Appointment10_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
+      return AppointmentResponse10_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
+      return AuditEvent10_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r5.model.Basic)
+      return Basic10_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r5.model.Binary)
+      return Binary10_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r5.model.Bundle)
+      return Bundle10_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src, advisor);
+    if (src instanceof org.hl7.fhir.r5.model.CarePlan)
+      return CarePlan10_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r5.model.Communication)
+      return Communication10_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r5.model.CommunicationRequest)
+      return CommunicationRequest10_50.convertCommunicationRequest((org.hl7.fhir.r5.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.Composition)
+      return Composition10_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
+      return ConceptMap10_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.Condition)
+      return Condition10_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
+      return Conformance10_50.convertConformance((org.hl7.fhir.r5.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
+      return DetectedIssue10_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceMetric)
+      return DeviceMetric10_50.convertDeviceMetric((org.hl7.fhir.r5.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
+      return DeviceUseStatement10_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
+      return DiagnosticReport10_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
+      return DocumentReference10_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r5.model.Encounter)
+      return Encounter10_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r5.model.EnrollmentRequest)
+      return EnrollmentRequest10_50.convertEnrollmentRequest((org.hl7.fhir.r5.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.EnrollmentResponse)
+      return EnrollmentResponse10_50.convertEnrollmentResponse((org.hl7.fhir.r5.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
+      return EpisodeOfCare10_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
+      return FamilyMemberHistory10_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r5.model.Flag) return Flag10_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r5.model.Group)
+      return Group10_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
+    if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
+      return HealthcareService10_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
+      return ImplementationGuide10_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r5.model.ListResource)
+      return List10_50.convertList((org.hl7.fhir.r5.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r5.model.Location)
+      return Location10_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
+      return MedicationDispense10_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
+      return MedicationStatement10_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
+    if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
+      return MessageHeader10_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
+      return NamingSystem10_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.Observation)
+      return Observation10_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
+      return OperationDefinition10_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
+      return OperationOutcome10_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r5.model.Organization)
+      return Organization10_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r5.model.Patient)
+      return Patient10_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r5.model.Person)
+      return Person10_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
+    if (src instanceof org.hl7.fhir.r5.model.Practitioner)
+      return Practitioner10_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r5.model.Provenance)
+      return Provenance10_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
+      return Questionnaire10_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
+      return QuestionnaireResponse10_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
+      return RiskAssessment10_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r5.model.Schedule)
+      return Schedule10_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
+      return SearchParameter10_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r5.model.Slot) return Slot10_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
+      return StructureDefinition10_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Substance)
+      return Substance10_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
+      return SupplyDelivery10_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r5.model.SupplyRequest)
+      return SupplyRequest10_50.convertSupplyRequest((org.hl7.fhir.r5.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.TestScript)
+      return TestScript10_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r5.model.ValueSet)
+      return ValueSet10_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src, advisor);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src) {
+    TerminologyCapabilities res = new TerminologyCapabilities();
+    for (ParametersParameterComponent p : src.getParameter()) {
+      if (p.getName().equals("system")) res.addCodeSystem().setUri(p.getValue().primitiveValue());
+      if (p.getName().equals("expansion.parameter"))
+        res.getExpansion().addParameter().setName(p.getValue().primitiveValue());
+    }
+    return res;
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "Bundle", "CarePlan", "Communication", "CommunicationRequest", "Composition", "ConceptMap", "Condition", "CapabilityStatement", "DetectedIssue", "DeviceMetric", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "EnrollmentRequest", "EnrollmentResponse", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Group", "HealthcareService", "ImplementationGuide", "ListResource", "Location", "MedicationDispense", "MedicationStatement", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "Person", "Practitioner", "Questionnaire", "QuestionnaireResponse", "RiskAssessment", "Schedule", "SearchParameter", "Slot", "StructureDefinition", "Subscription", "Substance", "SupplyDelivery", "SupplyRequest", "TestScript", "ValueSet");
+  }
+
+  public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2.model.Resource src) throws FHIRException {
+    return convertResource(src, null);
+  }
+
+  public static org.hl7.fhir.dstu2.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
+    return convertResource(src, null);
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_30.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_30.java
@@ -1,5 +1,15 @@
 package org.hl7.fhir.convertors;
 
+import org.hl7.fhir.convertors.conv14_30.*;
+import org.hl7.fhir.dstu2016may.model.CodeableConcept;
+import org.hl7.fhir.dstu3.conformance.ProfileUtilities;
+import org.hl7.fhir.dstu3.model.ConceptMap.SourceElementComponent;
+import org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.utilities.Utilities;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -27,2881 +37,2543 @@ package org.hl7.fhir.convertors;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
-import org.hl7.fhir.convertors.conv14_30.Bundle14_30;
-import org.hl7.fhir.convertors.conv14_30.CodeSystem14_30;
-import org.hl7.fhir.convertors.conv14_30.CompartmentDefinition14_30;
-import org.hl7.fhir.convertors.conv14_30.ConceptMap14_30;
-import org.hl7.fhir.convertors.conv14_30.Conformance14_30;
-import org.hl7.fhir.convertors.conv14_30.DataElement14_30;
-import org.hl7.fhir.convertors.conv14_30.ImplementationGuide14_30;
-import org.hl7.fhir.convertors.conv14_30.NamingSystem14_30;
-import org.hl7.fhir.convertors.conv14_30.OperationDefinition14_30;
-import org.hl7.fhir.convertors.conv14_30.OperationOutcome14_30;
-import org.hl7.fhir.convertors.conv14_30.Parameters14_30;
-import org.hl7.fhir.convertors.conv14_30.Questionnaire14_30;
-import org.hl7.fhir.convertors.conv14_30.QuestionnaireResponse14_30;
-import org.hl7.fhir.convertors.conv14_30.SearchParameter14_30;
-import org.hl7.fhir.convertors.conv14_30.StructureDefinition14_30;
-import org.hl7.fhir.convertors.conv14_30.TestScript14_30;
-import org.hl7.fhir.convertors.conv14_30.ValueSet14_30;
-import org.hl7.fhir.dstu2016may.model.CodeableConcept;
-import org.hl7.fhir.dstu3.conformance.ProfileUtilities;
-import org.hl7.fhir.dstu3.model.ConceptMap.SourceElementComponent;
-import org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
-import org.hl7.fhir.dstu3.model.Enumeration;
-import org.hl7.fhir.dstu3.model.Timing.EventTiming;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.utilities.Utilities;
-
-import java.util.Collections;
-import java.util.stream.Collectors;
 
 public class VersionConvertor_14_30 {
-
-    static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && (!(e.getUrl().equals(VersionConvertorConstants.PROFILE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION)))) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.Base64BinaryType tgt = new org.hl7.fhir.dstu3.model.Base64BinaryType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.BooleanType tgt = new org.hl7.fhir.dstu3.model.BooleanType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.CodeType tgt = new org.hl7.fhir.dstu3.model.CodeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateType tgt = new org.hl7.fhir.dstu3.model.DateType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateTimeType tgt = new org.hl7.fhir.dstu3.model.DateTimeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DecimalType tgt = new org.hl7.fhir.dstu3.model.DecimalType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IdType tgt = new org.hl7.fhir.dstu3.model.IdType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.InstantType tgt = new org.hl7.fhir.dstu3.model.InstantType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IntegerType tgt = new org.hl7.fhir.dstu3.model.IntegerType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.MarkdownType tgt = new org.hl7.fhir.dstu3.model.MarkdownType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.OidType tgt = new org.hl7.fhir.dstu3.model.OidType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.PositiveIntType tgt = new org.hl7.fhir.dstu3.model.PositiveIntType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.StringType tgt = new org.hl7.fhir.dstu3.model.StringType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.TimeType tgt = new org.hl7.fhir.dstu3.model.TimeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UnsignedIntType tgt = new org.hl7.fhir.dstu3.model.UnsignedIntType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UriType tgt = new org.hl7.fhir.dstu3.model.UriType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UuidType tgt = new org.hl7.fhir.dstu3.model.UuidType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
-        if (src.hasValue()) tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasTextElement())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_14_30::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasName())
-            tgt.setSliceNameElement(convertString(src.getNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComments())
-            tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType()) tgt.addType(convertTypeRefComponent(t));
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_14_30::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType()) tgt.addType(convertTypeRefComponent(t));
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.setExample(convertType(src.getExample().get(0).getValue()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCode(src.getCode());
-        for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
-            if (src.getCode().equals("Reference"))
-                tgt.setTargetProfile(u.getValue());
-            else
-                tgt.setProfile(u.getValue());
-        }
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
-            String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
-            tgt.setProfile(s);
-        }
-        tgt.setAggregation(src.getAggregation().stream()
-                .map(VersionConvertor_14_30::convertAggregationMode)
-                .collect(Collectors.toList()));
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCode(src.getCode());
-        if (src.hasTarget()) {
-            if (src.hasTargetProfile()) {
-                tgt.addProfile(src.getTargetProfile());
-            }
-            if (src.hasProfile()) {
-                if (src.getCode().equals("Reference")) {
-                    org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
-                    t.setValue(new org.hl7.fhir.dstu2016may.model.StringType(src.getProfile()));
-                    tgt.addExtension(t);
-                } else
-                    tgt.addProfile(src.getProfile());
-            }
-        } else
-            tgt.addProfile(src.getProfile());
-        tgt.setAggregation(src.getAggregation().stream()
-                .map(VersionConvertor_14_30::convertAggregationMode)
-                .collect(Collectors.toList()));
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet())
-            tgt.setValueSet(convertType(src.getValueSet()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet())
-            tgt.setValueSet(convertType(src.getValueSet()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.addFamily(src.getFamily());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCountElement(convertInteger(src.getCountElement()));
-        if (src.hasCountMax())
-            tgt.setCountMaxElement(convertInteger(src.getCountMaxElement()));
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
-        }
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCountElement(convertInteger(src.getCountElement()));
-        if (src.hasCountMax())
-            tgt.setCountMaxElement(convertInteger(src.getCountMaxElement()));
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
-        }
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
-            return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
-            return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
-            return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
-            return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
-            return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Age)
-            return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
-            return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
-            return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
-            return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
-            return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.dstu2016may.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateType)
-            return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IdType)
-            return convertId((org.hl7.fhir.dstu3.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OidType)
-            return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StringType)
-            return convertString((org.hl7.fhir.dstu3.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UriType)
-            return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Age)
-            return convertAge((org.hl7.fhir.dstu3.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Count)
-            return convertCount((org.hl7.fhir.dstu3.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Money)
-            return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Range)
-            return convertRange((org.hl7.fhir.dstu3.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Reference)
-            return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Address)
-            return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu3.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu3.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu3.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    public static org.hl7.fhir.dstu3.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Binary tgt = new org.hl7.fhir.dstu3.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasContentElement())
-            tgt.setContentElement(convertBase64Binary(src.getContentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.dstu3.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasContentElement())
-            tgt.setContentElement(convertBase64Binary(src.getContentElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public boolean isJurisdiction(CodeableConcept t) {
-        return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
-    }
-
-    public static org.hl7.fhir.dstu3.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UsageContext result = new org.hl7.fhir.dstu3.model.UsageContext();
-        result.setValue(convertCodeableConcept(t));
-        return result;
-    }
-
-    static public class SourceElementComponentWrapper {
-
-        public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
-            super();
-            this.source = source;
-            this.target = target;
-            this.comp = comp;
-        }
-
-        public String source;
-
-        public String target;
-
-        public org.hl7.fhir.dstu3.model.ConceptMap.SourceElementComponent comp;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_30.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
-            return Parameters14_30.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
-            return Bundle14_30.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
-            return CodeSystem14_30.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
-            return CompartmentDefinition14_30.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
-            return ConceptMap14_30.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
-            return Conformance14_30.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
-            return DataElement14_30.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
-            return ImplementationGuide14_30.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
-            return NamingSystem14_30.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
-            return OperationDefinition14_30.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
-            return OperationOutcome14_30.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
-            return Questionnaire14_30.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_30.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
-            return SearchParameter14_30.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
-            return StructureDefinition14_30.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.TestScript)
-            return TestScript14_30.convertTestScript((org.hl7.fhir.dstu2016may.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
-            return ValueSet14_30.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
-            return Parameters14_30.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
-            return Bundle14_30.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
-            return CodeSystem14_30.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
-            return CompartmentDefinition14_30.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
-            return ConceptMap14_30.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
-            return Conformance14_30.convertConformance((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
-            return DataElement14_30.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
-            return ImplementationGuide14_30.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
-            return NamingSystem14_30.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
-            return OperationDefinition14_30.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
-            return OperationOutcome14_30.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
-            return Questionnaire14_30.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_30.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
-            return SearchParameter14_30.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
-            return StructureDefinition14_30.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
-            return TestScript14_30.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
-            return ValueSet14_30.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "DataElement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "TestScript", "ValueSet");
-    }
+  static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && (!(e.getUrl().equals(VersionConvertorConstants.PROFILE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION)))) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.Base64BinaryType tgt = new org.hl7.fhir.dstu3.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.BooleanType tgt = new org.hl7.fhir.dstu3.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.CodeType tgt = new org.hl7.fhir.dstu3.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateType tgt = new org.hl7.fhir.dstu3.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateTimeType tgt = new org.hl7.fhir.dstu3.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DecimalType tgt = new org.hl7.fhir.dstu3.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IdType tgt = new org.hl7.fhir.dstu3.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.InstantType tgt = new org.hl7.fhir.dstu3.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IntegerType tgt = new org.hl7.fhir.dstu3.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.MarkdownType tgt = new org.hl7.fhir.dstu3.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.OidType tgt = new org.hl7.fhir.dstu3.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.PositiveIntType tgt = new org.hl7.fhir.dstu3.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.StringType tgt = new org.hl7.fhir.dstu3.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.TimeType tgt = new org.hl7.fhir.dstu3.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UnsignedIntType tgt = new org.hl7.fhir.dstu3.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UriType tgt = new org.hl7.fhir.dstu3.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UuidType tgt = new org.hl7.fhir.dstu3.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasTextElement()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setBlobElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_30::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasName()) tgt.setSliceNameElement(convertString(src.getNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType())
+      tgt.addType(convertTypeRefComponent(t));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_30::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType())
+      tgt.addType(convertTypeRefComponent(t));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExample().get(0).getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCode(src.getCode());
+    for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
+      if (src.getCode().equals("Reference")) tgt.setTargetProfile(u.getValue());
+      else tgt.setProfile(u.getValue());
+    }
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
+      String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
+      tgt.setProfile(s);
+    }
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_14_30::convertAggregationMode).collect(Collectors.toList()));
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCode(src.getCode());
+    if (src.hasTarget()) {
+      if (src.hasTargetProfile()) {
+        tgt.addProfile(src.getTargetProfile());
+      }
+      if (src.hasProfile()) {
+        if (src.getCode().equals("Reference")) {
+          org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
+          t.setValue(new org.hl7.fhir.dstu2016may.model.StringType(src.getProfile()));
+          tgt.addExtension(t);
+        } else tgt.addProfile(src.getProfile());
+      }
+    } else tgt.addProfile(src.getProfile());
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_14_30::convertAggregationMode).collect(Collectors.toList()));
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSet(convertType(src.getValueSet()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSet(convertType(src.getValueSet()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCountElement(convertInteger(src.getCountElement()));
+    if (src.hasCountMax()) tgt.setCountMaxElement(convertInteger(src.getCountMaxElement()));
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
+    if (src.hasFrequencyMax()) tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
+    }
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCountElement(convertInteger(src.getCountElement()));
+    if (src.hasCountMax()) tgt.setCountMaxElement(convertInteger(src.getCountMaxElement()));
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequencyElement(convertInteger(src.getFrequencyElement()));
+    if (src.hasFrequencyMax()) tgt.setFrequencyMaxElement(convertInteger(src.getFrequencyMaxElement()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    }
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
+      return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
+      return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
+      return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
+      return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
+      return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
+      return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
+      return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
+      return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Age) return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
+      return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
+      return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
+      return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
+      return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
+      return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
+      return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
+      return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
+      return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.dstu2016may.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
+      return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
+      return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeType) return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateType) return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IdType) return convertId((org.hl7.fhir.dstu3.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OidType) return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StringType)
+      return convertString((org.hl7.fhir.dstu3.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TimeType) return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UriType) return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UuidType) return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Age) return convertAge((org.hl7.fhir.dstu3.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Coding) return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Count) return convertCount((org.hl7.fhir.dstu3.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Money) return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Period) return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Range) return convertRange((org.hl7.fhir.dstu3.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Ratio) return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Reference)
+      return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Address) return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Meta) return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Timing) return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension())
+      tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu3.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu3.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu3.model.Extension t : src.getModifierExtension())
+      tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  public static org.hl7.fhir.dstu3.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Binary tgt = new org.hl7.fhir.dstu3.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasContentElement()) tgt.setContentElement(convertBase64Binary(src.getContentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.dstu3.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasContentElement()) tgt.setContentElement(convertBase64Binary(src.getContentElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public boolean isJurisdiction(CodeableConcept t) {
+    return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
+  }
+
+  public static org.hl7.fhir.dstu3.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UsageContext result = new org.hl7.fhir.dstu3.model.UsageContext();
+    result.setValue(convertCodeableConcept(t));
+    return result;
+  }
+
+  static public class SourceElementComponentWrapper {
+    public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
+      super();
+      this.source = source;
+      this.target = target;
+      this.comp = comp;
+    }
+
+    public String source;
+    public String target;
+    public org.hl7.fhir.dstu3.model.ConceptMap.SourceElementComponent comp;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_30.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
+      return Parameters14_30.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
+      return Bundle14_30.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
+      return CodeSystem14_30.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
+      return CompartmentDefinition14_30.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
+      return ConceptMap14_30.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
+      return Conformance14_30.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
+      return DataElement14_30.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
+      return ImplementationGuide14_30.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
+      return NamingSystem14_30.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
+      return OperationDefinition14_30.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
+      return OperationOutcome14_30.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
+      return Questionnaire14_30.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_30.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
+      return SearchParameter14_30.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
+      return StructureDefinition14_30.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.TestScript)
+      return TestScript14_30.convertTestScript((org.hl7.fhir.dstu2016may.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
+      return ValueSet14_30.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
+      return Parameters14_30.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
+      return Bundle14_30.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
+      return CodeSystem14_30.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
+      return CompartmentDefinition14_30.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
+      return ConceptMap14_30.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
+      return Conformance14_30.convertConformance((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
+      return DataElement14_30.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
+      return ImplementationGuide14_30.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
+      return NamingSystem14_30.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
+      return OperationDefinition14_30.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
+      return OperationOutcome14_30.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
+      return Questionnaire14_30.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_30.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
+      return SearchParameter14_30.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
+      return StructureDefinition14_30.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
+      return TestScript14_30.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
+      return ValueSet14_30.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "DataElement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "TestScript", "ValueSet");
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_40.java
@@ -1,5 +1,15 @@
 package org.hl7.fhir.convertors;
 
+import org.hl7.fhir.convertors.conv14_40.*;
+import org.hl7.fhir.dstu2016may.model.CodeableConcept;
+import org.hl7.fhir.dstu2016may.model.Reference;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.conformance.ProfileUtilities;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent;
+import org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
+import org.hl7.fhir.utilities.Utilities;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,3083 +41,2708 @@ import java.util.stream.Collectors;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
-import org.hl7.fhir.convertors.conv14_40.Bundle14_40;
-import org.hl7.fhir.convertors.conv14_40.CodeSystem14_40;
-import org.hl7.fhir.convertors.conv14_40.CompartmentDefinition14_40;
-import org.hl7.fhir.convertors.conv14_40.ConceptMap14_40;
-import org.hl7.fhir.convertors.conv14_40.Conformance14_40;
-import org.hl7.fhir.convertors.conv14_40.DataElement14_40;
-import org.hl7.fhir.convertors.conv14_40.ImplementationGuide14_40;
-import org.hl7.fhir.convertors.conv14_40.NamingSystem14_40;
-import org.hl7.fhir.convertors.conv14_40.OperationDefinition14_40;
-import org.hl7.fhir.convertors.conv14_40.OperationOutcome14_40;
-import org.hl7.fhir.convertors.conv14_40.Parameters14_40;
-import org.hl7.fhir.convertors.conv14_40.Questionnaire14_40;
-import org.hl7.fhir.convertors.conv14_40.QuestionnaireResponse14_40;
-import org.hl7.fhir.convertors.conv14_40.SearchParameter14_40;
-import org.hl7.fhir.convertors.conv14_40.StructureDefinition14_40;
-import org.hl7.fhir.convertors.conv14_40.StructureMap14_40;
-import org.hl7.fhir.convertors.conv14_40.ValueSet14_40;
-import org.hl7.fhir.dstu2016may.model.CodeableConcept;
-import org.hl7.fhir.dstu2016may.model.Reference;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r4.conformance.ProfileUtilities;
-import org.hl7.fhir.r4.model.CanonicalType;
-import org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent;
-import org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
-import org.hl7.fhir.r4.model.Enumeration;
-import org.hl7.fhir.r4.model.Timing.EventTiming;
-import org.hl7.fhir.utilities.Utilities;
 
 public class VersionConvertor_14_40 {
+  static public List<String> CANONICAL_URLS = new ArrayList<String>();
 
-    static public List<String> CANONICAL_URLS = new ArrayList<String>();
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  }
 
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && (!(e.getUrl().equals(VersionConvertorConstants.PROFILE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION)))) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
+  }
 
-    static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && (!(e.getUrl().equals(VersionConvertorConstants.PROFILE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || e.getUrl().equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION)))) {
-                tgt.addExtension(convertExtension(e));
-            }
+  static public void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r4.model.Base64BinaryType tgt = new org.hl7.fhir.r4.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r4.model.BooleanType tgt = new org.hl7.fhir.r4.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.CodeType tgt = new org.hl7.fhir.r4.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateType tgt = new org.hl7.fhir.r4.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = new org.hl7.fhir.r4.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DecimalType tgt = new org.hl7.fhir.r4.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IdType tgt = new org.hl7.fhir.r4.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r4.model.InstantType tgt = new org.hl7.fhir.r4.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IntegerType tgt = new org.hl7.fhir.r4.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r4.model.MarkdownType tgt = new org.hl7.fhir.r4.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.OidType tgt = new org.hl7.fhir.r4.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.PositiveIntType tgt = new org.hl7.fhir.r4.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r4.model.StringType tgt = new org.hl7.fhir.r4.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.TimeType tgt = new org.hl7.fhir.r4.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = new org.hl7.fhir.r4.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UriType tgt = new org.hl7.fhir.r4.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UuidType tgt = new org.hl7.fhir.r4.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2016may.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCode()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
+    else tgt.setWho(convertReference(src.getWhoReference()));
+    if (src.hasContentType()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasSigFormat()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasName()) tgt.setSliceNameElement(convertString(src.getNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (tgt.getIsModifier()) {
+      String reason = org.hl7.fhir.dstu2016may.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+      if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+      tgt.setIsModifierReason(reason);
+    }
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExample().get(0).getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu2016may.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    org.hl7.fhir.dstu2016may.model.ElementDefinition slicingElement = context.get(pos);
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator()) {
+      boolean isExists = false;
+      if (!t.asStringValue().contains("@")) {
+        int slices = 0;
+        boolean existsSlicePresent = false;
+        boolean notExistsSlicePresent = false;
+        String existsPath = slicingElement.getPath() + "." + t.asStringValue();
+        for (int i = pos + 1; i < context.size(); i++) {
+          org.hl7.fhir.dstu2016may.model.ElementDefinition e = context.get(i);
+          if (e.getPath().equals(slicingElement.getPath())) slices++;
+          else if (!e.getPath().startsWith(slicingElement.getPath() + ".")) break;
+          else if (e.getPath().equals(existsPath)) {
+            if (e.hasMin() && e.getMin() > 0 && !e.hasFixed()) existsSlicePresent = true;
+            else if (e.hasMax() && e.getMax().equals("0")) notExistsSlicePresent = true;
+          }
         }
-    }
-
-    static public void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r4.model.Base64BinaryType tgt = new org.hl7.fhir.r4.model.Base64BinaryType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r4.model.BooleanType tgt = new org.hl7.fhir.r4.model.BooleanType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.CodeType tgt = new org.hl7.fhir.r4.model.CodeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateType tgt = new org.hl7.fhir.r4.model.DateType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = new org.hl7.fhir.r4.model.DateTimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DecimalType tgt = new org.hl7.fhir.r4.model.DecimalType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IdType tgt = new org.hl7.fhir.r4.model.IdType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r4.model.InstantType tgt = new org.hl7.fhir.r4.model.InstantType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IntegerType tgt = new org.hl7.fhir.r4.model.IntegerType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r4.model.MarkdownType tgt = new org.hl7.fhir.r4.model.MarkdownType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.OidType tgt = new org.hl7.fhir.r4.model.OidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.PositiveIntType tgt = new org.hl7.fhir.r4.model.PositiveIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r4.model.StringType tgt = new org.hl7.fhir.r4.model.StringType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.TimeType tgt = new org.hl7.fhir.r4.model.TimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UnsignedIntType tgt = new org.hl7.fhir.r4.model.UnsignedIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UriType tgt = new org.hl7.fhir.r4.model.UriType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UuidType tgt = new org.hl7.fhir.r4.model.UuidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2016may.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCode())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWhoUriType())
-            tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
-        else
-            tgt.setWho(convertReference(src.getWhoReference()));
-        if (src.hasContentType())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasSigFormat())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_14_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasName())
-            tgt.setSliceNameElement(convertString(src.getNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComments())
-            tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu2016may.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-                reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
-        }
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_14_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.setExample(convertType(src.getExample().get(0).getValue()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu2016may.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        org.hl7.fhir.dstu2016may.model.ElementDefinition slicingElement = context.get(pos);
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator()) {
-            boolean isExists = false;
-            if (!t.asStringValue().contains("@")) {
-                int slices = 0;
-                boolean existsSlicePresent = false;
-                boolean notExistsSlicePresent = false;
-                String existsPath = slicingElement.getPath() + "." + t.asStringValue();
-                for (int i = pos + 1; i < context.size(); i++) {
-                    org.hl7.fhir.dstu2016may.model.ElementDefinition e = context.get(i);
-                    if (e.getPath().equals(slicingElement.getPath()))
-                        slices++;
-                    else if (!e.getPath().startsWith(slicingElement.getPath() + "."))
-                        break;
-                    else if (e.getPath().equals(existsPath)) {
-                        if (e.hasMin() && e.getMin() > 0 && !e.hasFixed())
-                            existsSlicePresent = true;
-                        else if (e.hasMax() && e.getMax().equals("0"))
-                            notExistsSlicePresent = true;
-                    }
-                }
-                isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
-            }
-            tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
-        }
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    static public void convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list) if (t.getCode().equals(src.getCode()))
-            tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCode(src.getCode());
-        }
-        if (tgt.hasTarget()) {
-            for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
-                if (src.getCode().equals("Reference"))
-                    tgt.addTargetProfile(u.getValue());
-                else
-                    tgt.addProfile(u.getValue());
-            }
-            for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
-                String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
-                tgt.addProfile(s);
-            }
-        } else {
-            for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
-        }
-        for (org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCode(src.getCode());
-        list.add(tgt);
-        if (src.hasTarget()) {
-            for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
-                tgt.addProfile(u.getValue());
-                String baseName = u.getValue().toLowerCase();
-                if (baseName.contains("reference") && !baseName.contains("documentreference"))
-                    throw new Error("2016May Target profile contains the word 'reference':" + u);
-            }
-            for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
-                if (src.getCode().equals("Reference")) {
-                    org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
-                    t.setValue(convertType(u));
-                    tgt.addExtension(t);
-                } else
-                    tgt.addProfile(u.getValue());
-            }
-        } else {
-            for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        }
-        for (org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpression(convertToR4Expression(src.getExpression()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpression(convertTo2016MayExpression(src.getExpression()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static String convertToR4Expression(String oldExpression) {
-        String pass1 = oldExpression.replaceAll("\\$context", "%context").replaceAll("\\$resource", "%resource").replaceAll("code\\+profile", "code&profile").replaceAll("path\\+'\\.'", "path&'.'").replaceAll("fullUrl\\+resource", "fullUrl&resource");
-        String pass2 = pass1;
-        if (pass1.endsWith(".distinct()"))
-            pass2 = pass1.substring(0, pass2.length() - 11) + ".isDistinct()";
-        String pass3 = pass2;
-        if (pass2.endsWith(".empty() or (type.count() = 1)"))
-            pass3 = pass2.substring(0, pass2.length() - 30) + ".empty() or (type.count() <= 1)";
-        String pass4 = pass3;
-        if (pass3.equals("duration >= 0"))
-            pass4 = "duration.exists() implies duration >= 0";
-        else if (pass3.equals("period >= 0"))
-            pass4 = "period.exists() implies period >= 0";
-        else if (pass3.equals("fullUrl.empty() xor resource"))
-            pass4 = "fullUrl.empty() xor resource.exists()";
-        return pass4;
-    }
-
-    public static String convertTo2016MayExpression(String newExpression) {
-        String pass1 = newExpression.replaceAll("%context", "\\$context").replaceAll("%resource", "\\$resource").replaceAll("code&profile", "code+profile").replaceAll("path&'\\.'", "path+'.'").replaceAll("fullUrl%resource", "fullUrl+resource");
-        String pass2 = pass1;
-        if (pass1.endsWith(".isDistinct()"))
-            pass2 = pass1.substring(0, pass1.length() - 13) + ".distinct()";
-        String pass3 = pass2;
-        if (pass2.endsWith(".empty() or (type.count() <= 1)"))
-            pass3 = pass2.substring(0, pass2.length() - 31) + ".empty() or (type.count() = 1)";
-        String pass4 = pass3;
-        if (pass3.equals("duration.exists() implies duration >= 0"))
-            pass4 = "duration >= 0";
-        else if (pass3.equals("period.exists() implies period >= 0"))
-            pass4 = "period >= 0";
-        else if (pass3.equals("fullUrl.empty() xor resource.exists()"))
-            pass4 = "fullUrl.empty() xor resource";
-        return pass4;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            org.hl7.fhir.r4.model.Type t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r4.model.Reference)
-                tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
-            else
-                tgt.setValueSet(t.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.Reference(src.getValueSet()));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.addFamily(src.getFamily());
-        for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
-        }
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen()) {
-            tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
-        }
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
-            return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
-            return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
-            return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
-            return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
-            return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Age)
-            return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
-            return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
-            return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
-            return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
-            return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r4.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeType)
-            return convertCode((org.hl7.fhir.r4.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateType)
-            return convertDate((org.hl7.fhir.r4.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IdType)
-            return convertId((org.hl7.fhir.r4.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r4.model.InstantType)
-            return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r4.model.OidType)
-            return convertOid((org.hl7.fhir.r4.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.StringType)
-            return convertString((org.hl7.fhir.r4.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r4.model.TimeType)
-            return convertTime((org.hl7.fhir.r4.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IntegerType)
-          return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UriType)
-            return convertUri((org.hl7.fhir.r4.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UuidType)
-            return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.Extension)
-            return convertExtension((org.hl7.fhir.r4.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r4.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r4.model.Age)
-            return convertAge((org.hl7.fhir.r4.model.Age) src);
-        if (src instanceof org.hl7.fhir.r4.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coding)
-            return convertCoding((org.hl7.fhir.r4.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r4.model.Count)
-            return convertCount((org.hl7.fhir.r4.model.Count) src);
-        if (src instanceof org.hl7.fhir.r4.model.Distance)
-            return convertDistance((org.hl7.fhir.r4.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Duration)
-            return convertDuration((org.hl7.fhir.r4.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r4.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r4.model.Money)
-            return convertMoney((org.hl7.fhir.r4.model.Money) src);
-        if (src instanceof org.hl7.fhir.r4.model.Period)
-            return convertPeriod((org.hl7.fhir.r4.model.Period) src);
-        if (src instanceof org.hl7.fhir.r4.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Range)
-            return convertRange((org.hl7.fhir.r4.model.Range) src);
-        if (src instanceof org.hl7.fhir.r4.model.Ratio)
-            return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r4.model.Reference)
-            return convertReference((org.hl7.fhir.r4.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r4.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r4.model.Signature)
-            return convertSignature((org.hl7.fhir.r4.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r4.model.Address)
-            return convertAddress((org.hl7.fhir.r4.model.Address) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r4.model.Meta)
-            return convertMeta((org.hl7.fhir.r4.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r4.model.Timing)
-            return convertTiming((org.hl7.fhir.r4.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    public static org.hl7.fhir.r4.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Binary tgt = new org.hl7.fhir.r4.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        tgt.setContent(src.getContent());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.r4.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        tgt.setContent(src.getContent());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public boolean isJurisdiction(CodeableConcept t) {
-        return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
-    }
-
-    public static org.hl7.fhir.r4.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
-        org.hl7.fhir.r4.model.UsageContext result = new org.hl7.fhir.r4.model.UsageContext();
-        result.setValue(convertCodeableConcept(t));
-        return result;
-    }
-
-    static public class SourceElementComponentWrapper {
-
-        public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
-            super();
-            this.source = source;
-            this.target = target;
-            this.comp = comp;
-        }
-
-        public String source;
-
-        public String target;
-
-        public org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent comp;
-    }
-
-    static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
-        CanonicalType dst = new CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
-        Reference dst = new Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityModeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventModeEnumFactory());
-        VersionConvertor_14_40.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
-            return Parameters14_40.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
-            return Bundle14_40.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
-            return CodeSystem14_40.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
-            return CompartmentDefinition14_40.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
-            return ConceptMap14_40.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
-            return Conformance14_40.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
-            return DataElement14_40.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
-            return ImplementationGuide14_40.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
-            return NamingSystem14_40.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
-            return OperationDefinition14_40.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
-            return OperationOutcome14_40.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
-            return Questionnaire14_40.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_40.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
-            return SearchParameter14_40.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
-            return StructureDefinition14_40.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StructureMap)
-            return StructureMap14_40.convertStructureMap((org.hl7.fhir.dstu2016may.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
-            return ValueSet14_40.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Parameters)
-            return Parameters14_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r4.model.Bundle)
-            return Bundle14_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
-            return CodeSystem14_40.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
-            return CompartmentDefinition14_40.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
-            return ConceptMap14_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
-            return Conformance14_40.convertConformance((org.hl7.fhir.r4.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
-            return ImplementationGuide14_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
-            return NamingSystem14_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
-            return OperationDefinition14_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
-            return OperationOutcome14_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
-            return Questionnaire14_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
-            return SearchParameter14_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
-            return StructureDefinition14_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureMap)
-            return StructureMap14_40.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.ValueSet)
-            return ValueSet14_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "StructureMap", "ValueSet");
-    }
+        isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
+      }
+      tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
+    }
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  static public void convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
+      copyElement(src, tgt);
+      tgt.setCode(src.getCode());
+    }
+    if (tgt.hasTarget()) {
+      for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
+        if (src.getCode().equals("Reference")) tgt.addTargetProfile(u.getValue());
+        else tgt.addProfile(u.getValue());
+      }
+      for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
+        String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
+        tgt.addProfile(s);
+      }
+    } else {
+      for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
+    }
+    for (org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCode(src.getCode());
+    list.add(tgt);
+    if (src.hasTarget()) {
+      for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
+        tgt.addProfile(u.getValue());
+        String baseName = u.getValue().toLowerCase();
+        if (baseName.contains("reference") && !baseName.contains("documentreference"))
+          throw new Error("2016May Target profile contains the word 'reference':" + u);
+      }
+      for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
+        if (src.getCode().equals("Reference")) {
+          org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
+          t.setValue(convertType(u));
+          tgt.addExtension(t);
+        } else tgt.addProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    }
+    for (org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpression(convertToR4Expression(src.getExpression()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpression(convertTo2016MayExpression(src.getExpression()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static String convertToR4Expression(String oldExpression) {
+    String pass1 = oldExpression.replaceAll("\\$context", "%context").replaceAll("\\$resource", "%resource").replaceAll("code\\+profile", "code&profile").replaceAll("path\\+'\\.'", "path&'.'").replaceAll("fullUrl\\+resource", "fullUrl&resource");
+    String pass2 = pass1;
+    if (pass1.endsWith(".distinct()")) pass2 = pass1.substring(0, pass2.length() - 11) + ".isDistinct()";
+    String pass3 = pass2;
+    if (pass2.endsWith(".empty() or (type.count() = 1)"))
+      pass3 = pass2.substring(0, pass2.length() - 30) + ".empty() or (type.count() <= 1)";
+    String pass4 = pass3;
+    if (pass3.equals("duration >= 0")) pass4 = "duration.exists() implies duration >= 0";
+    else if (pass3.equals("period >= 0")) pass4 = "period.exists() implies period >= 0";
+    else if (pass3.equals("fullUrl.empty() xor resource")) pass4 = "fullUrl.empty() xor resource.exists()";
+    return pass4;
+  }
+
+  public static String convertTo2016MayExpression(String newExpression) {
+    String pass1 = newExpression.replaceAll("%context", "\\$context").replaceAll("%resource", "\\$resource").replaceAll("code&profile", "code+profile").replaceAll("path&'\\.'", "path+'.'").replaceAll("fullUrl%resource", "fullUrl+resource");
+    String pass2 = pass1;
+    if (pass1.endsWith(".isDistinct()")) pass2 = pass1.substring(0, pass1.length() - 13) + ".distinct()";
+    String pass3 = pass2;
+    if (pass2.endsWith(".empty() or (type.count() <= 1)"))
+      pass3 = pass2.substring(0, pass2.length() - 31) + ".empty() or (type.count() = 1)";
+    String pass4 = pass3;
+    if (pass3.equals("duration.exists() implies duration >= 0")) pass4 = "duration >= 0";
+    else if (pass3.equals("period.exists() implies period >= 0")) pass4 = "period >= 0";
+    else if (pass3.equals("fullUrl.empty() xor resource.exists()")) pass4 = "fullUrl.empty() xor resource";
+    return pass4;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      org.hl7.fhir.r4.model.Type t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r4.model.Reference)
+        tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
+      else tgt.setValueSet(t.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.Reference(src.getValueSet()));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
+    for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
+    }
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) {
+      tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    }
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
+      return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
+      return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
+      return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
+      return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
+      return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
+      return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
+      return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
+      return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Age)
+      return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
+      return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
+      return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
+      return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
+      return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
+      return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
+      return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
+      return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
+      return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
+      return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
+      return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r4.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeType) return convertCode((org.hl7.fhir.r4.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateType) return convertDate((org.hl7.fhir.r4.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IdType) return convertId((org.hl7.fhir.r4.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r4.model.InstantType)
+      return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r4.model.OidType) return convertOid((org.hl7.fhir.r4.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.StringType)
+      return convertString((org.hl7.fhir.r4.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r4.model.TimeType) return convertTime((org.hl7.fhir.r4.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UriType) return convertUri((org.hl7.fhir.r4.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UuidType) return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.Extension)
+      return convertExtension((org.hl7.fhir.r4.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r4.model.Narrative)
+      return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r4.model.Age) return convertAge((org.hl7.fhir.r4.model.Age) src);
+    if (src instanceof org.hl7.fhir.r4.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coding) return convertCoding((org.hl7.fhir.r4.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r4.model.Count) return convertCount((org.hl7.fhir.r4.model.Count) src);
+    if (src instanceof org.hl7.fhir.r4.model.Distance) return convertDistance((org.hl7.fhir.r4.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Duration) return convertDuration((org.hl7.fhir.r4.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r4.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r4.model.Money) return convertMoney((org.hl7.fhir.r4.model.Money) src);
+    if (src instanceof org.hl7.fhir.r4.model.Period) return convertPeriod((org.hl7.fhir.r4.model.Period) src);
+    if (src instanceof org.hl7.fhir.r4.model.Quantity) return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Range) return convertRange((org.hl7.fhir.r4.model.Range) src);
+    if (src instanceof org.hl7.fhir.r4.model.Ratio) return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r4.model.Reference)
+      return convertReference((org.hl7.fhir.r4.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r4.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r4.model.Signature)
+      return convertSignature((org.hl7.fhir.r4.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r4.model.Address) return convertAddress((org.hl7.fhir.r4.model.Address) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.HumanName)
+      return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r4.model.Meta) return convertMeta((org.hl7.fhir.r4.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r4.model.Timing) return convertTiming((org.hl7.fhir.r4.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  public static org.hl7.fhir.r4.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Binary tgt = new org.hl7.fhir.r4.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    tgt.setContent(src.getContent());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.r4.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    tgt.setContent(src.getContent());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public boolean isJurisdiction(CodeableConcept t) {
+    return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
+  }
+
+  public static org.hl7.fhir.r4.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
+    org.hl7.fhir.r4.model.UsageContext result = new org.hl7.fhir.r4.model.UsageContext();
+    result.setValue(convertCodeableConcept(t));
+    return result;
+  }
+
+  static public class SourceElementComponentWrapper {
+    public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
+      super();
+      this.source = source;
+      this.target = target;
+      this.comp = comp;
+    }
+
+    public String source;
+    public String target;
+    public org.hl7.fhir.r4.model.ConceptMap.SourceElementComponent comp;
+  }
+
+  static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
+    CanonicalType dst = new CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
+    Reference dst = new Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventModeEnumFactory());
+    VersionConvertor_14_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
+      return Parameters14_40.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
+      return Bundle14_40.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
+      return CodeSystem14_40.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
+      return CompartmentDefinition14_40.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
+      return ConceptMap14_40.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
+      return Conformance14_40.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
+      return DataElement14_40.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
+      return ImplementationGuide14_40.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
+      return NamingSystem14_40.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
+      return OperationDefinition14_40.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
+      return OperationOutcome14_40.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
+      return Questionnaire14_40.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_40.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
+      return SearchParameter14_40.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
+      return StructureDefinition14_40.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StructureMap)
+      return StructureMap14_40.convertStructureMap((org.hl7.fhir.dstu2016may.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
+      return ValueSet14_40.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Parameters)
+      return Parameters14_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r4.model.Bundle)
+      return Bundle14_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
+      return CodeSystem14_40.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
+      return CompartmentDefinition14_40.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
+      return ConceptMap14_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
+      return Conformance14_40.convertConformance((org.hl7.fhir.r4.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
+      return ImplementationGuide14_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
+      return NamingSystem14_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
+      return OperationDefinition14_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
+      return OperationOutcome14_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
+      return Questionnaire14_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
+      return SearchParameter14_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
+      return StructureDefinition14_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureMap)
+      return StructureMap14_40.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.ValueSet)
+      return ValueSet14_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "StructureMap", "ValueSet");
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_14_50.java
@@ -1,5 +1,15 @@
 package org.hl7.fhir.convertors;
 
+import org.hl7.fhir.convertors.conv14_50.*;
+import org.hl7.fhir.dstu2016may.model.CodeableConcept;
+import org.hl7.fhir.dstu2016may.model.Reference;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.conformance.ProfileUtilities;
+import org.hl7.fhir.r5.model.CanonicalType;
+import org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent;
+import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
+import org.hl7.fhir.utilities.Utilities;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,3092 +41,2706 @@ import java.util.stream.Collectors;
   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
-import org.hl7.fhir.convertors.conv14_50.Bundle14_50;
-import org.hl7.fhir.convertors.conv14_50.CodeSystem14_50;
-import org.hl7.fhir.convertors.conv14_50.CompartmentDefinition14_50;
-import org.hl7.fhir.convertors.conv14_50.ConceptMap14_50;
-import org.hl7.fhir.convertors.conv14_50.Conformance14_50;
-import org.hl7.fhir.convertors.conv14_50.DataElement14_50;
-import org.hl7.fhir.convertors.conv14_50.ImplementationGuide14_50;
-import org.hl7.fhir.convertors.conv14_50.NamingSystem14_50;
-import org.hl7.fhir.convertors.conv14_50.OperationDefinition14_50;
-import org.hl7.fhir.convertors.conv14_50.OperationOutcome14_50;
-import org.hl7.fhir.convertors.conv14_50.Parameters14_50;
-import org.hl7.fhir.convertors.conv14_50.Questionnaire14_50;
-import org.hl7.fhir.convertors.conv14_50.QuestionnaireResponse14_50;
-import org.hl7.fhir.convertors.conv14_50.SearchParameter14_50;
-import org.hl7.fhir.convertors.conv14_50.StructureDefinition14_50;
-import org.hl7.fhir.convertors.conv14_50.StructureMap14_50;
-import org.hl7.fhir.convertors.conv14_50.ValueSet14_50;
-import org.hl7.fhir.dstu2016may.model.CodeableConcept;
-import org.hl7.fhir.dstu2016may.model.Reference;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.conformance.ProfileUtilities;
-import org.hl7.fhir.r5.model.CanonicalType;
-import org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent;
-import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent;
-import org.hl7.fhir.r5.model.Enumeration;
-import org.hl7.fhir.r5.model.Timing.EventTiming;
-import org.hl7.fhir.utilities.Utilities;
 
 public class VersionConvertor_14_50 {
-
-    static public List<String> CANONICAL_URLS = new ArrayList<String>();
-
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
-    }
-
-    static public boolean mappedExtension(String url) {
-        if (url.equals(VersionConvertorConstants.PROFILE_EXTENSION) || url.equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || url.equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION) || url.equals(VersionConvertorConstants.IG_CONFORMANCE_MESSAGE_EVENT))
-            return true;
-        return false;
-    }
-
-    static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && !mappedExtension(e.getUrl().toString()))
-                tgt.addExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r5.model.Base64BinaryType tgt = new org.hl7.fhir.r5.model.Base64BinaryType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r5.model.BooleanType tgt = new org.hl7.fhir.r5.model.BooleanType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CodeType tgt = new org.hl7.fhir.r5.model.CodeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateType tgt = new org.hl7.fhir.r5.model.DateType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = new org.hl7.fhir.r5.model.DateTimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DecimalType tgt = new org.hl7.fhir.r5.model.DecimalType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IdType tgt = new org.hl7.fhir.r5.model.IdType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r5.model.InstantType tgt = new org.hl7.fhir.r5.model.InstantType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IntegerType tgt = new org.hl7.fhir.r5.model.IntegerType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r5.model.MarkdownType tgt = new org.hl7.fhir.r5.model.MarkdownType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.OidType tgt = new org.hl7.fhir.r5.model.OidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.PositiveIntType tgt = new org.hl7.fhir.r5.model.PositiveIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.StringType tgt = new org.hl7.fhir.r5.model.StringType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.TimeType tgt = new org.hl7.fhir.r5.model.TimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UnsignedIntType tgt = new org.hl7.fhir.r5.model.UnsignedIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = new org.hl7.fhir.r5.model.UriType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UuidType tgt = new org.hl7.fhir.r5.model.UuidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2016may.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrlElement())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Long.valueOf(src.getSize()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Math.toIntExact(src.getSize()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCode())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriodElement())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensionsElement())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasDataElement())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWhoUriType())
-            tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
-        else
-            tgt.setWho(convertReference(src.getWhoReference()));
-        if (src.hasContentType())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhenElement())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasSigFormat())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-          tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-            .map(VersionConvertor_14_50::convertPropertyRepresentation)
-            .collect(Collectors.toList()));
-        if (src.hasName())
-          tgt.setSliceNameElement(convertString(src.getNameElement()));
-        if (src.hasLabel())
-          tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-          tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
-        if (src.hasShort())
-          tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-          tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComments())
-          tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
-        if (src.hasRequirements())
-          tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-          tgt.setMin(src.getMin());
-        if (src.hasMax())
-          tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-          tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-          tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        // work around for problem in R2B definitions:
-        if (!src.hasContentReference()) {
-          for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-          if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-          if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-          if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-          if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-          if (src.hasExample())
-            tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
-          if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-          if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-          if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-          for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-          for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-          if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-          if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-          if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu2016may.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-              reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
+  static public List<String> CANONICAL_URLS = new ArrayList<String>();
+
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  }
+
+  static public boolean mappedExtension(String url) {
+    if (url.equals(VersionConvertorConstants.PROFILE_EXTENSION) || url.equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION) || url.equals(VersionConvertorConstants.IG_DEPENDSON_VERSION_EXTENSION) || url.equals(VersionConvertorConstants.IG_CONFORMANCE_MESSAGE_EVENT))
+      return true;
+    return false;
+  }
+
+  static public void copyElement(org.hl7.fhir.dstu2016may.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions) && !mappedExtension(e.getUrl().toString()))
+        tgt.addExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu2016may.model.Element tgt, String... exemptExtensions) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      if (!Utilities.existsInList(e.getUrl(), exemptExtensions)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu2016may.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.dstu2016may.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu2016may.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r5.model.Base64BinaryType tgt = new org.hl7.fhir.r5.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.Base64BinaryType tgt = new org.hl7.fhir.dstu2016may.model.Base64BinaryType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu2016may.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r5.model.BooleanType tgt = new org.hl7.fhir.r5.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.BooleanType tgt = new org.hl7.fhir.dstu2016may.model.BooleanType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu2016may.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CodeType tgt = new org.hl7.fhir.r5.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.CodeType tgt = new org.hl7.fhir.dstu2016may.model.CodeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu2016may.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateType tgt = new org.hl7.fhir.r5.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateType tgt = new org.hl7.fhir.dstu2016may.model.DateType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu2016may.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = new org.hl7.fhir.r5.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DateTimeType tgt = new org.hl7.fhir.dstu2016may.model.DateTimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu2016may.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DecimalType tgt = new org.hl7.fhir.r5.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.DecimalType tgt = new org.hl7.fhir.dstu2016may.model.DecimalType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu2016may.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IdType tgt = new org.hl7.fhir.r5.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IdType tgt = new org.hl7.fhir.dstu2016may.model.IdType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu2016may.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r5.model.InstantType tgt = new org.hl7.fhir.r5.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.InstantType tgt = new org.hl7.fhir.dstu2016may.model.InstantType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu2016may.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IntegerType tgt = new org.hl7.fhir.r5.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.IntegerType tgt = new org.hl7.fhir.dstu2016may.model.IntegerType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu2016may.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = new org.hl7.fhir.r5.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.MarkdownType tgt = new org.hl7.fhir.dstu2016may.model.MarkdownType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu2016may.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.OidType tgt = new org.hl7.fhir.r5.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.OidType tgt = new org.hl7.fhir.dstu2016may.model.OidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu2016may.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.PositiveIntType tgt = new org.hl7.fhir.r5.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.PositiveIntType tgt = new org.hl7.fhir.dstu2016may.model.PositiveIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu2016may.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.StringType tgt = new org.hl7.fhir.r5.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.StringType tgt = new org.hl7.fhir.dstu2016may.model.StringType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu2016may.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.TimeType tgt = new org.hl7.fhir.r5.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.TimeType tgt = new org.hl7.fhir.dstu2016may.model.TimeType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu2016may.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UnsignedIntType tgt = new org.hl7.fhir.r5.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UnsignedIntType tgt = new org.hl7.fhir.dstu2016may.model.UnsignedIntType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu2016may.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = new org.hl7.fhir.r5.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UriType tgt = new org.hl7.fhir.dstu2016may.model.UriType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu2016may.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UuidType tgt = new org.hl7.fhir.r5.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu2016may.model.UuidType tgt = new org.hl7.fhir.dstu2016may.model.UuidType();
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu2016may.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu2016may.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Extension tgt = new org.hl7.fhir.dstu2016may.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrlElement()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((CanonicalType) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu2016may.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Narrative tgt = new org.hl7.fhir.dstu2016may.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu2016may.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Age tgt = new org.hl7.fhir.dstu2016may.model.Age();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu2016may.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Annotation tgt = new org.hl7.fhir.dstu2016may.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu2016may.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Long.valueOf(src.getSize()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Attachment tgt = new org.hl7.fhir.dstu2016may.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Math.toIntExact(src.getSize()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu2016may.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.CodeableConcept tgt = new org.hl7.fhir.dstu2016may.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu2016may.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Coding tgt = new org.hl7.fhir.dstu2016may.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu2016may.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Count tgt = new org.hl7.fhir.dstu2016may.model.Count();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu2016may.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Distance tgt = new org.hl7.fhir.dstu2016may.model.Distance();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu2016may.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Duration tgt = new org.hl7.fhir.dstu2016may.model.Duration();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu2016may.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCode()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Money tgt = new org.hl7.fhir.dstu2016may.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu2016may.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Identifier tgt = new org.hl7.fhir.dstu2016may.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu2016may.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Period tgt = new org.hl7.fhir.dstu2016may.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu2016may.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Quantity tgt = new org.hl7.fhir.dstu2016may.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu2016may.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Range tgt = new org.hl7.fhir.dstu2016may.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu2016may.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Ratio tgt = new org.hl7.fhir.dstu2016may.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu2016may.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Reference tgt = new org.hl7.fhir.dstu2016may.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu2016may.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SampledData tgt = new org.hl7.fhir.dstu2016may.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriodElement()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensionsElement()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasDataElement()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu2016may.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
+    else tgt.setWho(convertReference(src.getWhoReference()));
+    if (src.hasContentType()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Signature tgt = new org.hl7.fhir.dstu2016may.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhenElement()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasSigFormat()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu2016may.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Address tgt = new org.hl7.fhir.dstu2016may.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Address.AddressType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu2016may.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ContactPoint tgt = new org.hl7.fhir.dstu2016may.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu2016may.model.ElementDefinition src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasName()) tgt.setSliceNameElement(convertString(src.getNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing(), context, pos));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComments()) tgt.setCommentElement(convertMarkdown(src.getCommentsElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference())
+      tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    // work around for problem in R2B definitions:
+    if (!src.hasContentReference()) {
+      for (org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent t : src.getType())
+        convertTypeRefComponent(t, tgt.getType());
+      if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+      if (src.hasMeaningWhenMissing())
+        tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+      if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+      if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+      if (src.hasExample()) tgt.addExample().setLabel("General").setValue(convertType(src.getExample()));
+      if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+      if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+      if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+      for (org.hl7.fhir.dstu2016may.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+      for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+        tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+      if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+      if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+      if (tgt.getIsModifier()) {
+        String reason = org.hl7.fhir.dstu2016may.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+        if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+        tgt.setIsModifierReason(reason);
+      }
+      if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+      if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+      for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+        tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_14_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMin(src.getMin());
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    if (src.hasExample()) tgt.setExample(convertType(src.getExample().get(0).getValue()));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu2016may.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    org.hl7.fhir.dstu2016may.model.ElementDefinition slicingElement = context.get(pos);
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator()) {
+      boolean isExists = false;
+      if (!t.asStringValue().contains("@")) {
+        int slices = 0;
+        boolean existsSlicePresent = false;
+        boolean notExistsSlicePresent = false;
+        String existsPath = slicingElement.getPath() + "." + t.asStringValue();
+        for (int i = pos + 1; i < context.size(); i++) {
+          org.hl7.fhir.dstu2016may.model.ElementDefinition e = context.get(i);
+          if (e.getPath().equals(slicingElement.getPath())) slices++;
+          else if (!e.getPath().startsWith(slicingElement.getPath() + ".")) break;
+          else if (e.getPath().equals(existsPath)) {
+            if (e.hasMin() && e.getMin() > 0 && !e.hasFixed()) existsSlicePresent = true;
+            else if (e.hasMax() && e.getMax().equals("0")) notExistsSlicePresent = true;
           }
-          if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-          if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-          for (org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
         }
-        return tgt;
+        isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
+      }
+      tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
     }
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
 
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_14_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentsElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMin(src.getMin());
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        if (src.hasExample())
-            tgt.setExample(convertType(src.getExample().get(0).getValue()));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu2016may.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
     }
+    return tgt;
+  }
 
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPathElement()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setMin(src.getMin());
+    if (src.hasMaxElement()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  static public void convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
+      copyElement(src, tgt);
+      tgt.setCode(src.getCode());
+    }
+    if (tgt.hasTarget()) {
+      for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
+        if (src.getCode().equals("Reference")) tgt.addTargetProfile(u.getValue());
+        else tgt.addProfile(u.getValue());
+      }
+      for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
+        String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
+        tgt.addProfile(s);
+      }
+    } else {
+      for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
+    }
+    for (org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCode(src.getCode());
+    list.add(tgt);
+    if (src.hasTarget()) {
+      for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
+        org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
+        t.setValue(convertType(u));
+        tgt.addExtension(t);
+      }
+      for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
+        if (!u.equals(src.getTargetProfile().get(0))) {
+          tgt = tgt.copy();
+          tgt.getProfile().clear();
+          list.add(tgt);
         }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition> context, int pos) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        org.hl7.fhir.dstu2016may.model.ElementDefinition slicingElement = context.get(pos);
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getDiscriminator()) {
-            boolean isExists = false;
-            if (!t.asStringValue().contains("@")) {
-                int slices = 0;
-                boolean existsSlicePresent = false;
-                boolean notExistsSlicePresent = false;
-                String existsPath = slicingElement.getPath() + "." + t.asStringValue();
-                for (int i = pos + 1; i < context.size(); i++) {
-                    org.hl7.fhir.dstu2016may.model.ElementDefinition e = context.get(i);
-                    if (e.getPath().equals(slicingElement.getPath()))
-                        slices++;
-                    else if (!e.getPath().startsWith(slicingElement.getPath() + "."))
-                        break;
-                    else if (e.getPath().equals(existsPath)) {
-                        if (e.hasMin() && e.getMin() > 0 && !e.hasFixed())
-                            existsSlicePresent = true;
-                        else if (e.hasMax() && e.getMax().equals("0"))
-                            notExistsSlicePresent = true;
-                    }
-                }
-                isExists = (slices == 2 && existsSlicePresent && notExistsSlicePresent) || (slices == 1 && existsSlicePresent != notExistsSlicePresent);
-            }
-            tgt.addDiscriminator(ProfileUtilities.interpretR2Discriminator(t.getValue(), isExists));
-        }
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(ProfileUtilities.buildR2Discriminator(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPathElement())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setMin(src.getMin());
-        if (src.hasMaxElement())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    static public void convertTypeRefComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list) if (t.getCode().equals(src.getCode()))
-            tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCode(src.getCode());
-        }
-        if (tgt.hasTarget()) {
-            for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) {
-                if (src.getCode().equals("Reference"))
-                    tgt.addTargetProfile(u.getValue());
-                else
-                    tgt.addProfile(u.getValue());
-            }
-            for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtensionsByUrl(VersionConvertorConstants.PROFILE_EXTENSION)) {
-                String s = ((org.hl7.fhir.dstu2016may.model.PrimitiveType<String>) t.getValue()).getValue();
-                tgt.addProfile(s);
-            }
-        } else {
-            for (org.hl7.fhir.dstu2016may.model.UriType u : src.getProfile()) tgt.addProfile(u.getValue());
-        }
-        for (org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCode(src.getCode());
-        list.add(tgt);
-        if (src.hasTarget()) {
-            for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
-                org.hl7.fhir.dstu2016may.model.Extension t = new org.hl7.fhir.dstu2016may.model.Extension(VersionConvertorConstants.PROFILE_EXTENSION);
-                t.setValue(convertType(u));
-                tgt.addExtension(t);
-            }
-            for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
-                if (!u.equals(src.getTargetProfile().get(0))) {
-                    tgt = tgt.copy();
-                    tgt.getProfile().clear();
-                    list.add(tgt);
-                }
-                tgt.addProfile(u.getValue());
-            }
-        } else {
-            for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
-                tgt.addProfile(u.getValue());
-            }
-        }
-        for (org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregationElement().setValue(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpression(convertToR4Expression(src.getExpression()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKeyElement())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHumanElement())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpression(convertTo2016MayExpression(src.getExpression()));
-        if (src.hasXpathElement())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        return tgt;
-    }
-
-    public static String convertToR4Expression(String oldExpression) {
-        String pass1 = oldExpression.replaceAll("\\$context", "%context").replaceAll("\\$resource", "%resource").replaceAll("code\\+profile", "code&profile").replaceAll("path\\+'\\.'", "path&'.'").replaceAll("fullUrl\\+resource", "fullUrl&resource");
-        String pass2 = pass1;
-        if (pass1.endsWith(".distinct()"))
-            pass2 = pass1.substring(0, pass2.length() - 11) + ".isDistinct()";
-        String pass3 = pass2;
-        if (pass2.endsWith(".empty() or (type.count() = 1)"))
-            pass3 = pass2.substring(0, pass2.length() - 30) + ".empty() or (type.count() <= 1)";
-        String pass4 = pass3;
-        if (pass3.equals("duration >= 0"))
-            pass4 = "duration.exists() implies duration >= 0";
-        else if (pass3.equals("period >= 0"))
-            pass4 = "period.exists() implies period >= 0";
-        else if (pass3.equals("fullUrl.empty() xor resource"))
-            pass4 = "fullUrl.empty() xor resource.exists()";
-        return pass4;
-    }
-
-    public static String convertTo2016MayExpression(String newExpression) {
-        String pass1 = newExpression.replaceAll("%context", "\\$context").replaceAll("%resource", "\\$resource").replaceAll("code&profile", "code+profile").replaceAll("path&'\\.'", "path+'.'").replaceAll("fullUrl%resource", "fullUrl+resource");
-        String pass2 = pass1;
-        if (pass1.endsWith(".isDistinct()"))
-            pass2 = pass1.substring(0, pass1.length() - 13) + ".distinct()";
-        String pass3 = pass2;
-        if (pass2.endsWith(".empty() or (type.count() <= 1)"))
-            pass3 = pass2.substring(0, pass2.length() - 31) + ".empty() or (type.count() = 1)";
-        String pass4 = pass3;
-        if (pass3.equals("duration.exists() implies duration >= 0"))
-            pass4 = "duration >= 0";
-        else if (pass3.equals("period.exists() implies period >= 0"))
-            pass4 = "period >= 0";
-        else if (pass3.equals("fullUrl.empty() xor resource.exists()"))
-            pass4 = "fullUrl.empty() xor resource";
-        return pass4;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            org.hl7.fhir.r5.model.DataType t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r5.model.Reference)
-                tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
-            else
-                tgt.setValueSet(t.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.Reference(src.getValueSet()));
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentityElement())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMapElement())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.addFamily(src.getFamily());
-        for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen())
-            tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
-            return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
-            return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
-            return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
-            return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
-          return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
-            return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Age)
-            return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
-            return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
-            return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
-            return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
-            return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
-            return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r5.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeType)
-            return convertCode((org.hl7.fhir.r5.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateType)
-            return convertDate((org.hl7.fhir.r5.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IdType)
-            return convertId((org.hl7.fhir.r5.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r5.model.InstantType)
-            return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r5.model.OidType)
-            return convertOid((org.hl7.fhir.r5.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.StringType)
-            return convertString((org.hl7.fhir.r5.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r5.model.TimeType)
-            return convertTime((org.hl7.fhir.r5.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IntegerType)
-          return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UriType)
-            return convertUri((org.hl7.fhir.r5.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UuidType)
-            return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.Extension)
-            return convertExtension((org.hl7.fhir.r5.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r5.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r5.model.Age)
-            return convertAge((org.hl7.fhir.r5.model.Age) src);
-        if (src instanceof org.hl7.fhir.r5.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r5.model.Coding)
-            return convertCoding((org.hl7.fhir.r5.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r5.model.Count)
-            return convertCount((org.hl7.fhir.r5.model.Count) src);
-        if (src instanceof org.hl7.fhir.r5.model.Distance)
-            return convertDistance((org.hl7.fhir.r5.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Duration)
-            return convertDuration((org.hl7.fhir.r5.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r5.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r5.model.Money)
-            return convertMoney((org.hl7.fhir.r5.model.Money) src);
-        if (src instanceof org.hl7.fhir.r5.model.Period)
-            return convertPeriod((org.hl7.fhir.r5.model.Period) src);
-        if (src instanceof org.hl7.fhir.r5.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.Range)
-            return convertRange((org.hl7.fhir.r5.model.Range) src);
-        if (src instanceof org.hl7.fhir.r5.model.Ratio)
-            return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r5.model.Reference)
-            return convertReference((org.hl7.fhir.r5.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r5.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r5.model.Signature)
-            return convertSignature((org.hl7.fhir.r5.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r5.model.Address)
-            return convertAddress((org.hl7.fhir.r5.model.Address) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r5.model.Meta)
-            return convertMeta((org.hl7.fhir.r5.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r5.model.Timing)
-            return convertTiming((org.hl7.fhir.r5.model.Timing) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension()) if (!isExemptExtension(t.getUrl(), extensionsToIgnore))
-            tgt.addModifierExtension(convertExtension(t));
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    public static org.hl7.fhir.r5.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Binary tgt = new org.hl7.fhir.r5.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasContent())
-            tgt.setContent(src.getContent());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.r5.model.Binary src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
-        copyResource(src, tgt);
-        if (src.hasContentTypeElement())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        tgt.setContentElement(convertBase64Binary(src.getContentElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public boolean isJurisdiction(CodeableConcept t) {
-        return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
-    }
-
-    public static org.hl7.fhir.r5.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
-        org.hl7.fhir.r5.model.UsageContext result = new org.hl7.fhir.r5.model.UsageContext();
-        result.setValue(convertCodeableConcept(t));
-        return result;
-    }
-
-    static public class SourceElementComponentWrapper {
-
-        public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
-            super();
-            this.source = source;
-            this.target = target;
-            this.comp = comp;
-        }
-
-        public String source;
-
-        public String target;
-
-        public org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent comp;
-    }
-
-    static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
-        CanonicalType dst = new CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
-        Reference dst = new Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityModeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventModeEnumFactory());
-        VersionConvertor_14_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case SENDER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.SENDER);
-                break;
-            case RECEIVER:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.RECEIVER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
-            return Parameters14_50.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
-            return Bundle14_50.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
-            return CodeSystem14_50.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
-            return CompartmentDefinition14_50.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
-            return ConceptMap14_50.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
-            return Conformance14_50.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
-            return DataElement14_50.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
-            return ImplementationGuide14_50.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
-            return NamingSystem14_50.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
-            return OperationDefinition14_50.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
-            return OperationOutcome14_50.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
-            return Questionnaire14_50.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_50.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
-            return SearchParameter14_50.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
-            return StructureDefinition14_50.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.StructureMap)
-            return StructureMap14_50.convertStructureMap((org.hl7.fhir.dstu2016may.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
-            return ValueSet14_50.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Parameters)
-            return Parameters14_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r5.model.Bundle)
-            return Bundle14_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
-            return CodeSystem14_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
-            return CompartmentDefinition14_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
-            return ConceptMap14_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
-            return Conformance14_50.convertConformance((org.hl7.fhir.r5.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-            return ImplementationGuide14_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
-            return NamingSystem14_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
-            return OperationDefinition14_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
-            return OperationOutcome14_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
-            return Questionnaire14_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
-            return QuestionnaireResponse14_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
-            return SearchParameter14_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
-            return StructureDefinition14_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureMap)
-            return StructureMap14_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.ValueSet)
-            return ValueSet14_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "StructureMap", "ValueSet");
-    }
+        tgt.addProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
+        tgt.addProfile(u.getValue());
+      }
+    }
+    for (org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregationElement().setValue(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpression(convertToR4Expression(src.getExpression()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKeyElement()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHumanElement()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpression(convertTo2016MayExpression(src.getExpression()));
+    if (src.hasXpathElement()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    return tgt;
+  }
+
+  public static String convertToR4Expression(String oldExpression) {
+    String pass1 = oldExpression.replaceAll("\\$context", "%context").replaceAll("\\$resource", "%resource").replaceAll("code\\+profile", "code&profile").replaceAll("path\\+'\\.'", "path&'.'").replaceAll("fullUrl\\+resource", "fullUrl&resource");
+    String pass2 = pass1;
+    if (pass1.endsWith(".distinct()")) pass2 = pass1.substring(0, pass2.length() - 11) + ".isDistinct()";
+    String pass3 = pass2;
+    if (pass2.endsWith(".empty() or (type.count() = 1)"))
+      pass3 = pass2.substring(0, pass2.length() - 30) + ".empty() or (type.count() <= 1)";
+    String pass4 = pass3;
+    if (pass3.equals("duration >= 0")) pass4 = "duration.exists() implies duration >= 0";
+    else if (pass3.equals("period >= 0")) pass4 = "period.exists() implies period >= 0";
+    else if (pass3.equals("fullUrl.empty() xor resource")) pass4 = "fullUrl.empty() xor resource.exists()";
+    return pass4;
+  }
+
+  public static String convertTo2016MayExpression(String newExpression) {
+    String pass1 = newExpression.replaceAll("%context", "\\$context").replaceAll("%resource", "\\$resource").replaceAll("code&profile", "code+profile").replaceAll("path&'\\.'", "path+'.'").replaceAll("fullUrl%resource", "fullUrl+resource");
+    String pass2 = pass1;
+    if (pass1.endsWith(".isDistinct()")) pass2 = pass1.substring(0, pass1.length() - 13) + ".distinct()";
+    String pass3 = pass2;
+    if (pass2.endsWith(".empty() or (type.count() <= 1)"))
+      pass3 = pass2.substring(0, pass2.length() - 31) + ".empty() or (type.count() = 1)";
+    String pass4 = pass3;
+    if (pass3.equals("duration.exists() implies duration >= 0")) pass4 = "duration >= 0";
+    else if (pass3.equals("period.exists() implies period >= 0")) pass4 = "period >= 0";
+    else if (pass3.equals("fullUrl.empty() xor resource.exists()")) pass4 = "fullUrl.empty() xor resource";
+    return pass4;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      org.hl7.fhir.r5.model.DataType t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r5.model.Reference)
+        tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
+      else tgt.setValueSet(t.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu2016may.model.Reference(src.getValueSet()));
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu2016may.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentityElement()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMapElement()) tgt.setMapElement(convertString(src.getMapElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu2016may.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getFamily()) tgt.setFamily(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.HumanName tgt = new org.hl7.fhir.dstu2016may.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.addFamily(src.getFamily());
+    for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu2016may.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu2016may.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu2016may.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Meta tgt = new org.hl7.fhir.dstu2016may.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu2016may.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu2016may.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing tgt = new org.hl7.fhir.dstu2016may.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) tgt.setWhen(Collections.singletonList(convertEventTiming(src.getWhenElement())));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu2016may.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    if (src.hasWhen()) tgt.setWhenElement(convertEventTiming(src.getWhen().get(0)));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu2016may.model.SimpleQuantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.SimpleQuantity tgt = new org.hl7.fhir.dstu2016may.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu2016may.model.Type src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu2016may.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu2016may.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeType)
+      return convertCode((org.hl7.fhir.dstu2016may.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateType)
+      return convertDate((org.hl7.fhir.dstu2016may.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu2016may.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu2016may.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IdType)
+      return convertId((org.hl7.fhir.dstu2016may.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu2016may.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu2016may.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OidType)
+      return convertOid((org.hl7.fhir.dstu2016may.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu2016may.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StringType)
+      return convertString((org.hl7.fhir.dstu2016may.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.TimeType)
+      return convertTime((org.hl7.fhir.dstu2016may.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu2016may.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu2016may.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UriType)
+      return convertUri((org.hl7.fhir.dstu2016may.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.UuidType)
+      return convertUuid((org.hl7.fhir.dstu2016may.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu2016may.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu2016may.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Age) return convertAge((org.hl7.fhir.dstu2016may.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu2016may.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu2016may.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu2016may.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Coding)
+      return convertCoding((org.hl7.fhir.dstu2016may.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Count)
+      return convertCount((org.hl7.fhir.dstu2016may.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu2016may.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu2016may.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu2016may.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Money)
+      return convertMoney((org.hl7.fhir.dstu2016may.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Period)
+      return convertPeriod((org.hl7.fhir.dstu2016may.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu2016may.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Range)
+      return convertRange((org.hl7.fhir.dstu2016may.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Ratio)
+      return convertRatio((org.hl7.fhir.dstu2016may.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Reference)
+      return convertReference((org.hl7.fhir.dstu2016may.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu2016may.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu2016may.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Address)
+      return convertAddress((org.hl7.fhir.dstu2016may.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu2016may.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu2016may.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Meta)
+      return convertMeta((org.hl7.fhir.dstu2016may.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Timing)
+      return convertTiming((org.hl7.fhir.dstu2016may.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r5.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeType) return convertCode((org.hl7.fhir.r5.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateType) return convertDate((org.hl7.fhir.r5.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IdType) return convertId((org.hl7.fhir.r5.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r5.model.InstantType)
+      return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r5.model.OidType) return convertOid((org.hl7.fhir.r5.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.StringType) return convertString((org.hl7.fhir.r5.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r5.model.TimeType) return convertTime((org.hl7.fhir.r5.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UriType) return convertUri((org.hl7.fhir.r5.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UuidType) return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.Extension) return convertExtension((org.hl7.fhir.r5.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r5.model.Narrative) return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r5.model.Age) return convertAge((org.hl7.fhir.r5.model.Age) src);
+    if (src instanceof org.hl7.fhir.r5.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r5.model.Coding) return convertCoding((org.hl7.fhir.r5.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r5.model.Count) return convertCount((org.hl7.fhir.r5.model.Count) src);
+    if (src instanceof org.hl7.fhir.r5.model.Distance) return convertDistance((org.hl7.fhir.r5.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Duration) return convertDuration((org.hl7.fhir.r5.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r5.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r5.model.Money) return convertMoney((org.hl7.fhir.r5.model.Money) src);
+    if (src instanceof org.hl7.fhir.r5.model.Period) return convertPeriod((org.hl7.fhir.r5.model.Period) src);
+    if (src instanceof org.hl7.fhir.r5.model.Quantity) return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.Range) return convertRange((org.hl7.fhir.r5.model.Range) src);
+    if (src instanceof org.hl7.fhir.r5.model.Ratio) return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r5.model.Reference) return convertReference((org.hl7.fhir.r5.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r5.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r5.model.Signature) return convertSignature((org.hl7.fhir.r5.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r5.model.Address) return convertAddress((org.hl7.fhir.r5.model.Address) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.HumanName) return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r5.model.Meta) return convertMeta((org.hl7.fhir.r5.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r5.model.Timing) return convertTiming((org.hl7.fhir.r5.model.Timing) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu2016may.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu2016may.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.dstu2016may.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu2016may.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension())
+      if (!isExemptExtension(t.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu2016may.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu2016may.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  public static org.hl7.fhir.r5.model.Binary convertBinary(org.hl7.fhir.dstu2016may.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Binary tgt = new org.hl7.fhir.r5.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasContent()) tgt.setContent(src.getContent());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Binary convertBinary(org.hl7.fhir.r5.model.Binary src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Binary tgt = new org.hl7.fhir.dstu2016may.model.Binary();
+    copyResource(src, tgt);
+    if (src.hasContentTypeElement()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    tgt.setContentElement(convertBase64Binary(src.getContentElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertConformanceResourceStatus(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> convertConformanceResourceStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatusEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.RETIRED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.ConformanceResourceStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public boolean isJurisdiction(CodeableConcept t) {
+    return t.hasCoding() && ("http://unstats.un.org/unsd/methods/m49/m49.htm".equals(t.getCoding().get(0).getSystem()) || "urn:iso:std:iso:3166".equals(t.getCoding().get(0).getSystem()) || "https://www.usps.com/".equals(t.getCoding().get(0).getSystem()));
+  }
+
+  public static org.hl7.fhir.r5.model.UsageContext convertCodeableConceptToUsageContext(org.hl7.fhir.dstu2016may.model.CodeableConcept t) throws FHIRException {
+    org.hl7.fhir.r5.model.UsageContext result = new org.hl7.fhir.r5.model.UsageContext();
+    result.setValue(convertCodeableConcept(t));
+    return result;
+  }
+
+  static public class SourceElementComponentWrapper {
+    public SourceElementComponentWrapper(SourceElementComponent comp, String source, String target) {
+      super();
+      this.source = source;
+      this.target = target;
+      this.comp = comp;
+    }
+
+    public String source;
+    public String target;
+    public org.hl7.fhir.r5.model.ConceptMap.SourceElementComponent comp;
+  }
+
+  static public CanonicalType convertReferenceToCanonical(Reference src) throws FHIRException {
+    CanonicalType dst = new CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public Reference convertCanonicalToReference(CanonicalType src) throws FHIRException {
+    Reference dst = new Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> convertConformanceEventMode(org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> convertConformanceEventMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.CapabilityStatement.EventCapabilityMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu2016may.model.Enumeration<org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode> tgt = new org.hl7.fhir.dstu2016may.model.Enumeration<>(new org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventModeEnumFactory());
+    VersionConvertor_14_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case SENDER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.SENDER);
+          break;
+        case RECEIVER:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.RECEIVER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu2016may.model.Conformance.ConformanceEventMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu2016may.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Parameters)
+      return Parameters14_50.convertParameters((org.hl7.fhir.dstu2016may.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Bundle)
+      return Bundle14_50.convertBundle((org.hl7.fhir.dstu2016may.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CodeSystem)
+      return CodeSystem14_50.convertCodeSystem((org.hl7.fhir.dstu2016may.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.CompartmentDefinition)
+      return CompartmentDefinition14_50.convertCompartmentDefinition((org.hl7.fhir.dstu2016may.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ConceptMap)
+      return ConceptMap14_50.convertConceptMap((org.hl7.fhir.dstu2016may.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Conformance)
+      return Conformance14_50.convertConformance((org.hl7.fhir.dstu2016may.model.Conformance) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.DataElement)
+      return DataElement14_50.convertDataElement((org.hl7.fhir.dstu2016may.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ImplementationGuide)
+      return ImplementationGuide14_50.convertImplementationGuide((org.hl7.fhir.dstu2016may.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.NamingSystem)
+      return NamingSystem14_50.convertNamingSystem((org.hl7.fhir.dstu2016may.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationDefinition)
+      return OperationDefinition14_50.convertOperationDefinition((org.hl7.fhir.dstu2016may.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.OperationOutcome)
+      return OperationOutcome14_50.convertOperationOutcome((org.hl7.fhir.dstu2016may.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.Questionnaire)
+      return Questionnaire14_50.convertQuestionnaire((org.hl7.fhir.dstu2016may.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_50.convertQuestionnaireResponse((org.hl7.fhir.dstu2016may.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.SearchParameter)
+      return SearchParameter14_50.convertSearchParameter((org.hl7.fhir.dstu2016may.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StructureDefinition)
+      return StructureDefinition14_50.convertStructureDefinition((org.hl7.fhir.dstu2016may.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.StructureMap)
+      return StructureMap14_50.convertStructureMap((org.hl7.fhir.dstu2016may.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.dstu2016may.model.ValueSet)
+      return ValueSet14_50.convertValueSet((org.hl7.fhir.dstu2016may.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu2016may.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Parameters)
+      return Parameters14_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r5.model.Bundle)
+      return Bundle14_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
+      return CodeSystem14_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
+      return CompartmentDefinition14_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
+      return ConceptMap14_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
+      return Conformance14_50.convertConformance((org.hl7.fhir.r5.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
+      return ImplementationGuide14_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
+      return NamingSystem14_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
+      return OperationDefinition14_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
+      return OperationOutcome14_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
+      return Questionnaire14_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
+      return QuestionnaireResponse14_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
+      return SearchParameter14_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
+      return StructureDefinition14_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureMap)
+      return StructureMap14_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.ValueSet)
+      return ValueSet14_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "Bundle", "CodeSystem", "CompartmentDefinition", "ConceptMap", "CapabilityStatement", "ImplementationGuide", "NamingSystem", "OperationDefinition", "OperationOutcome", "Questionnaire", "QuestionnaireResponse", "SearchParameter", "StructureDefinition", "StructureMap", "ValueSet");
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_40.java
@@ -1,9 +1,5 @@
 package org.hl7.fhir.convertors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.hl7.fhir.convertors.conv30_40.*;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
@@ -14,5207 +10,4681 @@ import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.utilities.Utilities;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without modification, 
+
+  Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
-  
-   * Redistributions of source code must retain the above copyright notice, this 
+
+ * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+ * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   * Neither the name of HL7 nor the names of its contributors may be used to 
-     endorse or promote products derived from this software without specific 
+ * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
      prior written permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-  
-*/
+ */
+
 public class VersionConvertor_30_40 {
+  static final public String EXT_SRC_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type";
+  static public List<String> CANONICAL_URLS = new ArrayList<>();
 
-    static final public String EXT_SRC_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type";
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  }
 
-    static public List<String> CANONICAL_URLS = new ArrayList<>();
-
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
+  }
 
-    static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
+  static public void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu3.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu3.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateType convertDateTimeToDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu3.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IdType(src.getValue()) : new org.hl7.fhir.dstu3.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r4.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValue()) : new org.hl7.fhir.r4.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu3.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu3.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.OidType(src.getValue()) : new org.hl7.fhir.dstu3.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu3.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UriType(src.getValue()) : new org.hl7.fhir.dstu3.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu3.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu3.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((org.hl7.fhir.dstu3.model.Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((org.hl7.fhir.r4.model.CanonicalType) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    tgt.setCode(src.getValue());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasCoding()) {
+      if (src.getCodingFirstRep().hasSystem()) tgt.setSystem(src.getCodingFirstRep().getSystem());
+      if (src.getCodingFirstRep().hasVersion()) tgt.setVersion(src.getCodingFirstRep().getVersion());
+      if (src.getCodingFirstRep().hasCode()) tgt.setCode(src.getCodingFirstRep().getCode());
+      if (src.getCodingFirstRep().hasDisplay()) tgt.setDisplay(src.getCodingFirstRep().getDisplay());
+      if (src.getCodingFirstRep().hasUserSelected()) tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasCoding()) {
+      if (src.getCodingFirstRep().hasSystem()) tgt.setSystem(src.getCodingFirstRep().getSystem());
+      if (src.getCodingFirstRep().hasVersion()) tgt.setVersion(src.getCodingFirstRep().getVersion());
+      if (src.getCodingFirstRep().hasCode()) tgt.setCode(src.getCodingFirstRep().getCode());
+      if (src.getCodingFirstRep().hasDisplay()) tgt.setDisplay(src.getCodingFirstRep().getDisplay());
+      if (src.getCodingFirstRep().hasUserSelected()) tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCode()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static void copyQuantity(org.hl7.fhir.dstu3.model.Quantity src, org.hl7.fhir.r4.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnit(src.getUnit());
+    if (src.hasSystem()) tgt.setSystem(src.getSystem());
+    if (src.hasCode()) tgt.setCode(src.getCode());
+  }
+
+  public static void copyQuantity(org.hl7.fhir.r4.model.Quantity src, org.hl7.fhir.dstu3.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnit(src.getUnit());
+    if (src.hasSystem()) tgt.setSystem(src.getSystem());
+    if (src.hasCode()) tgt.setCode(src.getCode());
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) {
+      if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
+      else tgt.setWho(convertReference(src.getWhoReference()));
+    }
+    if (src.hasOnBehalfOf()) {
+      if (src.hasOnBehalfOfUriType()) tgt.setOnBehalfOf(new Reference(src.getOnBehalfOfUriType().primitiveValue()));
+      else tgt.setOnBehalfOf(convertReference(src.getOnBehalfOfReference()));
+    }
+    if (src.hasContentType()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasOnBehalfOf()) tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
+    if (src.hasSigFormat()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactDetail convertContactDetail(org.hl7.fhir.dstu3.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ContactDetail tgt = new org.hl7.fhir.r4.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.dstu3.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ContactDetail convertContactDetail(org.hl7.fhir.r4.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ContactDetail tgt = new org.hl7.fhir.dstu3.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r4.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Contributor convertContributor(org.hl7.fhir.dstu3.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Contributor tgt = new org.hl7.fhir.r4.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.dstu3.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Contributor convertContributor(org.hl7.fhir.r4.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Contributor tgt = new org.hl7.fhir.dstu3.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r4.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Dosage convertDosage(org.hl7.fhir.dstu3.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose() || src.hasRate()) {
+      org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
+      if (src.hasDose()) dr.setDose(convertType(src.getDose()));
+      if (src.hasRate()) dr.setRate(convertType(src.getRate()));
+    }
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Dosage convertDosage(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Dosage tgt = new org.hl7.fhir.dstu3.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose()) {
+      if (src.getDoseAndRate().get(0).getDose() instanceof org.hl7.fhir.r4.model.Quantity) {
+        tgt.setDose(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getDose()));
+      } else {
+        tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+      }
+    }
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate()) {
+      if (src.getDoseAndRate().get(0).getRate() instanceof org.hl7.fhir.r4.model.Quantity) {
+        tgt.setRate(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getRate()));
+      } else {
+        tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_30_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (tgt.getIsModifier()) {
+      String reason = org.hl7.fhir.dstu3.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+      if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+      tgt.setIsModifierReason(reason);
+    }
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_30_40::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu3.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
+      copyElement(src, tgt);
+      tgt.setCodeElement(convertUri(src.getCodeElement()));
+    }
+    if (src.hasProfile()) tgt.addProfile(src.getProfile());
+    if (src.hasTargetProfile()) tgt.addTargetProfile(src.getTargetProfile());
+    for (org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCodeElement(convertUri(src.getCodeElement()));
+    list.add(tgt);
+    if (src.hasTarget()) {
+      if (src.hasProfile()) tgt.setProfile(src.getProfile().get(0).getValue());
+      for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
+        if (tgt.hasTargetProfile()) {
+          tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+          list.add(tgt);
+          copyElement(src, tgt);
+          tgt.setCode(src.getCode());
+          if (src.hasProfile()) tgt.setProfile(src.getProfile().get(0).getValue());
         }
-    }
-
-    static public void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
+        tgt.setTargetProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
+        if (tgt.hasProfile()) {
+          tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+          list.add(tgt);
+          copyElement(src, tgt);
+          tgt.setCode(src.getCode());
         }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu3.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu3.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateType convertDateTimeToDate(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu3.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IdType(src.getValue()) : new org.hl7.fhir.dstu3.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r4.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValue()) : new org.hl7.fhir.r4.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu3.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu3.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.OidType(src.getValue()) : new org.hl7.fhir.dstu3.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu3.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UriType(src.getValue()) : new org.hl7.fhir.dstu3.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu3.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu3.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((org.hl7.fhir.dstu3.model.Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r4.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((org.hl7.fhir.r4.model.CanonicalType) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        tgt.setCode(src.getValue());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasCoding()) {
-            if (src.getCodingFirstRep().hasSystem())
-                tgt.setSystem(src.getCodingFirstRep().getSystem());
-            if (src.getCodingFirstRep().hasVersion())
-                tgt.setVersion(src.getCodingFirstRep().getVersion());
-            if (src.getCodingFirstRep().hasCode())
-                tgt.setCode(src.getCodingFirstRep().getCode());
-            if (src.getCodingFirstRep().hasDisplay())
-                tgt.setDisplay(src.getCodingFirstRep().getDisplay());
-            if (src.getCodingFirstRep().hasUserSelected())
-                tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasCoding()) {
-            if (src.getCodingFirstRep().hasSystem())
-                tgt.setSystem(src.getCodingFirstRep().getSystem());
-            if (src.getCodingFirstRep().hasVersion())
-                tgt.setVersion(src.getCodingFirstRep().getVersion());
-            if (src.getCodingFirstRep().hasCode())
-                tgt.setCode(src.getCodingFirstRep().getCode());
-            if (src.getCodingFirstRep().hasDisplay())
-                tgt.setDisplay(src.getCodingFirstRep().getDisplay());
-            if (src.getCodingFirstRep().hasUserSelected())
-                tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCode())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static void copyQuantity(org.hl7.fhir.dstu3.model.Quantity src, org.hl7.fhir.r4.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnit(src.getUnit());
-        if (src.hasSystem())
-            tgt.setSystem(src.getSystem());
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-    }
-
-    public static void copyQuantity(org.hl7.fhir.r4.model.Quantity src, org.hl7.fhir.dstu3.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnit(src.getUnit());
-        if (src.hasSystem())
-            tgt.setSystem(src.getSystem());
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho()) {
-            if (src.hasWhoUriType())
-                tgt.setWho(new org.hl7.fhir.r4.model.Reference(src.getWhoUriType().getValue()));
-            else
-                tgt.setWho(convertReference(src.getWhoReference()));
-        }
-        if (src.hasOnBehalfOf()) {
-            if (src.hasOnBehalfOfUriType())
-                tgt.setOnBehalfOf(new Reference(src.getOnBehalfOfUriType().primitiveValue()));
-            else
-                tgt.setOnBehalfOf(convertReference(src.getOnBehalfOfReference()));
-        }
-        if (src.hasContentType())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasOnBehalfOf())
-            tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
-        if (src.hasSigFormat())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactDetail convertContactDetail(org.hl7.fhir.dstu3.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ContactDetail tgt = new org.hl7.fhir.r4.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.dstu3.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ContactDetail convertContactDetail(org.hl7.fhir.r4.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ContactDetail tgt = new org.hl7.fhir.dstu3.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r4.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Contributor convertContributor(org.hl7.fhir.dstu3.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Contributor tgt = new org.hl7.fhir.r4.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.dstu3.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Contributor convertContributor(org.hl7.fhir.r4.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Contributor tgt = new org.hl7.fhir.dstu3.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r4.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Dosage convertDosage(org.hl7.fhir.dstu3.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getAdditionalInstruction())
-            tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDose() || src.hasRate()) {
-            org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
-            if (src.hasDose())
-                dr.setDose(convertType(src.getDose()));
-            if (src.hasRate())
-                dr.setRate(convertType(src.getRate()));
-        }
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Dosage convertDosage(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Dosage tgt = new org.hl7.fhir.dstu3.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.CodeableConcept t : src.getAdditionalInstruction())
-            tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose()) {
-            if (src.getDoseAndRate().get(0).getDose() instanceof org.hl7.fhir.r4.model.Quantity) {
-                tgt.setDose(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getDose()));
-            } else {
-                tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
-            }
-        }
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate()) {
-            if (src.getDoseAndRate().get(0).getRate() instanceof org.hl7.fhir.r4.model.Quantity) {
-                tgt.setRate(convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) src.getDoseAndRate().get(0).getRate()));
-            } else {
-                tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
-            }
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_30_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType())
-            convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
-            tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
-            tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu3.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-                reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
-        }
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
-            tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_30_40::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType())
-            convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
-            tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
-            tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu3.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
-            tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
-            tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
-            tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : list)
-            if (t.getCode().equals(src.getCode()))
-                tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCodeElement(convertUri(src.getCodeElement()));
-        }
-        if (src.hasProfile())
-            tgt.addProfile(src.getProfile());
-        if (src.hasTargetProfile())
-            tgt.addTargetProfile(src.getTargetProfile());
-        for (org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCodeElement(convertUri(src.getCodeElement()));
-        list.add(tgt);
-        if (src.hasTarget()) {
-            if (src.hasProfile())
-                tgt.setProfile(src.getProfile().get(0).getValue());
-            for (org.hl7.fhir.r4.model.UriType u : src.getTargetProfile()) {
-                if (tgt.hasTargetProfile()) {
-                    tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-                    list.add(tgt);
-                    copyElement(src, tgt);
-                    tgt.setCode(src.getCode());
-                    if (src.hasProfile())
-                        tgt.setProfile(src.getProfile().get(0).getValue());
-                }
-                tgt.setTargetProfile(u.getValue());
-            }
+        tgt.setProfile(u.getValue());
+      }
+    }
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSource(src.getSource());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSource(src.getSource());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt, EXT_SRC_TYPE);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      Type t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r4.model.Reference) {
+        tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
+        tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("Reference"));
+      } else {
+        tgt.setValueSet(t.primitiveValue());
+        tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("uri"));
+      }
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt, EXT_SRC_TYPE);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      org.hl7.fhir.r4.model.Extension ex = src.getValueSetElement().getExtensionByUrl(EXT_SRC_TYPE);
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (ex != null) {
+        if ("uri".equals(ex.getValue().primitiveValue())) {
+          tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr == null ? src.getValueSet() : vsr));
         } else {
-            for (org.hl7.fhir.r4.model.UriType u : src.getProfile()) {
-                if (tgt.hasProfile()) {
-                    tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-                    list.add(tgt);
-                    copyElement(src, tgt);
-                    tgt.setCode(src.getCode());
-                }
-                tgt.setProfile(u.getValue());
-            }
+          tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
         }
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSource(src.getSource());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSource(src.getSource());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt, EXT_SRC_TYPE);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            Type t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r4.model.Reference) {
-                tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
-                tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("Reference"));
-            } else {
-                tgt.setValueSet(t.primitiveValue());
-                tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("uri"));
-            }
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt, EXT_SRC_TYPE);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            org.hl7.fhir.r4.model.Extension ex = src.getValueSetElement().getExtensionByUrl(EXT_SRC_TYPE);
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (ex != null) {
-                if ("uri".equals(ex.getValue().primitiveValue())) {
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr == null ? src.getValueSet() : vsr));
-                } else {
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-                }
-            } else {
-                if (vsr != null)
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
-                else
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-            }
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.dstu3.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ParameterDefinition tgt = new org.hl7.fhir.r4.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertCode(src.getTypeElement()));
-        if (src.hasProfile()) {
-            tgt.setProfile(convertReference(src.getProfile()).getReference());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r4.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ParameterDefinition tgt = new org.hl7.fhir.dstu3.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertCode(src.getTypeElement()));
-        if (src.hasProfile())
-            tgt.setProfile(new org.hl7.fhir.dstu3.model.Reference(src.getProfile()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ParameterDefinition.ParameterUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUseEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.dstu3.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.RelatedArtifact tgt = new org.hl7.fhir.r4.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitation(src.getCitation());
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertReferenceToCanonical(src.getResource()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r4.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.RelatedArtifact tgt = new org.hl7.fhir.dstu3.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitation(src.getCitation());
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResource(convertCanonicalToReference(src.getResourceElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEventElement().setValueAsString(t.getValueAsString());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.addEventElement().setValueAsString(t.getValueAsString());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_30_40::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.dstu3.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_30_40::convertEventTiming)
-                .collect(Collectors.toList()));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_30_40::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.r4.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_30_40::convertEventTiming)
-                .collect(Collectors.toList()));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.DayOfWeekEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.DayOfWeekEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.MORN);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AFT);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.EVE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UsageContext convertUsageContext(org.hl7.fhir.dstu3.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.UsageContext tgt = new org.hl7.fhir.r4.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UsageContext convertUsageContext(org.hl7.fhir.r4.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.UsageContext tgt = new org.hl7.fhir.dstu3.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.dstu3.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TriggerDefinition tgt = new org.hl7.fhir.r4.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasEventName())
-            tgt.setNameElement(convertString(src.getEventNameElement()));
-        if (src.hasEventTiming())
-            tgt.setTiming(convertType(src.getEventTiming()));
-        if (src.hasEventData())
-            tgt.addData(convertDataRequirement(src.getEventData()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r4.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TriggerDefinition tgt = new org.hl7.fhir.dstu3.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setEventNameElement(convertString(src.getNameElement()));
-        if (src.hasTiming())
-            tgt.setEventTiming(convertType(src.getTiming()));
-        if (src.hasData())
-            tgt.setEventData(convertDataRequirement(src.getDataFirstRep()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement convertDataRequirement(org.hl7.fhir.dstu3.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement tgt = new org.hl7.fhir.r4.model.DataRequirement();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertCode(src.getTypeElement()));
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
-        for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
-            tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
-            tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement convertDataRequirement(org.hl7.fhir.r4.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement tgt = new org.hl7.fhir.dstu3.model.DataRequirement();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertCode(src.getTypeElement()));
-        for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r4.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
-        for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
-            tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
-            tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValueSet()) {
-            Type t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r4.model.Reference)
-                tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
-            else
-                tgt.setValueSet(t.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        for (org.hl7.fhir.dstu3.model.CodeType t : src.getValueCode()) tgt.addCode(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getValueCoding()) tgt.addCode(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getValueCodeableConcept()) tgt.addCode(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-        }
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) {
-            tgt.addValueCoding(convertCoding(t));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateType)
-            return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IdType)
-            return convertId((org.hl7.fhir.dstu3.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
-          return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
-          return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
-            return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OidType)
-            return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StringType)
-            return convertString((org.hl7.fhir.dstu3.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
-          return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UriType)
-            return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Age)
-            return convertAge((org.hl7.fhir.dstu3.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Count)
-            return convertCount((org.hl7.fhir.dstu3.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Money)
-            return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SimpleQuantity)
-          return convertSimpleQuantity((org.hl7.fhir.dstu3.model.SimpleQuantity) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Range)
-            return convertRange((org.hl7.fhir.dstu3.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Reference)
-            return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Address)
-            return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.dstu3.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Contributor)
-            return convertContributor((org.hl7.fhir.dstu3.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Dosage)
-            return convertDosage((org.hl7.fhir.dstu3.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.dstu3.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.dstu3.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.dstu3.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.dstu3.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.dstu3.model.TriggerDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r4.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeType)
-            return convertCode((org.hl7.fhir.r4.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateType)
-            return convertDate((org.hl7.fhir.r4.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IdType)
-            return convertId((org.hl7.fhir.r4.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r4.model.InstantType)
-            return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IntegerType)
-            return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r4.model.OidType)
-            return convertOid((org.hl7.fhir.r4.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.StringType)
-            return convertString((org.hl7.fhir.r4.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r4.model.TimeType)
-            return convertTime((org.hl7.fhir.r4.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UuidType)
-            return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UriType)
-            return convertUri((org.hl7.fhir.r4.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r4.model.Extension)
-            return convertExtension((org.hl7.fhir.r4.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r4.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r4.model.Age)
-            return convertAge((org.hl7.fhir.r4.model.Age) src);
-        if (src instanceof org.hl7.fhir.r4.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coding)
-            return convertCoding((org.hl7.fhir.r4.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r4.model.Count)
-            return convertCount((org.hl7.fhir.r4.model.Count) src);
-        if (src instanceof org.hl7.fhir.r4.model.Distance)
-            return convertDistance((org.hl7.fhir.r4.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Duration)
-            return convertDuration((org.hl7.fhir.r4.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r4.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r4.model.Money)
-            return convertMoney((org.hl7.fhir.r4.model.Money) src);
-        if (src instanceof org.hl7.fhir.r4.model.Period)
-            return convertPeriod((org.hl7.fhir.r4.model.Period) src);
-        if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
-          return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Range)
-            return convertRange((org.hl7.fhir.r4.model.Range) src);
-        if (src instanceof org.hl7.fhir.r4.model.Ratio)
-            return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r4.model.Reference)
-            return convertReference((org.hl7.fhir.r4.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r4.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r4.model.Signature)
-            return convertSignature((org.hl7.fhir.r4.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r4.model.Address)
-            return convertAddress((org.hl7.fhir.r4.model.Address) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.r4.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.Contributor)
-            return convertContributor((org.hl7.fhir.r4.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.r4.model.Dosage)
-            return convertDosage((org.hl7.fhir.r4.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.r4.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r4.model.Meta)
-            return convertMeta((org.hl7.fhir.r4.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r4.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.r4.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.r4.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.r4.model.Timing)
-            return convertTiming((org.hl7.fhir.r4.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r4.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.r4.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.r4.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.r4.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.r4.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.r4.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.r4.model.TriggerDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore)
-            if (s.equals(url))
-                ok = true;
-        return ok;
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu3.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
-        for (org.hl7.fhir.dstu3.model.Extension t2 : src.getExtension())
-            if (!isExemptExtension(t2.getUrl(), extensionsToIgnore))
-                tgt.addExtension(convertExtension(t2));
-        for (org.hl7.fhir.dstu3.model.Extension t3 : src.getModifierExtension())
-            if (!isExemptExtension(t3.getUrl(), extensionsToIgnore))
-                tgt.addModifierExtension(convertExtension(t3));
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r4.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
-        for (org.hl7.fhir.r4.model.Extension t2 : src.getExtension())
-            if (!isExemptExtension(t2.getUrl(), extensionsToIgnore))
-                tgt.addExtension(convertExtension(t2));
-        for (org.hl7.fhir.r4.model.Extension t3 : src.getModifierExtension())
-            if (!isExemptExtension(t3.getUrl(), extensionsToIgnore))
-                tgt.addModifierExtension(convertExtension(t3));
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguage(src.getLanguage());
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.CanonicalType convertReferenceToCanonical(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-        org.hl7.fhir.r4.model.CanonicalType dst = new org.hl7.fhir.r4.model.CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Reference convertCanonicalToReference(org.hl7.fhir.r4.model.CanonicalType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.Reference dst = new org.hl7.fhir.dstu3.model.Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case REPLACES:
-                tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.REPLACES);
-                break;
-            case TRANSFORMS:
-                tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.TRANSFORMS);
-                break;
-            case SIGNS:
-                tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.SIGNS);
-                break;
-            case APPENDS:
-                tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.APPENDS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case REPLACES:
-                tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.REPLACES);
-                break;
-            case TRANSFORMS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.TRANSFORMS);
-                break;
-            case SIGNS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.SIGNS);
-                break;
-            case APPENDS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.APPENDS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.r4.model.Encounter.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setUse(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r4.model.Encounter.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasUse())
-            tgt.setRole(convertCodeableConcept(src.getUse()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setRole(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setRole(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static final public String URN_IETF_RFC_3986 = "urn:ietf:rfc:3986";
-
-    public static String convertCoding2Uri(org.hl7.fhir.dstu3.model.Coding code) {
-        return code.getSystem() + "/" + code.getCode();
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertUri2Coding(String uri) {
-        int i = uri.lastIndexOf("/");
-        return new org.hl7.fhir.dstu3.model.Coding().setSystem(uri.substring(0, i)).setCode(uri.substring(i + 1));
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeekEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeekEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r4.model.TestReport.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertUri(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertUri(src.getDetailElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestReport.TestReportActionResultEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case PASS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.PASS);
-                break;
-            case SKIP:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.SKIP);
-                break;
-            case FAIL:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.FAIL);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.WARNING);
-                break;
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.ERROR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestReport.TestReportActionResultEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case PASS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.PASS);
-                break;
-            case SKIP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.SKIP);
-                break;
-            case FAIL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.FAIL);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.WARNING);
-                break;
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.ERROR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertString(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertString(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestReport.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.r4.model.TestReport.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r4.model.TestReport.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r4.model.TestScript.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCoding(src.getType()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCode(src.getResourceElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasAccept())
-            tgt.setAccept(convertContentType(src.getAccept()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasDestination())
-            tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
-        if (src.hasEncodeRequestUrl())
-            tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
-        if (src.hasOrigin())
-            tgt.setOriginElement(convertInteger(src.getOriginElement()));
-        if (src.hasParams())
-            tgt.setParamsElement(convertString(src.getParamsElement()));
-        for (org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
-            tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
-        if (src.hasRequestId())
-            tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
-        if (src.hasResponseId())
-            tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasTargetId())
-            tgt.setTargetId(src.getTargetId());
-        if (src.hasUrl())
-            tgt.setUrlElement(convertString(src.getUrlElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCoding(src.getType()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCode(src.getResourceElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasAccept())
-            tgt.setAccept(convertContentType(src.getAccept()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasDestination())
-            tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
-        if (src.hasEncodeRequestUrl())
-            tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
-        if (src.hasOrigin())
-            tgt.setOriginElement(convertInteger(src.getOriginElement()));
-        if (src.hasParams())
-            tgt.setParamsElement(convertString(src.getParamsElement()));
-        for (org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
-            tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
-        if (src.hasRequestId())
-            tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
-        if (src.hasResponseId())
-            tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasTargetId())
-            tgt.setTargetId(src.getTargetId());
-        if (src.hasUrl())
-            tgt.setUrlElement(convertString(src.getUrlElement()));
-        return tgt;
-    }
-
-    static public String convertContentType(org.hl7.fhir.dstu3.model.TestScript.ContentType src) throws FHIRException {
-        if (src == null)
-            return null;
-        switch (src) {
-            case XML:
-                return "application/fhir+xml";
-            case JSON:
-                return "application/fhir+json";
-            case TTL:
-                return "text/turtle";
-            case NONE:
-                return null;
-            default:
-                return null;
-        }
-    }
-
-    static public org.hl7.fhir.dstu3.model.TestScript.ContentType convertContentType(String src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src.contains("xml"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.XML;
-        if (src.contains("json"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.JSON;
-        if (src.contains("tu"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.TTL;
-        return org.hl7.fhir.dstu3.model.TestScript.ContentType.NONE;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent();
-        copyElement(src, tgt);
-        if (src.hasField())
-            tgt.setFieldElement(convertString(src.getFieldElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent();
-        copyElement(src, tgt);
-        if (src.hasField())
-            tgt.setFieldElement(convertString(src.getFieldElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
-        if (src.hasCompareToSourceId())
-            tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
-        if (src.hasCompareToSourceExpression())
-            tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
-        if (src.hasCompareToSourcePath())
-            tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasHeaderField())
-            tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
-        if (src.hasMinimumId())
-            tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
-        if (src.hasNavigationLinks())
-            tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
-        if (src.hasOperator())
-            tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasRequestMethod())
-            tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
-        if (src.hasRequestURL())
-            tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCode(src.getResourceElement()));
-        if (src.hasResponse())
-            tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
-        if (src.hasResponseCode())
-            tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasValidateProfileId())
-            tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasWarningOnly())
-            tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
-        if (src.hasCompareToSourceId())
-            tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
-        if (src.hasCompareToSourceExpression())
-            tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
-        if (src.hasCompareToSourcePath())
-            tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasHeaderField())
-            tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
-        if (src.hasMinimumId())
-            tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
-        if (src.hasNavigationLinks())
-            tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
-        if (src.hasOperator())
-            tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasRequestMethod())
-            tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
-        if (src.hasRequestURL())
-            tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCode(src.getResourceElement()));
-        if (src.hasResponse())
-            tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
-        if (src.hasResponseCode())
-            tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasValidateProfileId())
-            tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasWarningOnly())
-            tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionDirectionTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case RESPONSE:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.RESPONSE);
-                break;
-            case REQUEST:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.REQUEST);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case RESPONSE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.RESPONSE);
-                break;
-            case REQUEST:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.REQUEST);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionOperatorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EQUALS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EQUALS);
-                break;
-            case NOTEQUALS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTEQUALS);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTIN);
-                break;
-            case GREATERTHAN:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.GREATERTHAN);
-                break;
-            case LESSTHAN:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.LESSTHAN);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EMPTY);
-                break;
-            case NOTEMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTEMPTY);
-                break;
-            case CONTAINS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.CONTAINS);
-                break;
-            case NOTCONTAINS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTCONTAINS);
-                break;
-            case EVAL:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorTypeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EQUALS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EQUALS);
-                break;
-            case NOTEQUALS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEQUALS);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTIN);
-                break;
-            case GREATERTHAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.GREATERTHAN);
-                break;
-            case LESSTHAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.LESSTHAN);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EMPTY);
-                break;
-            case NOTEMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEMPTY);
-                break;
-            case CONTAINS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.CONTAINS);
-                break;
-            case NOTCONTAINS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTCONTAINS);
-                break;
-            case EVAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DELETE:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.DELETE);
-                break;
-            case GET:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.GET);
-                break;
-            case OPTIONS:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
-                break;
-            case PATCH:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.PATCH);
-                break;
-            case POST:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.POST);
-                break;
-            case PUT:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.PUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case DELETE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.DELETE);
-                break;
-            case GET:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.GET);
-                break;
-            case OPTIONS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
-                break;
-            case PATCH:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PATCH);
-                break;
-            case POST:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.POST);
-                break;
-            case PUT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionResponseTypesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case OKAY:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.OKAY);
-                break;
-            case CREATED:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.CREATED);
-                break;
-            case NOCONTENT:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOCONTENT);
-                break;
-            case NOTMODIFIED:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
-                break;
-            case BAD:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.BAD);
-                break;
-            case FORBIDDEN:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.FORBIDDEN);
-                break;
-            case NOTFOUND:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOTFOUND);
-                break;
-            case METHODNOTALLOWED:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
-                break;
-            case CONFLICT:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.CONFLICT);
-                break;
-            case GONE:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.GONE);
-                break;
-            case PRECONDITIONFAILED:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
-                break;
-            case UNPROCESSABLE:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypesEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case OKAY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.OKAY);
-                break;
-            case CREATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CREATED);
-                break;
-            case NOCONTENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOCONTENT);
-                break;
-            case NOTMODIFIED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
-                break;
-            case BAD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.BAD);
-                break;
-            case FORBIDDEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.FORBIDDEN);
-                break;
-            case NOTFOUND:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTFOUND);
-                break;
-            case METHODNOTALLOWED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
-                break;
-            case CONFLICT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CONFLICT);
-                break;
-            case GONE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.GONE);
-                break;
-            case PRECONDITIONFAILED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
-                break;
-            case UNPROCESSABLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestScript.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.r4.model.TestScript.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r4.model.TestScript.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> convertFilterOperator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ValueSet.FilterOperatorEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.EQUAL);
-                break;
-            case ISA:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.ISA);
-                break;
-            case DESCENDENTOF:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.DESCENDENTOF);
-                break;
-            case ISNOTA:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.ISNOTA);
-                break;
-            case REGEX:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.REGEX);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.NOTIN);
-                break;
-            case GENERALIZES:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.GENERALIZES);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.EXISTS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> convertFilterOperator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ValueSet.FilterOperatorEnumFactory());
-        VersionConvertor_30_40.copyElement(src, tgt);
-        switch (src.getValue()) {
-            case EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.EQUAL);
-                break;
-            case ISA:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.ISA);
-                break;
-            case DESCENDENTOF:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.DESCENDENTOF);
-                break;
-            case ISNOTA:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.ISNOTA);
-                break;
-            case REGEX:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.REGEX);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.NOTIN);
-                break;
-            case GENERALIZES:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.GENERALIZES);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.EXISTS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src, boolean nullOk) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
-            return Parameters30_40.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Account)
-          return Account30_40.convertAccount((org.hl7.fhir.dstu3.model.Account) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ActivityDefinition)
-            return ActivityDefinition30_40.convertActivityDefinition((org.hl7.fhir.dstu3.model.ActivityDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AllergyIntolerance)
-            return AllergyIntolerance30_40.convertAllergyIntolerance((org.hl7.fhir.dstu3.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Appointment)
-            return Appointment30_40.convertAppointment((org.hl7.fhir.dstu3.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AppointmentResponse)
-            return AppointmentResponse30_40.convertAppointmentResponse((org.hl7.fhir.dstu3.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AuditEvent)
-            return AuditEvent30_40.convertAuditEvent((org.hl7.fhir.dstu3.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Basic)
-            return Basic30_40.convertBasic((org.hl7.fhir.dstu3.model.Basic) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Binary)
-            return Binary30_40.convertBinary((org.hl7.fhir.dstu3.model.Binary) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.BodySite)
-            return BodySite30_40.convertBodySite((org.hl7.fhir.dstu3.model.BodySite) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
-            return Bundle30_40.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
-            return CapabilityStatement30_40.convertCapabilityStatement((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CarePlan)
-            return CarePlan30_40.convertCarePlan((org.hl7.fhir.dstu3.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CareTeam)
-            return CareTeam30_40.convertCareTeam((org.hl7.fhir.dstu3.model.CareTeam) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ClinicalImpression)
-            return ClinicalImpression30_40.convertClinicalImpression((org.hl7.fhir.dstu3.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
-            return CodeSystem30_40.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Communication)
-            return Communication30_40.convertCommunication((org.hl7.fhir.dstu3.model.Communication) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
-            return CompartmentDefinition30_40.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Composition)
-            return Composition30_40.convertComposition((org.hl7.fhir.dstu3.model.Composition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
-            return ConceptMap30_40.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Condition)
-            return Condition30_40.convertCondition((org.hl7.fhir.dstu3.model.Condition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Consent)
-            return Consent30_40.convertConsent((org.hl7.fhir.dstu3.model.Consent) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Coverage)
-          return Coverage30_40.convertCoverage((org.hl7.fhir.dstu3.model.Coverage) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
-            return DataElement30_40.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DetectedIssue)
-            return DetectedIssue30_40.convertDetectedIssue((org.hl7.fhir.dstu3.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DeviceUseStatement)
-            return DeviceUseStatement30_40.convertDeviceUseStatement((org.hl7.fhir.dstu3.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DiagnosticReport)
-            return DiagnosticReport30_40.convertDiagnosticReport((org.hl7.fhir.dstu3.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DocumentReference)
-            return DocumentReference30_40.convertDocumentReference((org.hl7.fhir.dstu3.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Encounter)
-            return Encounter30_40.convertEncounter((org.hl7.fhir.dstu3.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Endpoint)
-            return Endpoint30_40.convertEndpoint((org.hl7.fhir.dstu3.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.EpisodeOfCare)
-            return EpisodeOfCare30_40.convertEpisodeOfCare((org.hl7.fhir.dstu3.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ExpansionProfile)
-            return ExpansionProfile30_40.convertExpansionProfile((org.hl7.fhir.dstu3.model.ExpansionProfile) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.FamilyMemberHistory)
-            return FamilyMemberHistory30_40.convertFamilyMemberHistory((org.hl7.fhir.dstu3.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Flag)
-            return Flag30_40.convertFlag((org.hl7.fhir.dstu3.model.Flag) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Goal)
-            return Goal30_40.convertGoal((org.hl7.fhir.dstu3.model.Goal) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.GraphDefinition)
-            return GraphDefinition30_40.convertGraphDefinition((org.hl7.fhir.dstu3.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Group)
-            return Group30_40.convertGroup((org.hl7.fhir.dstu3.model.Group) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.HealthcareService)
-            return HealthcareService30_40.convertHealthcareService((org.hl7.fhir.dstu3.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ImagingStudy)
-            return ImagingStudy30_40.convertImagingStudy((org.hl7.fhir.dstu3.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Immunization)
-            return Immunization30_40.convertImmunization((org.hl7.fhir.dstu3.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
-            return ImplementationGuide30_40.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Library)
-            return Library30_40.convertLibrary((org.hl7.fhir.dstu3.model.Library) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Linkage)
-            return Linkage30_40.convertLinkage((org.hl7.fhir.dstu3.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ListResource)
-            return List30_40.convertList((org.hl7.fhir.dstu3.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Location)
-            return Location30_40.convertLocation((org.hl7.fhir.dstu3.model.Location) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Media)
-            return Media30_40.convertMedia((org.hl7.fhir.dstu3.model.Media) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Medication)
-            return Medication30_40.convertMedication((org.hl7.fhir.dstu3.model.Medication) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationAdministration)
-            return MedicationAdministration30_40.convertMedicationAdministration((org.hl7.fhir.dstu3.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationDispense)
-            return MedicationDispense30_40.convertMedicationDispense((org.hl7.fhir.dstu3.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationRequest)
-            return MedicationRequest30_40.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationStatement)
-            return MedicationStatement30_40.convertMedicationStatement((org.hl7.fhir.dstu3.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MessageDefinition)
-            return MessageDefinition30_40.convertMessageDefinition((org.hl7.fhir.dstu3.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MessageHeader)
-            return MessageHeader30_40.convertMessageHeader((org.hl7.fhir.dstu3.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
-            return NamingSystem30_40.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Observation)
-            return Observation30_40.convertObservation((org.hl7.fhir.dstu3.model.Observation) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
-            return OperationDefinition30_40.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
-            return OperationOutcome30_40.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Organization)
-            return Organization30_40.convertOrganization((org.hl7.fhir.dstu3.model.Organization) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Patient)
-            return Patient30_40.convertPatient((org.hl7.fhir.dstu3.model.Patient) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PaymentNotice)
-            return PaymentNotice30_40.convertPaymentNotice((org.hl7.fhir.dstu3.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Person)
-            return Person30_40.convertPerson((org.hl7.fhir.dstu3.model.Person) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PlanDefinition)
-            return PlanDefinition30_40.convertPlanDefinition((org.hl7.fhir.dstu3.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Practitioner)
-            return Practitioner30_40.convertPractitioner((org.hl7.fhir.dstu3.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PractitionerRole)
-            return PractitionerRole30_40.convertPractitionerRole((org.hl7.fhir.dstu3.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Procedure)
-            return Procedure30_40.convertProcedure((org.hl7.fhir.dstu3.model.Procedure) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ProcedureRequest)
-            return ProcedureRequest30_40.convertProcedureRequest((org.hl7.fhir.dstu3.model.ProcedureRequest) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Provenance)
-            return Provenance30_40.convertProvenance((org.hl7.fhir.dstu3.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
-            return Questionnaire30_40.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
-            return QuestionnaireResponse30_40.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RelatedPerson)
-            return RelatedPerson30_40.convertRelatedPerson((org.hl7.fhir.dstu3.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RiskAssessment)
-            return RiskAssessment30_40.convertRiskAssessment((org.hl7.fhir.dstu3.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Schedule)
-            return Schedule30_40.convertSchedule((org.hl7.fhir.dstu3.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
-            return SearchParameter30_40.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Sequence)
-            return Sequence30_40.convertSequence((org.hl7.fhir.dstu3.model.Sequence) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Slot)
-            return Slot30_40.convertSlot((org.hl7.fhir.dstu3.model.Slot) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Specimen)
-            return Specimen30_40.convertSpecimen((org.hl7.fhir.dstu3.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
-            return StructureDefinition30_40.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StructureMap)
-            return StructureMap30_40.convertStructureMap((org.hl7.fhir.dstu3.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Subscription)
-            return Subscription30_40.convertSubscription((org.hl7.fhir.dstu3.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Substance)
-            return Substance30_40.convertSubstance((org.hl7.fhir.dstu3.model.Substance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SupplyDelivery)
-            return SupplyDelivery30_40.convertSupplyDelivery((org.hl7.fhir.dstu3.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TestReport)
-            return TestReport30_40.convertTestReport((org.hl7.fhir.dstu3.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
-            return TestScript30_40.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
-            return ValueSet30_40.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
-        if (!nullOk)
-            throw new FHIRException("Unknown resource " + src.fhirType());
-        else
-            return null;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src, boolean nullOk) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Parameters) {
-            if (((org.hl7.fhir.r4.model.Parameters) src).hasParameter("profile-url"))
-                return ExpansionProfile30_40.convertExpansionProfile((org.hl7.fhir.r4.model.Parameters) src);
-            else
-                return Parameters30_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
-        }
-        if (src instanceof org.hl7.fhir.r4.model.Account)
-          return Account30_40.convertAccount((org.hl7.fhir.r4.model.Account) src);
-        if (src instanceof org.hl7.fhir.r4.model.ActivityDefinition)
-            return ActivityDefinition30_40.convertActivityDefinition((org.hl7.fhir.r4.model.ActivityDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.AllergyIntolerance)
-            return AllergyIntolerance30_40.convertAllergyIntolerance((org.hl7.fhir.r4.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Appointment)
-            return Appointment30_40.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
-            return AppointmentResponse30_40.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
-            return AuditEvent30_40.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r4.model.Basic)
-            return Basic30_40.convertBasic((org.hl7.fhir.r4.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r4.model.Binary)
-            return Binary30_40.convertBinary((org.hl7.fhir.r4.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r4.model.BodyStructure)
-            return BodySite30_40.convertBodySite((org.hl7.fhir.r4.model.BodyStructure) src);
-        if (src instanceof org.hl7.fhir.r4.model.Bundle)
-            return Bundle30_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
-            return CapabilityStatement30_40.convertCapabilityStatement((org.hl7.fhir.r4.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.CarePlan)
-            return CarePlan30_40.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r4.model.CareTeam)
-            return CareTeam30_40.convertCareTeam((org.hl7.fhir.r4.model.CareTeam) src);
-        if (src instanceof org.hl7.fhir.r4.model.ClinicalImpression)
-            return ClinicalImpression30_40.convertClinicalImpression((org.hl7.fhir.r4.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
-            return CodeSystem30_40.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.Communication)
-            return Communication30_40.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
-            return CompartmentDefinition30_40.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Composition)
-            return Composition30_40.convertComposition((org.hl7.fhir.r4.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
-            return ConceptMap30_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.Condition)
-            return Condition30_40.convertCondition((org.hl7.fhir.r4.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Consent)
-            return Consent30_40.convertConsent((org.hl7.fhir.r4.model.Consent) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coverage)
-          return Coverage30_40.convertCoverage((org.hl7.fhir.r4.model.Coverage) src);
-        if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
-            return DetectedIssue30_40.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r4.model.Device)
-            return Device30_40.convertDevice((org.hl7.fhir.r4.model.Device) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
-            return DeviceUseStatement30_40.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
-            return DiagnosticReport30_40.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
-            return DocumentReference30_40.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r4.model.Encounter)
-            return Encounter30_40.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r4.model.Endpoint)
-            return Endpoint30_40.convertEndpoint((org.hl7.fhir.r4.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
-            return EpisodeOfCare30_40.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
-            return FamilyMemberHistory30_40.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r4.model.Flag)
-            return Flag30_40.convertFlag((org.hl7.fhir.r4.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r4.model.Goal)
-            return Goal30_40.convertGoal((org.hl7.fhir.r4.model.Goal) src);
-        if (src instanceof org.hl7.fhir.r4.model.GraphDefinition)
-            return GraphDefinition30_40.convertGraphDefinition((org.hl7.fhir.r4.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Group)
-            return Group30_40.convertGroup((org.hl7.fhir.r4.model.Group) src);
-        if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
-            return HealthcareService30_40.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImagingStudy)
-            return ImagingStudy30_40.convertImagingStudy((org.hl7.fhir.r4.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.r4.model.Immunization)
-            return Immunization30_40.convertImmunization((org.hl7.fhir.r4.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
-            return ImplementationGuide30_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r4.model.Library)
-            return Library30_40.convertLibrary((org.hl7.fhir.r4.model.Library) src);
-        if (src instanceof org.hl7.fhir.r4.model.Linkage)
-            return Linkage30_40.convertLinkage((org.hl7.fhir.r4.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.r4.model.ListResource)
-            return List30_40.convertList((org.hl7.fhir.r4.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r4.model.Location)
-            return Location30_40.convertLocation((org.hl7.fhir.r4.model.Location) src);
-        if (src instanceof org.hl7.fhir.r4.model.Media)
-            return Media30_40.convertMedia((org.hl7.fhir.r4.model.Media) src);
-        if (src instanceof org.hl7.fhir.r4.model.Medication)
-            return Medication30_40.convertMedication((org.hl7.fhir.r4.model.Medication) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationAdministration)
-            return MedicationAdministration30_40.convertMedicationAdministration((org.hl7.fhir.r4.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
-            return MedicationDispense30_40.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationRequest)
-            return MedicationRequest30_40.convertMedicationRequest((org.hl7.fhir.r4.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
-            return MedicationStatement30_40.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.MessageDefinition)
-            return MessageDefinition30_40.convertMessageDefinition((org.hl7.fhir.r4.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
-            return MessageHeader30_40.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
-            return NamingSystem30_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.Observation)
-            return Observation30_40.convertObservation((org.hl7.fhir.r4.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
-            return OperationDefinition30_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
-            return OperationOutcome30_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r4.model.Organization)
-            return Organization30_40.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r4.model.Patient)
-            return Patient30_40.convertPatient((org.hl7.fhir.r4.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r4.model.PaymentNotice)
-            return PaymentNotice30_40.convertPaymentNotice((org.hl7.fhir.r4.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.r4.model.Person)
-            return Person30_40.convertPerson((org.hl7.fhir.r4.model.Person) src);
-        if (src instanceof org.hl7.fhir.r4.model.PlanDefinition)
-            return PlanDefinition30_40.convertPlanDefinition((org.hl7.fhir.r4.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Practitioner)
-            return Practitioner30_40.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r4.model.PractitionerRole)
-            return PractitionerRole30_40.convertPractitionerRole((org.hl7.fhir.r4.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.r4.model.Procedure)
-            return Procedure30_40.convertProcedure((org.hl7.fhir.r4.model.Procedure) src);
-        if (src instanceof org.hl7.fhir.r4.model.ServiceRequest)
-            return ProcedureRequest30_40.convertProcedureRequest((org.hl7.fhir.r4.model.ServiceRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.Provenance)
-            return Provenance30_40.convertProvenance((org.hl7.fhir.r4.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
-            return Questionnaire30_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
-            return QuestionnaireResponse30_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.RelatedPerson)
-            return RelatedPerson30_40.convertRelatedPerson((org.hl7.fhir.r4.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
-            return RiskAssessment30_40.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r4.model.Schedule)
-            return Schedule30_40.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
-            return SearchParameter30_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r4.model.MolecularSequence)
-            return Sequence30_40.convertSequence((org.hl7.fhir.r4.model.MolecularSequence) src);
-        if (src instanceof org.hl7.fhir.r4.model.Slot)
-            return Slot30_40.convertSlot((org.hl7.fhir.r4.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r4.model.Specimen)
-            return Specimen30_40.convertSpecimen((org.hl7.fhir.r4.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
-            return StructureDefinition30_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureMap)
-            return StructureMap30_40.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.Subscription)
-            return Subscription30_40.convertSubscription((org.hl7.fhir.r4.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.r4.model.Substance)
-            return Substance30_40.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
-            return SupplyDelivery30_40.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r4.model.TestReport)
-            return TestReport30_40.convertTestReport((org.hl7.fhir.r4.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.TestScript)
-            return TestScript30_40.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r4.model.ValueSet)
-            return ValueSet30_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
-        if (!nullOk)
-            throw new FHIRException("Unknown resource " + src.fhirType());
-        else
-            return null;
-    }
-
-    public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src, boolean b) {
-        TerminologyCapabilities res = new TerminologyCapabilities();
-        for (ParametersParameterComponent p : src.getParameter()) {
-            if (p.getName().equals("system"))
-                res.addCodeSystem().setUri(p.getValue().primitiveValue());
-        }
-        return res;
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "ActivityDefinition", "AllergyIntolerance", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "BodyStructure", "Bundle", "CapabilityStatement", "CarePlan", "CareTeam", "ClinicalImpression", "CodeSystem", "Communication", "CompartmentDefinition", "Composition", "ConceptMap", "Condition", "Consent", "DetectedIssue", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "Endpoint", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Goal", "GraphDefinition", "Group", "HealthcareService", "ImagingStudy", "Immunization", "ImplementationGuide", "Library", "Linkage", "ListResource", "Location", "Media", "Medication", "MedicationAdministration", "MedicationDispense", "MedicationRequest", "MedicationStatement", "MessageDefinition", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "PaymentNotice", "Person", "PlanDefinition", "Practitioner", "PractitionerRole", "Procedure", "ProcedureRequest", "ProcessRequest", "Provenance", "Questionnaire", "QuestionnaireResponse", "RelatedPerson", "RiskAssessment", "Schedule", "SearchParameter", "Sequence", "Slot", "Specimen", "StructureDefinition", "StructureMap", "Subscription", "Substance", "SupplyDelivery", "TestReport", "TestScript", "ValueSet");
-    }
+      } else {
+        if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
+        else tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.dstu3.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ParameterDefinition tgt = new org.hl7.fhir.r4.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setTypeElement(convertCode(src.getTypeElement()));
+    if (src.hasProfile()) {
+      tgt.setProfile(convertReference(src.getProfile()).getReference());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r4.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ParameterDefinition tgt = new org.hl7.fhir.dstu3.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setTypeElement(convertCode(src.getTypeElement()));
+    if (src.hasProfile()) tgt.setProfile(new org.hl7.fhir.dstu3.model.Reference(src.getProfile()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ParameterDefinition.ParameterUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUseEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.dstu3.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.RelatedArtifact tgt = new org.hl7.fhir.r4.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitation(src.getCitation());
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResourceElement(convertReferenceToCanonical(src.getResource()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r4.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.RelatedArtifact tgt = new org.hl7.fhir.dstu3.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitation(src.getCitation());
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResource(convertCanonicalToReference(src.getResourceElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent())
+      tgt.addEventElement().setValueAsString(t.getValueAsString());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent())
+      tgt.addEventElement().setValueAsString(t.getValueAsString());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_30_40::convertDayOfWeek).collect(Collectors.toList()));
+    for (org.hl7.fhir.dstu3.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_30_40::convertEventTiming).collect(Collectors.toList()));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_30_40::convertDayOfWeek).collect(Collectors.toList()));
+    for (org.hl7.fhir.r4.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_30_40::convertEventTiming).collect(Collectors.toList()));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.DayOfWeekEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.DayOfWeekEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.MORN);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AFT);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.EVE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UsageContext convertUsageContext(org.hl7.fhir.dstu3.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.UsageContext tgt = new org.hl7.fhir.r4.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UsageContext convertUsageContext(org.hl7.fhir.r4.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.UsageContext tgt = new org.hl7.fhir.dstu3.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.SimpleQuantity tgt = new org.hl7.fhir.r4.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.dstu3.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TriggerDefinition tgt = new org.hl7.fhir.r4.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasEventName()) tgt.setNameElement(convertString(src.getEventNameElement()));
+    if (src.hasEventTiming()) tgt.setTiming(convertType(src.getEventTiming()));
+    if (src.hasEventData()) tgt.addData(convertDataRequirement(src.getEventData()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r4.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TriggerDefinition tgt = new org.hl7.fhir.dstu3.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasName()) tgt.setEventNameElement(convertString(src.getNameElement()));
+    if (src.hasTiming()) tgt.setEventTiming(convertType(src.getTiming()));
+    if (src.hasData()) tgt.setEventData(convertDataRequirement(src.getDataFirstRep()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement convertDataRequirement(org.hl7.fhir.dstu3.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement tgt = new org.hl7.fhir.r4.model.DataRequirement();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertCode(src.getTypeElement()));
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
+    for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement convertDataRequirement(org.hl7.fhir.r4.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement tgt = new org.hl7.fhir.dstu3.model.DataRequirement();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertCode(src.getTypeElement()));
+    for (org.hl7.fhir.r4.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r4.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
+    for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValueSet()) {
+      Type t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r4.model.Reference)
+        tgt.setValueSet(((org.hl7.fhir.r4.model.Reference) t).getReference());
+      else tgt.setValueSet(t.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    for (org.hl7.fhir.dstu3.model.CodeType t : src.getValueCode()) tgt.addCode(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getValueCoding()) tgt.addCode(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getValueCodeableConcept()) tgt.addCode(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
+    }
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) {
+      tgt.addValueCoding(convertCoding(t));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeType) return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateType) return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IdType) return convertId((org.hl7.fhir.dstu3.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OidType) return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StringType)
+      return convertString((org.hl7.fhir.dstu3.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TimeType) return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UuidType) return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UriType) return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Age) return convertAge((org.hl7.fhir.dstu3.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Coding) return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Count) return convertCount((org.hl7.fhir.dstu3.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Money) return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Period) return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.dstu3.model.SimpleQuantity) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Range) return convertRange((org.hl7.fhir.dstu3.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Ratio) return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Reference)
+      return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Address) return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.dstu3.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Contributor)
+      return convertContributor((org.hl7.fhir.dstu3.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Dosage) return convertDosage((org.hl7.fhir.dstu3.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Meta) return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.dstu3.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.dstu3.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Timing) return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.dstu3.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.dstu3.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.dstu3.model.TriggerDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r4.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeType) return convertCode((org.hl7.fhir.r4.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateType) return convertDate((org.hl7.fhir.r4.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IdType) return convertId((org.hl7.fhir.r4.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r4.model.InstantType)
+      return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r4.model.OidType) return convertOid((org.hl7.fhir.r4.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.StringType) return convertString((org.hl7.fhir.r4.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r4.model.TimeType) return convertTime((org.hl7.fhir.r4.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UuidType) return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UriType) return convertUri((org.hl7.fhir.r4.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r4.model.Extension) return convertExtension((org.hl7.fhir.r4.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r4.model.Narrative) return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r4.model.Age) return convertAge((org.hl7.fhir.r4.model.Age) src);
+    if (src instanceof org.hl7.fhir.r4.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coding) return convertCoding((org.hl7.fhir.r4.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r4.model.Count) return convertCount((org.hl7.fhir.r4.model.Count) src);
+    if (src instanceof org.hl7.fhir.r4.model.Distance) return convertDistance((org.hl7.fhir.r4.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Duration) return convertDuration((org.hl7.fhir.r4.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r4.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r4.model.Money) return convertMoney((org.hl7.fhir.r4.model.Money) src);
+    if (src instanceof org.hl7.fhir.r4.model.Period) return convertPeriod((org.hl7.fhir.r4.model.Period) src);
+    if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Quantity) return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Range) return convertRange((org.hl7.fhir.r4.model.Range) src);
+    if (src instanceof org.hl7.fhir.r4.model.Ratio) return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r4.model.Reference) return convertReference((org.hl7.fhir.r4.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r4.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r4.model.Signature) return convertSignature((org.hl7.fhir.r4.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r4.model.Address) return convertAddress((org.hl7.fhir.r4.model.Address) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.r4.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.Contributor)
+      return convertContributor((org.hl7.fhir.r4.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.r4.model.Dosage) return convertDosage((org.hl7.fhir.r4.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.r4.model.HumanName) return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r4.model.Meta) return convertMeta((org.hl7.fhir.r4.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r4.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.r4.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.r4.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.r4.model.Timing) return convertTiming((org.hl7.fhir.r4.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r4.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.r4.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.r4.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.r4.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.r4.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.r4.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.r4.model.TriggerDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu3.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
+    for (org.hl7.fhir.dstu3.model.Extension t2 : src.getExtension())
+      if (!isExemptExtension(t2.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t2));
+    for (org.hl7.fhir.dstu3.model.Extension t3 : src.getModifierExtension())
+      if (!isExemptExtension(t3.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t3));
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r4.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
+    for (org.hl7.fhir.r4.model.Extension t2 : src.getExtension())
+      if (!isExemptExtension(t2.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t2));
+    for (org.hl7.fhir.r4.model.Extension t3 : src.getModifierExtension())
+      if (!isExemptExtension(t3.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t3));
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguage(src.getLanguage());
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.CanonicalType convertReferenceToCanonical(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
+    org.hl7.fhir.r4.model.CanonicalType dst = new org.hl7.fhir.r4.model.CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Reference convertCanonicalToReference(org.hl7.fhir.r4.model.CanonicalType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.Reference dst = new org.hl7.fhir.dstu3.model.Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r4.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REPLACES:
+          tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.REPLACES);
+          break;
+        case TRANSFORMS:
+          tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.TRANSFORMS);
+          break;
+        case SIGNS:
+          tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.SIGNS);
+          break;
+        case APPENDS:
+          tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.APPENDS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REPLACES:
+          tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.REPLACES);
+          break;
+        case TRANSFORMS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.TRANSFORMS);
+          break;
+        case SIGNS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.SIGNS);
+          break;
+        case APPENDS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.APPENDS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.r4.model.Encounter.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setUse(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r4.model.Encounter.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasUse()) tgt.setRole(convertCodeableConcept(src.getUse()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setRole(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r4.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setRole(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static final public String URN_IETF_RFC_3986 = "urn:ietf:rfc:3986";
+
+  public static String convertCoding2Uri(org.hl7.fhir.dstu3.model.Coding code) {
+    return code.getSystem() + "/" + code.getCode();
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertUri2Coding(String uri) {
+    int i = uri.lastIndexOf("/");
+    return new org.hl7.fhir.dstu3.model.Coding().setSystem(uri.substring(0, i)).setCode(uri.substring(i + 1));
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeekEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeekEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r4.model.TestReport.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertUri(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r4.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertUri(src.getDetailElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestReport.TestReportActionResultEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PASS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.PASS);
+          break;
+        case SKIP:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.SKIP);
+          break;
+        case FAIL:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.FAIL);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.WARNING);
+          break;
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.ERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TestReport.TestReportActionResult.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestReport.TestReportActionResult> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestReport.TestReportActionResultEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PASS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.PASS);
+          break;
+        case SKIP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.SKIP);
+          break;
+        case FAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.FAIL);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.WARNING);
+          break;
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.ERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertString(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertString(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestReport.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.r4.model.TestReport.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.r4.model.TestReport.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r4.model.TestReport.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r4.model.TestScript.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCoding(src.getType()));
+    if (src.hasResource()) tgt.setResourceElement(convertCode(src.getResourceElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasAccept()) tgt.setAccept(convertContentType(src.getAccept()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasDestination()) tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
+    if (src.hasEncodeRequestUrl()) tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
+    if (src.hasOrigin()) tgt.setOriginElement(convertInteger(src.getOriginElement()));
+    if (src.hasParams()) tgt.setParamsElement(convertString(src.getParamsElement()));
+    for (org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
+      tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
+    if (src.hasRequestId()) tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
+    if (src.hasResponseId()) tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasTargetId()) tgt.setTargetId(src.getTargetId());
+    if (src.hasUrl()) tgt.setUrlElement(convertString(src.getUrlElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r4.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCoding(src.getType()));
+    if (src.hasResource()) tgt.setResourceElement(convertCode(src.getResourceElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasAccept()) tgt.setAccept(convertContentType(src.getAccept()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasDestination()) tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
+    if (src.hasEncodeRequestUrl()) tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
+    if (src.hasOrigin()) tgt.setOriginElement(convertInteger(src.getOriginElement()));
+    if (src.hasParams()) tgt.setParamsElement(convertString(src.getParamsElement()));
+    for (org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
+      tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
+    if (src.hasRequestId()) tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
+    if (src.hasResponseId()) tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasTargetId()) tgt.setTargetId(src.getTargetId());
+    if (src.hasUrl()) tgt.setUrlElement(convertString(src.getUrlElement()));
+    return tgt;
+  }
+
+  static public String convertContentType(org.hl7.fhir.dstu3.model.TestScript.ContentType src) throws FHIRException {
+    if (src == null) return null;
+    switch (src) {
+      case XML:
+        return "application/fhir+xml";
+      case JSON:
+        return "application/fhir+json";
+      case TTL:
+        return "text/turtle";
+      case NONE:
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  static public org.hl7.fhir.dstu3.model.TestScript.ContentType convertContentType(String src) throws FHIRException {
+    if (src == null) return null;
+    if (src.contains("xml")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.XML;
+    if (src.contains("json")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.JSON;
+    if (src.contains("tu")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.TTL;
+    return org.hl7.fhir.dstu3.model.TestScript.ContentType.NONE;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent();
+    copyElement(src, tgt);
+    if (src.hasField()) tgt.setFieldElement(convertString(src.getFieldElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.r4.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent();
+    copyElement(src, tgt);
+    if (src.hasField()) tgt.setFieldElement(convertString(src.getFieldElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
+    if (src.hasCompareToSourceId()) tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
+    if (src.hasCompareToSourceExpression())
+      tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
+    if (src.hasCompareToSourcePath())
+      tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasHeaderField()) tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
+    if (src.hasMinimumId()) tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
+    if (src.hasNavigationLinks()) tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
+    if (src.hasOperator()) tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasRequestMethod())
+      tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
+    if (src.hasRequestURL()) tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
+    if (src.hasResource()) tgt.setResourceElement(convertCode(src.getResourceElement()));
+    if (src.hasResponse()) tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
+    if (src.hasResponseCode()) tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasValidateProfileId()) tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasWarningOnly()) tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r4.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
+    if (src.hasCompareToSourceId()) tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
+    if (src.hasCompareToSourceExpression())
+      tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
+    if (src.hasCompareToSourcePath())
+      tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasHeaderField()) tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
+    if (src.hasMinimumId()) tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
+    if (src.hasNavigationLinks()) tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
+    if (src.hasOperator()) tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasRequestMethod())
+      tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
+    if (src.hasRequestURL()) tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
+    if (src.hasResource()) tgt.setResourceElement(convertCode(src.getResourceElement()));
+    if (src.hasResponse()) tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
+    if (src.hasResponseCode()) tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasValidateProfileId()) tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasWarningOnly()) tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionDirectionTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case RESPONSE:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.RESPONSE);
+          break;
+        case REQUEST:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.REQUEST);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionDirectionType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionDirectionType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case RESPONSE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.RESPONSE);
+          break;
+        case REQUEST:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.REQUEST);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionOperatorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUALS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EQUALS);
+          break;
+        case NOTEQUALS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTEQUALS);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTIN);
+          break;
+        case GREATERTHAN:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.GREATERTHAN);
+          break;
+        case LESSTHAN:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.LESSTHAN);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EMPTY);
+          break;
+        case NOTEMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTEMPTY);
+          break;
+        case CONTAINS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.CONTAINS);
+          break;
+        case NOTCONTAINS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NOTCONTAINS);
+          break;
+        case EVAL:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.EVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionOperatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionOperatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorTypeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUALS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EQUALS);
+          break;
+        case NOTEQUALS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEQUALS);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTIN);
+          break;
+        case GREATERTHAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.GREATERTHAN);
+          break;
+        case LESSTHAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.LESSTHAN);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EMPTY);
+          break;
+        case NOTEMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEMPTY);
+          break;
+        case CONTAINS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.CONTAINS);
+          break;
+        case NOTCONTAINS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTCONTAINS);
+          break;
+        case EVAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DELETE:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.DELETE);
+          break;
+        case GET:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.GET);
+          break;
+        case OPTIONS:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
+          break;
+        case PATCH:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.PATCH);
+          break;
+        case POST:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.POST);
+          break;
+        case PUT:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.PUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DELETE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.DELETE);
+          break;
+        case GET:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.GET);
+          break;
+        case OPTIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
+          break;
+        case PATCH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PATCH);
+          break;
+        case POST:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.POST);
+          break;
+        case PUT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TestScript.AssertionResponseTypesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NULL);
+    } else {
+      switch (src.getValue()) {
+        case OKAY:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.OKAY);
+          break;
+        case CREATED:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.CREATED);
+          break;
+        case NOCONTENT:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOCONTENT);
+          break;
+        case NOTMODIFIED:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
+          break;
+        case BAD:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.BAD);
+          break;
+        case FORBIDDEN:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.FORBIDDEN);
+          break;
+        case NOTFOUND:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NOTFOUND);
+          break;
+        case METHODNOTALLOWED:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
+          break;
+        case CONFLICT:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.CONFLICT);
+          break;
+        case GONE:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.GONE);
+          break;
+        case PRECONDITIONFAILED:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
+          break;
+        case UNPROCESSABLE:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypesEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
+    } else {
+      switch (src.getValue()) {
+        case OKAY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.OKAY);
+          break;
+        case CREATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CREATED);
+          break;
+        case NOCONTENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOCONTENT);
+          break;
+        case NOTMODIFIED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
+          break;
+        case BAD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.BAD);
+          break;
+        case FORBIDDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.FORBIDDEN);
+          break;
+        case NOTFOUND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTFOUND);
+          break;
+        case METHODNOTALLOWED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
+          break;
+        case CONFLICT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CONFLICT);
+          break;
+        case GONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.GONE);
+          break;
+        case PRECONDITIONFAILED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
+          break;
+        case UNPROCESSABLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestScript.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.r4.model.TestScript.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.r4.model.TestScript.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r4.model.TestScript.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> convertFilterOperator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ValueSet.FilterOperatorEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.EQUAL);
+          break;
+        case ISA:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.ISA);
+          break;
+        case DESCENDENTOF:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.DESCENDENTOF);
+          break;
+        case ISNOTA:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.ISNOTA);
+          break;
+        case REGEX:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.REGEX);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.NOTIN);
+          break;
+        case GENERALIZES:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.GENERALIZES);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.EXISTS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ValueSet.FilterOperator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> convertFilterOperator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ValueSet.FilterOperator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ValueSet.FilterOperatorEnumFactory());
+    VersionConvertor_30_40.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.EQUAL);
+          break;
+        case ISA:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.ISA);
+          break;
+        case DESCENDENTOF:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.DESCENDENTOF);
+          break;
+        case ISNOTA:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.ISNOTA);
+          break;
+        case REGEX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.REGEX);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.NOTIN);
+          break;
+        case GENERALIZES:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.GENERALIZES);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.EXISTS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ValueSet.FilterOperator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src, boolean nullOk) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
+      return Parameters30_40.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Account)
+      return Account30_40.convertAccount((org.hl7.fhir.dstu3.model.Account) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ActivityDefinition)
+      return ActivityDefinition30_40.convertActivityDefinition((org.hl7.fhir.dstu3.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AllergyIntolerance)
+      return AllergyIntolerance30_40.convertAllergyIntolerance((org.hl7.fhir.dstu3.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Appointment)
+      return Appointment30_40.convertAppointment((org.hl7.fhir.dstu3.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AppointmentResponse)
+      return AppointmentResponse30_40.convertAppointmentResponse((org.hl7.fhir.dstu3.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AuditEvent)
+      return AuditEvent30_40.convertAuditEvent((org.hl7.fhir.dstu3.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Basic)
+      return Basic30_40.convertBasic((org.hl7.fhir.dstu3.model.Basic) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Binary)
+      return Binary30_40.convertBinary((org.hl7.fhir.dstu3.model.Binary) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.BodySite)
+      return BodySite30_40.convertBodySite((org.hl7.fhir.dstu3.model.BodySite) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
+      return Bundle30_40.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
+      return CapabilityStatement30_40.convertCapabilityStatement((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CarePlan)
+      return CarePlan30_40.convertCarePlan((org.hl7.fhir.dstu3.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CareTeam)
+      return CareTeam30_40.convertCareTeam((org.hl7.fhir.dstu3.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ClinicalImpression)
+      return ClinicalImpression30_40.convertClinicalImpression((org.hl7.fhir.dstu3.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
+      return CodeSystem30_40.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Communication)
+      return Communication30_40.convertCommunication((org.hl7.fhir.dstu3.model.Communication) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
+      return CompartmentDefinition30_40.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Composition)
+      return Composition30_40.convertComposition((org.hl7.fhir.dstu3.model.Composition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
+      return ConceptMap30_40.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Condition)
+      return Condition30_40.convertCondition((org.hl7.fhir.dstu3.model.Condition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Consent)
+      return Consent30_40.convertConsent((org.hl7.fhir.dstu3.model.Consent) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Coverage)
+      return Coverage30_40.convertCoverage((org.hl7.fhir.dstu3.model.Coverage) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
+      return DataElement30_40.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DetectedIssue)
+      return DetectedIssue30_40.convertDetectedIssue((org.hl7.fhir.dstu3.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DeviceUseStatement)
+      return DeviceUseStatement30_40.convertDeviceUseStatement((org.hl7.fhir.dstu3.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DiagnosticReport)
+      return DiagnosticReport30_40.convertDiagnosticReport((org.hl7.fhir.dstu3.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DocumentReference)
+      return DocumentReference30_40.convertDocumentReference((org.hl7.fhir.dstu3.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Encounter)
+      return Encounter30_40.convertEncounter((org.hl7.fhir.dstu3.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Endpoint)
+      return Endpoint30_40.convertEndpoint((org.hl7.fhir.dstu3.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.EpisodeOfCare)
+      return EpisodeOfCare30_40.convertEpisodeOfCare((org.hl7.fhir.dstu3.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ExpansionProfile)
+      return ExpansionProfile30_40.convertExpansionProfile((org.hl7.fhir.dstu3.model.ExpansionProfile) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.FamilyMemberHistory)
+      return FamilyMemberHistory30_40.convertFamilyMemberHistory((org.hl7.fhir.dstu3.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Flag) return Flag30_40.convertFlag((org.hl7.fhir.dstu3.model.Flag) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Goal) return Goal30_40.convertGoal((org.hl7.fhir.dstu3.model.Goal) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.GraphDefinition)
+      return GraphDefinition30_40.convertGraphDefinition((org.hl7.fhir.dstu3.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Group)
+      return Group30_40.convertGroup((org.hl7.fhir.dstu3.model.Group) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.HealthcareService)
+      return HealthcareService30_40.convertHealthcareService((org.hl7.fhir.dstu3.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ImagingStudy)
+      return ImagingStudy30_40.convertImagingStudy((org.hl7.fhir.dstu3.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Immunization)
+      return Immunization30_40.convertImmunization((org.hl7.fhir.dstu3.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
+      return ImplementationGuide30_40.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Library)
+      return Library30_40.convertLibrary((org.hl7.fhir.dstu3.model.Library) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Linkage)
+      return Linkage30_40.convertLinkage((org.hl7.fhir.dstu3.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ListResource)
+      return List30_40.convertList((org.hl7.fhir.dstu3.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Location)
+      return Location30_40.convertLocation((org.hl7.fhir.dstu3.model.Location) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Media)
+      return Media30_40.convertMedia((org.hl7.fhir.dstu3.model.Media) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Medication)
+      return Medication30_40.convertMedication((org.hl7.fhir.dstu3.model.Medication) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationAdministration)
+      return MedicationAdministration30_40.convertMedicationAdministration((org.hl7.fhir.dstu3.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationDispense)
+      return MedicationDispense30_40.convertMedicationDispense((org.hl7.fhir.dstu3.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationRequest)
+      return MedicationRequest30_40.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationStatement)
+      return MedicationStatement30_40.convertMedicationStatement((org.hl7.fhir.dstu3.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MessageDefinition)
+      return MessageDefinition30_40.convertMessageDefinition((org.hl7.fhir.dstu3.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MessageHeader)
+      return MessageHeader30_40.convertMessageHeader((org.hl7.fhir.dstu3.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
+      return NamingSystem30_40.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Observation)
+      return Observation30_40.convertObservation((org.hl7.fhir.dstu3.model.Observation) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
+      return OperationDefinition30_40.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
+      return OperationOutcome30_40.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Organization)
+      return Organization30_40.convertOrganization((org.hl7.fhir.dstu3.model.Organization) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Patient)
+      return Patient30_40.convertPatient((org.hl7.fhir.dstu3.model.Patient) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PaymentNotice)
+      return PaymentNotice30_40.convertPaymentNotice((org.hl7.fhir.dstu3.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Person)
+      return Person30_40.convertPerson((org.hl7.fhir.dstu3.model.Person) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PlanDefinition)
+      return PlanDefinition30_40.convertPlanDefinition((org.hl7.fhir.dstu3.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Practitioner)
+      return Practitioner30_40.convertPractitioner((org.hl7.fhir.dstu3.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PractitionerRole)
+      return PractitionerRole30_40.convertPractitionerRole((org.hl7.fhir.dstu3.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Procedure)
+      return Procedure30_40.convertProcedure((org.hl7.fhir.dstu3.model.Procedure) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ProcedureRequest)
+      return ProcedureRequest30_40.convertProcedureRequest((org.hl7.fhir.dstu3.model.ProcedureRequest) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Provenance)
+      return Provenance30_40.convertProvenance((org.hl7.fhir.dstu3.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
+      return Questionnaire30_40.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
+      return QuestionnaireResponse30_40.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RelatedPerson)
+      return RelatedPerson30_40.convertRelatedPerson((org.hl7.fhir.dstu3.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RiskAssessment)
+      return RiskAssessment30_40.convertRiskAssessment((org.hl7.fhir.dstu3.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Schedule)
+      return Schedule30_40.convertSchedule((org.hl7.fhir.dstu3.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
+      return SearchParameter30_40.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Sequence)
+      return Sequence30_40.convertSequence((org.hl7.fhir.dstu3.model.Sequence) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Slot) return Slot30_40.convertSlot((org.hl7.fhir.dstu3.model.Slot) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Specimen)
+      return Specimen30_40.convertSpecimen((org.hl7.fhir.dstu3.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
+      return StructureDefinition30_40.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StructureMap)
+      return StructureMap30_40.convertStructureMap((org.hl7.fhir.dstu3.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Subscription)
+      return Subscription30_40.convertSubscription((org.hl7.fhir.dstu3.model.Subscription) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Substance)
+      return Substance30_40.convertSubstance((org.hl7.fhir.dstu3.model.Substance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SupplyDelivery)
+      return SupplyDelivery30_40.convertSupplyDelivery((org.hl7.fhir.dstu3.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TestReport)
+      return TestReport30_40.convertTestReport((org.hl7.fhir.dstu3.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
+      return TestScript30_40.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
+      return ValueSet30_40.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
+    if (!nullOk) throw new FHIRException("Unknown resource " + src.fhirType());
+    else return null;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src, boolean nullOk) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Parameters) {
+      if (((org.hl7.fhir.r4.model.Parameters) src).hasParameter("profile-url"))
+        return ExpansionProfile30_40.convertExpansionProfile((org.hl7.fhir.r4.model.Parameters) src);
+      else return Parameters30_40.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
+    }
+    if (src instanceof org.hl7.fhir.r4.model.Account)
+      return Account30_40.convertAccount((org.hl7.fhir.r4.model.Account) src);
+    if (src instanceof org.hl7.fhir.r4.model.ActivityDefinition)
+      return ActivityDefinition30_40.convertActivityDefinition((org.hl7.fhir.r4.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.AllergyIntolerance)
+      return AllergyIntolerance30_40.convertAllergyIntolerance((org.hl7.fhir.r4.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Appointment)
+      return Appointment30_40.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
+      return AppointmentResponse30_40.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
+      return AuditEvent30_40.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r4.model.Basic) return Basic30_40.convertBasic((org.hl7.fhir.r4.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r4.model.Binary)
+      return Binary30_40.convertBinary((org.hl7.fhir.r4.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r4.model.BodyStructure)
+      return BodySite30_40.convertBodySite((org.hl7.fhir.r4.model.BodyStructure) src);
+    if (src instanceof org.hl7.fhir.r4.model.Bundle)
+      return Bundle30_40.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
+      return CapabilityStatement30_40.convertCapabilityStatement((org.hl7.fhir.r4.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.CarePlan)
+      return CarePlan30_40.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r4.model.CareTeam)
+      return CareTeam30_40.convertCareTeam((org.hl7.fhir.r4.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.r4.model.ClinicalImpression)
+      return ClinicalImpression30_40.convertClinicalImpression((org.hl7.fhir.r4.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
+      return CodeSystem30_40.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.Communication)
+      return Communication30_40.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
+      return CompartmentDefinition30_40.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Composition)
+      return Composition30_40.convertComposition((org.hl7.fhir.r4.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
+      return ConceptMap30_40.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.Condition)
+      return Condition30_40.convertCondition((org.hl7.fhir.r4.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Consent)
+      return Consent30_40.convertConsent((org.hl7.fhir.r4.model.Consent) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coverage)
+      return Coverage30_40.convertCoverage((org.hl7.fhir.r4.model.Coverage) src);
+    if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
+      return DetectedIssue30_40.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r4.model.Device)
+      return Device30_40.convertDevice((org.hl7.fhir.r4.model.Device) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
+      return DeviceUseStatement30_40.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
+      return DiagnosticReport30_40.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
+      return DocumentReference30_40.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r4.model.Encounter)
+      return Encounter30_40.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r4.model.Endpoint)
+      return Endpoint30_40.convertEndpoint((org.hl7.fhir.r4.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
+      return EpisodeOfCare30_40.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
+      return FamilyMemberHistory30_40.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r4.model.Flag) return Flag30_40.convertFlag((org.hl7.fhir.r4.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r4.model.Goal) return Goal30_40.convertGoal((org.hl7.fhir.r4.model.Goal) src);
+    if (src instanceof org.hl7.fhir.r4.model.GraphDefinition)
+      return GraphDefinition30_40.convertGraphDefinition((org.hl7.fhir.r4.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Group) return Group30_40.convertGroup((org.hl7.fhir.r4.model.Group) src);
+    if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
+      return HealthcareService30_40.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImagingStudy)
+      return ImagingStudy30_40.convertImagingStudy((org.hl7.fhir.r4.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.r4.model.Immunization)
+      return Immunization30_40.convertImmunization((org.hl7.fhir.r4.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
+      return ImplementationGuide30_40.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r4.model.Library)
+      return Library30_40.convertLibrary((org.hl7.fhir.r4.model.Library) src);
+    if (src instanceof org.hl7.fhir.r4.model.Linkage)
+      return Linkage30_40.convertLinkage((org.hl7.fhir.r4.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.r4.model.ListResource)
+      return List30_40.convertList((org.hl7.fhir.r4.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r4.model.Location)
+      return Location30_40.convertLocation((org.hl7.fhir.r4.model.Location) src);
+    if (src instanceof org.hl7.fhir.r4.model.Media) return Media30_40.convertMedia((org.hl7.fhir.r4.model.Media) src);
+    if (src instanceof org.hl7.fhir.r4.model.Medication)
+      return Medication30_40.convertMedication((org.hl7.fhir.r4.model.Medication) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationAdministration)
+      return MedicationAdministration30_40.convertMedicationAdministration((org.hl7.fhir.r4.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
+      return MedicationDispense30_40.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationRequest)
+      return MedicationRequest30_40.convertMedicationRequest((org.hl7.fhir.r4.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
+      return MedicationStatement30_40.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.MessageDefinition)
+      return MessageDefinition30_40.convertMessageDefinition((org.hl7.fhir.r4.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
+      return MessageHeader30_40.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
+      return NamingSystem30_40.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.Observation)
+      return Observation30_40.convertObservation((org.hl7.fhir.r4.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
+      return OperationDefinition30_40.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
+      return OperationOutcome30_40.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r4.model.Organization)
+      return Organization30_40.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r4.model.Patient)
+      return Patient30_40.convertPatient((org.hl7.fhir.r4.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r4.model.PaymentNotice)
+      return PaymentNotice30_40.convertPaymentNotice((org.hl7.fhir.r4.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.r4.model.Person)
+      return Person30_40.convertPerson((org.hl7.fhir.r4.model.Person) src);
+    if (src instanceof org.hl7.fhir.r4.model.PlanDefinition)
+      return PlanDefinition30_40.convertPlanDefinition((org.hl7.fhir.r4.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Practitioner)
+      return Practitioner30_40.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r4.model.PractitionerRole)
+      return PractitionerRole30_40.convertPractitionerRole((org.hl7.fhir.r4.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.r4.model.Procedure)
+      return Procedure30_40.convertProcedure((org.hl7.fhir.r4.model.Procedure) src);
+    if (src instanceof org.hl7.fhir.r4.model.ServiceRequest)
+      return ProcedureRequest30_40.convertProcedureRequest((org.hl7.fhir.r4.model.ServiceRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.Provenance)
+      return Provenance30_40.convertProvenance((org.hl7.fhir.r4.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
+      return Questionnaire30_40.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
+      return QuestionnaireResponse30_40.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.RelatedPerson)
+      return RelatedPerson30_40.convertRelatedPerson((org.hl7.fhir.r4.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
+      return RiskAssessment30_40.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r4.model.Schedule)
+      return Schedule30_40.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
+      return SearchParameter30_40.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r4.model.MolecularSequence)
+      return Sequence30_40.convertSequence((org.hl7.fhir.r4.model.MolecularSequence) src);
+    if (src instanceof org.hl7.fhir.r4.model.Slot) return Slot30_40.convertSlot((org.hl7.fhir.r4.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r4.model.Specimen)
+      return Specimen30_40.convertSpecimen((org.hl7.fhir.r4.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
+      return StructureDefinition30_40.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureMap)
+      return StructureMap30_40.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.Subscription)
+      return Subscription30_40.convertSubscription((org.hl7.fhir.r4.model.Subscription) src);
+    if (src instanceof org.hl7.fhir.r4.model.Substance)
+      return Substance30_40.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
+      return SupplyDelivery30_40.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r4.model.TestReport)
+      return TestReport30_40.convertTestReport((org.hl7.fhir.r4.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.TestScript)
+      return TestScript30_40.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r4.model.ValueSet)
+      return ValueSet30_40.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
+    if (!nullOk) throw new FHIRException("Unknown resource " + src.fhirType());
+    else return null;
+  }
+
+  public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src, boolean b) {
+    TerminologyCapabilities res = new TerminologyCapabilities();
+    for (ParametersParameterComponent p : src.getParameter()) {
+      if (p.getName().equals("system")) res.addCodeSystem().setUri(p.getValue().primitiveValue());
+    }
+    return res;
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "ActivityDefinition", "AllergyIntolerance", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "BodyStructure", "Bundle", "CapabilityStatement", "CarePlan", "CareTeam", "ClinicalImpression", "CodeSystem", "Communication", "CompartmentDefinition", "Composition", "ConceptMap", "Condition", "Consent", "DetectedIssue", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "Endpoint", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Goal", "GraphDefinition", "Group", "HealthcareService", "ImagingStudy", "Immunization", "ImplementationGuide", "Library", "Linkage", "ListResource", "Location", "Media", "Medication", "MedicationAdministration", "MedicationDispense", "MedicationRequest", "MedicationStatement", "MessageDefinition", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "PaymentNotice", "Person", "PlanDefinition", "Practitioner", "PractitionerRole", "Procedure", "ProcedureRequest", "ProcessRequest", "Provenance", "Questionnaire", "QuestionnaireResponse", "RelatedPerson", "RiskAssessment", "Schedule", "SearchParameter", "Sequence", "Slot", "Specimen", "StructureDefinition", "StructureMap", "Subscription", "Substance", "SupplyDelivery", "TestReport", "TestScript", "ValueSet");
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_30_50.java
@@ -1,5551 +1,4933 @@
 package org.hl7.fhir.convertors;
 
+import org.hl7.fhir.convertors.conv30_50.*;
+import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.*;
+import org.hl7.fhir.utilities.Utilities;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hl7.fhir.convertors.conv30_50.ActivityDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.AllergyIntolerance30_50;
-import org.hl7.fhir.convertors.conv30_50.Appointment30_50;
-import org.hl7.fhir.convertors.conv30_50.AppointmentResponse30_50;
-import org.hl7.fhir.convertors.conv30_50.AuditEvent30_50;
-import org.hl7.fhir.convertors.conv30_50.Basic30_50;
-import org.hl7.fhir.convertors.conv30_50.Binary30_50;
-import org.hl7.fhir.convertors.conv30_50.BodySite30_50;
-import org.hl7.fhir.convertors.conv30_50.Bundle30_50;
-import org.hl7.fhir.convertors.conv30_50.CapabilityStatement30_50;
-import org.hl7.fhir.convertors.conv30_50.CarePlan30_50;
-import org.hl7.fhir.convertors.conv30_50.CareTeam30_50;
-import org.hl7.fhir.convertors.conv30_50.ClinicalImpression30_50;
-import org.hl7.fhir.convertors.conv30_50.CodeSystem30_50;
-import org.hl7.fhir.convertors.conv30_50.Communication30_50;
-import org.hl7.fhir.convertors.conv30_50.CompartmentDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.Composition30_50;
-import org.hl7.fhir.convertors.conv30_50.ConceptMap30_50;
-import org.hl7.fhir.convertors.conv30_50.Condition30_50;
-import org.hl7.fhir.convertors.conv30_50.Consent30_50;
-import org.hl7.fhir.convertors.conv30_50.DataElement30_50;
-import org.hl7.fhir.convertors.conv30_50.DetectedIssue30_50;
-import org.hl7.fhir.convertors.conv30_50.DeviceUseStatement30_50;
-import org.hl7.fhir.convertors.conv30_50.DiagnosticReport30_50;
-import org.hl7.fhir.convertors.conv30_50.DocumentReference30_50;
-import org.hl7.fhir.convertors.conv30_50.Encounter30_50;
-import org.hl7.fhir.convertors.conv30_50.Endpoint30_50;
-import org.hl7.fhir.convertors.conv30_50.EpisodeOfCare30_50;
-import org.hl7.fhir.convertors.conv30_50.ExpansionProfile30_50;
-import org.hl7.fhir.convertors.conv30_50.FamilyMemberHistory30_50;
-import org.hl7.fhir.convertors.conv30_50.Flag30_50;
-import org.hl7.fhir.convertors.conv30_50.Goal30_50;
-import org.hl7.fhir.convertors.conv30_50.GraphDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.Group30_50;
-import org.hl7.fhir.convertors.conv30_50.HealthcareService30_50;
-import org.hl7.fhir.convertors.conv30_50.ImagingStudy30_50;
-import org.hl7.fhir.convertors.conv30_50.Immunization30_50;
-import org.hl7.fhir.convertors.conv30_50.ImplementationGuide30_50;
-import org.hl7.fhir.convertors.conv30_50.Library30_50;
-import org.hl7.fhir.convertors.conv30_50.Linkage30_50;
-import org.hl7.fhir.convertors.conv30_50.List30_50;
-import org.hl7.fhir.convertors.conv30_50.Location30_50;
-import org.hl7.fhir.convertors.conv30_50.Measure30_50;
-import org.hl7.fhir.convertors.conv30_50.Media30_50;
-import org.hl7.fhir.convertors.conv30_50.Medication30_50;
-import org.hl7.fhir.convertors.conv30_50.MedicationAdministration30_50;
-import org.hl7.fhir.convertors.conv30_50.MedicationDispense30_50;
-import org.hl7.fhir.convertors.conv30_50.MedicationRequest30_50;
-import org.hl7.fhir.convertors.conv30_50.MedicationStatement30_50;
-import org.hl7.fhir.convertors.conv30_50.MessageDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.MessageHeader30_50;
-import org.hl7.fhir.convertors.conv30_50.NamingSystem30_50;
-import org.hl7.fhir.convertors.conv30_50.Observation30_50;
-import org.hl7.fhir.convertors.conv30_50.OperationDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.OperationOutcome30_50;
-import org.hl7.fhir.convertors.conv30_50.Organization30_50;
-import org.hl7.fhir.convertors.conv30_50.Parameters30_50;
-import org.hl7.fhir.convertors.conv30_50.Patient30_50;
-import org.hl7.fhir.convertors.conv30_50.PaymentNotice30_50;
-import org.hl7.fhir.convertors.conv30_50.Person30_50;
-import org.hl7.fhir.convertors.conv30_50.PlanDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.Practitioner30_50;
-import org.hl7.fhir.convertors.conv30_50.PractitionerRole30_50;
-import org.hl7.fhir.convertors.conv30_50.Provenance30_50;
-import org.hl7.fhir.convertors.conv30_50.Questionnaire30_50;
-import org.hl7.fhir.convertors.conv30_50.QuestionnaireResponse30_50;
-import org.hl7.fhir.convertors.conv30_50.RelatedPerson30_50;
-import org.hl7.fhir.convertors.conv30_50.RiskAssessment30_50;
-import org.hl7.fhir.convertors.conv30_50.Schedule30_50;
-import org.hl7.fhir.convertors.conv30_50.SearchParameter30_50;
-import org.hl7.fhir.convertors.conv30_50.Sequence30_50;
-import org.hl7.fhir.convertors.conv30_50.Slot30_50;
-import org.hl7.fhir.convertors.conv30_50.Specimen30_50;
-import org.hl7.fhir.convertors.conv30_50.StructureDefinition30_50;
-import org.hl7.fhir.convertors.conv30_50.StructureMap30_50;
-import org.hl7.fhir.convertors.conv30_50.Substance30_50;
-import org.hl7.fhir.convertors.conv30_50.SupplyDelivery30_50;
-import org.hl7.fhir.convertors.conv30_50.TestReport30_50;
-import org.hl7.fhir.convertors.conv30_50.TestScript30_50;
-import org.hl7.fhir.convertors.conv30_50.ValueSet30_50;
-import org.hl7.fhir.dstu3.model.Parameters;
-import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.model.CanonicalType;
-import org.hl7.fhir.r5.model.CodeableReference;
-import org.hl7.fhir.r5.model.DataType;
-import org.hl7.fhir.r5.model.Enumerations;
-import org.hl7.fhir.r5.model.Identifier;
-import org.hl7.fhir.r5.model.Reference;
-import org.hl7.fhir.r5.model.TerminologyCapabilities;
-import org.hl7.fhir.r5.model.UriType;
-import org.hl7.fhir.utilities.Utilities;
-
 /*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without modification, 
+
+  Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
-  
-   * Redistributions of source code must retain the above copyright notice, this 
+
+ * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+ * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   * Neither the name of HL7 nor the names of its contributors may be used to 
-     endorse or promote products derived from this software without specific 
+ * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
      prior written permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-  
-*/
+ */
+
 public class VersionConvertor_30_50 {
+  static final public String EXT_SRC_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type";
+  static public List<String> CANONICAL_URLS = new ArrayList<>();
 
-    static final public String EXT_SRC_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type";
+  static {
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
+    CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  }
 
-    static public List<String> CANONICAL_URLS = new ArrayList<>();
-
-    static {
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/11179-permitted-value-valueset");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/codesystem-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/cqif-library");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-inheritedExtensibleValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/event-instantiatesCanonical");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-allowedProfile");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-deMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-sourceStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-targetStructureMap");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/questionnaire-unit-valueSet");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-map");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-supplement");
-        CANONICAL_URLS.add("http://hl7.org/fhir/StructureDefinition/valueset-system");
+  static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
     }
+  }
 
-    static public void copyElement(org.hl7.fhir.dstu3.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
+  static public void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  static public void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu3.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu3.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeType convertStringToCode(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.StringType convertCodeToString(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertStringToCode(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.StringType convertCodeToString(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateType convertDateTimeToDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu3.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IdType(src.getValue()) : new org.hl7.fhir.dstu3.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r5.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValue()) : new org.hl7.fhir.r5.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu3.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DecimalType convertInteger64(org.hl7.fhir.r5.model.Integer64Type src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DecimalType tgt = new org.hl7.fhir.dstu3.model.DecimalType(src.getValue().toString());
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu3.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.OidType(src.getValue()) : new org.hl7.fhir.dstu3.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.StringType convertMarkdownToString(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu3.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UriType(src.getValue()) : new org.hl7.fhir.dstu3.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertCodeToUri(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertUriToCode(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu3.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu3.model.Reference)
+        tgt.setValue(convertReferenceToCanonical((org.hl7.fhir.dstu3.model.Reference) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue())
+      if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
+        tgt.setValue(convertCanonicalToReference((org.hl7.fhir.r5.model.CanonicalType) src.getValue()));
+      else tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(src.getDiv());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setText(src.getText());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Long.valueOf(src.getSize()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasSize()) tgt.setSize(Math.toIntExact(src.getSize()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    tgt.setCode(src.getValue());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeableConcept convertCodingToCodeableConcept(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.getCodingFirstRep().setSystem(src.getSystem());
+    if (src.hasVersion()) tgt.getCodingFirstRep().setVersion(src.getVersion());
+    if (src.hasCode()) tgt.getCodingFirstRep().setCode(src.getCode());
+    if (src.hasDisplay()) tgt.getCodingFirstRep().setDisplay(src.getDisplay());
+    if (src.hasUserSelected()) tgt.getCodingFirstRep().setUserSelected(src.getUserSelected());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasCoding()) {
+      if (src.getCodingFirstRep().hasSystem()) tgt.setSystem(src.getCodingFirstRep().getSystem());
+      if (src.getCodingFirstRep().hasVersion()) tgt.setVersion(src.getCodingFirstRep().getVersion());
+      if (src.getCodingFirstRep().hasCode()) tgt.setCode(src.getCodingFirstRep().getCode());
+      if (src.getCodingFirstRep().hasDisplay()) tgt.setDisplay(src.getCodingFirstRep().getDisplay());
+      if (src.getCodingFirstRep().hasUserSelected()) tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasCoding()) {
+      if (src.getCodingFirstRep().hasSystem()) tgt.setSystem(src.getCodingFirstRep().getSystem());
+      if (src.getCodingFirstRep().hasVersion()) tgt.setVersion(src.getCodingFirstRep().getVersion());
+      if (src.getCodingFirstRep().hasCode()) tgt.setCode(src.getCodingFirstRep().getCode());
+      if (src.getCodingFirstRep().hasDisplay()) tgt.setDisplay(src.getCodingFirstRep().getDisplay());
+      if (src.getCodingFirstRep().hasUserSelected()) tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCode()) tgt.setCurrencyElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCodeElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static void copyQuantity(org.hl7.fhir.dstu3.model.Quantity src, org.hl7.fhir.r5.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+  }
+
+  public static void copyQuantity(org.hl7.fhir.r5.model.Quantity src, org.hl7.fhir.dstu3.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReference(src.getReference());
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) {
+      if (src.hasWhoUriType()) tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
+      else tgt.setWho(convertReference(src.getWhoReference()));
+    }
+    if (src.hasOnBehalfOf()) {
+      if (src.hasOnBehalfOfUriType()) tgt.setOnBehalfOf(new Reference(src.getOnBehalfOfUriType().primitiveValue()));
+      else tgt.setOnBehalfOf(convertReference(src.getOnBehalfOfReference()));
+    }
+    if (src.hasContentType()) tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
+    if (src.hasBlob()) tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasOnBehalfOf()) tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
+    if (src.hasSigFormat()) tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ContactDetail convertContactDetail(org.hl7.fhir.dstu3.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ContactDetail tgt = new org.hl7.fhir.r5.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.dstu3.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ContactDetail convertContactDetail(org.hl7.fhir.r5.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ContactDetail tgt = new org.hl7.fhir.dstu3.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r5.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Contributor convertContributor(org.hl7.fhir.dstu3.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Contributor tgt = new org.hl7.fhir.r5.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.dstu3.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Contributor convertContributor(org.hl7.fhir.r5.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Contributor tgt = new org.hl7.fhir.dstu3.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r5.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Dosage convertDosage(org.hl7.fhir.dstu3.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDose() || src.hasRate()) {
+      org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
+      if (src.hasDose()) dr.setDose(convertType(src.getDose()));
+      if (src.hasRate()) dr.setRate(convertType(src.getRate()));
+    }
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Dosage convertDosage(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Dosage tgt = new org.hl7.fhir.dstu3.model.Dosage();
+    copyElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
+      tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
+      tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_30_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (tgt.getIsModifier()) {
+      String reason = org.hl7.fhir.dstu3.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
+      if (Utilities.noString(reason)) reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
+      tgt.setIsModifierReason(reason);
+    }
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_30_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType())
+      convertTypeRefComponent(t, tgt.getType());
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
+      org.hl7.fhir.dstu3.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list)
+      if (t.getCode().equals(src.getCode())) tgt = t;
+    if (tgt == null) {
+      tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
+      list.add(tgt);
+      copyElement(src, tgt);
+      tgt.setCodeElement(convertUri(src.getCodeElement()));
+    }
+    if (src.hasProfile()) {
+      boolean found = false;
+      for (CanonicalType p : tgt.getProfile()) {
+        if (p.equals(src.getProfile())) found = true;
+      }
+      if (!found) tgt.addProfile(src.getProfile());
+    }
+    if (src.hasTargetProfile()) tgt.addTargetProfile(src.getTargetProfile());
+    for (org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
+      org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
+      if (!tgt.hasAggregation(a.getValue())) copyElement(t, tgt.addAggregation(a.getValue()));
+    }
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+  }
+
+  public static void convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
+    if (src == null) return;
+    org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    tgt.setCodeElement(convertUri(src.getCodeElement()));
+    list.add(tgt);
+    if (src.hasTarget()) {
+      if (src.hasProfile()) tgt.setProfile(src.getProfile().get(0).getValue());
+      for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
+        if (tgt.hasTargetProfile()) {
+          tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+          list.add(tgt);
+          copyElement(src, tgt);
+          tgt.setCode(src.getCode());
+          if (src.hasProfile()) tgt.setProfile(src.getProfile().get(0).getValue());
         }
-    }
-
-    static public void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.dstu3.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId())
-            tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
+        tgt.setTargetProfile(u.getValue());
+      }
+    } else {
+      for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
+        if (tgt.hasProfile()) {
+          tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
+          list.add(tgt);
+          copyElement(src, tgt);
+          tgt.setCode(src.getCode());
         }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.dstu3.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    static public void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.dstu3.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.dstu3.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.dstu3.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.dstu3.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.BooleanType(src.getValue()) : new org.hl7.fhir.dstu3.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeType convertStringToCode(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.StringType convertCodeToString(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeType convertStringToCode(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.StringType convertCodeToString(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateToDateTime(org.hl7.fhir.dstu3.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateType convertDateTimeToDate(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.dstu3.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DecimalType(src.getValue()) : new org.hl7.fhir.dstu3.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.dstu3.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IdType(src.getValue()) : new org.hl7.fhir.dstu3.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.dstu3.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r5.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.dstu3.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValue()) : new org.hl7.fhir.r5.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.IntegerType(src.getValue()) : new org.hl7.fhir.dstu3.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DecimalType convertInteger64(org.hl7.fhir.r5.model.Integer64Type src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.DecimalType tgt = new org.hl7.fhir.dstu3.model.DecimalType(src.getValue().toString());
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.dstu3.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.MarkdownType(src.getValue()) : new org.hl7.fhir.dstu3.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.dstu3.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.OidType(src.getValue()) : new org.hl7.fhir.dstu3.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.dstu3.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.dstu3.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.StringType convertMarkdownToString(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.StringType(src.getValue()) : new org.hl7.fhir.dstu3.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.dstu3.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.TimeType(src.getValue()) : new org.hl7.fhir.dstu3.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.dstu3.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.dstu3.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.dstu3.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UriType(src.getValue()) : new org.hl7.fhir.dstu3.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UriType convertCodeToUri(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeType convertUriToCode(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.CodeType(src.getValue()) : new org.hl7.fhir.dstu3.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.dstu3.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.UuidType(src.getValue()) : new org.hl7.fhir.dstu3.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.dstu3.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.dstu3.model.Reference)
-                tgt.setValue(convertReferenceToCanonical((org.hl7.fhir.dstu3.model.Reference) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Extension tgt = new org.hl7.fhir.dstu3.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            if (CANONICAL_URLS.contains(src.getUrl()) && src.getValue() instanceof org.hl7.fhir.r5.model.CanonicalType)
-                tgt.setValue(convertCanonicalToReference((org.hl7.fhir.r5.model.CanonicalType) src.getValue()));
-            else
-                tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.dstu3.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Narrative tgt = new org.hl7.fhir.dstu3.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(src.getDiv());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.dstu3.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Age tgt = new org.hl7.fhir.dstu3.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.dstu3.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Annotation tgt = new org.hl7.fhir.dstu3.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setText(src.getText());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.dstu3.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Long.valueOf(src.getSize()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Attachment tgt = new org.hl7.fhir.dstu3.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasSize())
-            tgt.setSize(Math.toIntExact(src.getSize()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.CodeableConcept tgt = new org.hl7.fhir.dstu3.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeType src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        tgt.setCode(src.getValue());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeableConcept convertCodingToCodeableConcept(org.hl7.fhir.dstu3.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.getCodingFirstRep().setSystem(src.getSystem());
-        if (src.hasVersion())
-            tgt.getCodingFirstRep().setVersion(src.getVersion());
-        if (src.hasCode())
-            tgt.getCodingFirstRep().setCode(src.getCode());
-        if (src.hasDisplay())
-            tgt.getCodingFirstRep().setDisplay(src.getDisplay());
-        if (src.hasUserSelected())
-            tgt.getCodingFirstRep().setUserSelected(src.getUserSelected());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.dstu3.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasCoding()) {
-            if (src.getCodingFirstRep().hasSystem())
-                tgt.setSystem(src.getCodingFirstRep().getSystem());
-            if (src.getCodingFirstRep().hasVersion())
-                tgt.setVersion(src.getCodingFirstRep().getVersion());
-            if (src.getCodingFirstRep().hasCode())
-                tgt.setCode(src.getCodingFirstRep().getCode());
-            if (src.getCodingFirstRep().hasDisplay())
-                tgt.setDisplay(src.getCodingFirstRep().getDisplay());
-            if (src.getCodingFirstRep().hasUserSelected())
-                tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasCoding()) {
-            if (src.getCodingFirstRep().hasSystem())
-                tgt.setSystem(src.getCodingFirstRep().getSystem());
-            if (src.getCodingFirstRep().hasVersion())
-                tgt.setVersion(src.getCodingFirstRep().getVersion());
-            if (src.getCodingFirstRep().hasCode())
-                tgt.setCode(src.getCodingFirstRep().getCode());
-            if (src.getCodingFirstRep().hasDisplay())
-                tgt.setDisplay(src.getCodingFirstRep().getDisplay());
-            if (src.getCodingFirstRep().hasUserSelected())
-                tgt.setUserSelected(src.getCodingFirstRep().getUserSelected());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Coding tgt = new org.hl7.fhir.dstu3.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.dstu3.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Count tgt = new org.hl7.fhir.dstu3.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.dstu3.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Distance tgt = new org.hl7.fhir.dstu3.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.dstu3.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Duration tgt = new org.hl7.fhir.dstu3.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.dstu3.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Identifier tgt = new org.hl7.fhir.dstu3.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.dstu3.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCode())
-            tgt.setCurrencyElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Money tgt = new org.hl7.fhir.dstu3.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCodeElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.dstu3.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Period tgt = new org.hl7.fhir.dstu3.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static void copyQuantity(org.hl7.fhir.dstu3.model.Quantity src, org.hl7.fhir.r5.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-    }
-
-    public static void copyQuantity(org.hl7.fhir.r5.model.Quantity src, org.hl7.fhir.dstu3.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.dstu3.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Quantity tgt = new org.hl7.fhir.dstu3.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.dstu3.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Range tgt = new org.hl7.fhir.dstu3.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.dstu3.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Ratio tgt = new org.hl7.fhir.dstu3.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Reference tgt = new org.hl7.fhir.dstu3.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReference(src.getReference());
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.dstu3.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.SampledData tgt = new org.hl7.fhir.dstu3.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.dstu3.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho()) {
-            if (src.hasWhoUriType())
-                tgt.setWho(new org.hl7.fhir.r5.model.Reference(src.getWhoUriType().getValue()));
-            else
-                tgt.setWho(convertReference(src.getWhoReference()));
-        }
-        if (src.hasOnBehalfOf()) {
-            if (src.hasOnBehalfOfUriType())
-                tgt.setOnBehalfOf(new Reference(src.getOnBehalfOfUriType().primitiveValue()));
-            else
-                tgt.setOnBehalfOf(convertReference(src.getOnBehalfOfReference()));
-        }
-        if (src.hasContentType())
-            tgt.setSigFormatElement(convertCode(src.getContentTypeElement()));
-        if (src.hasBlob())
-            tgt.setDataElement(convertBase64Binary(src.getBlobElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Signature tgt = new org.hl7.fhir.dstu3.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasOnBehalfOf())
-            tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
-        if (src.hasSigFormat())
-            tgt.setContentTypeElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setBlobElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.dstu3.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Address tgt = new org.hl7.fhir.dstu3.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.addLine(t.getValue());
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Address.AddressType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactDetail convertContactDetail(org.hl7.fhir.dstu3.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ContactDetail tgt = new org.hl7.fhir.r5.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.dstu3.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ContactDetail convertContactDetail(org.hl7.fhir.r5.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ContactDetail tgt = new org.hl7.fhir.dstu3.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r5.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.dstu3.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ContactPoint tgt = new org.hl7.fhir.dstu3.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Contributor convertContributor(org.hl7.fhir.dstu3.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Contributor tgt = new org.hl7.fhir.r5.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.dstu3.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Contributor convertContributor(org.hl7.fhir.r5.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Contributor tgt = new org.hl7.fhir.dstu3.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r5.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Contributor.ContributorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Dosage convertDosage(org.hl7.fhir.dstu3.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getAdditionalInstruction()) tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDose() || src.hasRate()) {
-            org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent dr = tgt.addDoseAndRate();
-            if (src.hasDose())
-                dr.setDose(convertType(src.getDose()));
-            if (src.hasRate())
-                dr.setRate(convertType(src.getRate()));
-        }
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Dosage convertDosage(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Dosage tgt = new org.hl7.fhir.dstu3.model.Dosage();
-        copyElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.CodeableConcept t : src.getAdditionalInstruction()) tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasDose())
-            tgt.setDose(convertType(src.getDoseAndRate().get(0).getDose()));
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        if (src.hasDoseAndRate() && src.getDoseAndRate().get(0).hasRate())
-            tgt.setRate(convertType(src.getDoseAndRate().get(0).getRate()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_30_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample()) tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.dstu3.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (tgt.getIsModifier()) {
-            String reason = org.hl7.fhir.dstu3.utils.ToolingExtensions.readStringExtension(src, VersionConvertorConstants.MODIFIER_REASON_EXTENSION);
-            if (Utilities.noString(reason))
-                reason = VersionConvertorConstants.MODIFIER_REASON_LEGACY;
-            tgt.setIsModifierReason(reason);
-        }
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition tgt = new org.hl7.fhir.dstu3.model.ElementDefinition();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_30_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.addAlias(t.getValue());
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType()) convertTypeRefComponent(t, tgt.getType());
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample()) tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.addCondition(t.getValue());
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason() && !VersionConvertorConstants.MODIFIER_REASON_LEGACY.equals(src.getIsModifierReason()))
-            org.hl7.fhir.dstu3.utils.ToolingExtensions.setStringExtension(tgt, VersionConvertorConstants.MODIFIER_REASON_EXTENSION, src.getIsModifierReason());
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = null;
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : list) if (t.getCode().equals(src.getCode()))
-            tgt = t;
-        if (tgt == null) {
-            tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
-            list.add(tgt);
-            copyElement(src, tgt);
-            tgt.setCodeElement(convertUri(src.getCodeElement()));
-        }
-        if (src.hasProfile()) {
-            boolean found = false;
-            for (CanonicalType p : tgt.getProfile()) {
-                if (p.equals(src.getProfile()))
-                    found = true;
-            }
-            if (!found)
-                tgt.addProfile(src.getProfile());
-        }
-        if (src.hasTargetProfile())
-            tgt.addTargetProfile(src.getTargetProfile());
-        for (org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> t : src.getAggregation()) {
-            org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> a = convertAggregationMode(t);
-            if (!tgt.hasAggregation(a.getValue()))
-                copyElement(t, tgt.addAggregation(a.getValue()));
-        }
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-    }
-
-    public static void convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src, List<org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent> list) throws FHIRException {
-        if (src == null)
-            return;
-        org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        tgt.setCodeElement(convertUri(src.getCodeElement()));
-        list.add(tgt);
-        if (src.hasTarget()) {
-            if (src.hasProfile())
-                tgt.setProfile(src.getProfile().get(0).getValue());
-            for (org.hl7.fhir.r5.model.UriType u : src.getTargetProfile()) {
-                if (tgt.hasTargetProfile()) {
-                    tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-                    list.add(tgt);
-                    copyElement(src, tgt);
-                    tgt.setCode(src.getCode());
-                    if (src.hasProfile())
-                        tgt.setProfile(src.getProfile().get(0).getValue());
-                }
-                tgt.setTargetProfile(u.getValue());
-            }
+        tgt.setProfile(u.getValue());
+      }
+    }
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSource(src.getSource());
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSource(src.getSource());
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt, EXT_SRC_TYPE);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      DataType t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r5.model.Reference) {
+        tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
+        tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("Reference"));
+      } else {
+        tgt.setValueSet(t.primitiveValue());
+        tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("uri"));
+      }
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt, EXT_SRC_TYPE);
+    if (src.hasStrength()) tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) {
+      org.hl7.fhir.r5.model.Extension ex = src.getValueSetElement().getExtensionByUrl(EXT_SRC_TYPE);
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (ex != null) {
+        if ("uri".equals(ex.getValue().primitiveValue())) {
+          tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr == null ? src.getValueSet() : vsr));
         } else {
-            for (org.hl7.fhir.r5.model.UriType u : src.getProfile()) {
-                if (tgt.hasProfile()) {
-                    tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.TypeRefComponent();
-                    list.add(tgt);
-                    copyElement(src, tgt);
-                    tgt.setCode(src.getCode());
-                }
-                tgt.setProfile(u.getValue());
-            }
-        }
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSource(src.getSource());
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSource(src.getSource());
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt, EXT_SRC_TYPE);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            DataType t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r5.model.Reference) {
-                tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
-                tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("Reference"));
-            } else {
-                tgt.setValueSet(t.primitiveValue());
-                tgt.getValueSetElement().addExtension(EXT_SRC_TYPE, new UriType("uri"));
-            }
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt, EXT_SRC_TYPE);
-        if (src.hasStrength())
-            tgt.setStrengthElement(convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet()) {
-            org.hl7.fhir.r5.model.Extension ex = src.getValueSetElement().getExtensionByUrl(EXT_SRC_TYPE);
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (ex != null) {
-                if ("uri".equals(ex.getValue().primitiveValue())) {
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr == null ? src.getValueSet() : vsr));
-                } else {
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-                }
-            } else {
-                if (vsr != null)
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
-                else
-                    tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-            }
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REQUIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
-                break;
-            case EXTENSIBLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
-                break;
-            case PREFERRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
-                break;
-            case EXAMPLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.dstu3.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ParameterDefinition tgt = new org.hl7.fhir.r5.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
-        if (src.hasProfile()) {
-            tgt.setProfile(convertReference(src.getProfile()).getReference());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r5.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.ParameterDefinition tgt = new org.hl7.fhir.dstu3.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setType(src.getType().toCode());
-        if (src.hasProfile())
-            tgt.setProfile(new org.hl7.fhir.dstu3.model.Reference(src.getProfile()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> convertParameterUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.OperationParameterUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUseEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.dstu3.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.RelatedArtifact tgt = new org.hl7.fhir.r5.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitation(src.getCitation());
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertReferenceToCanonical(src.getResource()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r5.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.RelatedArtifact tgt = new org.hl7.fhir.dstu3.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitation(src.getCitation());
-        if (src.hasUrl())
-            tgt.setUrl(src.getUrl());
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResource(convertCanonicalToReference(src.getResourceElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_30_50::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_30_50::convertEventTiming)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.dstu3.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCount(src.getCount());
-        if (src.hasCountMax())
-            tgt.setCountMax(src.getCountMax());
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequency(src.getFrequency());
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMax(src.getFrequencyMax());
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_30_50::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_30_50::convertEventTiming)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.r5.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDayOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.DayOfWeekEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.MORN);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AFT);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.EVE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UsageContext convertUsageContext(org.hl7.fhir.dstu3.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.UsageContext tgt = new org.hl7.fhir.r5.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.UsageContext convertUsageContext(org.hl7.fhir.r5.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.UsageContext tgt = new org.hl7.fhir.dstu3.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.dstu3.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TriggerDefinition tgt = new org.hl7.fhir.r5.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasEventName())
-            tgt.setNameElement(convertString(src.getEventNameElement()));
-        if (src.hasEventTiming())
-            tgt.setTiming(convertType(src.getEventTiming()));
-        if (src.hasEventData())
-            tgt.addData(convertDataRequirement(src.getEventData()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r5.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TriggerDefinition tgt = new org.hl7.fhir.dstu3.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setEventNameElement(convertString(src.getNameElement()));
-        if (src.hasTiming())
-            tgt.setEventTiming(convertType(src.getTiming()));
-        if (src.hasData())
-            tgt.setEventData(convertDataRequirement(src.getDataFirstRep()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement convertDataRequirement(org.hl7.fhir.dstu3.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement tgt = new org.hl7.fhir.r5.model.DataRequirement();
-        copyElement(src, tgt, VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME);
-        if (src.hasType()) {
-          if (src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
-            tgt.setType(Enumerations.FHIRAllTypes.fromCode(src.getExtensionString(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)));
-          } else {
-            String n = VersionConvertorResourceNameMapper.mapName3to5(src.getType());
-            if (n != null) {
-              tgt.setType(Enumerations.FHIRAllTypes.fromCode(n));
-            }
-            tgt.addExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME, new org.hl7.fhir.r5.model.CodeType(src.getType()));
-          }
-        }
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.dstu3.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
-        for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter()) tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter()) tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement convertDataRequirement(org.hl7.fhir.r5.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement tgt = new org.hl7.fhir.dstu3.model.DataRequirement();
-        copyElement(src, tgt, VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME);
-        if (src.hasType() || src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
-          if (src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
-            tgt.setType(src.getExtensionString(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME));
-          } else {
-            String n = VersionConvertorResourceNameMapper.mapName5to3(src.getType().toCode());
-            if (n != null) {
-              tgt.setType(n);
-            }
-            tgt.addExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME, new org.hl7.fhir.dstu3.model.CodeType(src.getType().toCode()));
-          }
-        }
-        for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
-        for (org.hl7.fhir.r5.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
-        for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter()) tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter()) tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValueSet()) {
-            DataType t = convertType(src.getValueSet());
-            if (t instanceof org.hl7.fhir.r5.model.Reference)
-                tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
-            else
-                tgt.setValueSet(t.primitiveValue());
-            tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
-        }
-        for (org.hl7.fhir.dstu3.model.CodeType t : src.getValueCode()) tgt.addCode(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getValueCoding()) tgt.addCode(convertCoding(t));
-        for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getValueCodeableConcept()) tgt.addCode(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValueSet()) {
-            String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
-            if (vsr != null)
-                tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
-            else
-                tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
-        }
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) {
-            tgt.addValueCoding(convertCoding(t));
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeType)
-            return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateType)
-            return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IdType)
-            return convertId((org.hl7.fhir.dstu3.model.IdType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
-            return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
-          return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
-          return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
-            return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OidType)
-            return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StringType)
-            return convertString((org.hl7.fhir.dstu3.model.StringType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TimeType)
-            return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UriType)
-            return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UuidType)
-            return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Extension)
-            return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
-            return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Age)
-            return convertAge((org.hl7.fhir.dstu3.model.Age) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
-            return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Coding)
-            return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Count)
-            return convertCount((org.hl7.fhir.dstu3.model.Count) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Distance)
-            return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Duration)
-            return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Money)
-            return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Period)
-            return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
-            return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Range)
-            return convertRange((org.hl7.fhir.dstu3.model.Range) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Ratio)
-            return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Reference)
-            return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
-            return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Signature)
-            return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Address)
-            return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.dstu3.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Contributor)
-            return convertContributor((org.hl7.fhir.dstu3.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Dosage)
-            return convertDosage((org.hl7.fhir.dstu3.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
-            return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Meta)
-            return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.dstu3.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.dstu3.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Timing)
-            return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.dstu3.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.dstu3.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.dstu3.model.TriggerDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r5.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeType)
-            return convertCode((org.hl7.fhir.r5.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateType)
-            return convertDate((org.hl7.fhir.r5.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IdType)
-            return convertId((org.hl7.fhir.r5.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r5.model.InstantType)
-            return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
-          return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
-          return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.Integer64Type)
-            return convertInteger64((org.hl7.fhir.r5.model.Integer64Type) src);
-        if (src instanceof org.hl7.fhir.r5.model.IntegerType)
-          return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r5.model.OidType)
-            return convertOid((org.hl7.fhir.r5.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.StringType)
-            return convertString((org.hl7.fhir.r5.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r5.model.TimeType)
-            return convertTime((org.hl7.fhir.r5.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UriType)
-            return convertUri((org.hl7.fhir.r5.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UuidType)
-            return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.Extension)
-            return convertExtension((org.hl7.fhir.r5.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r5.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r5.model.Age)
-            return convertAge((org.hl7.fhir.r5.model.Age) src);
-        if (src instanceof org.hl7.fhir.r5.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r5.model.Coding)
-            return convertCoding((org.hl7.fhir.r5.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r5.model.Count)
-            return convertCount((org.hl7.fhir.r5.model.Count) src);
-        if (src instanceof org.hl7.fhir.r5.model.Distance)
-            return convertDistance((org.hl7.fhir.r5.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Duration)
-            return convertDuration((org.hl7.fhir.r5.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r5.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r5.model.Money)
-            return convertMoney((org.hl7.fhir.r5.model.Money) src);
-        if (src instanceof org.hl7.fhir.r5.model.Period)
-            return convertPeriod((org.hl7.fhir.r5.model.Period) src);
-        if (src instanceof org.hl7.fhir.r5.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.Range)
-            return convertRange((org.hl7.fhir.r5.model.Range) src);
-        if (src instanceof org.hl7.fhir.r5.model.Ratio)
-            return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r5.model.Reference)
-            return convertReference((org.hl7.fhir.r5.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r5.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r5.model.Signature)
-            return convertSignature((org.hl7.fhir.r5.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r5.model.Address)
-            return convertAddress((org.hl7.fhir.r5.model.Address) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.r5.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.Contributor)
-            return convertContributor((org.hl7.fhir.r5.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.r5.model.Dosage)
-            return convertDosage((org.hl7.fhir.r5.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.r5.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r5.model.Meta)
-            return convertMeta((org.hl7.fhir.r5.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r5.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.r5.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.r5.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.r5.model.Timing)
-            return convertTiming((org.hl7.fhir.r5.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r5.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.r5.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.r5.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.r5.model.ElementDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.r5.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.r5.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.r5.model.TriggerDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.dstu3.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
-        for (org.hl7.fhir.dstu3.model.Extension t2 : src.getExtension()) {
-            if (!isExemptExtension(t2.getUrl(), extensionsToIgnore))
-                tgt.addExtension(convertExtension(t2));
-        }
-        for (org.hl7.fhir.dstu3.model.Extension t3 : src.getModifierExtension()) {
-            if (!isExemptExtension(t3.getUrl(), extensionsToIgnore))
-                tgt.addModifierExtension(convertExtension(t3));
-        }
-    }
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    static public void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r5.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
-        for (org.hl7.fhir.r5.model.Extension t2 : src.getExtension()) {
-            if (!isExemptExtension(t2.getUrl(), extensionsToIgnore))
-                tgt.addExtension(convertExtension(t2));
-        }
-        for (org.hl7.fhir.r5.model.Extension t3 : src.getModifierExtension()) {
-            if (!isExemptExtension(t3.getUrl(), extensionsToIgnore))
-                tgt.addModifierExtension(convertExtension(t3));
-        }
-    }
-
-    static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setIdElement(convertId(src.getIdElement()));
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    }
-
-    static public void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setIdElement(convertId(src.getIdElement()));
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRules(src.getImplicitRules());
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DRAFT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
-                break;
-            case ACTIVE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
-                break;
-            case RETIRED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public CodeableReference convertReferenceToCodableReference(org.hl7.fhir.dstu3.model.Reference src) {
-        CodeableReference tgt = new CodeableReference();
-        tgt.setReference(convertReference(src));
-        return tgt;
-    }
-
-    static public CodeableReference convertCodeableConceptToCodableReference(org.hl7.fhir.dstu3.model.CodeableConcept src) {
-        CodeableReference tgt = new CodeableReference();
-        tgt.setConcept(convertCodeableConcept(src));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.CanonicalType convertReferenceToCanonical(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
-        org.hl7.fhir.r5.model.CanonicalType dst = new org.hl7.fhir.r5.model.CanonicalType(src.getReference());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Reference convertCanonicalToReference(org.hl7.fhir.r5.model.CanonicalType src) throws FHIRException {
-        org.hl7.fhir.dstu3.model.Reference dst = new org.hl7.fhir.dstu3.model.Reference(src.getValue());
-        copyElement(src, dst);
-        return dst;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NUMBER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
-                break;
-            case DATE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
-                break;
-            case STRING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
-                break;
-            case TOKEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
-                break;
-            case REFERENCE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
-                break;
-            case COMPOSITE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
-                break;
-            case QUANTITY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
-                break;
-            case URI:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator> convertFilterOperator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.CodeSystem.FilterOperatorEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EQUAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.EQUAL);
-                break;
-            case ISA:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.ISA);
-                break;
-            case DESCENDENTOF:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.DESCENDENTOF);
-                break;
-            case ISNOTA:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.ISNOTA);
-                break;
-            case REGEX:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.REGEX);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.NOTIN);
-                break;
-            case GENERALIZES:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.GENERALIZES);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.EXISTS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent convertConsentPolicyComponent(org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent tgt = new org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent();
-        copyElement(src, tgt);
-        if (src.hasAuthority())
-            tgt.setAuthorityElement(convertUri(src.getAuthorityElement()));
-        if (src.hasUri())
-            tgt.setUriElement(convertUri(src.getUriElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent convertConsentPolicyComponent(org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent tgt = new org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent();
-        copyElement(src, tgt);
-        if (src.hasAuthority())
-            tgt.setAuthorityElement(convertUri(src.getAuthorityElement()));
-        if (src.hasUri())
-            tgt.setUriElement(convertUri(src.getUriElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> convertConsentDataMeaning(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Consent.ConsentDataMeaningEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case INSTANCE:
-                tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.INSTANCE);
-                break;
-            case RELATED:
-                tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.RELATED);
-                break;
-            case DEPENDENTS:
-                tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.DEPENDENTS);
-                break;
-            case AUTHOREDBY:
-                tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.AUTHOREDBY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> convertConsentDataMeaning(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaningEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case INSTANCE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.INSTANCE);
-                break;
-            case RELATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.RELATED);
-                break;
-            case DEPENDENTS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.DEPENDENTS);
-                break;
-            case AUTHOREDBY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.AUTHOREDBY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasRef())
-            tgt.setRef(convertReference(src.getRef()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case REPLACES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.REPLACES);
-                break;
-            case TRANSFORMS:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.TRANSFORMS);
-                break;
-            case SIGNS:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.SIGNS);
-                break;
-            case APPENDS:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.APPENDS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.r5.model.Encounter.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setUse(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r5.model.Encounter.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasUse())
-            tgt.setRole(convertCodeableConcept(src.getUse()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setRole(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent();
-        copyElement(src, tgt);
-        if (src.hasCondition())
-            tgt.setCondition(convertReference(src.getCondition()));
-        if (src.hasRole())
-            tgt.setRole(convertCodeableConcept(src.getRole()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGenderEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MALE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
-                break;
-            case FEMALE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
-                break;
-            case UNKNOWN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    private static final String CODE_SYSTEM_MEDIA_TYPE = "http://terminology.hl7.org/CodeSystem/media-type";
-
-    public static String convertCoding2Uri(org.hl7.fhir.dstu3.model.Coding code) {
-        return code.getSystem() + "/" + code.getCode();
-    }
-
-    public static org.hl7.fhir.dstu3.model.Coding convertUri2Coding(String uri) {
-        int i = uri.lastIndexOf("/");
-        return new org.hl7.fhir.dstu3.model.Coding().setSystem(uri.substring(0, i)).setCode(uri.substring(i + 1));
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Provenance convertProvenance(org.hl7.fhir.dstu3.model.Provenance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Provenance tgt = new org.hl7.fhir.r5.model.Provenance();
-        copyDomainResource(src, tgt);
-        for (org.hl7.fhir.dstu3.model.Reference t : src.getTarget()) tgt.addTarget(convertReference(t));
-        if (src.hasPeriod())
-            tgt.setOccurred(convertPeriod(src.getPeriod()));
-        if (src.hasRecorded())
-            tgt.setRecordedElement(convertInstant(src.getRecordedElement()));
-        for (org.hl7.fhir.dstu3.model.UriType t : src.getPolicy()) tgt.addPolicy(t.getValue());
-        if (src.hasLocation())
-            tgt.setLocation(convertReference(src.getLocation()));
-        for (org.hl7.fhir.dstu3.model.Coding t : src.getReason()) tgt.addReason(convertCodingToCodeableConcept(t));
-        if (src.hasActivity())
-            tgt.setActivity(convertCodingToCodeableConcept(src.getActivity()));
-        for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent t : src.getAgent()) tgt.addAgent(convertProvenanceAgentComponent(t));
-        for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent t : src.getEntity()) tgt.addEntity(convertProvenanceEntityComponent(t));
-        for (org.hl7.fhir.dstu3.model.Signature t : src.getSignature()) tgt.addSignature(convertSignature(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Provenance convertProvenance(org.hl7.fhir.r5.model.Provenance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Provenance tgt = new org.hl7.fhir.dstu3.model.Provenance();
-        copyDomainResource(src, tgt);
-        for (org.hl7.fhir.r5.model.Reference t : src.getTarget()) tgt.addTarget(convertReference(t));
-        if (src.hasOccurredPeriod())
-            tgt.setPeriod(convertPeriod(src.getOccurredPeriod()));
-        if (src.hasRecorded())
-            tgt.setRecordedElement(convertInstant(src.getRecordedElement()));
-        for (org.hl7.fhir.r5.model.UriType t : src.getPolicy()) tgt.addPolicy(t.getValue());
-        if (src.hasLocation())
-            tgt.setLocation(convertReference(src.getLocation()));
-        for (org.hl7.fhir.r5.model.CodeableConcept t : src.getReason()) for (org.hl7.fhir.r5.model.Coding tc : t.getCoding()) tgt.addReason(convertCoding(tc));
-        if (src.hasActivity())
-            tgt.setActivity(convertCoding(src.getActivity()));
-        for (org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent t : src.getAgent()) tgt.addAgent(convertProvenanceAgentComponent(t));
-        for (org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent t : src.getEntity()) tgt.addEntity(convertProvenanceEntityComponent(t));
-        for (org.hl7.fhir.r5.model.Signature t : src.getSignature()) tgt.addSignature(convertSignature(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent convertProvenanceAgentComponent(org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent tgt = new org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getRole()) tgt.addRole(convertCodeableConcept(t));
-        if (src.hasWho()) {
-            DataType t = convertType(src.getWho());
-            if (t instanceof Reference)
-                tgt.setWho((Reference) t);
-            if (t instanceof UriType)
-                tgt.getWho().setReference(t.primitiveValue());
-        }
-        if (src.hasOnBehalfOf()) {
-            DataType t = convertType(src.getOnBehalfOf());
-            if (t instanceof Reference)
-                tgt.setOnBehalfOf((Reference) t);
-            if (t instanceof UriType)
-                tgt.getOnBehalfOf().setReference(t.primitiveValue());
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent convertProvenanceAgentComponent(org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent tgt = new org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.CodeableConcept t : src.getRole()) tgt.addRole(convertCodeableConcept(t));
-        if (src.hasWho())
-            tgt.setWho(convertType(src.getWho()));
-        if (src.hasOnBehalfOf())
-            tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent convertProvenanceEntityComponent(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent tgt = new org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent();
-        copyElement(src, tgt);
-        if (src.hasRole())
-            tgt.setRoleElement(convertProvenanceEntityRole(src.getRoleElement()));
-        if (src.hasWhat()) {
-            DataType t = convertType(src.getWhat());
-            if (t instanceof Reference)
-                tgt.setWhat((Reference) t);
-            else if (t instanceof Identifier)
-                tgt.getWhat().setIdentifier((Identifier) t);
-            else if (t instanceof UriType)
-                tgt.getWhat().setReference(t.primitiveValue());
-        }
-        for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent t : src.getAgent()) tgt.addAgent(convertProvenanceAgentComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent convertProvenanceEntityComponent(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent tgt = new org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent();
-        copyElement(src, tgt);
-        if (src.hasRole())
-            tgt.setRoleElement(convertProvenanceEntityRole(src.getRoleElement()));
-        if (src.hasWhat())
-            tgt.setWhat(convertType(src.getWhat()));
-        for (org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent t : src.getAgent()) tgt.addAgent(convertProvenanceAgentComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> convertProvenanceEntityRole(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRoleEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DERIVATION:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.DERIVATION);
-                break;
-            case REVISION:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.REVISION);
-                break;
-            case QUOTATION:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.QUOTATION);
-                break;
-            case SOURCE:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.SOURCE);
-                break;
-            case REMOVAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.REMOVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> convertProvenanceEntityRole(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRoleEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DERIVATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.DERIVATION);
-                break;
-            case REVISION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.REVISION);
-                break;
-            case QUOTATION:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.QUOTATION);
-                break;
-            case SOURCE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.SOURCE);
-                break;
-            case REMOVAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.REMOVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r5.model.TestReport.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertUri(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertUri(src.getDetailElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestReport.TestReportActionResultEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PASS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.PASS);
-                break;
-            case SKIP:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.SKIP);
-                break;
-            case FAIL:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.FAIL);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.WARNING);
-                break;
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.ERROR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestReport.TestReportActionResultEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PASS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.PASS);
-                break;
-            case SKIP:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.SKIP);
-                break;
-            case FAIL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.FAIL);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.WARNING);
-                break;
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.ERROR);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertString(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasResult())
-            tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
-        if (src.hasMessage())
-            tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
-        if (src.hasDetail())
-            tgt.setDetailElement(convertString(src.getDetailElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestReport.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.r5.model.TestReport.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r5.model.TestReport.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r5.model.TestScript.SetupActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCoding(src.getType()));
-        if (src.hasResource())
-            tgt.setResource(org.hl7.fhir.r5.model.TestScript.FHIRDefinedType.fromCode(src.getResource()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasAccept())
-            tgt.setAccept(convertContentType(src.getAccept()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasDestination())
-            tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
-        if (src.hasEncodeRequestUrl())
-            tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
-        if (src.hasOrigin())
-            tgt.setOriginElement(convertInteger(src.getOriginElement()));
-        if (src.hasParams())
-            tgt.setParamsElement(convertString(src.getParamsElement()));
-        for (org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader()) tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
-        if (src.hasRequestId())
-            tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
-        if (src.hasResponseId())
-            tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasTargetId())
-            tgt.setTargetId(src.getTargetId());
-        if (src.hasUrl())
-            tgt.setUrlElement(convertString(src.getUrlElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCoding(src.getType()));
-        if (src.hasResource())
-            tgt.setResource(src.getResource().toCode());
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasAccept())
-            tgt.setAccept(convertContentType(src.getAccept()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasDestination())
-            tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
-        if (src.hasEncodeRequestUrl())
-            tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
-        if (src.hasOrigin())
-            tgt.setOriginElement(convertInteger(src.getOriginElement()));
-        if (src.hasParams())
-            tgt.setParamsElement(convertString(src.getParamsElement()));
-        for (org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader()) tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
-        if (src.hasRequestId())
-            tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
-        if (src.hasResponseId())
-            tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasTargetId())
-            tgt.setTargetId(src.getTargetId());
-        if (src.hasUrl())
-            tgt.setUrlElement(convertString(src.getUrlElement()));
-        return tgt;
-    }
-
-    static public String convertContentType(org.hl7.fhir.dstu3.model.TestScript.ContentType src) throws FHIRException {
-        if (src == null)
-            return null;
-        switch(src) {
-            case XML:
-                return "application/fhir+xml";
-            case JSON:
-                return "application/fhir+json";
-            case TTL:
-                return "text/turtle";
-            case NONE:
-                return null;
-            default:
-                return null;
-        }
-    }
-
-    static public org.hl7.fhir.dstu3.model.TestScript.ContentType convertContentType(String src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src.contains("xml"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.XML;
-        if (src.contains("json"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.JSON;
-        if (src.contains("tu"))
-            return org.hl7.fhir.dstu3.model.TestScript.ContentType.TTL;
-        return org.hl7.fhir.dstu3.model.TestScript.ContentType.NONE;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent();
-        copyElement(src, tgt);
-        if (src.hasField())
-            tgt.setFieldElement(convertString(src.getFieldElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent();
-        copyElement(src, tgt);
-        if (src.hasField())
-            tgt.setFieldElement(convertString(src.getFieldElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
-        if (src.hasCompareToSourceId())
-            tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
-        if (src.hasCompareToSourceExpression())
-            tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
-        if (src.hasCompareToSourcePath())
-            tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasHeaderField())
-            tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
-        if (src.hasMinimumId())
-            tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
-        if (src.hasNavigationLinks())
-            tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
-        if (src.hasOperator())
-            tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasRequestMethod())
-            tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
-        if (src.hasRequestURL())
-            tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
-        if (src.hasResource())
-            tgt.setResource(org.hl7.fhir.r5.model.TestScript.FHIRDefinedType.fromCode(src.getResource()));
-        if (src.hasResponse())
-            tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
-        if (src.hasResponseCode())
-            tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasValidateProfileId())
-            tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasWarningOnly())
-            tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
-        if (src.hasCompareToSourceId())
-            tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
-        if (src.hasCompareToSourceExpression())
-            tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
-        if (src.hasCompareToSourcePath())
-            tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
-        if (src.hasContentType())
-            tgt.setContentType(convertContentType(src.getContentType()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasHeaderField())
-            tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
-        if (src.hasMinimumId())
-            tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
-        if (src.hasNavigationLinks())
-            tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
-        if (src.hasOperator())
-            tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasRequestMethod())
-            tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
-        if (src.hasRequestURL())
-            tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
-        if (src.hasResource())
-            tgt.setResource(src.getResource().toCode());
-        if (src.hasResponse())
-            tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
-        if (src.hasResponseCode())
-            tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
-        if (src.hasSourceId())
-            tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
-        if (src.hasValidateProfileId())
-            tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasWarningOnly())
-            tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionDirectionTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case RESPONSE:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.RESPONSE);
-                break;
-            case REQUEST:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.REQUEST);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case RESPONSE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.RESPONSE);
-                break;
-            case REQUEST:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.REQUEST);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionOperatorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EQUALS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EQUALS);
-                break;
-            case NOTEQUALS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTEQUALS);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTIN);
-                break;
-            case GREATERTHAN:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.GREATERTHAN);
-                break;
-            case LESSTHAN:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.LESSTHAN);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EMPTY);
-                break;
-            case NOTEMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTEMPTY);
-                break;
-            case CONTAINS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.CONTAINS);
-                break;
-            case NOTCONTAINS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTCONTAINS);
-                break;
-            case EVAL:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorTypeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EQUALS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EQUALS);
-                break;
-            case NOTEQUALS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEQUALS);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTIN);
-                break;
-            case GREATERTHAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.GREATERTHAN);
-                break;
-            case LESSTHAN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.LESSTHAN);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EMPTY);
-                break;
-            case NOTEMPTY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEMPTY);
-                break;
-            case CONTAINS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.CONTAINS);
-                break;
-            case NOTCONTAINS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTCONTAINS);
-                break;
-            case EVAL:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EVAL);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DELETE:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.DELETE);
-                break;
-            case GET:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.GET);
-                break;
-            case OPTIONS:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
-                break;
-            case PATCH:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.PATCH);
-                break;
-            case POST:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.POST);
-                break;
-            case PUT:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.PUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DELETE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.DELETE);
-                break;
-            case GET:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.GET);
-                break;
-            case OPTIONS:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
-                break;
-            case PATCH:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PATCH);
-                break;
-            case POST:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.POST);
-                break;
-            case PUT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionResponseTypesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case OKAY:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.OKAY);
-                break;
-            case CREATED:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.CREATED);
-                break;
-            case NOCONTENT:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOCONTENT);
-                break;
-            case NOTMODIFIED:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
-                break;
-            case BAD:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.BAD);
-                break;
-            case FORBIDDEN:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.FORBIDDEN);
-                break;
-            case NOTFOUND:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOTFOUND);
-                break;
-            case METHODNOTALLOWED:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
-                break;
-            case CONFLICT:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.CONFLICT);
-                break;
-            case GONE:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.GONE);
-                break;
-            case PRECONDITIONFAILED:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
-                break;
-            case UNPROCESSABLE:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypesEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case OKAY:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.OKAY);
-                break;
-            case CREATED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CREATED);
-                break;
-            case NOCONTENT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOCONTENT);
-                break;
-            case NOTMODIFIED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
-                break;
-            case BAD:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.BAD);
-                break;
-            case FORBIDDEN:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.FORBIDDEN);
-                break;
-            case NOTFOUND:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTFOUND);
-                break;
-            case METHODNOTALLOWED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
-                break;
-            case CONFLICT:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CONFLICT);
-                break;
-            case GONE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.GONE);
-                break;
-            case PRECONDITIONFAILED:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
-                break;
-            case UNPROCESSABLE:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestScript.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.r5.model.TestScript.TestActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TestActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        if (src.hasAssert())
-            tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r5.model.TestScript.TeardownActionComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent();
-        copyElement(src, tgt);
-        if (src.hasOperation())
-            tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> convertFilterOperator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.FilterOperatorEnumFactory());
-        VersionConvertor_30_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.EQUAL);
-                break;
-            case ISA:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.ISA);
-                break;
-            case DESCENDENTOF:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.DESCENDENTOF);
-                break;
-            case ISNOTA:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.ISNOTA);
-                break;
-            case REGEX:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.REGEX);
-                break;
-            case IN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.IN);
-                break;
-            case NOTIN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.NOTIN);
-                break;
-            case GENERALIZES:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.GENERALIZES);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.EXISTS);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src, boolean nullOk) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
-            return Parameters30_50.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ActivityDefinition)
-            return ActivityDefinition30_50.convertActivityDefinition((org.hl7.fhir.dstu3.model.ActivityDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AllergyIntolerance)
-            return AllergyIntolerance30_50.convertAllergyIntolerance((org.hl7.fhir.dstu3.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Appointment)
-            return Appointment30_50.convertAppointment((org.hl7.fhir.dstu3.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AppointmentResponse)
-            return AppointmentResponse30_50.convertAppointmentResponse((org.hl7.fhir.dstu3.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.AuditEvent)
-            return AuditEvent30_50.convertAuditEvent((org.hl7.fhir.dstu3.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Basic)
-            return Basic30_50.convertBasic((org.hl7.fhir.dstu3.model.Basic) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Binary)
-            return Binary30_50.convertBinary((org.hl7.fhir.dstu3.model.Binary) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.BodySite)
-            return BodySite30_50.convertBodySite((org.hl7.fhir.dstu3.model.BodySite) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
-            return Bundle30_50.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
-            return CapabilityStatement30_50.convertCapabilityStatement((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CarePlan)
-            return CarePlan30_50.convertCarePlan((org.hl7.fhir.dstu3.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CareTeam)
-            return CareTeam30_50.convertCareTeam((org.hl7.fhir.dstu3.model.CareTeam) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ClinicalImpression)
-            return ClinicalImpression30_50.convertClinicalImpression((org.hl7.fhir.dstu3.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
-            return CodeSystem30_50.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Communication)
-            return Communication30_50.convertCommunication((org.hl7.fhir.dstu3.model.Communication) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
-            return CompartmentDefinition30_50.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Composition)
-            return Composition30_50.convertComposition((org.hl7.fhir.dstu3.model.Composition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
-            return ConceptMap30_50.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Condition)
-            return Condition30_50.convertCondition((org.hl7.fhir.dstu3.model.Condition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Consent)
-            return Consent30_50.convertConsent((org.hl7.fhir.dstu3.model.Consent) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
-            return DataElement30_50.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DetectedIssue)
-            return DetectedIssue30_50.convertDetectedIssue((org.hl7.fhir.dstu3.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DeviceUseStatement)
-            return DeviceUseStatement30_50.convertDeviceUseStatement((org.hl7.fhir.dstu3.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DiagnosticReport)
-            return DiagnosticReport30_50.convertDiagnosticReport((org.hl7.fhir.dstu3.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.DocumentReference)
-            return DocumentReference30_50.convertDocumentReference((org.hl7.fhir.dstu3.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Encounter)
-            return Encounter30_50.convertEncounter((org.hl7.fhir.dstu3.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Endpoint)
-            return Endpoint30_50.convertEndpoint((org.hl7.fhir.dstu3.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.EpisodeOfCare)
-            return EpisodeOfCare30_50.convertEpisodeOfCare((org.hl7.fhir.dstu3.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ExpansionProfile)
-            return ExpansionProfile30_50.convertExpansionProfile((org.hl7.fhir.dstu3.model.ExpansionProfile) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.FamilyMemberHistory)
-            return FamilyMemberHistory30_50.convertFamilyMemberHistory((org.hl7.fhir.dstu3.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Flag)
-            return Flag30_50.convertFlag((org.hl7.fhir.dstu3.model.Flag) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Goal)
-            return Goal30_50.convertGoal((org.hl7.fhir.dstu3.model.Goal) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.GraphDefinition)
-            return GraphDefinition30_50.convertGraphDefinition((org.hl7.fhir.dstu3.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Group)
-            return Group30_50.convertGroup((org.hl7.fhir.dstu3.model.Group) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.HealthcareService)
-            return HealthcareService30_50.convertHealthcareService((org.hl7.fhir.dstu3.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ImagingStudy)
-            return ImagingStudy30_50.convertImagingStudy((org.hl7.fhir.dstu3.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Immunization)
-            return Immunization30_50.convertImmunization((org.hl7.fhir.dstu3.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
-            return ImplementationGuide30_50.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Library)
-            return Library30_50.convertLibrary((org.hl7.fhir.dstu3.model.Library) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Linkage)
-            return Linkage30_50.convertLinkage((org.hl7.fhir.dstu3.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ListResource)
-            return List30_50.convertList((org.hl7.fhir.dstu3.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Location)
-            return Location30_50.convertLocation((org.hl7.fhir.dstu3.model.Location) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Measure)
-            return Measure30_50.convertMeasure((org.hl7.fhir.dstu3.model.Measure) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Media)
-            return Media30_50.convertMedia((org.hl7.fhir.dstu3.model.Media) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Medication)
-            return Medication30_50.convertMedication((org.hl7.fhir.dstu3.model.Medication) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationAdministration)
-            return MedicationAdministration30_50.convertMedicationAdministration((org.hl7.fhir.dstu3.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationDispense)
-            return MedicationDispense30_50.convertMedicationDispense((org.hl7.fhir.dstu3.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationRequest)
-            return MedicationRequest30_50.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MedicationStatement)
-            return MedicationStatement30_50.convertMedicationStatement((org.hl7.fhir.dstu3.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MessageDefinition)
-            return MessageDefinition30_50.convertMessageDefinition((org.hl7.fhir.dstu3.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.MessageHeader)
-            return MessageHeader30_50.convertMessageHeader((org.hl7.fhir.dstu3.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
-            return NamingSystem30_50.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Observation)
-            return Observation30_50.convertObservation((org.hl7.fhir.dstu3.model.Observation) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
-            return OperationDefinition30_50.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
-            return OperationOutcome30_50.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Organization)
-            return Organization30_50.convertOrganization((org.hl7.fhir.dstu3.model.Organization) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Patient)
-            return Patient30_50.convertPatient((org.hl7.fhir.dstu3.model.Patient) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PaymentNotice)
-            return PaymentNotice30_50.convertPaymentNotice((org.hl7.fhir.dstu3.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Person)
-            return Person30_50.convertPerson((org.hl7.fhir.dstu3.model.Person) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PlanDefinition)
-            return PlanDefinition30_50.convertPlanDefinition((org.hl7.fhir.dstu3.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Practitioner)
-            return Practitioner30_50.convertPractitioner((org.hl7.fhir.dstu3.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.PractitionerRole)
-            return PractitionerRole30_50.convertPractitionerRole((org.hl7.fhir.dstu3.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Provenance)
-          return Provenance30_50.convertProvenance((org.hl7.fhir.dstu3.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
-            return Questionnaire30_50.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
-            return QuestionnaireResponse30_50.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RelatedPerson)
-            return RelatedPerson30_50.convertRelatedPerson((org.hl7.fhir.dstu3.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.RiskAssessment)
-            return RiskAssessment30_50.convertRiskAssessment((org.hl7.fhir.dstu3.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Schedule)
-            return Schedule30_50.convertSchedule((org.hl7.fhir.dstu3.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
-            return SearchParameter30_50.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Sequence)
-            return Sequence30_50.convertSequence((org.hl7.fhir.dstu3.model.Sequence) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Slot)
-            return Slot30_50.convertSlot((org.hl7.fhir.dstu3.model.Slot) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Specimen)
-            return Specimen30_50.convertSpecimen((org.hl7.fhir.dstu3.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
-            return StructureDefinition30_50.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.StructureMap)
-            return StructureMap30_50.convertStructureMap((org.hl7.fhir.dstu3.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.Substance)
-            return Substance30_50.convertSubstance((org.hl7.fhir.dstu3.model.Substance) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.SupplyDelivery)
-            return SupplyDelivery30_50.convertSupplyDelivery((org.hl7.fhir.dstu3.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TestReport)
-            return TestReport30_50.convertTestReport((org.hl7.fhir.dstu3.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
-            return TestScript30_50.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
-            return ValueSet30_50.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
-        if (!nullOk)
-            throw new FHIRException("Unknown resource " + src.fhirType());
-        else
-            return null;
-    }
-
-    public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src, boolean nullOk) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Parameters) {
-            if (((org.hl7.fhir.r5.model.Parameters) src).hasParameter("profile-url"))
-                return ExpansionProfile30_50.convertExpansionProfile((org.hl7.fhir.r5.model.Parameters) src);
-            else
-                return Parameters30_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
-        }
-        if (src instanceof org.hl7.fhir.r5.model.ActivityDefinition)
-            return ActivityDefinition30_50.convertActivityDefinition((org.hl7.fhir.r5.model.ActivityDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.AllergyIntolerance)
-            return AllergyIntolerance30_50.convertAllergyIntolerance((org.hl7.fhir.r5.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Appointment)
-            return Appointment30_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
-            return AppointmentResponse30_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
-            return AuditEvent30_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r5.model.Basic)
-            return Basic30_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r5.model.Binary)
-            return Binary30_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r5.model.BodyStructure)
-            return BodySite30_50.convertBodySite((org.hl7.fhir.r5.model.BodyStructure) src);
-        if (src instanceof org.hl7.fhir.r5.model.Bundle)
-            return Bundle30_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
-            return CapabilityStatement30_50.convertCapabilityStatement((org.hl7.fhir.r5.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.CarePlan)
-            return CarePlan30_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r5.model.CareTeam)
-            return CareTeam30_50.convertCareTeam((org.hl7.fhir.r5.model.CareTeam) src);
-        if (src instanceof org.hl7.fhir.r5.model.ClinicalImpression)
-            return ClinicalImpression30_50.convertClinicalImpression((org.hl7.fhir.r5.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
-            return CodeSystem30_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.Communication)
-            return Communication30_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
-            return CompartmentDefinition30_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Composition)
-            return Composition30_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
-            return ConceptMap30_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.Condition)
-            return Condition30_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Consent)
-            return Consent30_50.convertConsent((org.hl7.fhir.r5.model.Consent) src);
-        if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
-            return DetectedIssue30_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
-            return DeviceUseStatement30_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
-            return DiagnosticReport30_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
-            return DocumentReference30_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r5.model.Encounter)
-            return Encounter30_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r5.model.Endpoint)
-            return Endpoint30_50.convertEndpoint((org.hl7.fhir.r5.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
-            return EpisodeOfCare30_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
-            return FamilyMemberHistory30_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r5.model.Flag)
-            return Flag30_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r5.model.Goal)
-            return Goal30_50.convertGoal((org.hl7.fhir.r5.model.Goal) src);
-        if (src instanceof org.hl7.fhir.r5.model.GraphDefinition)
-            return GraphDefinition30_50.convertGraphDefinition((org.hl7.fhir.r5.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Group)
-            return Group30_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
-        if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
-            return HealthcareService30_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImagingStudy)
-            return ImagingStudy30_50.convertImagingStudy((org.hl7.fhir.r5.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.r5.model.Immunization)
-            return Immunization30_50.convertImmunization((org.hl7.fhir.r5.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-            return ImplementationGuide30_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r5.model.Library)
-            return Library30_50.convertLibrary((org.hl7.fhir.r5.model.Library) src);
-        if (src instanceof org.hl7.fhir.r5.model.Linkage)
-            return Linkage30_50.convertLinkage((org.hl7.fhir.r5.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.r5.model.ListResource)
-            return List30_50.convertList((org.hl7.fhir.r5.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r5.model.Location)
-            return Location30_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
-        if (src instanceof org.hl7.fhir.r5.model.Measure)
-            return Measure30_50.convertMeasure((org.hl7.fhir.r5.model.Measure) src);
-        if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
-            return Media30_50.convertMedia((org.hl7.fhir.r5.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r5.model.Medication)
-            return Medication30_50.convertMedication((org.hl7.fhir.r5.model.Medication) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationAdministration)
-            return MedicationAdministration30_50.convertMedicationAdministration((org.hl7.fhir.r5.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
-            return MedicationDispense30_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationRequest)
-            return MedicationRequest30_50.convertMedicationRequest((org.hl7.fhir.r5.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
-            return MedicationStatement30_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
-        if (src instanceof org.hl7.fhir.r5.model.MessageDefinition)
-            return MessageDefinition30_50.convertMessageDefinition((org.hl7.fhir.r5.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
-            return MessageHeader30_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
-            return NamingSystem30_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.Observation)
-            return Observation30_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
-            return OperationDefinition30_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
-            return OperationOutcome30_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r5.model.Organization)
-            return Organization30_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r5.model.Patient)
-            return Patient30_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r5.model.PaymentNotice)
-            return PaymentNotice30_50.convertPaymentNotice((org.hl7.fhir.r5.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.r5.model.Person)
-            return Person30_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
-        if (src instanceof org.hl7.fhir.r5.model.PlanDefinition)
-            return PlanDefinition30_50.convertPlanDefinition((org.hl7.fhir.r5.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Practitioner)
-            return Practitioner30_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r5.model.PractitionerRole)
-            return PractitionerRole30_50.convertPractitionerRole((org.hl7.fhir.r5.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.r5.model.Provenance)
-          return Provenance30_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
-            return Questionnaire30_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
-            return QuestionnaireResponse30_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.RelatedPerson)
-            return RelatedPerson30_50.convertRelatedPerson((org.hl7.fhir.r5.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
-            return RiskAssessment30_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r5.model.Schedule)
-            return Schedule30_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
-            return SearchParameter30_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r5.model.MolecularSequence)
-            return Sequence30_50.convertSequence((org.hl7.fhir.r5.model.MolecularSequence) src);
-        if (src instanceof org.hl7.fhir.r5.model.Slot)
-            return Slot30_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r5.model.Specimen)
-            return Specimen30_50.convertSpecimen((org.hl7.fhir.r5.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
-            return StructureDefinition30_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureMap)
-            return StructureMap30_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.Substance)
-            return Substance30_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
-            return SupplyDelivery30_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r5.model.TestReport)
-            return TestReport30_50.convertTestReport((org.hl7.fhir.r5.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.r5.model.TestScript)
-            return TestScript30_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r5.model.ValueSet)
-            return ValueSet30_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
-        if (!nullOk)
-            throw new FHIRException("Unknown resource " + src.fhirType());
-        else
-            return null;
-    }
-
-    public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src, boolean b) {
-        TerminologyCapabilities res = new TerminologyCapabilities();
-        for (ParametersParameterComponent p : src.getParameter()) {
-            if (p.getName().equals("system"))
-                res.addCodeSystem().setUri(p.getValue().primitiveValue());
-            if (p.getName().equals("expansion.parameter"))
-              res.getExpansion().addParameter().setName(p.getValue().primitiveValue());
-        }
-        return res;
-    }
-
-    public static boolean convertsResource(String rt) {
-        return Utilities.existsInList(rt, "Parameters", "ActivityDefinition", "AllergyIntolerance", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "BodyStructure", "Bundle", "CapabilityStatement", "CarePlan", "CareTeam", "ClinicalImpression", "CodeSystem", "Communication", "CompartmentDefinition", "Composition", "ConceptMap", "Condition", "Consent", "DetectedIssue", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "Endpoint", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Goal", "GraphDefinition", "Group", "HealthcareService", "ImagingStudy", "Immunization", "ImplementationGuide", "Library", "Linkage", "ListResource", "Location", "Media", "Medication", "MedicationAdministration", "MedicationDispense", "MedicationRequest", "MedicationStatement", "MessageDefinition", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "PaymentNotice", "Person", "PlanDefinition", "Practitioner", "PractitionerRole", "ProcessRequest", "Questionnaire", "QuestionnaireResponse", "RelatedPerson", "RiskAssessment", "Schedule", "SearchParameter", "Sequence", "Slot", "Specimen", "StructureDefinition", "StructureMap", "Subscription", "Substance", "SupplyDelivery", "TestReport", "TestScript", "ValueSet");
-    }
+          tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
+        }
+      } else {
+        if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
+        else tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> convertBindingStrength(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.BindingStrength> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.BindingStrength> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.BindingStrengthEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REQUIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.REQUIRED);
+          break;
+        case EXTENSIBLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXTENSIBLE);
+          break;
+        case PREFERRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.PREFERRED);
+          break;
+        case EXAMPLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.EXAMPLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.BindingStrength.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.dstu3.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.dstu3.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.HumanName tgt = new org.hl7.fhir.dstu3.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.addGiven(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.addPrefix(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.addSuffix(t.getValue());
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.HumanName.NameUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.dstu3.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Meta tgt = new org.hl7.fhir.dstu3.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.dstu3.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ParameterDefinition tgt = new org.hl7.fhir.r5.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
+    if (src.hasProfile()) {
+      tgt.setProfile(convertReference(src.getProfile()).getReference());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r5.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.ParameterDefinition tgt = new org.hl7.fhir.dstu3.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setType(src.getType().toCode());
+    if (src.hasProfile()) tgt.setProfile(new org.hl7.fhir.dstu3.model.Reference(src.getProfile()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> convertParameterUse(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.OperationParameterUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUseEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.ParameterDefinition.ParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.dstu3.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.RelatedArtifact tgt = new org.hl7.fhir.r5.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitation(src.getCitation());
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResourceElement(convertReferenceToCanonical(src.getResource()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r5.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.RelatedArtifact tgt = new org.hl7.fhir.dstu3.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitation(src.getCitation());
+    if (src.hasUrl()) tgt.setUrl(src.getUrl());
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResource(convertCanonicalToReference(src.getResourceElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.dstu3.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Timing tgt = new org.hl7.fhir.dstu3.model.Timing();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.addEvent(t.getValue());
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_30_50::convertDayOfWeek).collect(Collectors.toList()));
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_30_50::convertEventTiming).collect(Collectors.toList()));
+    for (org.hl7.fhir.dstu3.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.dstu3.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCount(src.getCount());
+    if (src.hasCountMax()) tgt.setCountMax(src.getCountMax());
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequency(src.getFrequency());
+    if (src.hasFrequencyMax()) tgt.setFrequencyMax(src.getFrequencyMax());
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_30_50::convertDayOfWeek).collect(Collectors.toList()));
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_30_50::convertEventTiming).collect(Collectors.toList()));
+    for (org.hl7.fhir.r5.model.TimeType t : src.getTimeOfDay()) tgt.addTimeOfDay(t.getValue());
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDayOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.DayOfWeekEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.DayOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Timing.EventTiming> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.MORN);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AFT);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.EVE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UsageContext convertUsageContext(org.hl7.fhir.dstu3.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.UsageContext tgt = new org.hl7.fhir.r5.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.UsageContext convertUsageContext(org.hl7.fhir.r5.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.UsageContext tgt = new org.hl7.fhir.dstu3.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.dstu3.model.SimpleQuantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.SimpleQuantity tgt = new org.hl7.fhir.r5.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.SimpleQuantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.SimpleQuantity tgt = new org.hl7.fhir.dstu3.model.SimpleQuantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.dstu3.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TriggerDefinition tgt = new org.hl7.fhir.r5.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasEventName()) tgt.setNameElement(convertString(src.getEventNameElement()));
+    if (src.hasEventTiming()) tgt.setTiming(convertType(src.getEventTiming()));
+    if (src.hasEventData()) tgt.addData(convertDataRequirement(src.getEventData()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r5.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TriggerDefinition tgt = new org.hl7.fhir.dstu3.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasName()) tgt.setEventNameElement(convertString(src.getNameElement()));
+    if (src.hasTiming()) tgt.setEventTiming(convertType(src.getTiming()));
+    if (src.hasData()) tgt.setEventData(convertDataRequirement(src.getDataFirstRep()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement convertDataRequirement(org.hl7.fhir.dstu3.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement tgt = new org.hl7.fhir.r5.model.DataRequirement();
+    copyElement(src, tgt, VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME);
+    if (src.hasType()) {
+      if (src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
+        tgt.setType(Enumerations.FHIRAllTypes.fromCode(src.getExtensionString(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)));
+      } else {
+        String n = VersionConvertorResourceNameMapper.mapName3to5(src.getType());
+        if (n != null) {
+          tgt.setType(Enumerations.FHIRAllTypes.fromCode(n));
+        }
+        tgt.addExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME, new org.hl7.fhir.r5.model.CodeType(src.getType()));
+      }
+    }
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.dstu3.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
+    for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement convertDataRequirement(org.hl7.fhir.r5.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement tgt = new org.hl7.fhir.dstu3.model.DataRequirement();
+    copyElement(src, tgt, VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME);
+    if (src.hasType() || src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
+      if (src.hasExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME)) {
+        tgt.setType(src.getExtensionString(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME));
+      } else {
+        String n = VersionConvertorResourceNameMapper.mapName5to3(src.getType().toCode());
+        if (n != null) {
+          tgt.setType(n);
+        }
+        tgt.addExtension(VersionConvertorConstants.EXT_ACTUAL_RESOURCE_NAME, new org.hl7.fhir.dstu3.model.CodeType(src.getType().toCode()));
+      }
+    }
+    for (org.hl7.fhir.r5.model.UriType t : src.getProfile()) tgt.addProfile(t.getValue());
+    for (org.hl7.fhir.r5.model.StringType t : src.getMustSupport()) tgt.addMustSupport(t.getValue());
+    for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValueSet()) {
+      DataType t = convertType(src.getValueSet());
+      if (t instanceof org.hl7.fhir.r5.model.Reference)
+        tgt.setValueSet(((org.hl7.fhir.r5.model.Reference) t).getReference());
+      else tgt.setValueSet(t.primitiveValue());
+      tgt.setValueSet(VersionConvertorConstants.refToVS(tgt.getValueSet()));
+    }
+    for (org.hl7.fhir.dstu3.model.CodeType t : src.getValueCode()) tgt.addCode(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getValueCoding()) tgt.addCode(convertCoding(t));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getValueCodeableConcept()) tgt.addCode(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValueSet()) {
+      String vsr = VersionConvertorConstants.vsToRef(src.getValueSet());
+      if (vsr != null) tgt.setValueSet(new org.hl7.fhir.dstu3.model.UriType(vsr));
+      else tgt.setValueSet(new org.hl7.fhir.dstu3.model.Reference(src.getValueSet()));
+    }
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) {
+      tgt.addValueCoding(convertCoding(t));
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.dstu3.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.dstu3.model.Type src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.dstu3.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.dstu3.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeType) return convertCode((org.hl7.fhir.dstu3.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateType) return convertDate((org.hl7.fhir.dstu3.model.DateType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.dstu3.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.dstu3.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IdType) return convertId((org.hl7.fhir.dstu3.model.IdType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.InstantType)
+      return convertInstant((org.hl7.fhir.dstu3.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.dstu3.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.dstu3.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.IntegerType)
+      return convertInteger((org.hl7.fhir.dstu3.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.dstu3.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OidType) return convertOid((org.hl7.fhir.dstu3.model.OidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StringType)
+      return convertString((org.hl7.fhir.dstu3.model.StringType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TimeType) return convertTime((org.hl7.fhir.dstu3.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UriType) return convertUri((org.hl7.fhir.dstu3.model.UriType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UuidType) return convertUuid((org.hl7.fhir.dstu3.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Extension)
+      return convertExtension((org.hl7.fhir.dstu3.model.Extension) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Narrative)
+      return convertNarrative((org.hl7.fhir.dstu3.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Age) return convertAge((org.hl7.fhir.dstu3.model.Age) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.dstu3.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Attachment)
+      return convertAttachment((org.hl7.fhir.dstu3.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.dstu3.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Coding) return convertCoding((org.hl7.fhir.dstu3.model.Coding) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Count) return convertCount((org.hl7.fhir.dstu3.model.Count) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Distance)
+      return convertDistance((org.hl7.fhir.dstu3.model.Distance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Duration)
+      return convertDuration((org.hl7.fhir.dstu3.model.Duration) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.dstu3.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Money) return convertMoney((org.hl7.fhir.dstu3.model.Money) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Period) return convertPeriod((org.hl7.fhir.dstu3.model.Period) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Quantity)
+      return convertQuantity((org.hl7.fhir.dstu3.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Range) return convertRange((org.hl7.fhir.dstu3.model.Range) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Ratio) return convertRatio((org.hl7.fhir.dstu3.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Reference)
+      return convertReference((org.hl7.fhir.dstu3.model.Reference) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SampledData)
+      return convertSampledData((org.hl7.fhir.dstu3.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Signature)
+      return convertSignature((org.hl7.fhir.dstu3.model.Signature) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Address) return convertAddress((org.hl7.fhir.dstu3.model.Address) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.dstu3.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.dstu3.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Contributor)
+      return convertContributor((org.hl7.fhir.dstu3.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Dosage) return convertDosage((org.hl7.fhir.dstu3.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.HumanName)
+      return convertHumanName((org.hl7.fhir.dstu3.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Meta) return convertMeta((org.hl7.fhir.dstu3.model.Meta) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.dstu3.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.dstu3.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Timing) return convertTiming((org.hl7.fhir.dstu3.model.Timing) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.dstu3.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.dstu3.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.dstu3.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.dstu3.model.TriggerDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.dstu3.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r5.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeType) return convertCode((org.hl7.fhir.r5.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateType) return convertDate((org.hl7.fhir.r5.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IdType) return convertId((org.hl7.fhir.r5.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r5.model.InstantType)
+      return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.Integer64Type)
+      return convertInteger64((org.hl7.fhir.r5.model.Integer64Type) src);
+    if (src instanceof org.hl7.fhir.r5.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r5.model.OidType) return convertOid((org.hl7.fhir.r5.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.StringType) return convertString((org.hl7.fhir.r5.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r5.model.TimeType) return convertTime((org.hl7.fhir.r5.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UriType) return convertUri((org.hl7.fhir.r5.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UuidType) return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.Extension) return convertExtension((org.hl7.fhir.r5.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r5.model.Narrative) return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r5.model.Age) return convertAge((org.hl7.fhir.r5.model.Age) src);
+    if (src instanceof org.hl7.fhir.r5.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r5.model.Coding) return convertCoding((org.hl7.fhir.r5.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r5.model.Count) return convertCount((org.hl7.fhir.r5.model.Count) src);
+    if (src instanceof org.hl7.fhir.r5.model.Distance) return convertDistance((org.hl7.fhir.r5.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Duration) return convertDuration((org.hl7.fhir.r5.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r5.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r5.model.Money) return convertMoney((org.hl7.fhir.r5.model.Money) src);
+    if (src instanceof org.hl7.fhir.r5.model.Period) return convertPeriod((org.hl7.fhir.r5.model.Period) src);
+    if (src instanceof org.hl7.fhir.r5.model.Quantity) return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.Range) return convertRange((org.hl7.fhir.r5.model.Range) src);
+    if (src instanceof org.hl7.fhir.r5.model.Ratio) return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r5.model.Reference) return convertReference((org.hl7.fhir.r5.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r5.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r5.model.Signature) return convertSignature((org.hl7.fhir.r5.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r5.model.Address) return convertAddress((org.hl7.fhir.r5.model.Address) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.r5.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.Contributor)
+      return convertContributor((org.hl7.fhir.r5.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.r5.model.Dosage) return convertDosage((org.hl7.fhir.r5.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.r5.model.HumanName) return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r5.model.Meta) return convertMeta((org.hl7.fhir.r5.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r5.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.r5.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.r5.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.r5.model.Timing) return convertTiming((org.hl7.fhir.r5.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r5.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.r5.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.r5.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.r5.model.ElementDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.r5.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.r5.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.r5.model.TriggerDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.dstu3.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.dstu3.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
+    for (org.hl7.fhir.dstu3.model.Extension t2 : src.getExtension()) {
+      if (!isExemptExtension(t2.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t2));
+    }
+    for (org.hl7.fhir.dstu3.model.Extension t3 : src.getModifierExtension()) {
+      if (!isExemptExtension(t3.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t3));
+    }
+  }
+
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
+  }
+
+  static public void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.dstu3.model.DomainResource tgt, String... extensionsToIgnore) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r5.model.Resource t1 : src.getContained()) tgt.addContained(convertResource(t1, false));
+    for (org.hl7.fhir.r5.model.Extension t2 : src.getExtension()) {
+      if (!isExemptExtension(t2.getUrl(), extensionsToIgnore)) tgt.addExtension(convertExtension(t2));
+    }
+    for (org.hl7.fhir.r5.model.Extension t3 : src.getModifierExtension()) {
+      if (!isExemptExtension(t3.getUrl(), extensionsToIgnore)) tgt.addModifierExtension(convertExtension(t3));
+    }
+  }
+
+  static public void copyResource(org.hl7.fhir.dstu3.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setIdElement(convertId(src.getIdElement()));
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+  }
+
+  static public void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.dstu3.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setIdElement(convertId(src.getIdElement()));
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRules(src.getImplicitRules());
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> convertPublicationStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.PublicationStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.PublicationStatusEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.DRAFT);
+          break;
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+          break;
+        case RETIRED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.RETIRED);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public CodeableReference convertReferenceToCodableReference(org.hl7.fhir.dstu3.model.Reference src) {
+    CodeableReference tgt = new CodeableReference();
+    tgt.setReference(convertReference(src));
+    return tgt;
+  }
+
+  static public CodeableReference convertCodeableConceptToCodableReference(org.hl7.fhir.dstu3.model.CodeableConcept src) {
+    CodeableReference tgt = new CodeableReference();
+    tgt.setConcept(convertCodeableConcept(src));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.CanonicalType convertReferenceToCanonical(org.hl7.fhir.dstu3.model.Reference src) throws FHIRException {
+    org.hl7.fhir.r5.model.CanonicalType dst = new org.hl7.fhir.r5.model.CanonicalType(src.getReference());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Reference convertCanonicalToReference(org.hl7.fhir.r5.model.CanonicalType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.Reference dst = new org.hl7.fhir.dstu3.model.Reference(src.getValue());
+    copyElement(src, dst);
+    return dst;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> convertSearchParamType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.SearchParamType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.SearchParamType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.SearchParamTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NUMBER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NUMBER);
+          break;
+        case DATE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.DATE);
+          break;
+        case STRING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.STRING);
+          break;
+        case TOKEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.TOKEN);
+          break;
+        case REFERENCE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.REFERENCE);
+          break;
+        case COMPOSITE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.COMPOSITE);
+          break;
+        case QUANTITY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.QUANTITY);
+          break;
+        case URI:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.URI);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.SearchParamType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator> convertFilterOperator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.CodeSystem.FilterOperatorEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.EQUAL);
+          break;
+        case ISA:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.ISA);
+          break;
+        case DESCENDENTOF:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.DESCENDENTOF);
+          break;
+        case ISNOTA:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.ISNOTA);
+          break;
+        case REGEX:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.REGEX);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.NOTIN);
+          break;
+        case GENERALIZES:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.GENERALIZES);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.EXISTS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.CodeSystem.FilterOperator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent convertConsentPolicyComponent(org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent tgt = new org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent();
+    copyElement(src, tgt);
+    if (src.hasAuthority()) tgt.setAuthorityElement(convertUri(src.getAuthorityElement()));
+    if (src.hasUri()) tgt.setUriElement(convertUri(src.getUriElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent convertConsentPolicyComponent(org.hl7.fhir.r5.model.Consent.ConsentPolicyComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent tgt = new org.hl7.fhir.dstu3.model.Consent.ConsentPolicyComponent();
+    copyElement(src, tgt);
+    if (src.hasAuthority()) tgt.setAuthorityElement(convertUri(src.getAuthorityElement()));
+    if (src.hasUri()) tgt.setUriElement(convertUri(src.getUriElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> convertConsentDataMeaning(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Consent.ConsentDataMeaningEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.NULL);
+    } else {
+      switch (src.getValue()) {
+        case INSTANCE:
+          tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.INSTANCE);
+          break;
+        case RELATED:
+          tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.RELATED);
+          break;
+        case DEPENDENTS:
+          tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.DEPENDENTS);
+          break;
+        case AUTHOREDBY:
+          tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.AUTHOREDBY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Consent.ConsentDataMeaning.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> convertConsentDataMeaning(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Consent.ConsentDataMeaning> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaningEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.NULL);
+    } else {
+      switch (src.getValue()) {
+        case INSTANCE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.INSTANCE);
+          break;
+        case RELATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.RELATED);
+          break;
+        case DEPENDENTS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.DEPENDENTS);
+          break;
+        case AUTHOREDBY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.AUTHOREDBY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Consent.ConsentDataMeaning.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent convertDocumentManifestRelatedComponent(org.hl7.fhir.r5.model.DocumentManifest.DocumentManifestRelatedComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent tgt = new org.hl7.fhir.dstu3.model.DocumentManifest.DocumentManifestRelatedComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasRef()) tgt.setRef(convertReference(src.getRef()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType> convertDocumentRelationshipType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.DocumentReference.DocumentRelationshipType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case REPLACES:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.REPLACES);
+          break;
+        case TRANSFORMS:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.TRANSFORMS);
+          break;
+        case SIGNS:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.SIGNS);
+          break;
+        case APPENDS:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.APPENDS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DocumentRelationshipType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.r5.model.Encounter.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setUse(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r5.model.Encounter.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.Encounter.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasUse()) tgt.setRole(convertCodeableConcept(src.getUse()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setRole(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent convertDiagnosisComponent(org.hl7.fhir.r5.model.EpisodeOfCare.DiagnosisComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent tgt = new org.hl7.fhir.dstu3.model.EpisodeOfCare.DiagnosisComponent();
+    copyElement(src, tgt);
+    if (src.hasCondition()) tgt.setCondition(convertReference(src.getCondition()));
+    if (src.hasRole()) tgt.setRole(convertCodeableConcept(src.getRole()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> convertAdministrativeGender(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.AdministrativeGender> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGenderEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.MALE);
+          break;
+        case FEMALE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.FEMALE);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.OTHER);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  private static final String CODE_SYSTEM_MEDIA_TYPE = "http://terminology.hl7.org/CodeSystem/media-type";
+
+  public static String convertCoding2Uri(org.hl7.fhir.dstu3.model.Coding code) {
+    return code.getSystem() + "/" + code.getCode();
+  }
+
+  public static org.hl7.fhir.dstu3.model.Coding convertUri2Coding(String uri) {
+    int i = uri.lastIndexOf("/");
+    return new org.hl7.fhir.dstu3.model.Coding().setSystem(uri.substring(0, i)).setCode(uri.substring(i + 1));
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDaysOfWeek(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.PractitionerRole.DaysOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Provenance convertProvenance(org.hl7.fhir.dstu3.model.Provenance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Provenance tgt = new org.hl7.fhir.r5.model.Provenance();
+    copyDomainResource(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getTarget()) tgt.addTarget(convertReference(t));
+    if (src.hasPeriod()) tgt.setOccurred(convertPeriod(src.getPeriod()));
+    if (src.hasRecorded()) tgt.setRecordedElement(convertInstant(src.getRecordedElement()));
+    for (org.hl7.fhir.dstu3.model.UriType t : src.getPolicy()) tgt.addPolicy(t.getValue());
+    if (src.hasLocation()) tgt.setLocation(convertReference(src.getLocation()));
+    for (org.hl7.fhir.dstu3.model.Coding t : src.getReason()) tgt.addReason(convertCodingToCodeableConcept(t));
+    if (src.hasActivity()) tgt.setActivity(convertCodingToCodeableConcept(src.getActivity()));
+    for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent t : src.getAgent())
+      tgt.addAgent(convertProvenanceAgentComponent(t));
+    for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent t : src.getEntity())
+      tgt.addEntity(convertProvenanceEntityComponent(t));
+    for (org.hl7.fhir.dstu3.model.Signature t : src.getSignature()) tgt.addSignature(convertSignature(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Provenance convertProvenance(org.hl7.fhir.r5.model.Provenance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Provenance tgt = new org.hl7.fhir.dstu3.model.Provenance();
+    copyDomainResource(src, tgt);
+    for (org.hl7.fhir.r5.model.Reference t : src.getTarget()) tgt.addTarget(convertReference(t));
+    if (src.hasOccurredPeriod()) tgt.setPeriod(convertPeriod(src.getOccurredPeriod()));
+    if (src.hasRecorded()) tgt.setRecordedElement(convertInstant(src.getRecordedElement()));
+    for (org.hl7.fhir.r5.model.UriType t : src.getPolicy()) tgt.addPolicy(t.getValue());
+    if (src.hasLocation()) tgt.setLocation(convertReference(src.getLocation()));
+    for (org.hl7.fhir.r5.model.CodeableConcept t : src.getReason())
+      for (org.hl7.fhir.r5.model.Coding tc : t.getCoding()) tgt.addReason(convertCoding(tc));
+    if (src.hasActivity()) tgt.setActivity(convertCoding(src.getActivity()));
+    for (org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent t : src.getAgent())
+      tgt.addAgent(convertProvenanceAgentComponent(t));
+    for (org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent t : src.getEntity())
+      tgt.addEntity(convertProvenanceEntityComponent(t));
+    for (org.hl7.fhir.r5.model.Signature t : src.getSignature()) tgt.addSignature(convertSignature(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent convertProvenanceAgentComponent(org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent tgt = new org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getRole()) tgt.addRole(convertCodeableConcept(t));
+    if (src.hasWho()) {
+      DataType t = convertType(src.getWho());
+      if (t instanceof Reference) tgt.setWho((Reference) t);
+      if (t instanceof UriType) tgt.getWho().setReference(t.primitiveValue());
+    }
+    if (src.hasOnBehalfOf()) {
+      DataType t = convertType(src.getOnBehalfOf());
+      if (t instanceof Reference) tgt.setOnBehalfOf((Reference) t);
+      if (t instanceof UriType) tgt.getOnBehalfOf().setReference(t.primitiveValue());
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent convertProvenanceAgentComponent(org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent tgt = new org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.CodeableConcept t : src.getRole()) tgt.addRole(convertCodeableConcept(t));
+    if (src.hasWho()) tgt.setWho(convertType(src.getWho()));
+    if (src.hasOnBehalfOf()) tgt.setOnBehalfOf(convertType(src.getOnBehalfOf()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent convertProvenanceEntityComponent(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent tgt = new org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent();
+    copyElement(src, tgt);
+    if (src.hasRole()) tgt.setRoleElement(convertProvenanceEntityRole(src.getRoleElement()));
+    if (src.hasWhat()) {
+      DataType t = convertType(src.getWhat());
+      if (t instanceof Reference) tgt.setWhat((Reference) t);
+      else if (t instanceof Identifier) tgt.getWhat().setIdentifier((Identifier) t);
+      else if (t instanceof UriType) tgt.getWhat().setReference(t.primitiveValue());
+    }
+    for (org.hl7.fhir.dstu3.model.Provenance.ProvenanceAgentComponent t : src.getAgent())
+      tgt.addAgent(convertProvenanceAgentComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent convertProvenanceEntityComponent(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent tgt = new org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent();
+    copyElement(src, tgt);
+    if (src.hasRole()) tgt.setRoleElement(convertProvenanceEntityRole(src.getRoleElement()));
+    if (src.hasWhat()) tgt.setWhat(convertType(src.getWhat()));
+    for (org.hl7.fhir.r5.model.Provenance.ProvenanceAgentComponent t : src.getAgent())
+      tgt.addAgent(convertProvenanceAgentComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> convertProvenanceEntityRole(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRoleEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DERIVATION:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.DERIVATION);
+          break;
+        case REVISION:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.REVISION);
+          break;
+        case QUOTATION:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.QUOTATION);
+          break;
+        case SOURCE:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.SOURCE);
+          break;
+        case REMOVAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.REMOVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> convertProvenanceEntityRole(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Provenance.ProvenanceEntityRole> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRoleEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DERIVATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.DERIVATION);
+          break;
+        case REVISION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.REVISION);
+          break;
+        case QUOTATION:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.QUOTATION);
+          break;
+        case SOURCE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.SOURCE);
+          break;
+        case REMOVAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.REMOVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r5.model.TestReport.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertUri(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r5.model.TestReport.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertUri(src.getDetailElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestReport.TestReportActionResultEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PASS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.PASS);
+          break;
+        case SKIP:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.SKIP);
+          break;
+        case FAIL:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.FAIL);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.WARNING);
+          break;
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.ERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TestReport.TestReportActionResult.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> convertTestReportActionResult(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestReport.TestReportActionResult> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestReport.TestReportActionResultEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PASS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.PASS);
+          break;
+        case SKIP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.SKIP);
+          break;
+        case FAIL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.FAIL);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.WARNING);
+          break;
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.ERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestReport.TestReportActionResult.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertString(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r5.model.TestReport.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasResult()) tgt.setResultElement(convertTestReportActionResult(src.getResultElement()));
+    if (src.hasMessage()) tgt.setMessageElement(convertMarkdown(src.getMessageElement()));
+    if (src.hasDetail()) tgt.setDetailElement(convertString(src.getDetailElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestReport.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.TestActionComponent convertTestActionComponent(org.hl7.fhir.r5.model.TestReport.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.r5.model.TestReport.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r5.model.TestReport.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestReport.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent convertSetupActionComponent(org.hl7.fhir.r5.model.TestScript.SetupActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCoding(src.getType()));
+    if (src.hasResource())
+      tgt.setResource(org.hl7.fhir.r5.model.TestScript.FHIRDefinedType.fromCode(src.getResource()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasAccept()) tgt.setAccept(convertContentType(src.getAccept()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasDestination()) tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
+    if (src.hasEncodeRequestUrl()) tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
+    if (src.hasOrigin()) tgt.setOriginElement(convertInteger(src.getOriginElement()));
+    if (src.hasParams()) tgt.setParamsElement(convertString(src.getParamsElement()));
+    for (org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
+      tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
+    if (src.hasRequestId()) tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
+    if (src.hasResponseId()) tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasTargetId()) tgt.setTargetId(src.getTargetId());
+    if (src.hasUrl()) tgt.setUrlElement(convertString(src.getUrlElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent convertSetupActionOperationComponent(org.hl7.fhir.r5.model.TestScript.SetupActionOperationComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCoding(src.getType()));
+    if (src.hasResource()) tgt.setResource(src.getResource().toCode());
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasAccept()) tgt.setAccept(convertContentType(src.getAccept()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasDestination()) tgt.setDestinationElement(convertInteger(src.getDestinationElement()));
+    if (src.hasEncodeRequestUrl()) tgt.setEncodeRequestUrlElement(convertBoolean(src.getEncodeRequestUrlElement()));
+    if (src.hasOrigin()) tgt.setOriginElement(convertInteger(src.getOriginElement()));
+    if (src.hasParams()) tgt.setParamsElement(convertString(src.getParamsElement()));
+    for (org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent t : src.getRequestHeader())
+      tgt.addRequestHeader(convertSetupActionOperationRequestHeaderComponent(t));
+    if (src.hasRequestId()) tgt.setRequestIdElement(convertId(src.getRequestIdElement()));
+    if (src.hasResponseId()) tgt.setResponseIdElement(convertId(src.getResponseIdElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasTargetId()) tgt.setTargetId(src.getTargetId());
+    if (src.hasUrl()) tgt.setUrlElement(convertString(src.getUrlElement()));
+    return tgt;
+  }
+
+  static public String convertContentType(org.hl7.fhir.dstu3.model.TestScript.ContentType src) throws FHIRException {
+    if (src == null) return null;
+    switch (src) {
+      case XML:
+        return "application/fhir+xml";
+      case JSON:
+        return "application/fhir+json";
+      case TTL:
+        return "text/turtle";
+      case NONE:
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  static public org.hl7.fhir.dstu3.model.TestScript.ContentType convertContentType(String src) throws FHIRException {
+    if (src == null) return null;
+    if (src.contains("xml")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.XML;
+    if (src.contains("json")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.JSON;
+    if (src.contains("tu")) return org.hl7.fhir.dstu3.model.TestScript.ContentType.TTL;
+    return org.hl7.fhir.dstu3.model.TestScript.ContentType.NONE;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent();
+    copyElement(src, tgt);
+    if (src.hasField()) tgt.setFieldElement(convertString(src.getFieldElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent convertSetupActionOperationRequestHeaderComponent(org.hl7.fhir.r5.model.TestScript.SetupActionOperationRequestHeaderComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionOperationRequestHeaderComponent();
+    copyElement(src, tgt);
+    if (src.hasField()) tgt.setFieldElement(convertString(src.getFieldElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
+    if (src.hasCompareToSourceId()) tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
+    if (src.hasCompareToSourceExpression())
+      tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
+    if (src.hasCompareToSourcePath())
+      tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasHeaderField()) tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
+    if (src.hasMinimumId()) tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
+    if (src.hasNavigationLinks()) tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
+    if (src.hasOperator()) tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasRequestMethod())
+      tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
+    if (src.hasRequestURL()) tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
+    if (src.hasResource())
+      tgt.setResource(org.hl7.fhir.r5.model.TestScript.FHIRDefinedType.fromCode(src.getResource()));
+    if (src.hasResponse()) tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
+    if (src.hasResponseCode()) tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasValidateProfileId()) tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasWarningOnly()) tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent convertSetupActionAssertComponent(org.hl7.fhir.r5.model.TestScript.SetupActionAssertComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.SetupActionAssertComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertAssertionDirectionType(src.getDirectionElement()));
+    if (src.hasCompareToSourceId()) tgt.setCompareToSourceIdElement(convertString(src.getCompareToSourceIdElement()));
+    if (src.hasCompareToSourceExpression())
+      tgt.setCompareToSourceExpressionElement(convertString(src.getCompareToSourceExpressionElement()));
+    if (src.hasCompareToSourcePath())
+      tgt.setCompareToSourcePathElement(convertString(src.getCompareToSourcePathElement()));
+    if (src.hasContentType()) tgt.setContentType(convertContentType(src.getContentType()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasHeaderField()) tgt.setHeaderFieldElement(convertString(src.getHeaderFieldElement()));
+    if (src.hasMinimumId()) tgt.setMinimumIdElement(convertString(src.getMinimumIdElement()));
+    if (src.hasNavigationLinks()) tgt.setNavigationLinksElement(convertBoolean(src.getNavigationLinksElement()));
+    if (src.hasOperator()) tgt.setOperatorElement(convertAssertionOperatorType(src.getOperatorElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasRequestMethod())
+      tgt.setRequestMethodElement(convertTestScriptRequestMethodCode(src.getRequestMethodElement()));
+    if (src.hasRequestURL()) tgt.setRequestURLElement(convertString(src.getRequestURLElement()));
+    if (src.hasResource()) tgt.setResource(src.getResource().toCode());
+    if (src.hasResponse()) tgt.setResponseElement(convertAssertionResponseTypes(src.getResponseElement()));
+    if (src.hasResponseCode()) tgt.setResponseCodeElement(convertString(src.getResponseCodeElement()));
+    if (src.hasSourceId()) tgt.setSourceIdElement(convertId(src.getSourceIdElement()));
+    if (src.hasValidateProfileId()) tgt.setValidateProfileIdElement(convertId(src.getValidateProfileIdElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasWarningOnly()) tgt.setWarningOnlyElement(convertBoolean(src.getWarningOnlyElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionDirectionTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case RESPONSE:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.RESPONSE);
+          break;
+        case REQUEST:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.REQUEST);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionDirectionType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> convertAssertionDirectionType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionDirectionType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case RESPONSE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.RESPONSE);
+          break;
+        case REQUEST:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.REQUEST);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionDirectionType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionOperatorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUALS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EQUALS);
+          break;
+        case NOTEQUALS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTEQUALS);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTIN);
+          break;
+        case GREATERTHAN:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.GREATERTHAN);
+          break;
+        case LESSTHAN:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.LESSTHAN);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EMPTY);
+          break;
+        case NOTEMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTEMPTY);
+          break;
+        case CONTAINS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.CONTAINS);
+          break;
+        case NOTCONTAINS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NOTCONTAINS);
+          break;
+        case EVAL:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.EVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionOperatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> convertAssertionOperatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionOperatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorTypeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUALS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EQUALS);
+          break;
+        case NOTEQUALS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEQUALS);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTIN);
+          break;
+        case GREATERTHAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.GREATERTHAN);
+          break;
+        case LESSTHAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.LESSTHAN);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EMPTY);
+          break;
+        case NOTEMPTY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTEMPTY);
+          break;
+        case CONTAINS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.CONTAINS);
+          break;
+        case NOTCONTAINS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NOTCONTAINS);
+          break;
+        case EVAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.EVAL);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionOperatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DELETE:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.DELETE);
+          break;
+        case GET:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.GET);
+          break;
+        case OPTIONS:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
+          break;
+        case PATCH:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.PATCH);
+          break;
+        case POST:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.POST);
+          break;
+        case PUT:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.PUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> convertTestScriptRequestMethodCode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.TestScriptRequestMethodCode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCodeEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DELETE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.DELETE);
+          break;
+        case GET:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.GET);
+          break;
+        case OPTIONS:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.OPTIONS);
+          break;
+        case PATCH:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PATCH);
+          break;
+        case POST:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.POST);
+          break;
+        case PUT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.PUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TestScript.AssertionResponseTypesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NULL);
+    } else {
+      switch (src.getValue()) {
+        case OKAY:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.OKAY);
+          break;
+        case CREATED:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.CREATED);
+          break;
+        case NOCONTENT:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOCONTENT);
+          break;
+        case NOTMODIFIED:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
+          break;
+        case BAD:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.BAD);
+          break;
+        case FORBIDDEN:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.FORBIDDEN);
+          break;
+        case NOTFOUND:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NOTFOUND);
+          break;
+        case METHODNOTALLOWED:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
+          break;
+        case CONFLICT:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.CONFLICT);
+          break;
+        case GONE:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.GONE);
+          break;
+        case PRECONDITIONFAILED:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
+          break;
+        case UNPROCESSABLE:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> convertAssertionResponseTypes(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TestScript.AssertionResponseTypes> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypesEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
+    } else {
+      switch (src.getValue()) {
+        case OKAY:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.OKAY);
+          break;
+        case CREATED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CREATED);
+          break;
+        case NOCONTENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOCONTENT);
+          break;
+        case NOTMODIFIED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTMODIFIED);
+          break;
+        case BAD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.BAD);
+          break;
+        case FORBIDDEN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.FORBIDDEN);
+          break;
+        case NOTFOUND:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NOTFOUND);
+          break;
+        case METHODNOTALLOWED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.METHODNOTALLOWED);
+          break;
+        case CONFLICT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.CONFLICT);
+          break;
+        case GONE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.GONE);
+          break;
+        case PRECONDITIONFAILED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.PRECONDITIONFAILED);
+          break;
+        case UNPROCESSABLE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.UNPROCESSABLE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.TestScript.AssertionResponseTypes.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.dstu3.model.TestScript.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.TestActionComponent convertTestActionComponent(org.hl7.fhir.r5.model.TestScript.TestActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.TestActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TestActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    if (src.hasAssert()) tgt.setAssert(convertSetupActionAssertComponent(src.getAssert()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.r5.model.TestScript.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent convertTeardownActionComponent(org.hl7.fhir.r5.model.TestScript.TeardownActionComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent tgt = new org.hl7.fhir.dstu3.model.TestScript.TeardownActionComponent();
+    copyElement(src, tgt);
+    if (src.hasOperation()) tgt.setOperation(convertSetupActionOperationComponent(src.getOperation()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> convertFilterOperator(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.ValueSet.FilterOperator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.FilterOperator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.FilterOperatorEnumFactory());
+    VersionConvertor_30_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.EQUAL);
+          break;
+        case ISA:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.ISA);
+          break;
+        case DESCENDENTOF:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.DESCENDENTOF);
+          break;
+        case ISNOTA:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.ISNOTA);
+          break;
+        case REGEX:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.REGEX);
+          break;
+        case IN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.IN);
+          break;
+        case NOTIN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.NOTIN);
+          break;
+        case GENERALIZES:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.GENERALIZES);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.EXISTS);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.FilterOperator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.dstu3.model.Resource src, boolean nullOk) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.dstu3.model.Parameters)
+      return Parameters30_50.convertParameters((org.hl7.fhir.dstu3.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ActivityDefinition)
+      return ActivityDefinition30_50.convertActivityDefinition((org.hl7.fhir.dstu3.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AllergyIntolerance)
+      return AllergyIntolerance30_50.convertAllergyIntolerance((org.hl7.fhir.dstu3.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Appointment)
+      return Appointment30_50.convertAppointment((org.hl7.fhir.dstu3.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AppointmentResponse)
+      return AppointmentResponse30_50.convertAppointmentResponse((org.hl7.fhir.dstu3.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.AuditEvent)
+      return AuditEvent30_50.convertAuditEvent((org.hl7.fhir.dstu3.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Basic)
+      return Basic30_50.convertBasic((org.hl7.fhir.dstu3.model.Basic) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Binary)
+      return Binary30_50.convertBinary((org.hl7.fhir.dstu3.model.Binary) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.BodySite)
+      return BodySite30_50.convertBodySite((org.hl7.fhir.dstu3.model.BodySite) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Bundle)
+      return Bundle30_50.convertBundle((org.hl7.fhir.dstu3.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CapabilityStatement)
+      return CapabilityStatement30_50.convertCapabilityStatement((org.hl7.fhir.dstu3.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CarePlan)
+      return CarePlan30_50.convertCarePlan((org.hl7.fhir.dstu3.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CareTeam)
+      return CareTeam30_50.convertCareTeam((org.hl7.fhir.dstu3.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ClinicalImpression)
+      return ClinicalImpression30_50.convertClinicalImpression((org.hl7.fhir.dstu3.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CodeSystem)
+      return CodeSystem30_50.convertCodeSystem((org.hl7.fhir.dstu3.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Communication)
+      return Communication30_50.convertCommunication((org.hl7.fhir.dstu3.model.Communication) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.CompartmentDefinition)
+      return CompartmentDefinition30_50.convertCompartmentDefinition((org.hl7.fhir.dstu3.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Composition)
+      return Composition30_50.convertComposition((org.hl7.fhir.dstu3.model.Composition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ConceptMap)
+      return ConceptMap30_50.convertConceptMap((org.hl7.fhir.dstu3.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Condition)
+      return Condition30_50.convertCondition((org.hl7.fhir.dstu3.model.Condition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Consent)
+      return Consent30_50.convertConsent((org.hl7.fhir.dstu3.model.Consent) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DataElement)
+      return DataElement30_50.convertDataElement((org.hl7.fhir.dstu3.model.DataElement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DetectedIssue)
+      return DetectedIssue30_50.convertDetectedIssue((org.hl7.fhir.dstu3.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DeviceUseStatement)
+      return DeviceUseStatement30_50.convertDeviceUseStatement((org.hl7.fhir.dstu3.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DiagnosticReport)
+      return DiagnosticReport30_50.convertDiagnosticReport((org.hl7.fhir.dstu3.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.DocumentReference)
+      return DocumentReference30_50.convertDocumentReference((org.hl7.fhir.dstu3.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Encounter)
+      return Encounter30_50.convertEncounter((org.hl7.fhir.dstu3.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Endpoint)
+      return Endpoint30_50.convertEndpoint((org.hl7.fhir.dstu3.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.EpisodeOfCare)
+      return EpisodeOfCare30_50.convertEpisodeOfCare((org.hl7.fhir.dstu3.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ExpansionProfile)
+      return ExpansionProfile30_50.convertExpansionProfile((org.hl7.fhir.dstu3.model.ExpansionProfile) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.FamilyMemberHistory)
+      return FamilyMemberHistory30_50.convertFamilyMemberHistory((org.hl7.fhir.dstu3.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Flag) return Flag30_50.convertFlag((org.hl7.fhir.dstu3.model.Flag) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Goal) return Goal30_50.convertGoal((org.hl7.fhir.dstu3.model.Goal) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.GraphDefinition)
+      return GraphDefinition30_50.convertGraphDefinition((org.hl7.fhir.dstu3.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Group)
+      return Group30_50.convertGroup((org.hl7.fhir.dstu3.model.Group) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.HealthcareService)
+      return HealthcareService30_50.convertHealthcareService((org.hl7.fhir.dstu3.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ImagingStudy)
+      return ImagingStudy30_50.convertImagingStudy((org.hl7.fhir.dstu3.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Immunization)
+      return Immunization30_50.convertImmunization((org.hl7.fhir.dstu3.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ImplementationGuide)
+      return ImplementationGuide30_50.convertImplementationGuide((org.hl7.fhir.dstu3.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Library)
+      return Library30_50.convertLibrary((org.hl7.fhir.dstu3.model.Library) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Linkage)
+      return Linkage30_50.convertLinkage((org.hl7.fhir.dstu3.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ListResource)
+      return List30_50.convertList((org.hl7.fhir.dstu3.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Location)
+      return Location30_50.convertLocation((org.hl7.fhir.dstu3.model.Location) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Measure)
+      return Measure30_50.convertMeasure((org.hl7.fhir.dstu3.model.Measure) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Media)
+      return Media30_50.convertMedia((org.hl7.fhir.dstu3.model.Media) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Medication)
+      return Medication30_50.convertMedication((org.hl7.fhir.dstu3.model.Medication) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationAdministration)
+      return MedicationAdministration30_50.convertMedicationAdministration((org.hl7.fhir.dstu3.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationDispense)
+      return MedicationDispense30_50.convertMedicationDispense((org.hl7.fhir.dstu3.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationRequest)
+      return MedicationRequest30_50.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MedicationStatement)
+      return MedicationStatement30_50.convertMedicationStatement((org.hl7.fhir.dstu3.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MessageDefinition)
+      return MessageDefinition30_50.convertMessageDefinition((org.hl7.fhir.dstu3.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.MessageHeader)
+      return MessageHeader30_50.convertMessageHeader((org.hl7.fhir.dstu3.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.NamingSystem)
+      return NamingSystem30_50.convertNamingSystem((org.hl7.fhir.dstu3.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Observation)
+      return Observation30_50.convertObservation((org.hl7.fhir.dstu3.model.Observation) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationDefinition)
+      return OperationDefinition30_50.convertOperationDefinition((org.hl7.fhir.dstu3.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.OperationOutcome)
+      return OperationOutcome30_50.convertOperationOutcome((org.hl7.fhir.dstu3.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Organization)
+      return Organization30_50.convertOrganization((org.hl7.fhir.dstu3.model.Organization) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Patient)
+      return Patient30_50.convertPatient((org.hl7.fhir.dstu3.model.Patient) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PaymentNotice)
+      return PaymentNotice30_50.convertPaymentNotice((org.hl7.fhir.dstu3.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Person)
+      return Person30_50.convertPerson((org.hl7.fhir.dstu3.model.Person) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PlanDefinition)
+      return PlanDefinition30_50.convertPlanDefinition((org.hl7.fhir.dstu3.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Practitioner)
+      return Practitioner30_50.convertPractitioner((org.hl7.fhir.dstu3.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.PractitionerRole)
+      return PractitionerRole30_50.convertPractitionerRole((org.hl7.fhir.dstu3.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Provenance)
+      return Provenance30_50.convertProvenance((org.hl7.fhir.dstu3.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Questionnaire)
+      return Questionnaire30_50.convertQuestionnaire((org.hl7.fhir.dstu3.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.QuestionnaireResponse)
+      return QuestionnaireResponse30_50.convertQuestionnaireResponse((org.hl7.fhir.dstu3.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RelatedPerson)
+      return RelatedPerson30_50.convertRelatedPerson((org.hl7.fhir.dstu3.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.RiskAssessment)
+      return RiskAssessment30_50.convertRiskAssessment((org.hl7.fhir.dstu3.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Schedule)
+      return Schedule30_50.convertSchedule((org.hl7.fhir.dstu3.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SearchParameter)
+      return SearchParameter30_50.convertSearchParameter((org.hl7.fhir.dstu3.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Sequence)
+      return Sequence30_50.convertSequence((org.hl7.fhir.dstu3.model.Sequence) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Slot) return Slot30_50.convertSlot((org.hl7.fhir.dstu3.model.Slot) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Specimen)
+      return Specimen30_50.convertSpecimen((org.hl7.fhir.dstu3.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StructureDefinition)
+      return StructureDefinition30_50.convertStructureDefinition((org.hl7.fhir.dstu3.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.StructureMap)
+      return StructureMap30_50.convertStructureMap((org.hl7.fhir.dstu3.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.Substance)
+      return Substance30_50.convertSubstance((org.hl7.fhir.dstu3.model.Substance) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.SupplyDelivery)
+      return SupplyDelivery30_50.convertSupplyDelivery((org.hl7.fhir.dstu3.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TestReport)
+      return TestReport30_50.convertTestReport((org.hl7.fhir.dstu3.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.TestScript)
+      return TestScript30_50.convertTestScript((org.hl7.fhir.dstu3.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.dstu3.model.ValueSet)
+      return ValueSet30_50.convertValueSet((org.hl7.fhir.dstu3.model.ValueSet) src);
+    if (!nullOk) throw new FHIRException("Unknown resource " + src.fhirType());
+    else return null;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src, boolean nullOk) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Parameters) {
+      if (((org.hl7.fhir.r5.model.Parameters) src).hasParameter("profile-url"))
+        return ExpansionProfile30_50.convertExpansionProfile((org.hl7.fhir.r5.model.Parameters) src);
+      else return Parameters30_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
+    }
+    if (src instanceof org.hl7.fhir.r5.model.ActivityDefinition)
+      return ActivityDefinition30_50.convertActivityDefinition((org.hl7.fhir.r5.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.AllergyIntolerance)
+      return AllergyIntolerance30_50.convertAllergyIntolerance((org.hl7.fhir.r5.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Appointment)
+      return Appointment30_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
+      return AppointmentResponse30_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
+      return AuditEvent30_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r5.model.Basic) return Basic30_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r5.model.Binary)
+      return Binary30_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r5.model.BodyStructure)
+      return BodySite30_50.convertBodySite((org.hl7.fhir.r5.model.BodyStructure) src);
+    if (src instanceof org.hl7.fhir.r5.model.Bundle)
+      return Bundle30_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
+      return CapabilityStatement30_50.convertCapabilityStatement((org.hl7.fhir.r5.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.CarePlan)
+      return CarePlan30_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r5.model.CareTeam)
+      return CareTeam30_50.convertCareTeam((org.hl7.fhir.r5.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.r5.model.ClinicalImpression)
+      return ClinicalImpression30_50.convertClinicalImpression((org.hl7.fhir.r5.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
+      return CodeSystem30_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.Communication)
+      return Communication30_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
+      return CompartmentDefinition30_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Composition)
+      return Composition30_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
+      return ConceptMap30_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.Condition)
+      return Condition30_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Consent)
+      return Consent30_50.convertConsent((org.hl7.fhir.r5.model.Consent) src);
+    if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
+      return DetectedIssue30_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
+      return DeviceUseStatement30_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
+      return DiagnosticReport30_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
+      return DocumentReference30_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r5.model.Encounter)
+      return Encounter30_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r5.model.Endpoint)
+      return Endpoint30_50.convertEndpoint((org.hl7.fhir.r5.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
+      return EpisodeOfCare30_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
+      return FamilyMemberHistory30_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r5.model.Flag) return Flag30_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r5.model.Goal) return Goal30_50.convertGoal((org.hl7.fhir.r5.model.Goal) src);
+    if (src instanceof org.hl7.fhir.r5.model.GraphDefinition)
+      return GraphDefinition30_50.convertGraphDefinition((org.hl7.fhir.r5.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Group) return Group30_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
+    if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
+      return HealthcareService30_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImagingStudy)
+      return ImagingStudy30_50.convertImagingStudy((org.hl7.fhir.r5.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.r5.model.Immunization)
+      return Immunization30_50.convertImmunization((org.hl7.fhir.r5.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
+      return ImplementationGuide30_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r5.model.Library)
+      return Library30_50.convertLibrary((org.hl7.fhir.r5.model.Library) src);
+    if (src instanceof org.hl7.fhir.r5.model.Linkage)
+      return Linkage30_50.convertLinkage((org.hl7.fhir.r5.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.r5.model.ListResource)
+      return List30_50.convertList((org.hl7.fhir.r5.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r5.model.Location)
+      return Location30_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
+    if (src instanceof org.hl7.fhir.r5.model.Measure)
+      return Measure30_50.convertMeasure((org.hl7.fhir.r5.model.Measure) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
+      return Media30_50.convertMedia((org.hl7.fhir.r5.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r5.model.Medication)
+      return Medication30_50.convertMedication((org.hl7.fhir.r5.model.Medication) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationAdministration)
+      return MedicationAdministration30_50.convertMedicationAdministration((org.hl7.fhir.r5.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
+      return MedicationDispense30_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationRequest)
+      return MedicationRequest30_50.convertMedicationRequest((org.hl7.fhir.r5.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
+      return MedicationStatement30_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
+    if (src instanceof org.hl7.fhir.r5.model.MessageDefinition)
+      return MessageDefinition30_50.convertMessageDefinition((org.hl7.fhir.r5.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
+      return MessageHeader30_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
+      return NamingSystem30_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.Observation)
+      return Observation30_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
+      return OperationDefinition30_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
+      return OperationOutcome30_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r5.model.Organization)
+      return Organization30_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r5.model.Patient)
+      return Patient30_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r5.model.PaymentNotice)
+      return PaymentNotice30_50.convertPaymentNotice((org.hl7.fhir.r5.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.r5.model.Person)
+      return Person30_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
+    if (src instanceof org.hl7.fhir.r5.model.PlanDefinition)
+      return PlanDefinition30_50.convertPlanDefinition((org.hl7.fhir.r5.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Practitioner)
+      return Practitioner30_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r5.model.PractitionerRole)
+      return PractitionerRole30_50.convertPractitionerRole((org.hl7.fhir.r5.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.r5.model.Provenance)
+      return Provenance30_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
+      return Questionnaire30_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
+      return QuestionnaireResponse30_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.RelatedPerson)
+      return RelatedPerson30_50.convertRelatedPerson((org.hl7.fhir.r5.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
+      return RiskAssessment30_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r5.model.Schedule)
+      return Schedule30_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
+      return SearchParameter30_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r5.model.MolecularSequence)
+      return Sequence30_50.convertSequence((org.hl7.fhir.r5.model.MolecularSequence) src);
+    if (src instanceof org.hl7.fhir.r5.model.Slot) return Slot30_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r5.model.Specimen)
+      return Specimen30_50.convertSpecimen((org.hl7.fhir.r5.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
+      return StructureDefinition30_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureMap)
+      return StructureMap30_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.Substance)
+      return Substance30_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
+      return SupplyDelivery30_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r5.model.TestReport)
+      return TestReport30_50.convertTestReport((org.hl7.fhir.r5.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.TestScript)
+      return TestScript30_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r5.model.ValueSet)
+      return ValueSet30_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
+    if (!nullOk) throw new FHIRException("Unknown resource " + src.fhirType());
+    else return null;
+  }
+
+  public static TerminologyCapabilities convertTerminologyCapabilities(Parameters src, boolean b) {
+    TerminologyCapabilities res = new TerminologyCapabilities();
+    for (ParametersParameterComponent p : src.getParameter()) {
+      if (p.getName().equals("system")) res.addCodeSystem().setUri(p.getValue().primitiveValue());
+      if (p.getName().equals("expansion.parameter"))
+        res.getExpansion().addParameter().setName(p.getValue().primitiveValue());
+    }
+    return res;
+  }
+
+  public static boolean convertsResource(String rt) {
+    return Utilities.existsInList(rt, "Parameters", "ActivityDefinition", "AllergyIntolerance", "Appointment", "AppointmentResponse", "AuditEvent", "Basic", "Binary", "BodyStructure", "Bundle", "CapabilityStatement", "CarePlan", "CareTeam", "ClinicalImpression", "CodeSystem", "Communication", "CompartmentDefinition", "Composition", "ConceptMap", "Condition", "Consent", "DetectedIssue", "DeviceUseStatement", "DiagnosticReport", "DocumentReference", "Encounter", "Endpoint", "EpisodeOfCare", "FamilyMemberHistory", "Flag", "Goal", "GraphDefinition", "Group", "HealthcareService", "ImagingStudy", "Immunization", "ImplementationGuide", "Library", "Linkage", "ListResource", "Location", "Media", "Medication", "MedicationAdministration", "MedicationDispense", "MedicationRequest", "MedicationStatement", "MessageDefinition", "MessageHeader", "NamingSystem", "Observation", "OperationDefinition", "OperationOutcome", "Organization", "Patient", "PaymentNotice", "Person", "PlanDefinition", "Practitioner", "PractitionerRole", "ProcessRequest", "Questionnaire", "QuestionnaireResponse", "RelatedPerson", "RiskAssessment", "Schedule", "SearchParameter", "Sequence", "Slot", "Specimen", "StructureDefinition", "StructureMap", "Subscription", "Substance", "SupplyDelivery", "TestReport", "TestScript", "ValueSet");
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertor_40_50.java
@@ -1,12 +1,5 @@
 package org.hl7.fhir.convertors;
 
-
-/*
- *   public static final String EXT_JSON_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-json-type"; 
-  public static final String EXT_RDF_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-rdf-type"; 
-  public static final String EXT_XML_TYPE = "http://hl7.org/fhir/StructureDefinition/structuredefinition-xml-type"; 
-
- */
 import org.hl7.fhir.convertors.conv40_50.*;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.model.CodeableReference;
@@ -17,4450 +10,3915 @@ import java.util.stream.Collectors;
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
 
-  Redistribution and use in source and binary forms, with or without modification, 
+  Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright notice, this 
+ * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+ * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
- * Neither the name of HL7 nor the names of its contributors may be used to 
-     endorse or promote products derived from this software without specific 
+ * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
      prior written permission.
 
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-
  */
-// Generated on Sun, Feb 24, 2019 11:37+1100 for FHIR v4.0.0
+
 public class VersionConvertor_40_50 {
-
-    static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
-        boolean ok = false;
-        for (String s : extensionsToIgnore) if (s.equals(url))
-            ok = true;
-        return ok;
-    }
-
-    protected static void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    protected static void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
-                tgt.addExtension(convertExtension(e));
-            }
-        }
-    }
-
-    protected static void copyEnumeration(org.hl7.fhir.r4.model.Enumeration<?> src, org.hl7.fhir.r5.model.Enumeration<?> tgt) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
-            tgt.addExtension(convertExtension(e));
-        }
-    }
-
-    protected static void copyEnumeration(org.hl7.fhir.r5.model.Enumeration<?> src, org.hl7.fhir.r4.model.Enumeration<?> tgt) throws FHIRException {
-        if (src.hasId()) tgt.setId(src.getId());
-        for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
-            tgt.addExtension(convertExtension(e));
-        }
-    }
-
-    protected static void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    protected static void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    protected static void copyBackboneElement(org.hl7.fhir.r5.model.BackboneType src, org.hl7.fhir.r4.model.BackboneType tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    protected static void copyBackboneElement(org.hl7.fhir.r4.model.BackboneType src, org.hl7.fhir.r5.model.BackboneType tgt) throws FHIRException {
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
-            tgt.addModifierExtension(convertExtension(e));
-        }
-    }
-
-    protected static org.hl7.fhir.utilities.xhtml.XhtmlNode convertXhtml(org.hl7.fhir.utilities.xhtml.XhtmlNode src) throws FHIRException {
-        return src;
-    }
-
-    public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
-        org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
-        org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CanonicalType convertCanonical(org.hl7.fhir.r4.model.CanonicalType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CanonicalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CanonicalType(src.getValue()) : new org.hl7.fhir.r5.model.CanonicalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CanonicalType convertCanonical(org.hl7.fhir.r5.model.CanonicalType src) throws FHIRException {
-        org.hl7.fhir.r4.model.CanonicalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CanonicalType(src.getValue()) : new org.hl7.fhir.r4.model.CanonicalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValue()) : new org.hl7.fhir.r5.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValue()) : new org.hl7.fhir.r4.model.DateType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
-        org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValue()) : new org.hl7.fhir.r5.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
-        org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r4.model.InstantType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValueAsString()) : new org.hl7.fhir.r5.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Integer64Type convertUnsignedIntToInteger64(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.Integer64Type tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Integer64Type(src.getValueAsString()) : new org.hl7.fhir.r5.model.Integer64Type();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UnsignedIntType convertInteger64ToUnsignedInt(org.hl7.fhir.r5.model.Integer64Type src) throws FHIRException {
-        org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValueAsString()) : new org.hl7.fhir.r4.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
-        org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValueAsString()) : new org.hl7.fhir.r4.model.IntegerType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
-        org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
-      org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
-      copyElement(src, tgt);
-      return tgt;
+  static public boolean isExemptExtension(String url, String[] extensionsToIgnore) {
+    boolean ok = false;
+    for (String s : extensionsToIgnore) if (s.equals(url)) ok = true;
+    return ok;
   }
 
-    public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
-        org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
-        org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UrlType convertUrl(org.hl7.fhir.r4.model.UrlType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UrlType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UrlType(src.getValue()) : new org.hl7.fhir.r5.model.UrlType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UrlType convertUrl(org.hl7.fhir.r5.model.UrlType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UrlType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UrlType(src.getValue()) : new org.hl7.fhir.r4.model.UrlType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
-        org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
-        copyElement(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
-        copyElement(src, tgt);
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUri(src.getUrlElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(convertXhtml(src.getDiv()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
-        copyElement(src, tgt);
-        if (src.hasStatus())
-            tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
-        if (src.hasDiv())
-            tgt.setDiv(convertXhtml(src.getDiv()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case GENERATED:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
-                break;
-            case EXTENSIONS:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
-                break;
-            case ADDITIONAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
-                break;
-            case EMPTY:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.getLine().add(convertString(t));
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertAddressUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setTypeElement(convertAddressType(src.getTypeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.getLine().add(convertString(t));
-        if (src.hasCity())
-            tgt.setCityElement(convertString(src.getCityElement()));
-        if (src.hasDistrict())
-            tgt.setDistrictElement(convertString(src.getDistrictElement()));
-        if (src.hasState())
-            tgt.setStateElement(convertString(src.getStateElement()));
-        if (src.hasPostalCode())
-            tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
-        if (src.hasCountry())
-            tgt.setCountryElement(convertString(src.getCountryElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
-                break;
-            case BILLING:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.BILLING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
-                break;
-            case BILLING:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.BILLING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case POSTAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
-                break;
-            case PHYSICAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
-                break;
-            case BOTH:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertMarkdown(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
-        copyElement(src, tgt);
-        if (src.hasAuthor())
-            tgt.setAuthor(convertType(src.getAuthor()));
-        if (src.hasTime())
-            tgt.setTimeElement(convertDateTime(src.getTimeElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertMarkdown(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUrl(src.getUrlElement()));
-        if (src.hasSize())
-            tgt.setSizeElement(convertUnsignedIntToInteger64(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
-        copyElement(src, tgt);
-        if (src.hasContentType())
-            tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUrl(src.getUrlElement()));
-        if (src.hasSize())
-            tgt.setSizeElement(convertInteger64ToUnsignedInt(src.getSizeElement()));
-        if (src.hasHash())
-            tgt.setHashElement(convertBase64Binary(src.getHashElement()));
-        if (src.hasTitle())
-            tgt.setTitleElement(convertString(src.getTitleElement()));
-        if (src.hasCreation())
-            tgt.setCreationElement(convertDateTime(src.getCreationElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasVersion())
-            tgt.setVersionElement(convertString(src.getVersionElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasUserSelected())
-            tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactDetail convertContactDetail(org.hl7.fhir.r4.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ContactDetail tgt = new org.hl7.fhir.r5.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r4.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactDetail convertContactDetail(org.hl7.fhir.r5.model.ContactDetail src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ContactDetail tgt = new org.hl7.fhir.r4.model.ContactDetail();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r5.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
-        copyElement(src, tgt);
-        if (src.hasSystem())
-            tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertContactPointUse(src.getUseElement()));
-        if (src.hasRank())
-            tgt.setRankElement(convertPositiveInt(src.getRankElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case PHONE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
-                break;
-            case FAX:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
-                break;
-            case EMAIL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
-                break;
-            case PAGER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
-                break;
-            case URL:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
-                break;
-            case SMS:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.SMS);
-                break;
-            case OTHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case HOME:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
-                break;
-            case WORK:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
-                break;
-            case MOBILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Contributor convertContributor(org.hl7.fhir.r4.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Contributor tgt = new org.hl7.fhir.r5.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r4.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Contributor convertContributor(org.hl7.fhir.r5.model.Contributor src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Contributor tgt = new org.hl7.fhir.r4.model.Contributor();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertContributorType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        for (org.hl7.fhir.r5.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Contributor.ContributorTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case AUTHOR:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.AUTHOR);
-                break;
-            case EDITOR:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.EDITOR);
-                break;
-            case REVIEWER:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.REVIEWER);
-                break;
-            case ENDORSER:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.ENDORSER);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement convertDataRequirement(org.hl7.fhir.r4.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement tgt = new org.hl7.fhir.r5.model.DataRequirement();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
-        for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        if (src.hasSubject())
-            tgt.setSubject(convertType(src.getSubject()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getMustSupport()) tgt.getMustSupport().add(convertString(t));
-        for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter()) tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter()) tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        if (src.hasLimit())
-            tgt.setLimitElement(convertPositiveInt(src.getLimitElement()));
-        for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent t : src.getSort()) tgt.addSort(convertDataRequirementSortComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement convertDataRequirement(org.hl7.fhir.r5.model.DataRequirement src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement tgt = new org.hl7.fhir.r4.model.DataRequirement();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(src.getType().toCode());
-        for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        if (src.hasSubject())
-            tgt.setSubject(convertType(src.getSubject()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getMustSupport()) tgt.getMustSupport().add(convertString(t));
-        for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter()) tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
-        for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter()) tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
-        if (src.hasLimit())
-            tgt.setLimitElement(convertPositiveInt(src.getLimitElement()));
-        for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent t : src.getSort()) tgt.addSort(convertDataRequirementSortComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasSearchParam())
-            tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
-        if (src.hasValueSet())
-            tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasSearchParam())
-            tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
-        if (src.hasValueSet())
-            tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasSearchParam())
-            tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasSearchParam())
-            tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent convertDataRequirementSortComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertSortDirection(src.getDirectionElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent convertDataRequirementSortComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasDirection())
-            tgt.setDirectionElement(convertSortDirection(src.getDirectionElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> convertSortDirection(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.DataRequirement.SortDirectionEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ASCENDING:
-                tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.ASCENDING);
-                break;
-            case DESCENDING:
-                tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.DESCENDING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> convertSortDirection(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.DataRequirement.SortDirectionEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ASCENDING:
-                tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.ASCENDING);
-                break;
-            case DESCENDING:
-                tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.DESCENDING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Dosage convertDosage(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
-        copyBackboneElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r4.model.CodeableConcept t : src.getAdditionalInstruction()) tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        for (org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent t : src.getDoseAndRate()) tgt.addDoseAndRate(convertDosageDoseAndRateComponent(t));
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Dosage convertDosage(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
-        copyBackboneElement(src, tgt);
-        if (src.hasSequence())
-            tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        for (org.hl7.fhir.r5.model.CodeableConcept t : src.getAdditionalInstruction()) tgt.addAdditionalInstruction(convertCodeableConcept(t));
-        if (src.hasPatientInstruction())
-            tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertTiming(src.getTiming()));
-        if (src.hasAsNeeded())
-            tgt.setAsNeeded(convertType(src.getAsNeeded()));
-        if (src.hasSite())
-            tgt.setSite(convertCodeableConcept(src.getSite()));
-        if (src.hasRoute())
-            tgt.setRoute(convertCodeableConcept(src.getRoute()));
-        if (src.hasMethod())
-            tgt.setMethod(convertCodeableConcept(src.getMethod()));
-        for (org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent t : src.getDoseAndRate()) tgt.addDoseAndRate(convertDosageDoseAndRateComponent(t));
-        if (src.hasMaxDosePerPeriod())
-            tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
-        if (src.hasMaxDosePerAdministration())
-            tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
-        if (src.hasMaxDosePerLifetime())
-            tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent convertDosageDoseAndRateComponent(org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent tgt = new org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasDose())
-            tgt.setDose(convertType(src.getDose()));
-        if (src.hasRate())
-            tgt.setRate(convertType(src.getRate()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent convertDosageDoseAndRateComponent(org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent tgt = new org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasDose())
-            tgt.setDose(convertType(src.getDose()));
-        if (src.hasRate())
-            tgt.setRate(convertType(src.getRate()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
-        copyQuantity(src, tgt);
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Expression convertExpression(org.hl7.fhir.r4.model.Expression src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Expression tgt = new org.hl7.fhir.r5.model.Expression();
-        copyElement(src, tgt);
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertId(src.getNameElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasReference())
-            tgt.setReferenceElement(convertUri(src.getReferenceElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Expression convertExpression(org.hl7.fhir.r5.model.Expression src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Expression tgt = new org.hl7.fhir.r4.model.Expression();
-        copyElement(src, tgt);
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertId(src.getNameElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasReference())
-            tgt.setReferenceElement(convertUri(src.getReferenceElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.getGiven().add(convertString(t));
-        for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.getPrefix().add(convertString(t));
-        for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.getSuffix().add(convertString(t));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertNameUse(src.getUseElement()));
-        if (src.hasText())
-            tgt.setTextElement(convertString(src.getTextElement()));
-        if (src.hasFamily())
-            tgt.setFamilyElement(convertString(src.getFamilyElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.getGiven().add(convertString(t));
-        for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.getPrefix().add(convertString(t));
-        for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.getSuffix().add(convertString(t));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
-                break;
-            case NICKNAME:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
-                break;
-            case ANONYMOUS:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
-                break;
-            case MAIDEN:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
-        copyElement(src, tgt);
-        if (src.hasUse())
-            tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasValue())
-            tgt.setValueElement(convertString(src.getValueElement()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertPeriod(src.getPeriod()));
-        if (src.hasAssigner())
-            tgt.setAssigner(convertReference(src.getAssigner()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case USUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
-                break;
-            case OFFICIAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
-                break;
-            case TEMP:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
-                break;
-            case SECONDARY:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
-                break;
-            case OLD:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OLD);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.MarketingStatus convertMarketingStatus(org.hl7.fhir.r4.model.MarketingStatus src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.MarketingStatus tgt = new org.hl7.fhir.r5.model.MarketingStatus();
-        copyBackboneElement(src, tgt);
-        if (src.hasCountry())
-            tgt.setCountry(convertCodeableConcept(src.getCountry()));
-        if (src.hasJurisdiction())
-            tgt.setJurisdiction(convertCodeableConcept(src.getJurisdiction()));
-        if (src.hasStatus())
-            tgt.setStatus(convertCodeableConcept(src.getStatus()));
-        if (src.hasDateRange())
-            tgt.setDateRange(convertPeriod(src.getDateRange()));
-        if (src.hasRestoreDate())
-            tgt.setRestoreDateElement(convertDateTime(src.getRestoreDateElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.MarketingStatus convertMarketingStatus(org.hl7.fhir.r5.model.MarketingStatus src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.MarketingStatus tgt = new org.hl7.fhir.r4.model.MarketingStatus();
-        copyBackboneElement(src, tgt);
-        if (src.hasCountry())
-            tgt.setCountry(convertCodeableConcept(src.getCountry()));
-        if (src.hasJurisdiction())
-            tgt.setJurisdiction(convertCodeableConcept(src.getJurisdiction()));
-        if (src.hasStatus())
-            tgt.setStatus(convertCodeableConcept(src.getStatus()));
-        if (src.hasDateRange())
-            tgt.setDateRange(convertPeriod(src.getDateRange()));
-        if (src.hasRestoreDate())
-            tgt.setRestoreDateElement(convertDateTime(src.getRestoreDateElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        if (src.hasSource())
-            tgt.setSourceElement(convertUri(src.getSourceElement()));
-        for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
-        copyElement(src, tgt);
-        if (src.hasVersionId())
-            tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
-        if (src.hasLastUpdated())
-            tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
-        if (src.hasSource())
-            tgt.setSourceElement(convertUri(src.getSourceElement()));
-        for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
-        for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCurrencyElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasCurrency())
-            tgt.setCurrencyElement(convertCode(src.getCurrencyElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r4.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ParameterDefinition tgt = new org.hl7.fhir.r5.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
-        if (src.hasProfile())
-            tgt.setProfileElement(convertCanonical(src.getProfileElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r5.model.ParameterDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ParameterDefinition tgt = new org.hl7.fhir.r4.model.ParameterDefinition();
-        copyElement(src, tgt);
-        if (src.hasName())
-            tgt.setNameElement(convertCode(src.getNameElement()));
-        if (src.hasUse())
-            tgt.setUseElement(convertParameterUse(src.getUseElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertInteger(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasDocumentation())
-            tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
-        if (src.hasType())
-            tgt.setType(src.getType().toCode());
-        if (src.hasProfile())
-            tgt.setProfileElement(convertCanonical(src.getProfileElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> convertParameterUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.OperationParameterUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ParameterDefinition.ParameterUseEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case IN:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
-                break;
-            case OUT:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.OUT);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
-        copyElement(src, tgt);
-        if (src.hasStart())
-            tgt.setStartElement(convertDateTime(src.getStartElement()));
-        if (src.hasEnd())
-            tgt.setEndElement(convertDateTime(src.getEndElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Population convertPopulation(org.hl7.fhir.r4.model.Population src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Population tgt = new org.hl7.fhir.r5.model.Population();
-        copyBackboneElement(src, tgt);
-        if (src.hasAge())
-            tgt.setAge(convertType(src.getAge()));
-        if (src.hasGender())
-            tgt.setGender(convertCodeableConcept(src.getGender()));
-        if (src.hasRace())
-            tgt.setRace(convertCodeableConcept(src.getRace()));
-        if (src.hasPhysiologicalCondition())
-            tgt.setPhysiologicalCondition(convertCodeableConcept(src.getPhysiologicalCondition()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Population convertPopulation(org.hl7.fhir.r5.model.Population src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Population tgt = new org.hl7.fhir.r4.model.Population();
-        copyBackboneElement(src, tgt);
-        if (src.hasAge())
-            tgt.setAge(convertType(src.getAge()));
-        if (src.hasGender())
-            tgt.setGender(convertCodeableConcept(src.getGender()));
-        if (src.hasRace())
-            tgt.setRace(convertCodeableConcept(src.getRace()));
-        if (src.hasPhysiologicalCondition())
-            tgt.setPhysiologicalCondition(convertCodeableConcept(src.getPhysiologicalCondition()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ProdCharacteristic convertProdCharacteristic(org.hl7.fhir.r4.model.ProdCharacteristic src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ProdCharacteristic tgt = new org.hl7.fhir.r5.model.ProdCharacteristic();
-        copyBackboneElement(src, tgt);
-        if (src.hasHeight())
-            tgt.setHeight(convertQuantity(src.getHeight()));
-        if (src.hasWidth())
-            tgt.setWidth(convertQuantity(src.getWidth()));
-        if (src.hasDepth())
-            tgt.setDepth(convertQuantity(src.getDepth()));
-        if (src.hasWeight())
-            tgt.setWeight(convertQuantity(src.getWeight()));
-        if (src.hasNominalVolume())
-            tgt.setNominalVolume(convertQuantity(src.getNominalVolume()));
-        if (src.hasExternalDiameter())
-            tgt.setExternalDiameter(convertQuantity(src.getExternalDiameter()));
-        if (src.hasShape())
-            tgt.setShapeElement(convertString(src.getShapeElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getColor()) tgt.getColor().add(convertString(t));
-        for (org.hl7.fhir.r4.model.StringType t : src.getImprint()) tgt.getImprint().add(convertString(t));
-        for (org.hl7.fhir.r4.model.Attachment t : src.getImage()) tgt.addImage(convertAttachment(t));
-        if (src.hasScoring())
-            tgt.setScoring(convertCodeableConcept(src.getScoring()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ProdCharacteristic convertProdCharacteristic(org.hl7.fhir.r5.model.ProdCharacteristic src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ProdCharacteristic tgt = new org.hl7.fhir.r4.model.ProdCharacteristic();
-        copyBackboneElement(src, tgt);
-        if (src.hasHeight())
-            tgt.setHeight(convertQuantity(src.getHeight()));
-        if (src.hasWidth())
-            tgt.setWidth(convertQuantity(src.getWidth()));
-        if (src.hasDepth())
-            tgt.setDepth(convertQuantity(src.getDepth()));
-        if (src.hasWeight())
-            tgt.setWeight(convertQuantity(src.getWeight()));
-        if (src.hasNominalVolume())
-            tgt.setNominalVolume(convertQuantity(src.getNominalVolume()));
-        if (src.hasExternalDiameter())
-            tgt.setExternalDiameter(convertQuantity(src.getExternalDiameter()));
-        if (src.hasShape())
-            tgt.setShapeElement(convertString(src.getShapeElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getColor()) tgt.getColor().add(convertString(t));
-        for (org.hl7.fhir.r5.model.StringType t : src.getImprint()) tgt.getImprint().add(convertString(t));
-        for (org.hl7.fhir.r5.model.Attachment t : src.getImage()) tgt.addImage(convertAttachment(t));
-        if (src.hasScoring())
-            tgt.setScoring(convertCodeableConcept(src.getScoring()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ProductShelfLife convertProductShelfLife(org.hl7.fhir.r4.model.ProductShelfLife src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ProductShelfLife tgt = new org.hl7.fhir.r5.model.ProductShelfLife();
-        copyBackboneElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasPeriod())
-            tgt.setPeriod(convertQuantity(src.getPeriod()));
-        for (org.hl7.fhir.r4.model.CodeableConcept t : src.getSpecialPrecautionsForStorage()) tgt.addSpecialPrecautionsForStorage(convertCodeableConcept(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ProductShelfLife convertProductShelfLife(org.hl7.fhir.r5.model.ProductShelfLife src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ProductShelfLife tgt = new org.hl7.fhir.r4.model.ProductShelfLife();
-        copyBackboneElement(src, tgt);
-        if (src.hasType())
-            tgt.setType(convertCodeableConcept(src.getType()));
-        if (src.hasPeriodQuantity())
-            tgt.setPeriod(convertQuantity(src.getPeriodQuantity()));
-        for (org.hl7.fhir.r5.model.CodeableConcept t : src.getSpecialPrecautionsForStorage()) tgt.addSpecialPrecautionsForStorage(convertCodeableConcept(t));
-        return tgt;
-    }
-
-    public static void copyQuantity(org.hl7.fhir.r4.model.Quantity src, org.hl7.fhir.r5.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnit(src.getUnit());
-        if (src.hasSystem())
-            tgt.setSystem(src.getSystem());
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-    }
-
-    public static void copyQuantity(org.hl7.fhir.r5.model.Quantity src, org.hl7.fhir.r4.model.Quantity tgt) throws FHIRException {
-        if (src == null || tgt == null)
-            return;
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValue(src.getValue());
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnit(src.getUnit());
-        if (src.hasSystem())
-            tgt.setSystem(src.getSystem());
-        if (src.hasCode())
-            tgt.setCode(src.getCode());
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case LESS_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
-                break;
-            case LESS_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
-                break;
-            case GREATER_OR_EQUAL:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
-                break;
-            case GREATER_THAN:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
-        copyElement(src, tgt);
-        if (src.hasLow())
-            tgt.setLow(convertSimpleQuantity(src.getLow()));
-        if (src.hasHigh())
-            tgt.setHigh(convertSimpleQuantity(src.getHigh()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
-        copyElement(src, tgt);
-        if (src.hasNumerator())
-            tgt.setNumerator(convertQuantity(src.getNumerator()));
-        if (src.hasDenominator())
-            tgt.setDenominator(convertQuantity(src.getDenominator()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReferenceElement(convertString(src.getReferenceElement_()));
-        if (src.hasType())
-            tgt.setTypeElement(convertUri(src.getTypeElement()));
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
-        copyElement(src, tgt);
-        if (src.hasReference())
-            tgt.setReferenceElement(convertString(src.getReferenceElement_()));
-        if (src.hasType())
-            tgt.setTypeElement(convertUri(src.getTypeElement()));
-        if (src.hasIdentifier())
-            tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r4.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.RelatedArtifact tgt = new org.hl7.fhir.r5.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitationElement(convertMarkdown(src.getCitationElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUrl(src.getUrlElement()));
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCanonical(src.getResourceElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r5.model.RelatedArtifact src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.RelatedArtifact tgt = new org.hl7.fhir.r4.model.RelatedArtifact();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasDisplay())
-            tgt.setDisplayElement(convertString(src.getDisplayElement()));
-        if (src.hasCitation())
-            tgt.setCitationElement(convertMarkdown(src.getCitationElement()));
-        if (src.hasUrl())
-            tgt.setUrlElement(convertUrl(src.getUrlElement()));
-        if (src.hasDocument())
-            tgt.setDocument(convertAttachment(src.getDocument()));
-        if (src.hasResource())
-            tgt.setResourceElement(convertCanonical(src.getResourceElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case DOCUMENTATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
-                break;
-            case JUSTIFICATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
-                break;
-            case CITATION:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.CITATION);
-                break;
-            case PREDECESSOR:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
-                break;
-            case SUCCESSOR:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
-                break;
-            case DERIVEDFROM:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
-                break;
-            case DEPENDSON:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
-                break;
-            case COMPOSEDOF:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
-        copyElement(src, tgt);
-        if (src.hasOrigin())
-            tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasFactor())
-            tgt.setFactorElement(convertDecimal(src.getFactorElement()));
-        if (src.hasLowerLimit())
-            tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
-        if (src.hasUpperLimit())
-            tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
-        if (src.hasDimensions())
-            tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertString(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertReference(src.getWho()));
-        if (src.hasOnBehalfOf())
-            tgt.setOnBehalfOf(convertReference(src.getOnBehalfOf()));
-        if (src.hasTargetFormat())
-            tgt.setTargetFormatElement(convertCode(src.getTargetFormatElement()));
-        if (src.hasSigFormat())
-            tgt.setSigFormatElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
-        if (src.hasWhen())
-            tgt.setWhenElement(convertInstant(src.getWhenElement()));
-        if (src.hasWho())
-            tgt.setWho(convertReference(src.getWho()));
-        if (src.hasOnBehalfOf())
-            tgt.setOnBehalfOf(convertReference(src.getOnBehalfOf()));
-        if (src.hasTargetFormat())
-            tgt.setTargetFormatElement(convertCode(src.getTargetFormatElement()));
-        if (src.hasSigFormat())
-            tgt.setSigFormatElement(convertCode(src.getSigFormatElement()));
-        if (src.hasData())
-            tgt.setDataElement(convertBase64Binary(src.getDataElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SubstanceAmount convertSubstanceAmount(org.hl7.fhir.r4.model.SubstanceAmount src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.SubstanceAmount tgt = new org.hl7.fhir.r5.model.SubstanceAmount();
-        copyBackboneElement(src, tgt);
-        if (src.hasAmount())
-            tgt.setAmount(convertType(src.getAmount()));
-        if (src.hasAmountType())
-            tgt.setAmountType(convertCodeableConcept(src.getAmountType()));
-        if (src.hasAmountText())
-            tgt.setAmountTextElement(convertString(src.getAmountTextElement()));
-        if (src.hasReferenceRange())
-            tgt.setReferenceRange(convertSubstanceAmountReferenceRangeComponent(src.getReferenceRange()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SubstanceAmount convertSubstanceAmount(org.hl7.fhir.r5.model.SubstanceAmount src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.SubstanceAmount tgt = new org.hl7.fhir.r4.model.SubstanceAmount();
-        copyBackboneElement(src, tgt);
-        if (src.hasAmount())
-            tgt.setAmount(convertType(src.getAmount()));
-        if (src.hasAmountType())
-            tgt.setAmountType(convertCodeableConcept(src.getAmountType()));
-        if (src.hasAmountText())
-            tgt.setAmountTextElement(convertString(src.getAmountTextElement()));
-        if (src.hasReferenceRange())
-            tgt.setReferenceRange(convertSubstanceAmountReferenceRangeComponent(src.getReferenceRange()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent convertSubstanceAmountReferenceRangeComponent(org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent tgt = new org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent();
-        copyElement(src, tgt);
-        if (src.hasLowLimit())
-            tgt.setLowLimit(convertQuantity(src.getLowLimit()));
-        if (src.hasHighLimit())
-            tgt.setHighLimit(convertQuantity(src.getHighLimit()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent convertSubstanceAmountReferenceRangeComponent(org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent tgt = new org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent();
-        copyElement(src, tgt);
-        if (src.hasLowLimit())
-            tgt.setLowLimit(convertQuantity(src.getLowLimit()));
-        if (src.hasHighLimit())
-            tgt.setHighLimit(convertQuantity(src.getHighLimit()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
-        copyBackboneElement(src, tgt);
-        for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.getEvent().add(convertDateTime(t));
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
-        copyBackboneElement(src, tgt);
-        for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.getEvent().add(convertDateTime(t));
-        if (src.hasRepeat())
-            tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
-        if (src.hasCode())
-            tgt.setCode(convertCodeableConcept(src.getCode()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCountElement(convertPositiveInt(src.getCountElement()));
-        if (src.hasCountMax())
-            tgt.setCountMaxElement(convertPositiveInt(src.getCountMaxElement()));
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequencyElement(convertPositiveInt(src.getFrequencyElement()));
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMaxElement(convertPositiveInt(src.getFrequencyMaxElement()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_40_50::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_40_50::convertEventTiming)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.r4.model.TimeType t : src.getTimeOfDay()) tgt.getTimeOfDay().add(convertTime(t));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
-        copyElement(src, tgt);
-        if (src.hasBounds())
-            tgt.setBounds(convertType(src.getBounds()));
-        if (src.hasCount())
-            tgt.setCountElement(convertPositiveInt(src.getCountElement()));
-        if (src.hasCountMax())
-            tgt.setCountMaxElement(convertPositiveInt(src.getCountMaxElement()));
-        if (src.hasDuration())
-            tgt.setDurationElement(convertDecimal(src.getDurationElement()));
-        if (src.hasDurationMax())
-            tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
-        if (src.hasDurationUnit())
-            tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
-        if (src.hasFrequency())
-            tgt.setFrequencyElement(convertPositiveInt(src.getFrequencyElement()));
-        if (src.hasFrequencyMax())
-            tgt.setFrequencyMaxElement(convertPositiveInt(src.getFrequencyMaxElement()));
-        if (src.hasPeriod())
-            tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
-        if (src.hasPeriodMax())
-            tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
-        if (src.hasPeriodUnit())
-            tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
-        tgt.setDayOfWeek(src.getDayOfWeek().stream()
-                .map(VersionConvertor_40_50::convertDayOfWeek)
-                .collect(Collectors.toList()));
-        tgt.setWhen(src.getWhen().stream()
-                .map(VersionConvertor_40_50::convertEventTiming)
-                .collect(Collectors.toList()));
-        for (org.hl7.fhir.r5.model.TimeType t : src.getTimeOfDay()) tgt.getTimeOfDay().add(convertTime(t));
-        if (src.hasOffset())
-            tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case S:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
-                break;
-            case MIN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
-                break;
-            case H:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
-                break;
-            case D:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
-                break;
-            case WK:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
-                break;
-            case MO:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
-                break;
-            case A:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDayOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.DayOfWeekEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MON:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.MON);
-                break;
-            case TUE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.TUE);
-                break;
-            case WED:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.WED);
-                break;
-            case THU:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.THU);
-                break;
-            case FRI:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.FRI);
-                break;
-            case SAT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SAT);
-                break;
-            case SUN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SUN);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN);
-                break;
-            case MORN_EARLY:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN_EARLY);
-                break;
-            case MORN_LATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN_LATE);
-                break;
-            case NOON:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NOON);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT);
-                break;
-            case AFT_EARLY:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT_EARLY);
-                break;
-            case AFT_LATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT_LATE);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE);
-                break;
-            case EVE_EARLY:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE_EARLY);
-                break;
-            case EVE_LATE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE_LATE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case MORN:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN);
-                break;
-            case MORN_EARLY:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN_EARLY);
-                break;
-            case MORN_LATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN_LATE);
-                break;
-            case NOON:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NOON);
-                break;
-            case AFT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT);
-                break;
-            case AFT_EARLY:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT_EARLY);
-                break;
-            case AFT_LATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT_LATE);
-                break;
-            case EVE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE);
-                break;
-            case EVE_EARLY:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE_EARLY);
-                break;
-            case EVE_LATE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE_LATE);
-                break;
-            case NIGHT:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NIGHT);
-                break;
-            case PHS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PHS);
-                break;
-            case HS:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
-                break;
-            case WAKE:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
-                break;
-            case C:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
-                break;
-            case CM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
-                break;
-            case CD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
-                break;
-            case CV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
-                break;
-            case AC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
-                break;
-            case ACM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
-                break;
-            case ACD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
-                break;
-            case ACV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
-                break;
-            case PC:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
-                break;
-            case PCM:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
-                break;
-            case PCD:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
-                break;
-            case PCV:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r4.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.TriggerDefinition tgt = new org.hl7.fhir.r5.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertType(src.getTiming()));
-        for (org.hl7.fhir.r4.model.DataRequirement t : src.getData()) tgt.addData(convertDataRequirement(t));
-        if (src.hasCondition())
-            tgt.setCondition(convertExpression(src.getCondition()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r5.model.TriggerDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.TriggerDefinition tgt = new org.hl7.fhir.r4.model.TriggerDefinition();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
-        if (src.hasName())
-            tgt.setNameElement(convertString(src.getNameElement()));
-        if (src.hasTiming())
-            tgt.setTiming(convertType(src.getTiming()));
-        for (org.hl7.fhir.r5.model.DataRequirement t : src.getData()) tgt.addData(convertDataRequirement(t));
-        if (src.hasCondition())
-            tgt.setCondition(convertExpression(src.getCondition()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATACHANGED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATACHANGED);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TriggerDefinition.TriggerTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case NAMEDEVENT:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NAMEDEVENT);
-                break;
-            case PERIODIC:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.PERIODIC);
-                break;
-            case DATACHANGED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATACHANGED);
-                break;
-            case DATAADDED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAADDED);
-                break;
-            case DATAMODIFIED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAMODIFIED);
-                break;
-            case DATAREMOVED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAREMOVED);
-                break;
-            case DATAACCESSED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSED);
-                break;
-            case DATAACCESSENDED:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.UsageContext convertUsageContext(org.hl7.fhir.r4.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.UsageContext tgt = new org.hl7.fhir.r5.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.UsageContext convertUsageContext(org.hl7.fhir.r5.model.UsageContext src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.UsageContext tgt = new org.hl7.fhir.r4.model.UsageContext();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCode(convertCoding(src.getCode()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
-        copyBackboneElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_40_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasSliceIsConstraining())
-            tgt.setSliceIsConstrainingElement(convertBoolean(src.getSliceIsConstrainingElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.getAlias().add(convertString(t));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType()) tgt.addType(convertTypeRefComponent(t));
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample()) tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.getCondition().add(convertId(t));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason())
-            tgt.setIsModifierReasonElement(convertString(src.getIsModifierReasonElement()));
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
-        copyBackboneElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        tgt.setRepresentation(src.getRepresentation().stream()
-                .map(VersionConvertor_40_50::convertPropertyRepresentation)
-                .collect(Collectors.toList()));
-        if (src.hasSliceName())
-            tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
-        if (src.hasSliceIsConstraining())
-            tgt.setSliceIsConstrainingElement(convertBoolean(src.getSliceIsConstrainingElement()));
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
-        if (src.hasSlicing())
-            tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
-        if (src.hasShort())
-            tgt.setShortElement(convertString(src.getShortElement()));
-        if (src.hasDefinition())
-            tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
-        for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.getAlias().add(convertString(t));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        if (src.hasBase())
-            tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
-        if (src.hasContentReference())
-            tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType()) tgt.addType(convertTypeRefComponent(t));
-        if (src.hasDefaultValue())
-            tgt.setDefaultValue(convertType(src.getDefaultValue()));
-        if (src.hasMeaningWhenMissing())
-            tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
-        if (src.hasOrderMeaning())
-            tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
-        if (src.hasFixed())
-            tgt.setFixed(convertType(src.getFixed()));
-        if (src.hasPattern())
-            tgt.setPattern(convertType(src.getPattern()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample()) tgt.addExample(convertElementDefinitionExampleComponent(t));
-        if (src.hasMinValue())
-            tgt.setMinValue(convertType(src.getMinValue()));
-        if (src.hasMaxValue())
-            tgt.setMaxValue(convertType(src.getMaxValue()));
-        if (src.hasMaxLength())
-            tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
-        for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.getCondition().add(convertId(t));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint()) tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
-        if (src.hasMustSupport())
-            tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
-        if (src.hasIsModifier())
-            tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
-        if (src.hasIsModifierReason())
-            tgt.setIsModifierReasonElement(convertString(src.getIsModifierReasonElement()));
-        if (src.hasIsSummary())
-            tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
-        if (src.hasBinding())
-            tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping()) tgt.addMapping(convertElementDefinitionMappingComponent(t));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case XMLATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
-                break;
-            case XMLTEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
-                break;
-            case TYPEATTR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
-                break;
-            case CDATEXT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
-                break;
-            case XHTML:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XHTML);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
-        copyElement(src, tgt);
-        for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator()) tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasOrdered())
-            tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
-        if (src.hasRules())
-            tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CLOSED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
-                break;
-            case OPEN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
-                break;
-            case OPENATEND:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
-        copyElement(src, tgt);
-        if (src.hasType())
-            tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorTypeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case VALUE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.VALUE);
-                break;
-            case EXISTS:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.EXISTS);
-                break;
-            case PATTERN:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PATTERN);
-                break;
-            case TYPE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.TYPE);
-                break;
-            case PROFILE:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PROFILE);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
-        copyElement(src, tgt);
-        if (src.hasPath())
-            tgt.setPathElement(convertString(src.getPathElement()));
-        if (src.hasMin())
-            tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
-        if (src.hasMax())
-            tgt.setMaxElement(convertString(src.getMaxElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCodeElement(convertUri(src.getCodeElement()));
-        for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        for (org.hl7.fhir.r4.model.CanonicalType t : src.getTargetProfile()) tgt.getTargetProfile().add(convertCanonical(t));
-        tgt.setAggregation(src.getAggregation().stream()
-                .map(VersionConvertor_40_50::convertAggregationMode)
-                .collect(Collectors.toList()));
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
-        copyElement(src, tgt);
-        if (src.hasCode())
-            tgt.setCodeElement(convertUri(src.getCodeElement()));
-        for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
-        for (org.hl7.fhir.r5.model.CanonicalType t : src.getTargetProfile()) tgt.getTargetProfile().add(convertCanonical(t));
-        tgt.setAggregation(src.getAggregation().stream()
-                .map(VersionConvertor_40_50::convertAggregationMode)
-                .collect(Collectors.toList()));
-        if (src.hasVersioning())
-            tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case CONTAINED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
-                break;
-            case REFERENCED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
-                break;
-            case BUNDLED:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case EITHER:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
-                break;
-            case INDEPENDENT:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
-                break;
-            case SPECIFIC:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent();
-        copyElement(src, tgt);
-        if (src.hasLabel())
-            tgt.setLabelElement(convertString(src.getLabelElement()));
-        if (src.hasValue())
-            tgt.setValue(convertType(src.getValue()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSourceElement(convertCanonical(src.getSourceElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
-        copyElement(src, tgt);
-        if (src.hasKey())
-            tgt.setKeyElement(convertId(src.getKeyElement()));
-        if (src.hasRequirements())
-            tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
-        if (src.hasSeverity())
-            tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
-        if (src.hasHuman())
-            tgt.setHumanElement(convertString(src.getHumanElement()));
-        if (src.hasExpression())
-            tgt.setExpressionElement(convertString(src.getExpressionElement()));
-        if (src.hasXpath())
-            tgt.setXpathElement(convertString(src.getXpathElement()));
-        if (src.hasSource())
-            tgt.setSourceElement(convertCanonical(src.getSourceElement()));
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
-        if (src == null || src.isEmpty())
-            return null;
-        org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
-        VersionConvertor_40_50.copyElement(src, tgt);
-        switch(src.getValue()) {
-            case ERROR:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
-                break;
-            case WARNING:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
-                break;
-            default:
-                tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
-                break;
-        }
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(Enumerations40_50.convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet())
-            tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
-        copyElement(src, tgt);
-        if (src.hasStrength())
-            tgt.setStrengthElement(Enumerations40_50.convertBindingStrength(src.getStrengthElement()));
-        if (src.hasDescription())
-            tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
-        if (src.hasValueSet())
-            tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
-        copyElement(src, tgt);
-        if (src.hasIdentity())
-            tgt.setIdentityElement(convertId(src.getIdentityElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-        if (src.hasMap())
-            tgt.setMapElement(convertString(src.getMapElement()));
-        if (src.hasComment())
-            tgt.setCommentElement(convertString(src.getCommentElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertMoneyQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertMoneyQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
-        if (src == null)
-            return null;
-        org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
-        copyElement(src, tgt);
-        if (src.hasValue())
-            tgt.setValueElement(convertDecimal(src.getValueElement()));
-        if (src.hasComparator())
-            tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
-        if (src.hasUnit())
-            tgt.setUnitElement(convertString(src.getUnitElement()));
-        if (src.hasSystem())
-            tgt.setSystemElement(convertUri(src.getSystemElement()));
-        if (src.hasCode())
-            tgt.setCodeElement(convertCode(src.getCodeElement()));
-        return tgt;
-    }
-
-    public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r4.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r4.model.CanonicalType)
-            return convertCanonical((org.hl7.fhir.r4.model.CanonicalType) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeType)
-            return convertCode((org.hl7.fhir.r4.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateType)
-            return convertDate((org.hl7.fhir.r4.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IdType)
-            return convertId((org.hl7.fhir.r4.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r4.model.InstantType)
-            return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r4.model.IntegerType)
-            return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r4.model.OidType)
-            return convertOid((org.hl7.fhir.r4.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.StringType)
-            return convertString((org.hl7.fhir.r4.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r4.model.TimeType)
-            return convertTime((org.hl7.fhir.r4.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UrlType)
-            return convertUrl((org.hl7.fhir.r4.model.UrlType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UuidType)
-          return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r4.model.UriType)
-            return convertUri((org.hl7.fhir.r4.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r4.model.Extension)
-            return convertExtension((org.hl7.fhir.r4.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r4.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r4.model.Address)
-            return convertAddress((org.hl7.fhir.r4.model.Address) src);
-        if (src instanceof org.hl7.fhir.r4.model.Age)
-            return convertAge((org.hl7.fhir.r4.model.Age) src);
-        if (src instanceof org.hl7.fhir.r4.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coding)
-            return convertCoding((org.hl7.fhir.r4.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.r4.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.Contributor)
-            return convertContributor((org.hl7.fhir.r4.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.r4.model.Count)
-            return convertCount((org.hl7.fhir.r4.model.Count) src);
-        if (src instanceof org.hl7.fhir.r4.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.r4.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.r4.model.Distance)
-            return convertDistance((org.hl7.fhir.r4.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Dosage)
-            return convertDosage((org.hl7.fhir.r4.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.r4.model.Duration)
-            return convertDuration((org.hl7.fhir.r4.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r4.model.Expression)
-            return convertExpression((org.hl7.fhir.r4.model.Expression) src);
-        if (src instanceof org.hl7.fhir.r4.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r4.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r4.model.MarketingStatus)
-            return convertMarketingStatus((org.hl7.fhir.r4.model.MarketingStatus) src);
-        if (src instanceof org.hl7.fhir.r4.model.Meta)
-            return convertMeta((org.hl7.fhir.r4.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r4.model.Money)
-            return convertMoney((org.hl7.fhir.r4.model.Money) src);
-        if (src instanceof org.hl7.fhir.r4.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.r4.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Period)
-            return convertPeriod((org.hl7.fhir.r4.model.Period) src);
-        if (src instanceof org.hl7.fhir.r4.model.Population)
-            return convertPopulation((org.hl7.fhir.r4.model.Population) src);
-        if (src instanceof org.hl7.fhir.r4.model.ProdCharacteristic)
-            return convertProdCharacteristic((org.hl7.fhir.r4.model.ProdCharacteristic) src);
-        if (src instanceof org.hl7.fhir.r4.model.ProductShelfLife)
-            return convertProductShelfLife((org.hl7.fhir.r4.model.ProductShelfLife) src);
-        if (src instanceof org.hl7.fhir.r4.model.MoneyQuantity)
-          return convertMoneyQuantity((org.hl7.fhir.r4.model.MoneyQuantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
-          return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r4.model.Range)
-            return convertRange((org.hl7.fhir.r4.model.Range) src);
-        if (src instanceof org.hl7.fhir.r4.model.Ratio)
-            return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r4.model.Reference)
-            return convertReference((org.hl7.fhir.r4.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r4.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.r4.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.r4.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r4.model.Signature)
-            return convertSignature((org.hl7.fhir.r4.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstanceAmount)
-            return convertSubstanceAmount((org.hl7.fhir.r4.model.SubstanceAmount) src);
-        if (src instanceof org.hl7.fhir.r4.model.Timing)
-            return convertTiming((org.hl7.fhir.r4.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r4.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.r4.model.TriggerDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.r4.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.r4.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.r4.model.ElementDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
-            return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
-        if (src instanceof org.hl7.fhir.r5.model.BooleanType)
-            return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
-        if (src instanceof org.hl7.fhir.r5.model.CanonicalType)
-            return convertCanonical((org.hl7.fhir.r5.model.CanonicalType) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeType)
-            return convertCode((org.hl7.fhir.r5.model.CodeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateType)
-            return convertDate((org.hl7.fhir.r5.model.DateType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
-            return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.DecimalType)
-            return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IdType)
-            return convertId((org.hl7.fhir.r5.model.IdType) src);
-        if (src instanceof org.hl7.fhir.r5.model.InstantType)
-            return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
-        if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
-            return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
-        if (src instanceof org.hl7.fhir.r5.model.OidType)
-            return convertOid((org.hl7.fhir.r5.model.OidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
-            return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.StringType)
-            return convertString((org.hl7.fhir.r5.model.StringType) src);
-        if (src instanceof org.hl7.fhir.r5.model.TimeType)
-            return convertTime((org.hl7.fhir.r5.model.TimeType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
-            return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
-        if (src instanceof org.hl7.fhir.r5.model.IntegerType)
-            return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UrlType)
-            return convertUrl((org.hl7.fhir.r5.model.UrlType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UuidType)
-          return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
-        if (src instanceof org.hl7.fhir.r5.model.UriType)
-            return convertUri((org.hl7.fhir.r5.model.UriType) src);
-        if (src instanceof org.hl7.fhir.r5.model.Extension)
-            return convertExtension((org.hl7.fhir.r5.model.Extension) src);
-        if (src instanceof org.hl7.fhir.r5.model.Narrative)
-            return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
-        if (src instanceof org.hl7.fhir.r5.model.Address)
-            return convertAddress((org.hl7.fhir.r5.model.Address) src);
-        if (src instanceof org.hl7.fhir.r5.model.Age)
-            return convertAge((org.hl7.fhir.r5.model.Age) src);
-        if (src instanceof org.hl7.fhir.r5.model.Annotation)
-            return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Attachment)
-            return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
-            return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
-        if (src instanceof org.hl7.fhir.r5.model.Coding)
-            return convertCoding((org.hl7.fhir.r5.model.Coding) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactDetail)
-            return convertContactDetail((org.hl7.fhir.r5.model.ContactDetail) src);
-        if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
-            return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.Contributor)
-            return convertContributor((org.hl7.fhir.r5.model.Contributor) src);
-        if (src instanceof org.hl7.fhir.r5.model.Count)
-            return convertCount((org.hl7.fhir.r5.model.Count) src);
-        if (src instanceof org.hl7.fhir.r5.model.DataRequirement)
-            return convertDataRequirement((org.hl7.fhir.r5.model.DataRequirement) src);
-        if (src instanceof org.hl7.fhir.r5.model.Distance)
-            return convertDistance((org.hl7.fhir.r5.model.Distance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Dosage)
-            return convertDosage((org.hl7.fhir.r5.model.Dosage) src);
-        if (src instanceof org.hl7.fhir.r5.model.Duration)
-            return convertDuration((org.hl7.fhir.r5.model.Duration) src);
-        if (src instanceof org.hl7.fhir.r5.model.Expression)
-            return convertExpression((org.hl7.fhir.r5.model.Expression) src);
-        if (src instanceof org.hl7.fhir.r5.model.HumanName)
-            return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
-        if (src instanceof org.hl7.fhir.r5.model.Identifier)
-            return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
-        if (src instanceof org.hl7.fhir.r5.model.MarketingStatus)
-            return convertMarketingStatus((org.hl7.fhir.r5.model.MarketingStatus) src);
-        if (src instanceof org.hl7.fhir.r5.model.Meta)
-            return convertMeta((org.hl7.fhir.r5.model.Meta) src);
-        if (src instanceof org.hl7.fhir.r5.model.Money)
-            return convertMoney((org.hl7.fhir.r5.model.Money) src);
-        if (src instanceof org.hl7.fhir.r5.model.ParameterDefinition)
-            return convertParameterDefinition((org.hl7.fhir.r5.model.ParameterDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Period)
-            return convertPeriod((org.hl7.fhir.r5.model.Period) src);
-        if (src instanceof org.hl7.fhir.r5.model.Population)
-            return convertPopulation((org.hl7.fhir.r5.model.Population) src);
-        if (src instanceof org.hl7.fhir.r5.model.ProdCharacteristic)
-            return convertProdCharacteristic((org.hl7.fhir.r5.model.ProdCharacteristic) src);
-        if (src instanceof org.hl7.fhir.r5.model.ProductShelfLife)
-            return convertProductShelfLife((org.hl7.fhir.r5.model.ProductShelfLife) src);
-        if (src instanceof org.hl7.fhir.r5.model.MoneyQuantity)
-          return convertMoneyQuantity((org.hl7.fhir.r5.model.MoneyQuantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.SimpleQuantity)
-          return convertSimpleQuantity((org.hl7.fhir.r5.model.SimpleQuantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.Quantity)
-            return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
-        if (src instanceof org.hl7.fhir.r5.model.Range)
-            return convertRange((org.hl7.fhir.r5.model.Range) src);
-        if (src instanceof org.hl7.fhir.r5.model.Ratio)
-            return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
-        if (src instanceof org.hl7.fhir.r5.model.Reference)
-            return convertReference((org.hl7.fhir.r5.model.Reference) src);
-        if (src instanceof org.hl7.fhir.r5.model.RelatedArtifact)
-            return convertRelatedArtifact((org.hl7.fhir.r5.model.RelatedArtifact) src);
-        if (src instanceof org.hl7.fhir.r5.model.SampledData)
-            return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
-        if (src instanceof org.hl7.fhir.r5.model.Signature)
-            return convertSignature((org.hl7.fhir.r5.model.Signature) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstanceAmount)
-            return convertSubstanceAmount((org.hl7.fhir.r5.model.SubstanceAmount) src);
-        if (src instanceof org.hl7.fhir.r5.model.Timing)
-            return convertTiming((org.hl7.fhir.r5.model.Timing) src);
-        if (src instanceof org.hl7.fhir.r5.model.TriggerDefinition)
-            return convertTriggerDefinition((org.hl7.fhir.r5.model.TriggerDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.UsageContext)
-            return convertUsageContext((org.hl7.fhir.r5.model.UsageContext) src);
-        if (src instanceof org.hl7.fhir.r5.model.ElementDefinition)
-            return convertElementDefinition((org.hl7.fhir.r5.model.ElementDefinition) src);
-        throw new FHIRException("Unknown type " + src.fhirType());
-    }
-
-    protected static void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
-    }
-
-    protected static void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt) throws FHIRException {
-        copyResource(src, tgt);
-        if (src.hasText())
-            tgt.setText(convertNarrative(src.getText()));
-        for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
-        for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
-    }
-
-    protected static void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setIdElement(convertId(src.getIdElement()));
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRulesElement(convertUri(src.getImplicitRulesElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    }
-
-    protected static void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
-        if (src.hasId())
-            tgt.setIdElement(convertId(src.getIdElement()));
-        if (src.hasMeta())
-            tgt.setMeta(convertMeta(src.getMeta()));
-        if (src.hasImplicitRules())
-            tgt.setImplicitRulesElement(convertUri(src.getImplicitRulesElement()));
-        if (src.hasLanguage())
-            tgt.setLanguageElement(convertCode(src.getLanguageElement()));
-    }
-
-    public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r4.model.Parameters)
-            return Parameters40_50.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r4.model.Account)
-            return Account40_50.convertAccount((org.hl7.fhir.r4.model.Account) src);
-        if (src instanceof org.hl7.fhir.r4.model.ActivityDefinition)
-            return ActivityDefinition40_50.convertActivityDefinition((org.hl7.fhir.r4.model.ActivityDefinition) src);
-        // if (src instanceof org.hl7.fhir.r4.model.AdverseEvent)
-        // return AdverseEvent.convertAdverseEvent((org.hl7.fhir.r4.model.AdverseEvent) src);
-        if (src instanceof org.hl7.fhir.r4.model.AllergyIntolerance)
-            return AllergyIntolerance40_50.convertAllergyIntolerance((org.hl7.fhir.r4.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Appointment)
-            return Appointment40_50.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
-            return AppointmentResponse40_50.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
-            return AuditEvent40_50.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r4.model.Basic)
-            return Basic40_50.convertBasic((org.hl7.fhir.r4.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r4.model.Binary)
-            return Binary40_50.convertBinary((org.hl7.fhir.r4.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r4.model.BiologicallyDerivedProduct)
-            return BiologicallyDerivedProduct40_50.convertBiologicallyDerivedProduct((org.hl7.fhir.r4.model.BiologicallyDerivedProduct) src);
-        if (src instanceof org.hl7.fhir.r4.model.BodyStructure)
-            return BodyStructure40_50.convertBodyStructure((org.hl7.fhir.r4.model.BodyStructure) src);
-        if (src instanceof org.hl7.fhir.r4.model.Bundle)
-            return Bundle40_50.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
-            return CapabilityStatement40_50.convertCapabilityStatement((org.hl7.fhir.r4.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.CarePlan)
-            return CarePlan40_50.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r4.model.CareTeam)
-            return CareTeam40_50.convertCareTeam((org.hl7.fhir.r4.model.CareTeam) src);
-        // if (src instanceof org.hl7.fhir.r4.model.CatalogEntry)
-        // return CatalogEntry.convertCatalogEntry((org.hl7.fhir.r4.model.CatalogEntry) src);
-        if (src instanceof org.hl7.fhir.r4.model.ChargeItem)
-            return ChargeItem40_50.convertChargeItem((org.hl7.fhir.r4.model.ChargeItem) src);
-        if (src instanceof org.hl7.fhir.r4.model.ChargeItemDefinition)
-            return ChargeItemDefinition40_50.convertChargeItemDefinition((org.hl7.fhir.r4.model.ChargeItemDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Claim)
-            return Claim40_50.convertClaim((org.hl7.fhir.r4.model.Claim) src);
-        if (src instanceof org.hl7.fhir.r4.model.ClaimResponse)
-            return ClaimResponse40_50.convertClaimResponse((org.hl7.fhir.r4.model.ClaimResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.ClinicalImpression)
-            return ClinicalImpression40_50.convertClinicalImpression((org.hl7.fhir.r4.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
-            return CodeSystem40_50.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.Communication)
-            return Communication40_50.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r4.model.CommunicationRequest)
-            return CommunicationRequest40_50.convertCommunicationRequest((org.hl7.fhir.r4.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
-            return CompartmentDefinition40_50.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Composition)
-            return Composition40_50.convertComposition((org.hl7.fhir.r4.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
-            return ConceptMap40_50.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r4.model.Condition)
-            return Condition40_50.convertCondition((org.hl7.fhir.r4.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Consent)
-            return Consent40_50.convertConsent((org.hl7.fhir.r4.model.Consent) src);
-        if (src instanceof org.hl7.fhir.r4.model.Contract)
-            return Contract40_50.convertContract((org.hl7.fhir.r4.model.Contract) src);
-        if (src instanceof org.hl7.fhir.r4.model.Coverage)
-            return Coverage40_50.convertCoverage((org.hl7.fhir.r4.model.Coverage) src);
-        if (src instanceof org.hl7.fhir.r4.model.CoverageEligibilityRequest)
-            return CoverageEligibilityRequest40_50.convertCoverageEligibilityRequest((org.hl7.fhir.r4.model.CoverageEligibilityRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.CoverageEligibilityResponse)
-            return CoverageEligibilityResponse40_50.convertCoverageEligibilityResponse((org.hl7.fhir.r4.model.CoverageEligibilityResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
-            return DetectedIssue40_50.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r4.model.Device)
-            return Device40_50.convertDevice((org.hl7.fhir.r4.model.Device) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceDefinition)
-            return DeviceDefinition40_50.convertDeviceDefinition((org.hl7.fhir.r4.model.DeviceDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceMetric)
-            return DeviceMetric40_50.convertDeviceMetric((org.hl7.fhir.r4.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceRequest)
-            return DeviceRequest40_50.convertDeviceRequest((org.hl7.fhir.r4.model.DeviceRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
-            return DeviceUseStatement40_50.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
-            return DiagnosticReport40_50.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.DocumentManifest)
-            return DocumentManifest40_50.convertDocumentManifest((org.hl7.fhir.r4.model.DocumentManifest) src);
-        if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
-            return DocumentReference40_50.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r4.model.Encounter)
-            return Encounter40_50.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r4.model.Endpoint)
-            return Endpoint40_50.convertEndpoint((org.hl7.fhir.r4.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.r4.model.EnrollmentRequest)
-            return EnrollmentRequest40_50.convertEnrollmentRequest((org.hl7.fhir.r4.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.EnrollmentResponse)
-            return EnrollmentResponse40_50.convertEnrollmentResponse((org.hl7.fhir.r4.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
-            return EpisodeOfCare40_50.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r4.model.EventDefinition)
-            return EventDefinition40_50.convertEventDefinition((org.hl7.fhir.r4.model.EventDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.ExampleScenario)
-            return ExampleScenario40_50.convertExampleScenario((org.hl7.fhir.r4.model.ExampleScenario) src);
-        if (src instanceof org.hl7.fhir.r4.model.ExplanationOfBenefit)
-            return ExplanationOfBenefit40_50.convertExplanationOfBenefit((org.hl7.fhir.r4.model.ExplanationOfBenefit) src);
-        if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
-            return FamilyMemberHistory40_50.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r4.model.Flag)
-            return Flag40_50.convertFlag((org.hl7.fhir.r4.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r4.model.Goal)
-            return Goal40_50.convertGoal((org.hl7.fhir.r4.model.Goal) src);
-        if (src instanceof org.hl7.fhir.r4.model.GraphDefinition)
-            return GraphDefinition40_50.convertGraphDefinition((org.hl7.fhir.r4.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Group)
-            return Group40_50.convertGroup((org.hl7.fhir.r4.model.Group) src);
-        if (src instanceof org.hl7.fhir.r4.model.GuidanceResponse)
-            return GuidanceResponse40_50.convertGuidanceResponse((org.hl7.fhir.r4.model.GuidanceResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
-            return HealthcareService40_50.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImagingStudy)
-            return ImagingStudy40_50.convertImagingStudy((org.hl7.fhir.r4.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.r4.model.Immunization)
-            return Immunization40_50.convertImmunization((org.hl7.fhir.r4.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImmunizationEvaluation)
-            return ImmunizationEvaluation40_50.convertImmunizationEvaluation((org.hl7.fhir.r4.model.ImmunizationEvaluation) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImmunizationRecommendation)
-            return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r4.model.ImmunizationRecommendation) src);
-        if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
-            return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r4.model.InsurancePlan)
-            return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r4.model.InsurancePlan) src);
-        if (src instanceof org.hl7.fhir.r4.model.Invoice)
-            return Invoice40_50.convertInvoice((org.hl7.fhir.r4.model.Invoice) src);
-        if (src instanceof org.hl7.fhir.r4.model.Library)
-            return Library40_50.convertLibrary((org.hl7.fhir.r4.model.Library) src);
-        if (src instanceof org.hl7.fhir.r4.model.Linkage)
-            return Linkage40_50.convertLinkage((org.hl7.fhir.r4.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.r4.model.ListResource)
-            return ListResource40_50.convertListResource((org.hl7.fhir.r4.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r4.model.Location)
-            return Location40_50.convertLocation((org.hl7.fhir.r4.model.Location) src);
-        if (src instanceof org.hl7.fhir.r4.model.Measure)
-            return Measure40_50.convertMeasure((org.hl7.fhir.r4.model.Measure) src);
-        if (src instanceof org.hl7.fhir.r4.model.MeasureReport)
-            return MeasureReport40_50.convertMeasureReport((org.hl7.fhir.r4.model.MeasureReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.Media)
-            return Media40_50.convertMedia((org.hl7.fhir.r4.model.Media) src);
-        if (src instanceof org.hl7.fhir.r4.model.Medication)
-            return Medication40_50.convertMedication((org.hl7.fhir.r4.model.Medication) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationAdministration)
-            return MedicationAdministration40_50.convertMedicationAdministration((org.hl7.fhir.r4.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
-            return MedicationDispense40_50.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationKnowledge)
-            return MedicationKnowledge40_50.convertMedicationKnowledge((org.hl7.fhir.r4.model.MedicationKnowledge) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationRequest)
-            return MedicationRequest40_50.convertMedicationRequest((org.hl7.fhir.r4.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
-            return MedicationStatement40_50.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
-        if (src instanceof org.hl7.fhir.r4.model.MedicinalProduct)
-          return MedicinalProductDefinition40_50.convertMedicinalProduct((org.hl7.fhir.r4.model.MedicinalProduct) src);
-        if (src instanceof org.hl7.fhir.r4.model.MessageDefinition)
-            return MessageDefinition40_50.convertMessageDefinition((org.hl7.fhir.r4.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
-            return MessageHeader40_50.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r4.model.MolecularSequence)
-            return MolecularSequence40_50.convertMolecularSequence((org.hl7.fhir.r4.model.MolecularSequence) src);
-        if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
-            return NamingSystem40_50.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r4.model.NutritionOrder)
-            return NutritionOrder40_50.convertNutritionOrder((org.hl7.fhir.r4.model.NutritionOrder) src);
-        if (src instanceof org.hl7.fhir.r4.model.Observation)
-            return Observation40_50.convertObservation((org.hl7.fhir.r4.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r4.model.ObservationDefinition)
-            return ObservationDefinition40_50.convertObservationDefinition((org.hl7.fhir.r4.model.ObservationDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
-            return OperationDefinition40_50.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
-            return OperationOutcome40_50.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r4.model.Organization)
-            return Organization40_50.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r4.model.OrganizationAffiliation)
-            return OrganizationAffiliation40_50.convertOrganizationAffiliation((org.hl7.fhir.r4.model.OrganizationAffiliation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Patient)
-            return Patient40_50.convertPatient((org.hl7.fhir.r4.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r4.model.PaymentNotice)
-            return PaymentNotice40_50.convertPaymentNotice((org.hl7.fhir.r4.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.r4.model.PaymentReconciliation)
-            return PaymentReconciliation40_50.convertPaymentReconciliation((org.hl7.fhir.r4.model.PaymentReconciliation) src);
-        if (src instanceof org.hl7.fhir.r4.model.Person)
-            return Person40_50.convertPerson((org.hl7.fhir.r4.model.Person) src);
-        if (src instanceof org.hl7.fhir.r4.model.PlanDefinition)
-            return PlanDefinition40_50.convertPlanDefinition((org.hl7.fhir.r4.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.Practitioner)
-            return Practitioner40_50.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r4.model.PractitionerRole)
-            return PractitionerRole40_50.convertPractitionerRole((org.hl7.fhir.r4.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.r4.model.Procedure)
-            return Procedure40_50.convertProcedure((org.hl7.fhir.r4.model.Procedure) src);
-        if (src instanceof org.hl7.fhir.r4.model.Provenance)
-            return Provenance40_50.convertProvenance((org.hl7.fhir.r4.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
-            return Questionnaire40_50.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
-            return QuestionnaireResponse40_50.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r4.model.RelatedPerson)
-            return RelatedPerson40_50.convertRelatedPerson((org.hl7.fhir.r4.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.r4.model.RequestGroup)
-            return RequestGroup40_50.convertRequestGroup((org.hl7.fhir.r4.model.RequestGroup) src);
-        if (src instanceof org.hl7.fhir.r4.model.ResearchStudy)
-            return ResearchStudy40_50.convertResearchStudy((org.hl7.fhir.r4.model.ResearchStudy) src);
-        if (src instanceof org.hl7.fhir.r4.model.ResearchSubject)
-            return ResearchSubject40_50.convertResearchSubject((org.hl7.fhir.r4.model.ResearchSubject) src);
-        if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
-            return RiskAssessment40_50.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r4.model.Schedule)
-            return Schedule40_50.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
-            return SearchParameter40_50.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r4.model.ServiceRequest)
-            return ServiceRequest40_50.convertServiceRequest((org.hl7.fhir.r4.model.ServiceRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.Slot)
-            return Slot40_50.convertSlot((org.hl7.fhir.r4.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r4.model.Specimen)
-            return Specimen40_50.convertSpecimen((org.hl7.fhir.r4.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.r4.model.SpecimenDefinition)
-            return SpecimenDefinition40_50.convertSpecimenDefinition((org.hl7.fhir.r4.model.SpecimenDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
-            return StructureDefinition40_50.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r4.model.StructureMap)
-            return StructureMap40_50.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
-        // if (src instanceof org.hl7.fhir.r4.model.Subscription)
-        // return Subscription.convertSubscription((org.hl7.fhir.r4.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.r4.model.Substance)
-            return Substance40_50.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstanceNucleicAcid)
-            return SubstanceNucleicAcid40_50.convertSubstanceNucleicAcid((org.hl7.fhir.r4.model.SubstanceNucleicAcid) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstancePolymer)
-            return SubstancePolymer40_50.convertSubstancePolymer((org.hl7.fhir.r4.model.SubstancePolymer) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstanceProtein)
-            return SubstanceProtein40_50.convertSubstanceProtein((org.hl7.fhir.r4.model.SubstanceProtein) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstanceReferenceInformation)
-            return SubstanceReferenceInformation40_50.convertSubstanceReferenceInformation((org.hl7.fhir.r4.model.SubstanceReferenceInformation) src);
-        if (src instanceof org.hl7.fhir.r4.model.SubstanceSourceMaterial)
-            return SubstanceSourceMaterial40_50.convertSubstanceSourceMaterial((org.hl7.fhir.r4.model.SubstanceSourceMaterial) src);
-        if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
-            return SupplyDelivery40_50.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r4.model.SupplyRequest)
-            return SupplyRequest40_50.convertSupplyRequest((org.hl7.fhir.r4.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.r4.model.Task)
-            return Task40_50.convertTask((org.hl7.fhir.r4.model.Task) src);
-        if (src instanceof org.hl7.fhir.r4.model.TerminologyCapabilities)
-            return TerminologyCapabilities40_50.convertTerminologyCapabilities((org.hl7.fhir.r4.model.TerminologyCapabilities) src);
-        if (src instanceof org.hl7.fhir.r4.model.TestReport)
-            return TestReport40_50.convertTestReport((org.hl7.fhir.r4.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.r4.model.TestScript)
-            return TestScript40_50.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r4.model.ValueSet)
-            return ValueSet40_50.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
-        if (src instanceof org.hl7.fhir.r4.model.VerificationResult)
-            return VerificationResult40_50.convertVerificationResult((org.hl7.fhir.r4.model.VerificationResult) src);
-        if (src instanceof org.hl7.fhir.r4.model.VisionPrescription)
-            return VisionPrescription40_50.convertVisionPrescription((org.hl7.fhir.r4.model.VisionPrescription) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
-        if (src == null)
-            return null;
-        if (src instanceof org.hl7.fhir.r5.model.Parameters)
-            return Parameters40_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
-        if (src instanceof org.hl7.fhir.r5.model.Account)
-            return Account40_50.convertAccount((org.hl7.fhir.r5.model.Account) src);
-        if (src instanceof org.hl7.fhir.r5.model.ActivityDefinition)
-            return ActivityDefinition40_50.convertActivityDefinition((org.hl7.fhir.r5.model.ActivityDefinition) src);
-        // if (src instanceof org.hl7.fhir.r5.model.AdverseEvent)
-        // return AdverseEvent.convertAdverseEvent((org.hl7.fhir.r5.model.AdverseEvent) src);
-        if (src instanceof org.hl7.fhir.r5.model.AllergyIntolerance)
-            return AllergyIntolerance40_50.convertAllergyIntolerance((org.hl7.fhir.r5.model.AllergyIntolerance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Appointment)
-            return Appointment40_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
-        if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
-            return AppointmentResponse40_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
-            return AuditEvent40_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
-        if (src instanceof org.hl7.fhir.r5.model.Basic)
-            return Basic40_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
-        if (src instanceof org.hl7.fhir.r5.model.Binary)
-            return Binary40_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
-        if (src instanceof org.hl7.fhir.r5.model.BiologicallyDerivedProduct)
-            return BiologicallyDerivedProduct40_50.convertBiologicallyDerivedProduct((org.hl7.fhir.r5.model.BiologicallyDerivedProduct) src);
-        if (src instanceof org.hl7.fhir.r5.model.BodyStructure)
-            return BodyStructure40_50.convertBodyStructure((org.hl7.fhir.r5.model.BodyStructure) src);
-        if (src instanceof org.hl7.fhir.r5.model.Bundle)
-            return Bundle40_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
-        if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
-            return CapabilityStatement40_50.convertCapabilityStatement((org.hl7.fhir.r5.model.CapabilityStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.CarePlan)
-            return CarePlan40_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
-        if (src instanceof org.hl7.fhir.r5.model.CareTeam)
-            return CareTeam40_50.convertCareTeam((org.hl7.fhir.r5.model.CareTeam) src);
-        // if (src instanceof org.hl7.fhir.r5.model.CatalogEntry)
-        // return CatalogEntry.convertCatalogEntry((org.hl7.fhir.r5.model.CatalogEntry) src);
-        if (src instanceof org.hl7.fhir.r5.model.ChargeItem)
-            return ChargeItem40_50.convertChargeItem((org.hl7.fhir.r5.model.ChargeItem) src);
-        if (src instanceof org.hl7.fhir.r5.model.ChargeItemDefinition)
-            return ChargeItemDefinition40_50.convertChargeItemDefinition((org.hl7.fhir.r5.model.ChargeItemDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Claim)
-            return Claim40_50.convertClaim((org.hl7.fhir.r5.model.Claim) src);
-        if (src instanceof org.hl7.fhir.r5.model.ClaimResponse)
-            return ClaimResponse40_50.convertClaimResponse((org.hl7.fhir.r5.model.ClaimResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.ClinicalImpression)
-            return ClinicalImpression40_50.convertClinicalImpression((org.hl7.fhir.r5.model.ClinicalImpression) src);
-        if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
-            return CodeSystem40_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.Communication)
-            return Communication40_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
-        if (src instanceof org.hl7.fhir.r5.model.CommunicationRequest)
-            return CommunicationRequest40_50.convertCommunicationRequest((org.hl7.fhir.r5.model.CommunicationRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
-            return CompartmentDefinition40_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Composition)
-            return Composition40_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
-        if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
-            return ConceptMap40_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
-        if (src instanceof org.hl7.fhir.r5.model.Condition)
-            return Condition40_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Consent)
-            return Consent40_50.convertConsent((org.hl7.fhir.r5.model.Consent) src);
-        if (src instanceof org.hl7.fhir.r5.model.Contract)
-            return Contract40_50.convertContract((org.hl7.fhir.r5.model.Contract) src);
-        if (src instanceof org.hl7.fhir.r5.model.Coverage)
-            return Coverage40_50.convertCoverage((org.hl7.fhir.r5.model.Coverage) src);
-        if (src instanceof org.hl7.fhir.r5.model.CoverageEligibilityRequest)
-            return CoverageEligibilityRequest40_50.convertCoverageEligibilityRequest((org.hl7.fhir.r5.model.CoverageEligibilityRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.CoverageEligibilityResponse)
-            return CoverageEligibilityResponse40_50.convertCoverageEligibilityResponse((org.hl7.fhir.r5.model.CoverageEligibilityResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
-            return DetectedIssue40_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
-        if (src instanceof org.hl7.fhir.r5.model.Device)
-            return Device40_50.convertDevice((org.hl7.fhir.r5.model.Device) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceDefinition)
-            return DeviceDefinition40_50.convertDeviceDefinition((org.hl7.fhir.r5.model.DeviceDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceMetric)
-            return DeviceMetric40_50.convertDeviceMetric((org.hl7.fhir.r5.model.DeviceMetric) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceRequest)
-            return DeviceRequest40_50.convertDeviceRequest((org.hl7.fhir.r5.model.DeviceRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
-            return DeviceUseStatement40_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
-        if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
-            return DiagnosticReport40_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
-        if (src instanceof org.hl7.fhir.r5.model.DocumentManifest)
-            return DocumentManifest40_50.convertDocumentManifest((org.hl7.fhir.r5.model.DocumentManifest) src);
-        if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
-            return DocumentReference40_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r5.model.Encounter)
-            return Encounter40_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
-        if (src instanceof org.hl7.fhir.r5.model.Endpoint)
-            return Endpoint40_50.convertEndpoint((org.hl7.fhir.r5.model.Endpoint) src);
-        if (src instanceof org.hl7.fhir.r5.model.EnrollmentRequest)
-            return EnrollmentRequest40_50.convertEnrollmentRequest((org.hl7.fhir.r5.model.EnrollmentRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.EnrollmentResponse)
-            return EnrollmentResponse40_50.convertEnrollmentResponse((org.hl7.fhir.r5.model.EnrollmentResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
-            return EpisodeOfCare40_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
-        if (src instanceof org.hl7.fhir.r5.model.EventDefinition)
-            return EventDefinition40_50.convertEventDefinition((org.hl7.fhir.r5.model.EventDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.ExampleScenario)
-            return ExampleScenario40_50.convertExampleScenario((org.hl7.fhir.r5.model.ExampleScenario) src);
-        if (src instanceof org.hl7.fhir.r5.model.ExplanationOfBenefit)
-            return ExplanationOfBenefit40_50.convertExplanationOfBenefit((org.hl7.fhir.r5.model.ExplanationOfBenefit) src);
-        if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
-            return FamilyMemberHistory40_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
-        if (src instanceof org.hl7.fhir.r5.model.Flag)
-            return Flag40_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
-        if (src instanceof org.hl7.fhir.r5.model.Goal)
-            return Goal40_50.convertGoal((org.hl7.fhir.r5.model.Goal) src);
-        if (src instanceof org.hl7.fhir.r5.model.GraphDefinition)
-            return GraphDefinition40_50.convertGraphDefinition((org.hl7.fhir.r5.model.GraphDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Group)
-            return Group40_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
-        if (src instanceof org.hl7.fhir.r5.model.GuidanceResponse)
-            return GuidanceResponse40_50.convertGuidanceResponse((org.hl7.fhir.r5.model.GuidanceResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
-            return HealthcareService40_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImagingStudy)
-            return ImagingStudy40_50.convertImagingStudy((org.hl7.fhir.r5.model.ImagingStudy) src);
-        if (src instanceof org.hl7.fhir.r5.model.Immunization)
-            return Immunization40_50.convertImmunization((org.hl7.fhir.r5.model.Immunization) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImmunizationEvaluation)
-            return ImmunizationEvaluation40_50.convertImmunizationEvaluation((org.hl7.fhir.r5.model.ImmunizationEvaluation) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImmunizationRecommendation)
-            return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r5.model.ImmunizationRecommendation) src);
-        if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-            return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
-        if (src instanceof org.hl7.fhir.r5.model.InsurancePlan)
-            return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r5.model.InsurancePlan) src);
-        if (src instanceof org.hl7.fhir.r5.model.Invoice)
-            return Invoice40_50.convertInvoice((org.hl7.fhir.r5.model.Invoice) src);
-        if (src instanceof org.hl7.fhir.r5.model.Library)
-            return Library40_50.convertLibrary((org.hl7.fhir.r5.model.Library) src);
-        if (src instanceof org.hl7.fhir.r5.model.Linkage)
-            return Linkage40_50.convertLinkage((org.hl7.fhir.r5.model.Linkage) src);
-        if (src instanceof org.hl7.fhir.r5.model.ListResource)
-            return ListResource40_50.convertListResource((org.hl7.fhir.r5.model.ListResource) src);
-        if (src instanceof org.hl7.fhir.r5.model.Location)
-            return Location40_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
-        if (src instanceof org.hl7.fhir.r5.model.Measure)
-            return Measure40_50.convertMeasure((org.hl7.fhir.r5.model.Measure) src);
-        if (src instanceof org.hl7.fhir.r5.model.MeasureReport)
-            return MeasureReport40_50.convertMeasureReport((org.hl7.fhir.r5.model.MeasureReport) src);
-        if (// todo: will never get here (doesn't work anyway)
-        src instanceof org.hl7.fhir.r5.model.DocumentReference)
-            return Media40_50.convertMedia((org.hl7.fhir.r5.model.DocumentReference) src);
-        if (src instanceof org.hl7.fhir.r5.model.Medication)
-            return Medication40_50.convertMedication((org.hl7.fhir.r5.model.Medication) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationAdministration)
-            return MedicationAdministration40_50.convertMedicationAdministration((org.hl7.fhir.r5.model.MedicationAdministration) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
-            return MedicationDispense40_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationKnowledge)
-            return MedicationKnowledge40_50.convertMedicationKnowledge((org.hl7.fhir.r5.model.MedicationKnowledge) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationRequest)
-            return MedicationRequest40_50.convertMedicationRequest((org.hl7.fhir.r5.model.MedicationRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
-            return MedicationStatement40_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
-        if (src instanceof org.hl7.fhir.r5.model.MedicinalProductDefinition)
-          return MedicinalProductDefinition40_50.convertMedicinalProductDefinition((org.hl7.fhir.r5.model.MedicinalProductDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.MessageDefinition)
-            return MessageDefinition40_50.convertMessageDefinition((org.hl7.fhir.r5.model.MessageDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
-            return MessageHeader40_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
-        if (src instanceof org.hl7.fhir.r5.model.MolecularSequence)
-            return MolecularSequence40_50.convertMolecularSequence((org.hl7.fhir.r5.model.MolecularSequence) src);
-        if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
-            return NamingSystem40_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
-        if (src instanceof org.hl7.fhir.r5.model.NutritionOrder)
-            return NutritionOrder40_50.convertNutritionOrder((org.hl7.fhir.r5.model.NutritionOrder) src);
-        if (src instanceof org.hl7.fhir.r5.model.Observation)
-            return Observation40_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
-        if (src instanceof org.hl7.fhir.r5.model.ObservationDefinition)
-            return ObservationDefinition40_50.convertObservationDefinition((org.hl7.fhir.r5.model.ObservationDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
-            return OperationDefinition40_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
-            return OperationOutcome40_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
-        if (src instanceof org.hl7.fhir.r5.model.Organization)
-            return Organization40_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
-        if (src instanceof org.hl7.fhir.r5.model.OrganizationAffiliation)
-            return OrganizationAffiliation40_50.convertOrganizationAffiliation((org.hl7.fhir.r5.model.OrganizationAffiliation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Patient)
-            return Patient40_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
-        if (src instanceof org.hl7.fhir.r5.model.PaymentNotice)
-            return PaymentNotice40_50.convertPaymentNotice((org.hl7.fhir.r5.model.PaymentNotice) src);
-        if (src instanceof org.hl7.fhir.r5.model.PaymentReconciliation)
-            return PaymentReconciliation40_50.convertPaymentReconciliation((org.hl7.fhir.r5.model.PaymentReconciliation) src);
-        if (src instanceof org.hl7.fhir.r5.model.Person)
-            return Person40_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
-        if (src instanceof org.hl7.fhir.r5.model.PlanDefinition)
-            return PlanDefinition40_50.convertPlanDefinition((org.hl7.fhir.r5.model.PlanDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.Practitioner)
-            return Practitioner40_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
-        if (src instanceof org.hl7.fhir.r5.model.PractitionerRole)
-            return PractitionerRole40_50.convertPractitionerRole((org.hl7.fhir.r5.model.PractitionerRole) src);
-        if (src instanceof org.hl7.fhir.r5.model.Procedure)
-            return Procedure40_50.convertProcedure((org.hl7.fhir.r5.model.Procedure) src);
-        if (src instanceof org.hl7.fhir.r5.model.Provenance)
-            return Provenance40_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
-        if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
-            return Questionnaire40_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
-        if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
-            return QuestionnaireResponse40_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
-        if (src instanceof org.hl7.fhir.r5.model.RelatedPerson)
-            return RelatedPerson40_50.convertRelatedPerson((org.hl7.fhir.r5.model.RelatedPerson) src);
-        if (src instanceof org.hl7.fhir.r5.model.RequestGroup)
-            return RequestGroup40_50.convertRequestGroup((org.hl7.fhir.r5.model.RequestGroup) src);
-        if (src instanceof org.hl7.fhir.r5.model.ResearchStudy)
-            return ResearchStudy40_50.convertResearchStudy((org.hl7.fhir.r5.model.ResearchStudy) src);
-        if (src instanceof org.hl7.fhir.r5.model.ResearchSubject)
-            return ResearchSubject40_50.convertResearchSubject((org.hl7.fhir.r5.model.ResearchSubject) src);
-        if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
-            return RiskAssessment40_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
-        if (src instanceof org.hl7.fhir.r5.model.Schedule)
-            return Schedule40_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
-        if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
-            return SearchParameter40_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
-        if (src instanceof org.hl7.fhir.r5.model.ServiceRequest)
-            return ServiceRequest40_50.convertServiceRequest((org.hl7.fhir.r5.model.ServiceRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.Slot)
-            return Slot40_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
-        if (src instanceof org.hl7.fhir.r5.model.Specimen)
-            return Specimen40_50.convertSpecimen((org.hl7.fhir.r5.model.Specimen) src);
-        if (src instanceof org.hl7.fhir.r5.model.SpecimenDefinition)
-            return SpecimenDefinition40_50.convertSpecimenDefinition((org.hl7.fhir.r5.model.SpecimenDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
-            return StructureDefinition40_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
-        if (src instanceof org.hl7.fhir.r5.model.StructureMap)
-            return StructureMap40_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
-        // if (src instanceof org.hl7.fhir.r5.model.Subscription)
-        // return Subscription.convertSubscription((org.hl7.fhir.r5.model.Subscription) src);
-        if (src instanceof org.hl7.fhir.r5.model.Substance)
-            return Substance40_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstanceNucleicAcid)
-            return SubstanceNucleicAcid40_50.convertSubstanceNucleicAcid((org.hl7.fhir.r5.model.SubstanceNucleicAcid) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstancePolymer)
-            return SubstancePolymer40_50.convertSubstancePolymer((org.hl7.fhir.r5.model.SubstancePolymer) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstanceProtein)
-            return SubstanceProtein40_50.convertSubstanceProtein((org.hl7.fhir.r5.model.SubstanceProtein) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstanceReferenceInformation)
-            return SubstanceReferenceInformation40_50.convertSubstanceReferenceInformation((org.hl7.fhir.r5.model.SubstanceReferenceInformation) src);
-        if (src instanceof org.hl7.fhir.r5.model.SubstanceSourceMaterial)
-            return SubstanceSourceMaterial40_50.convertSubstanceSourceMaterial((org.hl7.fhir.r5.model.SubstanceSourceMaterial) src);
-        if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
-            return SupplyDelivery40_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
-        if (src instanceof org.hl7.fhir.r5.model.SupplyRequest)
-            return SupplyRequest40_50.convertSupplyRequest((org.hl7.fhir.r5.model.SupplyRequest) src);
-        if (src instanceof org.hl7.fhir.r5.model.Task)
-            return Task40_50.convertTask((org.hl7.fhir.r5.model.Task) src);
-        if (src instanceof org.hl7.fhir.r5.model.TerminologyCapabilities)
-            return TerminologyCapabilities40_50.convertTerminologyCapabilities((org.hl7.fhir.r5.model.TerminologyCapabilities) src);
-        if (src instanceof org.hl7.fhir.r5.model.TestReport)
-            return TestReport40_50.convertTestReport((org.hl7.fhir.r5.model.TestReport) src);
-        if (src instanceof org.hl7.fhir.r5.model.TestScript)
-            return TestScript40_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
-        if (src instanceof org.hl7.fhir.r5.model.ValueSet)
-            return ValueSet40_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
-        if (src instanceof org.hl7.fhir.r5.model.VerificationResult)
-            return VerificationResult40_50.convertVerificationResult((org.hl7.fhir.r5.model.VerificationResult) src);
-        if (src instanceof org.hl7.fhir.r5.model.VisionPrescription)
-            return VisionPrescription40_50.convertVisionPrescription((org.hl7.fhir.r5.model.VisionPrescription) src);
-        throw new FHIRException("Unknown resource " + src.fhirType());
-    }
-
-    protected static org.hl7.fhir.r5.model.CodeType convertResourceEnum(org.hl7.fhir.r4.model.CodeType src) {
-        return convertCode(src);
-    }
-
-    protected static org.hl7.fhir.r4.model.CodeType convertResourceEnum(org.hl7.fhir.r5.model.CodeType src) {
-        return convertCode(src);
-    }
-
-    protected static CodeableReference convertReferenceToCodeableReference(org.hl7.fhir.r4.model.Reference src) {
-        CodeableReference tgt = new CodeableReference();
-        tgt.setReference(convertReference(src));
-        return tgt;
-    }
-
-    protected static CodeableReference convertCodeableConceptToCodeableReference(org.hl7.fhir.r4.model.CodeableConcept src) {
-        CodeableReference tgt = new CodeableReference();
-        tgt.setConcept(convertCodeableConcept(src));
-        return tgt;
-    }
+  protected static void copyElement(org.hl7.fhir.r4.model.Element src, org.hl7.fhir.r5.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  protected static void copyElement(org.hl7.fhir.r5.model.Element src, org.hl7.fhir.r4.model.Element tgt, String... extensionsToIgnore) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      if (!isExemptExtension(e.getUrl(), extensionsToIgnore)) {
+        tgt.addExtension(convertExtension(e));
+      }
+    }
+  }
+
+  protected static void copyEnumeration(org.hl7.fhir.r4.model.Enumeration<?> src, org.hl7.fhir.r5.model.Enumeration<?> tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r4.model.Extension e : src.getExtension()) {
+      tgt.addExtension(convertExtension(e));
+    }
+  }
+
+  protected static void copyEnumeration(org.hl7.fhir.r5.model.Enumeration<?> src, org.hl7.fhir.r4.model.Enumeration<?> tgt) throws FHIRException {
+    if (src.hasId()) tgt.setId(src.getId());
+    for (org.hl7.fhir.r5.model.Extension e : src.getExtension()) {
+      tgt.addExtension(convertExtension(e));
+    }
+  }
+
+  protected static void copyBackboneElement(org.hl7.fhir.r4.model.BackboneElement src, org.hl7.fhir.r5.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  protected static void copyBackboneElement(org.hl7.fhir.r5.model.BackboneElement src, org.hl7.fhir.r4.model.BackboneElement tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  protected static void copyBackboneElement(org.hl7.fhir.r5.model.BackboneType src, org.hl7.fhir.r4.model.BackboneType tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  protected static void copyBackboneElement(org.hl7.fhir.r4.model.BackboneType src, org.hl7.fhir.r5.model.BackboneType tgt) throws FHIRException {
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Extension e : src.getModifierExtension()) {
+      tgt.addModifierExtension(convertExtension(e));
+    }
+  }
+
+  protected static org.hl7.fhir.utilities.xhtml.XhtmlNode convertXhtml(org.hl7.fhir.utilities.xhtml.XhtmlNode src) throws FHIRException {
+    return src;
+  }
+
+  public static org.hl7.fhir.r5.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r4.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r5.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r5.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Base64BinaryType convertBase64Binary(org.hl7.fhir.r5.model.Base64BinaryType src) throws FHIRException {
+    org.hl7.fhir.r4.model.Base64BinaryType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.Base64BinaryType(src.getValue()) : new org.hl7.fhir.r4.model.Base64BinaryType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.BooleanType convertBoolean(org.hl7.fhir.r4.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r5.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.BooleanType(src.getValue()) : new org.hl7.fhir.r5.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.BooleanType convertBoolean(org.hl7.fhir.r5.model.BooleanType src) throws FHIRException {
+    org.hl7.fhir.r4.model.BooleanType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.BooleanType(src.getValue()) : new org.hl7.fhir.r4.model.BooleanType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CanonicalType convertCanonical(org.hl7.fhir.r4.model.CanonicalType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CanonicalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CanonicalType(src.getValue()) : new org.hl7.fhir.r5.model.CanonicalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CanonicalType convertCanonical(org.hl7.fhir.r5.model.CanonicalType src) throws FHIRException {
+    org.hl7.fhir.r4.model.CanonicalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CanonicalType(src.getValue()) : new org.hl7.fhir.r4.model.CanonicalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeType convertCode(org.hl7.fhir.r4.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.CodeType(src.getValue()) : new org.hl7.fhir.r5.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeType convertCode(org.hl7.fhir.r5.model.CodeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.CodeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.CodeType(src.getValue()) : new org.hl7.fhir.r4.model.CodeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateType convertDate(org.hl7.fhir.r4.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateType(src.getValue()) : new org.hl7.fhir.r5.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateType convertDate(org.hl7.fhir.r5.model.DateType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateType(src.getValue()) : new org.hl7.fhir.r4.model.DateType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r5.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.r5.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DecimalType convertDecimal(org.hl7.fhir.r4.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r5.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.DecimalType(src.getValue()) : new org.hl7.fhir.r5.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DecimalType convertDecimal(org.hl7.fhir.r5.model.DecimalType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DecimalType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DecimalType(src.getValue()) : new org.hl7.fhir.r4.model.DecimalType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IdType convertId(org.hl7.fhir.r4.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IdType(src.getValue()) : new org.hl7.fhir.r5.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IdType convertId(org.hl7.fhir.r5.model.IdType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IdType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IdType(src.getValue()) : new org.hl7.fhir.r4.model.IdType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.InstantType convertInstant(org.hl7.fhir.r4.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r5.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.InstantType(src.getValue()) : new org.hl7.fhir.r5.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.InstantType convertInstant(org.hl7.fhir.r5.model.InstantType src) throws FHIRException {
+    org.hl7.fhir.r4.model.InstantType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.InstantType(src.getValueAsString()) : new org.hl7.fhir.r4.model.InstantType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.IntegerType convertInteger(org.hl7.fhir.r4.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r5.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.IntegerType(src.getValueAsString()) : new org.hl7.fhir.r5.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Integer64Type convertUnsignedIntToInteger64(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.Integer64Type tgt = src.hasValue() ? new org.hl7.fhir.r5.model.Integer64Type(src.getValueAsString()) : new org.hl7.fhir.r5.model.Integer64Type();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UnsignedIntType convertInteger64ToUnsignedInt(org.hl7.fhir.r5.model.Integer64Type src) throws FHIRException {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValueAsString()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.IntegerType convertInteger(org.hl7.fhir.r5.model.IntegerType src) throws FHIRException {
+    org.hl7.fhir.r4.model.IntegerType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.IntegerType(src.getValueAsString()) : new org.hl7.fhir.r4.model.IntegerType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertMarkdown(org.hl7.fhir.r4.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.MarkdownType convertMarkdown(org.hl7.fhir.r5.model.MarkdownType src) throws FHIRException {
+    org.hl7.fhir.r4.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r4.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.OidType convertOid(org.hl7.fhir.r4.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.OidType(src.getValue()) : new org.hl7.fhir.r5.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.OidType convertOid(org.hl7.fhir.r5.model.OidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.OidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.OidType(src.getValue()) : new org.hl7.fhir.r4.model.OidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r4.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r5.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.PositiveIntType convertPositiveInt(org.hl7.fhir.r5.model.PositiveIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.PositiveIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.PositiveIntType(src.getValue()) : new org.hl7.fhir.r4.model.PositiveIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.StringType convertString(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.StringType(src.getValue()) : new org.hl7.fhir.r5.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarkdownType convertStringToMarkdown(org.hl7.fhir.r4.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r5.model.MarkdownType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.MarkdownType(src.getValue()) : new org.hl7.fhir.r5.model.MarkdownType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.StringType convertString(org.hl7.fhir.r5.model.StringType src) throws FHIRException {
+    org.hl7.fhir.r4.model.StringType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.StringType(src.getValue()) : new org.hl7.fhir.r4.model.StringType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TimeType convertTime(org.hl7.fhir.r4.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r5.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.TimeType(src.getValue()) : new org.hl7.fhir.r5.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TimeType convertTime(org.hl7.fhir.r5.model.TimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.TimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.TimeType(src.getValue()) : new org.hl7.fhir.r4.model.TimeType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r4.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r5.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UnsignedIntType convertUnsignedInt(org.hl7.fhir.r5.model.UnsignedIntType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UnsignedIntType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UnsignedIntType(src.getValue()) : new org.hl7.fhir.r4.model.UnsignedIntType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UriType convertUri(org.hl7.fhir.r4.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UriType(src.getValue()) : new org.hl7.fhir.r5.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UriType convertUri(org.hl7.fhir.r5.model.UriType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UriType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UriType(src.getValue()) : new org.hl7.fhir.r4.model.UriType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UrlType convertUrl(org.hl7.fhir.r4.model.UrlType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UrlType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UrlType(src.getValue()) : new org.hl7.fhir.r5.model.UrlType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UrlType convertUrl(org.hl7.fhir.r5.model.UrlType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UrlType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UrlType(src.getValue()) : new org.hl7.fhir.r4.model.UrlType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UuidType convertUuid(org.hl7.fhir.r4.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r5.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r5.model.UuidType(src.getValue()) : new org.hl7.fhir.r5.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UuidType convertUuid(org.hl7.fhir.r5.model.UuidType src) throws FHIRException {
+    org.hl7.fhir.r4.model.UuidType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.UuidType(src.getValue()) : new org.hl7.fhir.r4.model.UuidType();
+    copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Extension convertExtension(org.hl7.fhir.r4.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Extension tgt = new org.hl7.fhir.r5.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Extension convertExtension(org.hl7.fhir.r5.model.Extension src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
+    copyElement(src, tgt);
+    if (src.hasUrl()) tgt.setUrlElement(convertUri(src.getUrlElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Narrative convertNarrative(org.hl7.fhir.r4.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Narrative tgt = new org.hl7.fhir.r5.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(convertXhtml(src.getDiv()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Narrative convertNarrative(org.hl7.fhir.r5.model.Narrative src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Narrative tgt = new org.hl7.fhir.r4.model.Narrative();
+    copyElement(src, tgt);
+    if (src.hasStatus()) tgt.setStatusElement(convertNarrativeStatus(src.getStatusElement()));
+    if (src.hasDiv()) tgt.setDiv(convertXhtml(src.getDiv()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> convertNarrativeStatus(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Narrative.NarrativeStatus> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Narrative.NarrativeStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Narrative.NarrativeStatusEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+    } else {
+      switch (src.getValue()) {
+        case GENERATED:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.GENERATED);
+          break;
+        case EXTENSIONS:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EXTENSIONS);
+          break;
+        case ADDITIONAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.ADDITIONAL);
+          break;
+        case EMPTY:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.EMPTY);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Narrative.NarrativeStatus.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Address convertAddress(org.hl7.fhir.r4.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Address tgt = new org.hl7.fhir.r5.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getLine()) tgt.getLine().add(convertString(t));
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Address convertAddress(org.hl7.fhir.r5.model.Address src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Address tgt = new org.hl7.fhir.r4.model.Address();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertAddressUse(src.getUseElement()));
+    if (src.hasType()) tgt.setTypeElement(convertAddressType(src.getTypeElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getLine()) tgt.getLine().add(convertString(t));
+    if (src.hasCity()) tgt.setCityElement(convertString(src.getCityElement()));
+    if (src.hasDistrict()) tgt.setDistrictElement(convertString(src.getDistrictElement()));
+    if (src.hasState()) tgt.setStateElement(convertString(src.getStateElement()));
+    if (src.hasPostalCode()) tgt.setPostalCodeElement(convertString(src.getPostalCodeElement()));
+    if (src.hasCountry()) tgt.setCountryElement(convertString(src.getCountryElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.OLD);
+          break;
+        case BILLING:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.BILLING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> convertAddressUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.OLD);
+          break;
+        case BILLING:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.BILLING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> convertAddressType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> convertAddressType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Address.AddressType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Address.AddressType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Address.AddressTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case POSTAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.POSTAL);
+          break;
+        case PHYSICAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.PHYSICAL);
+          break;
+        case BOTH:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.BOTH);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Address.AddressType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Age convertAge(org.hl7.fhir.r4.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Age tgt = new org.hl7.fhir.r5.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Age convertAge(org.hl7.fhir.r5.model.Age src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Age tgt = new org.hl7.fhir.r4.model.Age();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Annotation convertAnnotation(org.hl7.fhir.r4.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Annotation tgt = new org.hl7.fhir.r5.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setTextElement(convertMarkdown(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Annotation convertAnnotation(org.hl7.fhir.r5.model.Annotation src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Annotation tgt = new org.hl7.fhir.r4.model.Annotation();
+    copyElement(src, tgt);
+    if (src.hasAuthor()) tgt.setAuthor(convertType(src.getAuthor()));
+    if (src.hasTime()) tgt.setTimeElement(convertDateTime(src.getTimeElement()));
+    if (src.hasText()) tgt.setTextElement(convertMarkdown(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Attachment convertAttachment(org.hl7.fhir.r4.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Attachment tgt = new org.hl7.fhir.r5.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUrl(src.getUrlElement()));
+    if (src.hasSize()) tgt.setSizeElement(convertUnsignedIntToInteger64(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Attachment convertAttachment(org.hl7.fhir.r5.model.Attachment src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Attachment tgt = new org.hl7.fhir.r4.model.Attachment();
+    copyElement(src, tgt);
+    if (src.hasContentType()) tgt.setContentTypeElement(convertCode(src.getContentTypeElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUrl(src.getUrlElement()));
+    if (src.hasSize()) tgt.setSizeElement(convertInteger64ToUnsignedInt(src.getSizeElement()));
+    if (src.hasHash()) tgt.setHashElement(convertBase64Binary(src.getHashElement()));
+    if (src.hasTitle()) tgt.setTitleElement(convertString(src.getTitleElement()));
+    if (src.hasCreation()) tgt.setCreationElement(convertDateTime(src.getCreationElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r4.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.CodeableConcept tgt = new org.hl7.fhir.r5.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.CodeableConcept convertCodeableConcept(org.hl7.fhir.r5.model.CodeableConcept src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.CodeableConcept tgt = new org.hl7.fhir.r4.model.CodeableConcept();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getCoding()) tgt.addCoding(convertCoding(t));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Coding convertCoding(org.hl7.fhir.r4.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Coding tgt = new org.hl7.fhir.r5.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Coding convertCoding(org.hl7.fhir.r5.model.Coding src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Coding tgt = new org.hl7.fhir.r4.model.Coding();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasVersion()) tgt.setVersionElement(convertString(src.getVersionElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasUserSelected()) tgt.setUserSelectedElement(convertBoolean(src.getUserSelectedElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ContactDetail convertContactDetail(org.hl7.fhir.r4.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ContactDetail tgt = new org.hl7.fhir.r5.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r4.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactDetail convertContactDetail(org.hl7.fhir.r5.model.ContactDetail src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ContactDetail tgt = new org.hl7.fhir.r4.model.ContactDetail();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r5.model.ContactPoint t : src.getTelecom()) tgt.addTelecom(convertContactPoint(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ContactPoint convertContactPoint(org.hl7.fhir.r4.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ContactPoint tgt = new org.hl7.fhir.r5.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ContactPoint convertContactPoint(org.hl7.fhir.r5.model.ContactPoint src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ContactPoint tgt = new org.hl7.fhir.r4.model.ContactPoint();
+    copyElement(src, tgt);
+    if (src.hasSystem()) tgt.setSystemElement(convertContactPointSystem(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasUse()) tgt.setUseElement(convertContactPointUse(src.getUseElement()));
+    if (src.hasRank()) tgt.setRankElement(convertPositiveInt(src.getRankElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> convertContactPointSystem(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointSystem> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointSystemEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+    } else {
+      switch (src.getValue()) {
+        case PHONE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PHONE);
+          break;
+        case FAX:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.FAX);
+          break;
+        case EMAIL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.EMAIL);
+          break;
+        case PAGER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.PAGER);
+          break;
+        case URL:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.URL);
+          break;
+        case SMS:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.SMS);
+          break;
+        case OTHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.OTHER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> convertContactPointUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ContactPoint.ContactPointUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ContactPoint.ContactPointUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ContactPoint.ContactPointUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case HOME:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.HOME);
+          break;
+        case WORK:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.WORK);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.TEMP);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.OLD);
+          break;
+        case MOBILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.MOBILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ContactPoint.ContactPointUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Contributor convertContributor(org.hl7.fhir.r4.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Contributor tgt = new org.hl7.fhir.r5.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r4.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Contributor convertContributor(org.hl7.fhir.r5.model.Contributor src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Contributor tgt = new org.hl7.fhir.r4.model.Contributor();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertContributorType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    for (org.hl7.fhir.r5.model.ContactDetail t : src.getContact()) tgt.addContact(convertContactDetail(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> convertContributorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Contributor.ContributorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Contributor.ContributorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Contributor.ContributorTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case AUTHOR:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.AUTHOR);
+          break;
+        case EDITOR:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.EDITOR);
+          break;
+        case REVIEWER:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.REVIEWER);
+          break;
+        case ENDORSER:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.ENDORSER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Contributor.ContributorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Count convertCount(org.hl7.fhir.r4.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Count tgt = new org.hl7.fhir.r5.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Count convertCount(org.hl7.fhir.r5.model.Count src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Count tgt = new org.hl7.fhir.r4.model.Count();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement convertDataRequirement(org.hl7.fhir.r4.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement tgt = new org.hl7.fhir.r5.model.DataRequirement();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
+    for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    if (src.hasSubject()) tgt.setSubject(convertType(src.getSubject()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getMustSupport()) tgt.getMustSupport().add(convertString(t));
+    for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    if (src.hasLimit()) tgt.setLimitElement(convertPositiveInt(src.getLimitElement()));
+    for (org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent t : src.getSort())
+      tgt.addSort(convertDataRequirementSortComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement convertDataRequirement(org.hl7.fhir.r5.model.DataRequirement src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement tgt = new org.hl7.fhir.r4.model.DataRequirement();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(src.getType().toCode());
+    for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    if (src.hasSubject()) tgt.setSubject(convertType(src.getSubject()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getMustSupport()) tgt.getMustSupport().add(convertString(t));
+    for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent t : src.getCodeFilter())
+      tgt.addCodeFilter(convertDataRequirementCodeFilterComponent(t));
+    for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent t : src.getDateFilter())
+      tgt.addDateFilter(convertDataRequirementDateFilterComponent(t));
+    if (src.hasLimit()) tgt.setLimitElement(convertPositiveInt(src.getLimitElement()));
+    for (org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent t : src.getSort())
+      tgt.addSort(convertDataRequirementSortComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasSearchParam()) tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
+    if (src.hasValueSet()) tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent convertDataRequirementCodeFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementCodeFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementCodeFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasSearchParam()) tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
+    if (src.hasValueSet()) tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasSearchParam()) tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent convertDataRequirementDateFilterComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementDateFilterComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementDateFilterComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasSearchParam()) tgt.setSearchParamElement(convertString(src.getSearchParamElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent convertDataRequirementSortComponent(org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent tgt = new org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertSortDirection(src.getDirectionElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent convertDataRequirementSortComponent(org.hl7.fhir.r5.model.DataRequirement.DataRequirementSortComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent tgt = new org.hl7.fhir.r4.model.DataRequirement.DataRequirementSortComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasDirection()) tgt.setDirectionElement(convertSortDirection(src.getDirectionElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> convertSortDirection(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.DataRequirement.SortDirectionEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ASCENDING:
+          tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.ASCENDING);
+          break;
+        case DESCENDING:
+          tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.DESCENDING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.DataRequirement.SortDirection.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> convertSortDirection(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.DataRequirement.SortDirection> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.DataRequirement.SortDirection> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.DataRequirement.SortDirectionEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ASCENDING:
+          tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.ASCENDING);
+          break;
+        case DESCENDING:
+          tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.DESCENDING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.DataRequirement.SortDirection.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Distance convertDistance(org.hl7.fhir.r4.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Distance tgt = new org.hl7.fhir.r5.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Distance convertDistance(org.hl7.fhir.r5.model.Distance src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Distance tgt = new org.hl7.fhir.r4.model.Distance();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Dosage convertDosage(org.hl7.fhir.r4.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Dosage tgt = new org.hl7.fhir.r5.model.Dosage();
+    copyBackboneElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r4.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    for (org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent t : src.getDoseAndRate())
+      tgt.addDoseAndRate(convertDosageDoseAndRateComponent(t));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Dosage convertDosage(org.hl7.fhir.r5.model.Dosage src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Dosage tgt = new org.hl7.fhir.r4.model.Dosage();
+    copyBackboneElement(src, tgt);
+    if (src.hasSequence()) tgt.setSequenceElement(convertInteger(src.getSequenceElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    for (org.hl7.fhir.r5.model.CodeableConcept t : src.getAdditionalInstruction())
+      tgt.addAdditionalInstruction(convertCodeableConcept(t));
+    if (src.hasPatientInstruction())
+      tgt.setPatientInstructionElement(convertString(src.getPatientInstructionElement()));
+    if (src.hasTiming()) tgt.setTiming(convertTiming(src.getTiming()));
+    if (src.hasAsNeeded()) tgt.setAsNeeded(convertType(src.getAsNeeded()));
+    if (src.hasSite()) tgt.setSite(convertCodeableConcept(src.getSite()));
+    if (src.hasRoute()) tgt.setRoute(convertCodeableConcept(src.getRoute()));
+    if (src.hasMethod()) tgt.setMethod(convertCodeableConcept(src.getMethod()));
+    for (org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent t : src.getDoseAndRate())
+      tgt.addDoseAndRate(convertDosageDoseAndRateComponent(t));
+    if (src.hasMaxDosePerPeriod()) tgt.setMaxDosePerPeriod(convertRatio(src.getMaxDosePerPeriod()));
+    if (src.hasMaxDosePerAdministration())
+      tgt.setMaxDosePerAdministration(convertSimpleQuantity(src.getMaxDosePerAdministration()));
+    if (src.hasMaxDosePerLifetime()) tgt.setMaxDosePerLifetime(convertSimpleQuantity(src.getMaxDosePerLifetime()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent convertDosageDoseAndRateComponent(org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent tgt = new org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasDose()) tgt.setDose(convertType(src.getDose()));
+    if (src.hasRate()) tgt.setRate(convertType(src.getRate()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent convertDosageDoseAndRateComponent(org.hl7.fhir.r5.model.Dosage.DosageDoseAndRateComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent tgt = new org.hl7.fhir.r4.model.Dosage.DosageDoseAndRateComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasDose()) tgt.setDose(convertType(src.getDose()));
+    if (src.hasRate()) tgt.setRate(convertType(src.getRate()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Duration convertDuration(org.hl7.fhir.r4.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Duration tgt = new org.hl7.fhir.r5.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Duration convertDuration(org.hl7.fhir.r5.model.Duration src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Duration tgt = new org.hl7.fhir.r4.model.Duration();
+    copyQuantity(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Expression convertExpression(org.hl7.fhir.r4.model.Expression src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Expression tgt = new org.hl7.fhir.r5.model.Expression();
+    copyElement(src, tgt);
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasName()) tgt.setNameElement(convertId(src.getNameElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasReference()) tgt.setReferenceElement(convertUri(src.getReferenceElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Expression convertExpression(org.hl7.fhir.r5.model.Expression src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Expression tgt = new org.hl7.fhir.r4.model.Expression();
+    copyElement(src, tgt);
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasName()) tgt.setNameElement(convertId(src.getNameElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasReference()) tgt.setReferenceElement(convertUri(src.getReferenceElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.HumanName convertHumanName(org.hl7.fhir.r4.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.HumanName tgt = new org.hl7.fhir.r5.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getGiven()) tgt.getGiven().add(convertString(t));
+    for (org.hl7.fhir.r4.model.StringType t : src.getPrefix()) tgt.getPrefix().add(convertString(t));
+    for (org.hl7.fhir.r4.model.StringType t : src.getSuffix()) tgt.getSuffix().add(convertString(t));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.HumanName convertHumanName(org.hl7.fhir.r5.model.HumanName src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.HumanName tgt = new org.hl7.fhir.r4.model.HumanName();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertNameUse(src.getUseElement()));
+    if (src.hasText()) tgt.setTextElement(convertString(src.getTextElement()));
+    if (src.hasFamily()) tgt.setFamilyElement(convertString(src.getFamilyElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getGiven()) tgt.getGiven().add(convertString(t));
+    for (org.hl7.fhir.r5.model.StringType t : src.getPrefix()) tgt.getPrefix().add(convertString(t));
+    for (org.hl7.fhir.r5.model.StringType t : src.getSuffix()) tgt.getSuffix().add(convertString(t));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> convertNameUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.HumanName.NameUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.HumanName.NameUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.HumanName.NameUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.TEMP);
+          break;
+        case NICKNAME:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NICKNAME);
+          break;
+        case ANONYMOUS:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.ANONYMOUS);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.OLD);
+          break;
+        case MAIDEN:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.MAIDEN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.HumanName.NameUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Identifier convertIdentifier(org.hl7.fhir.r4.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Identifier tgt = new org.hl7.fhir.r5.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Identifier convertIdentifier(org.hl7.fhir.r5.model.Identifier src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Identifier tgt = new org.hl7.fhir.r4.model.Identifier();
+    copyElement(src, tgt);
+    if (src.hasUse()) tgt.setUseElement(convertIdentifierUse(src.getUseElement()));
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasValue()) tgt.setValueElement(convertString(src.getValueElement()));
+    if (src.hasPeriod()) tgt.setPeriod(convertPeriod(src.getPeriod()));
+    if (src.hasAssigner()) tgt.setAssigner(convertReference(src.getAssigner()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> convertIdentifierUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Identifier.IdentifierUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Identifier.IdentifierUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Identifier.IdentifierUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case USUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.USUAL);
+          break;
+        case OFFICIAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OFFICIAL);
+          break;
+        case TEMP:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.TEMP);
+          break;
+        case SECONDARY:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.SECONDARY);
+          break;
+        case OLD:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.OLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Identifier.IdentifierUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.MarketingStatus convertMarketingStatus(org.hl7.fhir.r4.model.MarketingStatus src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.MarketingStatus tgt = new org.hl7.fhir.r5.model.MarketingStatus();
+    copyBackboneElement(src, tgt);
+    if (src.hasCountry()) tgt.setCountry(convertCodeableConcept(src.getCountry()));
+    if (src.hasJurisdiction()) tgt.setJurisdiction(convertCodeableConcept(src.getJurisdiction()));
+    if (src.hasStatus()) tgt.setStatus(convertCodeableConcept(src.getStatus()));
+    if (src.hasDateRange()) tgt.setDateRange(convertPeriod(src.getDateRange()));
+    if (src.hasRestoreDate()) tgt.setRestoreDateElement(convertDateTime(src.getRestoreDateElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.MarketingStatus convertMarketingStatus(org.hl7.fhir.r5.model.MarketingStatus src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.MarketingStatus tgt = new org.hl7.fhir.r4.model.MarketingStatus();
+    copyBackboneElement(src, tgt);
+    if (src.hasCountry()) tgt.setCountry(convertCodeableConcept(src.getCountry()));
+    if (src.hasJurisdiction()) tgt.setJurisdiction(convertCodeableConcept(src.getJurisdiction()));
+    if (src.hasStatus()) tgt.setStatus(convertCodeableConcept(src.getStatus()));
+    if (src.hasDateRange()) tgt.setDateRange(convertPeriod(src.getDateRange()));
+    if (src.hasRestoreDate()) tgt.setRestoreDateElement(convertDateTime(src.getRestoreDateElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Meta convertMeta(org.hl7.fhir.r4.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Meta tgt = new org.hl7.fhir.r5.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    if (src.hasSource()) tgt.setSourceElement(convertUri(src.getSourceElement()));
+    for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    for (org.hl7.fhir.r4.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r4.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Meta convertMeta(org.hl7.fhir.r5.model.Meta src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Meta tgt = new org.hl7.fhir.r4.model.Meta();
+    copyElement(src, tgt);
+    if (src.hasVersionId()) tgt.setVersionIdElement(convertId(src.getVersionIdElement()));
+    if (src.hasLastUpdated()) tgt.setLastUpdatedElement(convertInstant(src.getLastUpdatedElement()));
+    if (src.hasSource()) tgt.setSourceElement(convertUri(src.getSourceElement()));
+    for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    for (org.hl7.fhir.r5.model.Coding t : src.getSecurity()) tgt.addSecurity(convertCoding(t));
+    for (org.hl7.fhir.r5.model.Coding t : src.getTag()) tgt.addTag(convertCoding(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Money convertMoney(org.hl7.fhir.r4.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Money tgt = new org.hl7.fhir.r5.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCurrencyElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Money convertMoney(org.hl7.fhir.r5.model.Money src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Money tgt = new org.hl7.fhir.r4.model.Money();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasCurrency()) tgt.setCurrencyElement(convertCode(src.getCurrencyElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r4.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ParameterDefinition tgt = new org.hl7.fhir.r5.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setType(org.hl7.fhir.r5.model.Enumerations.FHIRAllTypes.fromCode(src.getType()));
+    if (src.hasProfile()) tgt.setProfileElement(convertCanonical(src.getProfileElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ParameterDefinition convertParameterDefinition(org.hl7.fhir.r5.model.ParameterDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ParameterDefinition tgt = new org.hl7.fhir.r4.model.ParameterDefinition();
+    copyElement(src, tgt);
+    if (src.hasName()) tgt.setNameElement(convertCode(src.getNameElement()));
+    if (src.hasUse()) tgt.setUseElement(convertParameterUse(src.getUseElement()));
+    if (src.hasMin()) tgt.setMinElement(convertInteger(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasDocumentation()) tgt.setDocumentationElement(convertString(src.getDocumentationElement()));
+    if (src.hasType()) tgt.setType(src.getType().toCode());
+    if (src.hasProfile()) tgt.setProfileElement(convertCanonical(src.getProfileElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> convertParameterUse(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.OperationParameterUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.OperationParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> convertParameterUse(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.OperationParameterUse> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ParameterDefinition.ParameterUseEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
+    } else {
+      switch (src.getValue()) {
+        case IN:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.IN);
+          break;
+        case OUT:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.OUT);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ParameterDefinition.ParameterUse.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Period convertPeriod(org.hl7.fhir.r4.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Period tgt = new org.hl7.fhir.r5.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Period convertPeriod(org.hl7.fhir.r5.model.Period src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Period tgt = new org.hl7.fhir.r4.model.Period();
+    copyElement(src, tgt);
+    if (src.hasStart()) tgt.setStartElement(convertDateTime(src.getStartElement()));
+    if (src.hasEnd()) tgt.setEndElement(convertDateTime(src.getEndElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Population convertPopulation(org.hl7.fhir.r4.model.Population src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Population tgt = new org.hl7.fhir.r5.model.Population();
+    copyBackboneElement(src, tgt);
+    if (src.hasAge()) tgt.setAge(convertType(src.getAge()));
+    if (src.hasGender()) tgt.setGender(convertCodeableConcept(src.getGender()));
+    if (src.hasRace()) tgt.setRace(convertCodeableConcept(src.getRace()));
+    if (src.hasPhysiologicalCondition())
+      tgt.setPhysiologicalCondition(convertCodeableConcept(src.getPhysiologicalCondition()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Population convertPopulation(org.hl7.fhir.r5.model.Population src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Population tgt = new org.hl7.fhir.r4.model.Population();
+    copyBackboneElement(src, tgt);
+    if (src.hasAge()) tgt.setAge(convertType(src.getAge()));
+    if (src.hasGender()) tgt.setGender(convertCodeableConcept(src.getGender()));
+    if (src.hasRace()) tgt.setRace(convertCodeableConcept(src.getRace()));
+    if (src.hasPhysiologicalCondition())
+      tgt.setPhysiologicalCondition(convertCodeableConcept(src.getPhysiologicalCondition()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ProdCharacteristic convertProdCharacteristic(org.hl7.fhir.r4.model.ProdCharacteristic src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ProdCharacteristic tgt = new org.hl7.fhir.r5.model.ProdCharacteristic();
+    copyBackboneElement(src, tgt);
+    if (src.hasHeight()) tgt.setHeight(convertQuantity(src.getHeight()));
+    if (src.hasWidth()) tgt.setWidth(convertQuantity(src.getWidth()));
+    if (src.hasDepth()) tgt.setDepth(convertQuantity(src.getDepth()));
+    if (src.hasWeight()) tgt.setWeight(convertQuantity(src.getWeight()));
+    if (src.hasNominalVolume()) tgt.setNominalVolume(convertQuantity(src.getNominalVolume()));
+    if (src.hasExternalDiameter()) tgt.setExternalDiameter(convertQuantity(src.getExternalDiameter()));
+    if (src.hasShape()) tgt.setShapeElement(convertString(src.getShapeElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getColor()) tgt.getColor().add(convertString(t));
+    for (org.hl7.fhir.r4.model.StringType t : src.getImprint()) tgt.getImprint().add(convertString(t));
+    for (org.hl7.fhir.r4.model.Attachment t : src.getImage()) tgt.addImage(convertAttachment(t));
+    if (src.hasScoring()) tgt.setScoring(convertCodeableConcept(src.getScoring()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ProdCharacteristic convertProdCharacteristic(org.hl7.fhir.r5.model.ProdCharacteristic src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ProdCharacteristic tgt = new org.hl7.fhir.r4.model.ProdCharacteristic();
+    copyBackboneElement(src, tgt);
+    if (src.hasHeight()) tgt.setHeight(convertQuantity(src.getHeight()));
+    if (src.hasWidth()) tgt.setWidth(convertQuantity(src.getWidth()));
+    if (src.hasDepth()) tgt.setDepth(convertQuantity(src.getDepth()));
+    if (src.hasWeight()) tgt.setWeight(convertQuantity(src.getWeight()));
+    if (src.hasNominalVolume()) tgt.setNominalVolume(convertQuantity(src.getNominalVolume()));
+    if (src.hasExternalDiameter()) tgt.setExternalDiameter(convertQuantity(src.getExternalDiameter()));
+    if (src.hasShape()) tgt.setShapeElement(convertString(src.getShapeElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getColor()) tgt.getColor().add(convertString(t));
+    for (org.hl7.fhir.r5.model.StringType t : src.getImprint()) tgt.getImprint().add(convertString(t));
+    for (org.hl7.fhir.r5.model.Attachment t : src.getImage()) tgt.addImage(convertAttachment(t));
+    if (src.hasScoring()) tgt.setScoring(convertCodeableConcept(src.getScoring()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ProductShelfLife convertProductShelfLife(org.hl7.fhir.r4.model.ProductShelfLife src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ProductShelfLife tgt = new org.hl7.fhir.r5.model.ProductShelfLife();
+    copyBackboneElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasPeriod()) tgt.setPeriod(convertQuantity(src.getPeriod()));
+    for (org.hl7.fhir.r4.model.CodeableConcept t : src.getSpecialPrecautionsForStorage())
+      tgt.addSpecialPrecautionsForStorage(convertCodeableConcept(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ProductShelfLife convertProductShelfLife(org.hl7.fhir.r5.model.ProductShelfLife src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ProductShelfLife tgt = new org.hl7.fhir.r4.model.ProductShelfLife();
+    copyBackboneElement(src, tgt);
+    if (src.hasType()) tgt.setType(convertCodeableConcept(src.getType()));
+    if (src.hasPeriodQuantity()) tgt.setPeriod(convertQuantity(src.getPeriodQuantity()));
+    for (org.hl7.fhir.r5.model.CodeableConcept t : src.getSpecialPrecautionsForStorage())
+      tgt.addSpecialPrecautionsForStorage(convertCodeableConcept(t));
+    return tgt;
+  }
+
+  public static void copyQuantity(org.hl7.fhir.r4.model.Quantity src, org.hl7.fhir.r5.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnit(src.getUnit());
+    if (src.hasSystem()) tgt.setSystem(src.getSystem());
+    if (src.hasCode()) tgt.setCode(src.getCode());
+  }
+
+  public static void copyQuantity(org.hl7.fhir.r5.model.Quantity src, org.hl7.fhir.r4.model.Quantity tgt) throws FHIRException {
+    if (src == null || tgt == null) return;
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValue(src.getValue());
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnit(src.getUnit());
+    if (src.hasSystem()) tgt.setSystem(src.getSystem());
+    if (src.hasCode()) tgt.setCode(src.getCode());
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.QuantityComparatorEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> convertQuantityComparator(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.QuantityComparator> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Quantity.QuantityComparator> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Quantity.QuantityComparatorEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+    } else {
+      switch (src.getValue()) {
+        case LESS_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_THAN);
+          break;
+        case LESS_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.LESS_OR_EQUAL);
+          break;
+        case GREATER_OR_EQUAL:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_OR_EQUAL);
+          break;
+        case GREATER_THAN:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.GREATER_THAN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Quantity.QuantityComparator.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Range convertRange(org.hl7.fhir.r4.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Range tgt = new org.hl7.fhir.r5.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Range convertRange(org.hl7.fhir.r5.model.Range src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Range tgt = new org.hl7.fhir.r4.model.Range();
+    copyElement(src, tgt);
+    if (src.hasLow()) tgt.setLow(convertSimpleQuantity(src.getLow()));
+    if (src.hasHigh()) tgt.setHigh(convertSimpleQuantity(src.getHigh()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Ratio convertRatio(org.hl7.fhir.r4.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Ratio tgt = new org.hl7.fhir.r5.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Ratio convertRatio(org.hl7.fhir.r5.model.Ratio src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Ratio tgt = new org.hl7.fhir.r4.model.Ratio();
+    copyElement(src, tgt);
+    if (src.hasNumerator()) tgt.setNumerator(convertQuantity(src.getNumerator()));
+    if (src.hasDenominator()) tgt.setDenominator(convertQuantity(src.getDenominator()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Reference convertReference(org.hl7.fhir.r4.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Reference tgt = new org.hl7.fhir.r5.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReferenceElement(convertString(src.getReferenceElement_()));
+    if (src.hasType()) tgt.setTypeElement(convertUri(src.getTypeElement()));
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Reference convertReference(org.hl7.fhir.r5.model.Reference src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Reference tgt = new org.hl7.fhir.r4.model.Reference();
+    copyElement(src, tgt);
+    if (src.hasReference()) tgt.setReferenceElement(convertString(src.getReferenceElement_()));
+    if (src.hasType()) tgt.setTypeElement(convertUri(src.getTypeElement()));
+    if (src.hasIdentifier()) tgt.setIdentifier(convertIdentifier(src.getIdentifier()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r4.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.RelatedArtifact tgt = new org.hl7.fhir.r5.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitationElement(convertMarkdown(src.getCitationElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUrl(src.getUrlElement()));
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResourceElement(convertCanonical(src.getResourceElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.RelatedArtifact convertRelatedArtifact(org.hl7.fhir.r5.model.RelatedArtifact src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.RelatedArtifact tgt = new org.hl7.fhir.r4.model.RelatedArtifact();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertRelatedArtifactType(src.getTypeElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasDisplay()) tgt.setDisplayElement(convertString(src.getDisplayElement()));
+    if (src.hasCitation()) tgt.setCitationElement(convertMarkdown(src.getCitationElement()));
+    if (src.hasUrl()) tgt.setUrlElement(convertUrl(src.getUrlElement()));
+    if (src.hasDocument()) tgt.setDocument(convertAttachment(src.getDocument()));
+    if (src.hasResource()) tgt.setResourceElement(convertCanonical(src.getResourceElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> convertRelatedArtifactType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.RelatedArtifact.RelatedArtifactType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case DOCUMENTATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DOCUMENTATION);
+          break;
+        case JUSTIFICATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.JUSTIFICATION);
+          break;
+        case CITATION:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.CITATION);
+          break;
+        case PREDECESSOR:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.PREDECESSOR);
+          break;
+        case SUCCESSOR:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.SUCCESSOR);
+          break;
+        case DERIVEDFROM:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DERIVEDFROM);
+          break;
+        case DEPENDSON:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.DEPENDSON);
+          break;
+        case COMPOSEDOF:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.COMPOSEDOF);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SampledData convertSampledData(org.hl7.fhir.r4.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.SampledData tgt = new org.hl7.fhir.r5.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SampledData convertSampledData(org.hl7.fhir.r5.model.SampledData src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.SampledData tgt = new org.hl7.fhir.r4.model.SampledData();
+    copyElement(src, tgt);
+    if (src.hasOrigin()) tgt.setOrigin(convertSimpleQuantity(src.getOrigin()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasFactor()) tgt.setFactorElement(convertDecimal(src.getFactorElement()));
+    if (src.hasLowerLimit()) tgt.setLowerLimitElement(convertDecimal(src.getLowerLimitElement()));
+    if (src.hasUpperLimit()) tgt.setUpperLimitElement(convertDecimal(src.getUpperLimitElement()));
+    if (src.hasDimensions()) tgt.setDimensionsElement(convertPositiveInt(src.getDimensionsElement()));
+    if (src.hasData()) tgt.setDataElement(convertString(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Signature convertSignature(org.hl7.fhir.r4.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Signature tgt = new org.hl7.fhir.r5.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertReference(src.getWho()));
+    if (src.hasOnBehalfOf()) tgt.setOnBehalfOf(convertReference(src.getOnBehalfOf()));
+    if (src.hasTargetFormat()) tgt.setTargetFormatElement(convertCode(src.getTargetFormatElement()));
+    if (src.hasSigFormat()) tgt.setSigFormatElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Signature convertSignature(org.hl7.fhir.r5.model.Signature src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Signature tgt = new org.hl7.fhir.r4.model.Signature();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.Coding t : src.getType()) tgt.addType(convertCoding(t));
+    if (src.hasWhen()) tgt.setWhenElement(convertInstant(src.getWhenElement()));
+    if (src.hasWho()) tgt.setWho(convertReference(src.getWho()));
+    if (src.hasOnBehalfOf()) tgt.setOnBehalfOf(convertReference(src.getOnBehalfOf()));
+    if (src.hasTargetFormat()) tgt.setTargetFormatElement(convertCode(src.getTargetFormatElement()));
+    if (src.hasSigFormat()) tgt.setSigFormatElement(convertCode(src.getSigFormatElement()));
+    if (src.hasData()) tgt.setDataElement(convertBase64Binary(src.getDataElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SubstanceAmount convertSubstanceAmount(org.hl7.fhir.r4.model.SubstanceAmount src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.SubstanceAmount tgt = new org.hl7.fhir.r5.model.SubstanceAmount();
+    copyBackboneElement(src, tgt);
+    if (src.hasAmount()) tgt.setAmount(convertType(src.getAmount()));
+    if (src.hasAmountType()) tgt.setAmountType(convertCodeableConcept(src.getAmountType()));
+    if (src.hasAmountText()) tgt.setAmountTextElement(convertString(src.getAmountTextElement()));
+    if (src.hasReferenceRange())
+      tgt.setReferenceRange(convertSubstanceAmountReferenceRangeComponent(src.getReferenceRange()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SubstanceAmount convertSubstanceAmount(org.hl7.fhir.r5.model.SubstanceAmount src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.SubstanceAmount tgt = new org.hl7.fhir.r4.model.SubstanceAmount();
+    copyBackboneElement(src, tgt);
+    if (src.hasAmount()) tgt.setAmount(convertType(src.getAmount()));
+    if (src.hasAmountType()) tgt.setAmountType(convertCodeableConcept(src.getAmountType()));
+    if (src.hasAmountText()) tgt.setAmountTextElement(convertString(src.getAmountTextElement()));
+    if (src.hasReferenceRange())
+      tgt.setReferenceRange(convertSubstanceAmountReferenceRangeComponent(src.getReferenceRange()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent convertSubstanceAmountReferenceRangeComponent(org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent tgt = new org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent();
+    copyElement(src, tgt);
+    if (src.hasLowLimit()) tgt.setLowLimit(convertQuantity(src.getLowLimit()));
+    if (src.hasHighLimit()) tgt.setHighLimit(convertQuantity(src.getHighLimit()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent convertSubstanceAmountReferenceRangeComponent(org.hl7.fhir.r5.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent tgt = new org.hl7.fhir.r4.model.SubstanceAmount.SubstanceAmountReferenceRangeComponent();
+    copyElement(src, tgt);
+    if (src.hasLowLimit()) tgt.setLowLimit(convertQuantity(src.getLowLimit()));
+    if (src.hasHighLimit()) tgt.setHighLimit(convertQuantity(src.getHighLimit()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing convertTiming(org.hl7.fhir.r4.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Timing tgt = new org.hl7.fhir.r5.model.Timing();
+    copyBackboneElement(src, tgt);
+    for (org.hl7.fhir.r4.model.DateTimeType t : src.getEvent()) tgt.getEvent().add(convertDateTime(t));
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing convertTiming(org.hl7.fhir.r5.model.Timing src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Timing tgt = new org.hl7.fhir.r4.model.Timing();
+    copyBackboneElement(src, tgt);
+    for (org.hl7.fhir.r5.model.DateTimeType t : src.getEvent()) tgt.getEvent().add(convertDateTime(t));
+    if (src.hasRepeat()) tgt.setRepeat(convertTimingRepeatComponent(src.getRepeat()));
+    if (src.hasCode()) tgt.setCode(convertCodeableConcept(src.getCode()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r4.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r5.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCountElement(convertPositiveInt(src.getCountElement()));
+    if (src.hasCountMax()) tgt.setCountMaxElement(convertPositiveInt(src.getCountMaxElement()));
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequencyElement(convertPositiveInt(src.getFrequencyElement()));
+    if (src.hasFrequencyMax()) tgt.setFrequencyMaxElement(convertPositiveInt(src.getFrequencyMaxElement()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_40_50::convertDayOfWeek).collect(Collectors.toList()));
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_40_50::convertEventTiming).collect(Collectors.toList()));
+    for (org.hl7.fhir.r4.model.TimeType t : src.getTimeOfDay()) tgt.getTimeOfDay().add(convertTime(t));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Timing.TimingRepeatComponent convertTimingRepeatComponent(org.hl7.fhir.r5.model.Timing.TimingRepeatComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Timing.TimingRepeatComponent tgt = new org.hl7.fhir.r4.model.Timing.TimingRepeatComponent();
+    copyElement(src, tgt);
+    if (src.hasBounds()) tgt.setBounds(convertType(src.getBounds()));
+    if (src.hasCount()) tgt.setCountElement(convertPositiveInt(src.getCountElement()));
+    if (src.hasCountMax()) tgt.setCountMaxElement(convertPositiveInt(src.getCountMaxElement()));
+    if (src.hasDuration()) tgt.setDurationElement(convertDecimal(src.getDurationElement()));
+    if (src.hasDurationMax()) tgt.setDurationMaxElement(convertDecimal(src.getDurationMaxElement()));
+    if (src.hasDurationUnit()) tgt.setDurationUnitElement(convertUnitsOfTime(src.getDurationUnitElement()));
+    if (src.hasFrequency()) tgt.setFrequencyElement(convertPositiveInt(src.getFrequencyElement()));
+    if (src.hasFrequencyMax()) tgt.setFrequencyMaxElement(convertPositiveInt(src.getFrequencyMaxElement()));
+    if (src.hasPeriod()) tgt.setPeriodElement(convertDecimal(src.getPeriodElement()));
+    if (src.hasPeriodMax()) tgt.setPeriodMaxElement(convertDecimal(src.getPeriodMaxElement()));
+    if (src.hasPeriodUnit()) tgt.setPeriodUnitElement(convertUnitsOfTime(src.getPeriodUnitElement()));
+    tgt.setDayOfWeek(src.getDayOfWeek().stream().map(VersionConvertor_40_50::convertDayOfWeek).collect(Collectors.toList()));
+    tgt.setWhen(src.getWhen().stream().map(VersionConvertor_40_50::convertEventTiming).collect(Collectors.toList()));
+    for (org.hl7.fhir.r5.model.TimeType t : src.getTimeOfDay()) tgt.getTimeOfDay().add(convertTime(t));
+    if (src.hasOffset()) tgt.setOffsetElement(convertUnsignedInt(src.getOffsetElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> convertUnitsOfTime(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.UnitsOfTime> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.UnitsOfTime> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.UnitsOfTimeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+    } else {
+      switch (src.getValue()) {
+        case S:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.S);
+          break;
+        case MIN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MIN);
+          break;
+        case H:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.H);
+          break;
+        case D:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.D);
+          break;
+        case WK:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.WK);
+          break;
+        case MO:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.MO);
+          break;
+        case A:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.A);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.UnitsOfTime.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> convertDayOfWeek(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Enumerations.DaysOfWeekEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Enumerations.DaysOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> convertDayOfWeek(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Enumerations.DaysOfWeek> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.DayOfWeek> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.DayOfWeekEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MON:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.MON);
+          break;
+        case TUE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.TUE);
+          break;
+        case WED:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.WED);
+          break;
+        case THU:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.THU);
+          break;
+        case FRI:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.FRI);
+          break;
+        case SAT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SAT);
+          break;
+        case SUN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.SUN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.DayOfWeek.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN);
+          break;
+        case MORN_EARLY:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN_EARLY);
+          break;
+        case MORN_LATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.MORN_LATE);
+          break;
+        case NOON:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NOON);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT);
+          break;
+        case AFT_EARLY:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT_EARLY);
+          break;
+        case AFT_LATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AFT_LATE);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE);
+          break;
+        case EVE_EARLY:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE_EARLY);
+          break;
+        case EVE_LATE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.EVE_LATE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> convertEventTiming(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.Timing.EventTiming> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Timing.EventTiming> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Timing.EventTimingEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+    } else {
+      switch (src.getValue()) {
+        case MORN:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN);
+          break;
+        case MORN_EARLY:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN_EARLY);
+          break;
+        case MORN_LATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.MORN_LATE);
+          break;
+        case NOON:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NOON);
+          break;
+        case AFT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT);
+          break;
+        case AFT_EARLY:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT_EARLY);
+          break;
+        case AFT_LATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AFT_LATE);
+          break;
+        case EVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE);
+          break;
+        case EVE_EARLY:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE_EARLY);
+          break;
+        case EVE_LATE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.EVE_LATE);
+          break;
+        case NIGHT:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NIGHT);
+          break;
+        case PHS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PHS);
+          break;
+        case HS:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.HS);
+          break;
+        case WAKE:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.WAKE);
+          break;
+        case C:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.C);
+          break;
+        case CM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CM);
+          break;
+        case CD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CD);
+          break;
+        case CV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.CV);
+          break;
+        case AC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.AC);
+          break;
+        case ACM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACM);
+          break;
+        case ACD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACD);
+          break;
+        case ACV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.ACV);
+          break;
+        case PC:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PC);
+          break;
+        case PCM:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCM);
+          break;
+        case PCD:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCD);
+          break;
+        case PCV:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.PCV);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Timing.EventTiming.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r4.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.TriggerDefinition tgt = new org.hl7.fhir.r5.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    if (src.hasTiming()) tgt.setTiming(convertType(src.getTiming()));
+    for (org.hl7.fhir.r4.model.DataRequirement t : src.getData()) tgt.addData(convertDataRequirement(t));
+    if (src.hasCondition()) tgt.setCondition(convertExpression(src.getCondition()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.TriggerDefinition convertTriggerDefinition(org.hl7.fhir.r5.model.TriggerDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.TriggerDefinition tgt = new org.hl7.fhir.r4.model.TriggerDefinition();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertTriggerType(src.getTypeElement()));
+    if (src.hasName()) tgt.setNameElement(convertString(src.getNameElement()));
+    if (src.hasTiming()) tgt.setTiming(convertType(src.getTiming()));
+    for (org.hl7.fhir.r5.model.DataRequirement t : src.getData()) tgt.addData(convertDataRequirement(t));
+    if (src.hasCondition()) tgt.setCondition(convertExpression(src.getCondition()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATACHANGED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATACHANGED);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> convertTriggerType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.TriggerDefinition.TriggerType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.TriggerDefinition.TriggerType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.TriggerDefinition.TriggerTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case NAMEDEVENT:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NAMEDEVENT);
+          break;
+        case PERIODIC:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.PERIODIC);
+          break;
+        case DATACHANGED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATACHANGED);
+          break;
+        case DATAADDED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAADDED);
+          break;
+        case DATAMODIFIED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAMODIFIED);
+          break;
+        case DATAREMOVED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAREMOVED);
+          break;
+        case DATAACCESSED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSED);
+          break;
+        case DATAACCESSENDED:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.DATAACCESSENDED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.TriggerDefinition.TriggerType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.UsageContext convertUsageContext(org.hl7.fhir.r4.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.UsageContext tgt = new org.hl7.fhir.r5.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.UsageContext convertUsageContext(org.hl7.fhir.r5.model.UsageContext src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.UsageContext tgt = new org.hl7.fhir.r4.model.UsageContext();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCode(convertCoding(src.getCode()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r4.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition tgt = new org.hl7.fhir.r5.model.ElementDefinition();
+    copyBackboneElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_40_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasSliceIsConstraining())
+      tgt.setSliceIsConstrainingElement(convertBoolean(src.getSliceIsConstrainingElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r4.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r4.model.StringType t : src.getAlias()) tgt.getAlias().add(convertString(t));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent t : src.getType())
+      tgt.addType(convertTypeRefComponent(t));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r4.model.IdType t : src.getCondition()) tgt.getCondition().add(convertId(t));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason()) tgt.setIsModifierReasonElement(convertString(src.getIsModifierReasonElement()));
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.r5.model.ElementDefinition src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
+    copyBackboneElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    tgt.setRepresentation(src.getRepresentation().stream().map(VersionConvertor_40_50::convertPropertyRepresentation).collect(Collectors.toList()));
+    if (src.hasSliceName()) tgt.setSliceNameElement(convertString(src.getSliceNameElement()));
+    if (src.hasSliceIsConstraining())
+      tgt.setSliceIsConstrainingElement(convertBoolean(src.getSliceIsConstrainingElement()));
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    for (org.hl7.fhir.r5.model.Coding t : src.getCode()) tgt.addCode(convertCoding(t));
+    if (src.hasSlicing()) tgt.setSlicing(convertElementDefinitionSlicingComponent(src.getSlicing()));
+    if (src.hasShort()) tgt.setShortElement(convertString(src.getShortElement()));
+    if (src.hasDefinition()) tgt.setDefinitionElement(convertMarkdown(src.getDefinitionElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertMarkdown(src.getCommentElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertMarkdown(src.getRequirementsElement()));
+    for (org.hl7.fhir.r5.model.StringType t : src.getAlias()) tgt.getAlias().add(convertString(t));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    if (src.hasBase()) tgt.setBase(convertElementDefinitionBaseComponent(src.getBase()));
+    if (src.hasContentReference()) tgt.setContentReferenceElement(convertUri(src.getContentReferenceElement()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent t : src.getType())
+      tgt.addType(convertTypeRefComponent(t));
+    if (src.hasDefaultValue()) tgt.setDefaultValue(convertType(src.getDefaultValue()));
+    if (src.hasMeaningWhenMissing())
+      tgt.setMeaningWhenMissingElement(convertMarkdown(src.getMeaningWhenMissingElement()));
+    if (src.hasOrderMeaning()) tgt.setOrderMeaningElement(convertString(src.getOrderMeaningElement()));
+    if (src.hasFixed()) tgt.setFixed(convertType(src.getFixed()));
+    if (src.hasPattern()) tgt.setPattern(convertType(src.getPattern()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent t : src.getExample())
+      tgt.addExample(convertElementDefinitionExampleComponent(t));
+    if (src.hasMinValue()) tgt.setMinValue(convertType(src.getMinValue()));
+    if (src.hasMaxValue()) tgt.setMaxValue(convertType(src.getMaxValue()));
+    if (src.hasMaxLength()) tgt.setMaxLengthElement(convertInteger(src.getMaxLengthElement()));
+    for (org.hl7.fhir.r5.model.IdType t : src.getCondition()) tgt.getCondition().add(convertId(t));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent t : src.getConstraint())
+      tgt.addConstraint(convertElementDefinitionConstraintComponent(t));
+    if (src.hasMustSupport()) tgt.setMustSupportElement(convertBoolean(src.getMustSupportElement()));
+    if (src.hasIsModifier()) tgt.setIsModifierElement(convertBoolean(src.getIsModifierElement()));
+    if (src.hasIsModifierReason()) tgt.setIsModifierReasonElement(convertString(src.getIsModifierReasonElement()));
+    if (src.hasIsSummary()) tgt.setIsSummaryElement(convertBoolean(src.getIsSummaryElement()));
+    if (src.hasBinding()) tgt.setBinding(convertElementDefinitionBindingComponent(src.getBinding()));
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent t : src.getMapping())
+      tgt.addMapping(convertElementDefinitionMappingComponent(t));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> convertPropertyRepresentation(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.PropertyRepresentation> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentationEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+    } else {
+      switch (src.getValue()) {
+        case XMLATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLATTR);
+          break;
+        case XMLTEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XMLTEXT);
+          break;
+        case TYPEATTR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.TYPEATTR);
+          break;
+        case CDATEXT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.CDATEXT);
+          break;
+        case XHTML:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.XHTML);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.PropertyRepresentation.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent convertElementDefinitionSlicingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingComponent();
+    copyElement(src, tgt);
+    for (org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent t : src.getDiscriminator())
+      tgt.addDiscriminator(convertElementDefinitionSlicingDiscriminatorComponent(t));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasOrdered()) tgt.setOrderedElement(convertBoolean(src.getOrderedElement()));
+    if (src.hasRules()) tgt.setRulesElement(convertSlicingRules(src.getRulesElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> convertSlicingRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.SlicingRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.SlicingRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.SlicingRulesEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CLOSED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.CLOSED);
+          break;
+        case OPEN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPEN);
+          break;
+        case OPENATEND:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.OPENATEND);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.SlicingRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent convertElementDefinitionSlicingDiscriminatorComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionSlicingDiscriminatorComponent();
+    copyElement(src, tgt);
+    if (src.hasType()) tgt.setTypeElement(convertDiscriminatorType(src.getTypeElement()));
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> convertDiscriminatorType(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorTypeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
+    } else {
+      switch (src.getValue()) {
+        case VALUE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.VALUE);
+          break;
+        case EXISTS:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.EXISTS);
+          break;
+        case PATTERN:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PATTERN);
+          break;
+        case TYPE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.TYPE);
+          break;
+        case PROFILE:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.PROFILE);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.DiscriminatorType.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent convertElementDefinitionBaseComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBaseComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBaseComponent();
+    copyElement(src, tgt);
+    if (src.hasPath()) tgt.setPathElement(convertString(src.getPathElement()));
+    if (src.hasMin()) tgt.setMinElement(convertUnsignedInt(src.getMinElement()));
+    if (src.hasMax()) tgt.setMaxElement(convertString(src.getMaxElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCodeElement(convertUri(src.getCodeElement()));
+    for (org.hl7.fhir.r4.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    for (org.hl7.fhir.r4.model.CanonicalType t : src.getTargetProfile())
+      tgt.getTargetProfile().add(convertCanonical(t));
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_40_50::convertAggregationMode).collect(Collectors.toList()));
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent convertTypeRefComponent(org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.TypeRefComponent();
+    copyElement(src, tgt);
+    if (src.hasCode()) tgt.setCodeElement(convertUri(src.getCodeElement()));
+    for (org.hl7.fhir.r5.model.CanonicalType t : src.getProfile()) tgt.getProfile().add(convertCanonical(t));
+    for (org.hl7.fhir.r5.model.CanonicalType t : src.getTargetProfile())
+      tgt.getTargetProfile().add(convertCanonical(t));
+    tgt.setAggregation(src.getAggregation().stream().map(VersionConvertor_40_50::convertAggregationMode).collect(Collectors.toList()));
+    if (src.hasVersioning()) tgt.setVersioningElement(convertReferenceVersionRules(src.getVersioningElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> convertAggregationMode(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.AggregationMode> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.AggregationMode> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.AggregationModeEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+    } else {
+      switch (src.getValue()) {
+        case CONTAINED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.CONTAINED);
+          break;
+        case REFERENCED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.REFERENCED);
+          break;
+        case BUNDLED:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.BUNDLED);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.AggregationMode.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> convertReferenceVersionRules(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ReferenceVersionRules> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRulesEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+    } else {
+      switch (src.getValue()) {
+        case EITHER:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.EITHER);
+          break;
+        case INDEPENDENT:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.INDEPENDENT);
+          break;
+        case SPECIFIC:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.SPECIFIC);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ReferenceVersionRules.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent convertElementDefinitionExampleComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionExampleComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionExampleComponent();
+    copyElement(src, tgt);
+    if (src.hasLabel()) tgt.setLabelElement(convertString(src.getLabelElement()));
+    if (src.hasValue()) tgt.setValue(convertType(src.getValue()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSourceElement(convertCanonical(src.getSourceElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent convertElementDefinitionConstraintComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionConstraintComponent();
+    copyElement(src, tgt);
+    if (src.hasKey()) tgt.setKeyElement(convertId(src.getKeyElement()));
+    if (src.hasRequirements()) tgt.setRequirementsElement(convertString(src.getRequirementsElement()));
+    if (src.hasSeverity()) tgt.setSeverityElement(convertConstraintSeverity(src.getSeverityElement()));
+    if (src.hasHuman()) tgt.setHumanElement(convertString(src.getHumanElement()));
+    if (src.hasExpression()) tgt.setExpressionElement(convertString(src.getExpressionElement()));
+    if (src.hasXpath()) tgt.setXpathElement(convertString(src.getXpathElement()));
+    if (src.hasSource()) tgt.setSourceElement(convertCanonical(src.getSourceElement()));
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r5.model.Enumeration<>(new org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> convertConstraintSeverity(org.hl7.fhir.r5.model.Enumeration<org.hl7.fhir.r5.model.ElementDefinition.ConstraintSeverity> src) throws FHIRException {
+    if (src == null || src.isEmpty()) return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverityEnumFactory());
+    VersionConvertor_40_50.copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+    } else {
+      switch (src.getValue()) {
+        case ERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.ERROR);
+          break;
+        case WARNING:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.WARNING);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.ElementDefinition.ConstraintSeverity.NULL);
+          break;
+      }
+    }
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(Enumerations40_50.convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent convertElementDefinitionBindingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent();
+    copyElement(src, tgt);
+    if (src.hasStrength()) tgt.setStrengthElement(Enumerations40_50.convertBindingStrength(src.getStrengthElement()));
+    if (src.hasDescription()) tgt.setDescriptionElement(convertString(src.getDescriptionElement()));
+    if (src.hasValueSet()) tgt.setValueSetElement(convertCanonical(src.getValueSetElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent convertElementDefinitionMappingComponent(org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionMappingComponent src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent tgt = new org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionMappingComponent();
+    copyElement(src, tgt);
+    if (src.hasIdentity()) tgt.setIdentityElement(convertId(src.getIdentityElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+    if (src.hasMap()) tgt.setMapElement(convertString(src.getMapElement()));
+    if (src.hasComment()) tgt.setCommentElement(convertString(src.getCommentElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertMoneyQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertMoneyQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.Quantity convertSimpleQuantity(org.hl7.fhir.r4.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r5.model.Quantity tgt = new org.hl7.fhir.r5.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Quantity convertSimpleQuantity(org.hl7.fhir.r5.model.Quantity src) throws FHIRException {
+    if (src == null) return null;
+    org.hl7.fhir.r4.model.Quantity tgt = new org.hl7.fhir.r4.model.Quantity();
+    copyElement(src, tgt);
+    if (src.hasValue()) tgt.setValueElement(convertDecimal(src.getValueElement()));
+    if (src.hasComparator()) tgt.setComparatorElement(convertQuantityComparator(src.getComparatorElement()));
+    if (src.hasUnit()) tgt.setUnitElement(convertString(src.getUnitElement()));
+    if (src.hasSystem()) tgt.setSystemElement(convertUri(src.getSystemElement()));
+    if (src.hasCode()) tgt.setCodeElement(convertCode(src.getCodeElement()));
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r5.model.DataType convertType(org.hl7.fhir.r4.model.Type src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r4.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r4.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r4.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r4.model.CanonicalType)
+      return convertCanonical((org.hl7.fhir.r4.model.CanonicalType) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeType) return convertCode((org.hl7.fhir.r4.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateType) return convertDate((org.hl7.fhir.r4.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r4.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r4.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IdType) return convertId((org.hl7.fhir.r4.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r4.model.InstantType)
+      return convertInstant((org.hl7.fhir.r4.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r4.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r4.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r4.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r4.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r4.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r4.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r4.model.OidType) return convertOid((org.hl7.fhir.r4.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.StringType) return convertString((org.hl7.fhir.r4.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r4.model.TimeType) return convertTime((org.hl7.fhir.r4.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UrlType) return convertUrl((org.hl7.fhir.r4.model.UrlType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UuidType) return convertUuid((org.hl7.fhir.r4.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r4.model.UriType) return convertUri((org.hl7.fhir.r4.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r4.model.Extension) return convertExtension((org.hl7.fhir.r4.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r4.model.Narrative) return convertNarrative((org.hl7.fhir.r4.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r4.model.Address) return convertAddress((org.hl7.fhir.r4.model.Address) src);
+    if (src instanceof org.hl7.fhir.r4.model.Age) return convertAge((org.hl7.fhir.r4.model.Age) src);
+    if (src instanceof org.hl7.fhir.r4.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r4.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r4.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coding) return convertCoding((org.hl7.fhir.r4.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.r4.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.r4.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r4.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.Contributor)
+      return convertContributor((org.hl7.fhir.r4.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.r4.model.Count) return convertCount((org.hl7.fhir.r4.model.Count) src);
+    if (src instanceof org.hl7.fhir.r4.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.r4.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.r4.model.Distance) return convertDistance((org.hl7.fhir.r4.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Dosage) return convertDosage((org.hl7.fhir.r4.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.r4.model.Duration) return convertDuration((org.hl7.fhir.r4.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r4.model.Expression)
+      return convertExpression((org.hl7.fhir.r4.model.Expression) src);
+    if (src instanceof org.hl7.fhir.r4.model.HumanName) return convertHumanName((org.hl7.fhir.r4.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r4.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r4.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r4.model.MarketingStatus)
+      return convertMarketingStatus((org.hl7.fhir.r4.model.MarketingStatus) src);
+    if (src instanceof org.hl7.fhir.r4.model.Meta) return convertMeta((org.hl7.fhir.r4.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r4.model.Money) return convertMoney((org.hl7.fhir.r4.model.Money) src);
+    if (src instanceof org.hl7.fhir.r4.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.r4.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Period) return convertPeriod((org.hl7.fhir.r4.model.Period) src);
+    if (src instanceof org.hl7.fhir.r4.model.Population)
+      return convertPopulation((org.hl7.fhir.r4.model.Population) src);
+    if (src instanceof org.hl7.fhir.r4.model.ProdCharacteristic)
+      return convertProdCharacteristic((org.hl7.fhir.r4.model.ProdCharacteristic) src);
+    if (src instanceof org.hl7.fhir.r4.model.ProductShelfLife)
+      return convertProductShelfLife((org.hl7.fhir.r4.model.ProductShelfLife) src);
+    if (src instanceof org.hl7.fhir.r4.model.MoneyQuantity)
+      return convertMoneyQuantity((org.hl7.fhir.r4.model.MoneyQuantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.r4.model.SimpleQuantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Quantity) return convertQuantity((org.hl7.fhir.r4.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r4.model.Range) return convertRange((org.hl7.fhir.r4.model.Range) src);
+    if (src instanceof org.hl7.fhir.r4.model.Ratio) return convertRatio((org.hl7.fhir.r4.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r4.model.Reference) return convertReference((org.hl7.fhir.r4.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r4.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.r4.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.r4.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r4.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r4.model.Signature) return convertSignature((org.hl7.fhir.r4.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstanceAmount)
+      return convertSubstanceAmount((org.hl7.fhir.r4.model.SubstanceAmount) src);
+    if (src instanceof org.hl7.fhir.r4.model.Timing) return convertTiming((org.hl7.fhir.r4.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r4.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.r4.model.TriggerDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.r4.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.r4.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.r4.model.ElementDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.r4.model.Type convertType(org.hl7.fhir.r5.model.DataType src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Base64BinaryType)
+      return convertBase64Binary((org.hl7.fhir.r5.model.Base64BinaryType) src);
+    if (src instanceof org.hl7.fhir.r5.model.BooleanType)
+      return convertBoolean((org.hl7.fhir.r5.model.BooleanType) src);
+    if (src instanceof org.hl7.fhir.r5.model.CanonicalType)
+      return convertCanonical((org.hl7.fhir.r5.model.CanonicalType) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeType) return convertCode((org.hl7.fhir.r5.model.CodeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateType) return convertDate((org.hl7.fhir.r5.model.DateType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DateTimeType)
+      return convertDateTime((org.hl7.fhir.r5.model.DateTimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.DecimalType)
+      return convertDecimal((org.hl7.fhir.r5.model.DecimalType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IdType) return convertId((org.hl7.fhir.r5.model.IdType) src);
+    if (src instanceof org.hl7.fhir.r5.model.InstantType)
+      return convertInstant((org.hl7.fhir.r5.model.InstantType) src);
+    if (src instanceof org.hl7.fhir.r5.model.MarkdownType)
+      return convertMarkdown((org.hl7.fhir.r5.model.MarkdownType) src);
+    if (src instanceof org.hl7.fhir.r5.model.OidType) return convertOid((org.hl7.fhir.r5.model.OidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.PositiveIntType)
+      return convertPositiveInt((org.hl7.fhir.r5.model.PositiveIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.StringType) return convertString((org.hl7.fhir.r5.model.StringType) src);
+    if (src instanceof org.hl7.fhir.r5.model.TimeType) return convertTime((org.hl7.fhir.r5.model.TimeType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UnsignedIntType)
+      return convertUnsignedInt((org.hl7.fhir.r5.model.UnsignedIntType) src);
+    if (src instanceof org.hl7.fhir.r5.model.IntegerType)
+      return convertInteger((org.hl7.fhir.r5.model.IntegerType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UrlType) return convertUrl((org.hl7.fhir.r5.model.UrlType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UuidType) return convertUuid((org.hl7.fhir.r5.model.UuidType) src);
+    if (src instanceof org.hl7.fhir.r5.model.UriType) return convertUri((org.hl7.fhir.r5.model.UriType) src);
+    if (src instanceof org.hl7.fhir.r5.model.Extension) return convertExtension((org.hl7.fhir.r5.model.Extension) src);
+    if (src instanceof org.hl7.fhir.r5.model.Narrative) return convertNarrative((org.hl7.fhir.r5.model.Narrative) src);
+    if (src instanceof org.hl7.fhir.r5.model.Address) return convertAddress((org.hl7.fhir.r5.model.Address) src);
+    if (src instanceof org.hl7.fhir.r5.model.Age) return convertAge((org.hl7.fhir.r5.model.Age) src);
+    if (src instanceof org.hl7.fhir.r5.model.Annotation)
+      return convertAnnotation((org.hl7.fhir.r5.model.Annotation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Attachment)
+      return convertAttachment((org.hl7.fhir.r5.model.Attachment) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeableConcept)
+      return convertCodeableConcept((org.hl7.fhir.r5.model.CodeableConcept) src);
+    if (src instanceof org.hl7.fhir.r5.model.Coding) return convertCoding((org.hl7.fhir.r5.model.Coding) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactDetail)
+      return convertContactDetail((org.hl7.fhir.r5.model.ContactDetail) src);
+    if (src instanceof org.hl7.fhir.r5.model.ContactPoint)
+      return convertContactPoint((org.hl7.fhir.r5.model.ContactPoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.Contributor)
+      return convertContributor((org.hl7.fhir.r5.model.Contributor) src);
+    if (src instanceof org.hl7.fhir.r5.model.Count) return convertCount((org.hl7.fhir.r5.model.Count) src);
+    if (src instanceof org.hl7.fhir.r5.model.DataRequirement)
+      return convertDataRequirement((org.hl7.fhir.r5.model.DataRequirement) src);
+    if (src instanceof org.hl7.fhir.r5.model.Distance) return convertDistance((org.hl7.fhir.r5.model.Distance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Dosage) return convertDosage((org.hl7.fhir.r5.model.Dosage) src);
+    if (src instanceof org.hl7.fhir.r5.model.Duration) return convertDuration((org.hl7.fhir.r5.model.Duration) src);
+    if (src instanceof org.hl7.fhir.r5.model.Expression)
+      return convertExpression((org.hl7.fhir.r5.model.Expression) src);
+    if (src instanceof org.hl7.fhir.r5.model.HumanName) return convertHumanName((org.hl7.fhir.r5.model.HumanName) src);
+    if (src instanceof org.hl7.fhir.r5.model.Identifier)
+      return convertIdentifier((org.hl7.fhir.r5.model.Identifier) src);
+    if (src instanceof org.hl7.fhir.r5.model.MarketingStatus)
+      return convertMarketingStatus((org.hl7.fhir.r5.model.MarketingStatus) src);
+    if (src instanceof org.hl7.fhir.r5.model.Meta) return convertMeta((org.hl7.fhir.r5.model.Meta) src);
+    if (src instanceof org.hl7.fhir.r5.model.Money) return convertMoney((org.hl7.fhir.r5.model.Money) src);
+    if (src instanceof org.hl7.fhir.r5.model.ParameterDefinition)
+      return convertParameterDefinition((org.hl7.fhir.r5.model.ParameterDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Period) return convertPeriod((org.hl7.fhir.r5.model.Period) src);
+    if (src instanceof org.hl7.fhir.r5.model.Population)
+      return convertPopulation((org.hl7.fhir.r5.model.Population) src);
+    if (src instanceof org.hl7.fhir.r5.model.ProdCharacteristic)
+      return convertProdCharacteristic((org.hl7.fhir.r5.model.ProdCharacteristic) src);
+    if (src instanceof org.hl7.fhir.r5.model.ProductShelfLife)
+      return convertProductShelfLife((org.hl7.fhir.r5.model.ProductShelfLife) src);
+    if (src instanceof org.hl7.fhir.r5.model.MoneyQuantity)
+      return convertMoneyQuantity((org.hl7.fhir.r5.model.MoneyQuantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.SimpleQuantity)
+      return convertSimpleQuantity((org.hl7.fhir.r5.model.SimpleQuantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.Quantity) return convertQuantity((org.hl7.fhir.r5.model.Quantity) src);
+    if (src instanceof org.hl7.fhir.r5.model.Range) return convertRange((org.hl7.fhir.r5.model.Range) src);
+    if (src instanceof org.hl7.fhir.r5.model.Ratio) return convertRatio((org.hl7.fhir.r5.model.Ratio) src);
+    if (src instanceof org.hl7.fhir.r5.model.Reference) return convertReference((org.hl7.fhir.r5.model.Reference) src);
+    if (src instanceof org.hl7.fhir.r5.model.RelatedArtifact)
+      return convertRelatedArtifact((org.hl7.fhir.r5.model.RelatedArtifact) src);
+    if (src instanceof org.hl7.fhir.r5.model.SampledData)
+      return convertSampledData((org.hl7.fhir.r5.model.SampledData) src);
+    if (src instanceof org.hl7.fhir.r5.model.Signature) return convertSignature((org.hl7.fhir.r5.model.Signature) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstanceAmount)
+      return convertSubstanceAmount((org.hl7.fhir.r5.model.SubstanceAmount) src);
+    if (src instanceof org.hl7.fhir.r5.model.Timing) return convertTiming((org.hl7.fhir.r5.model.Timing) src);
+    if (src instanceof org.hl7.fhir.r5.model.TriggerDefinition)
+      return convertTriggerDefinition((org.hl7.fhir.r5.model.TriggerDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.UsageContext)
+      return convertUsageContext((org.hl7.fhir.r5.model.UsageContext) src);
+    if (src instanceof org.hl7.fhir.r5.model.ElementDefinition)
+      return convertElementDefinition((org.hl7.fhir.r5.model.ElementDefinition) src);
+    throw new FHIRException("Unknown type " + src.fhirType());
+  }
+
+  protected static void copyDomainResource(org.hl7.fhir.r4.model.DomainResource src, org.hl7.fhir.r5.model.DomainResource tgt) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r4.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r4.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  protected static void copyDomainResource(org.hl7.fhir.r5.model.DomainResource src, org.hl7.fhir.r4.model.DomainResource tgt) throws FHIRException {
+    copyResource(src, tgt);
+    if (src.hasText()) tgt.setText(convertNarrative(src.getText()));
+    for (org.hl7.fhir.r5.model.Resource t : src.getContained()) tgt.addContained(convertResource(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getExtension()) tgt.addExtension(convertExtension(t));
+    for (org.hl7.fhir.r5.model.Extension t : src.getModifierExtension()) tgt.addModifierExtension(convertExtension(t));
+  }
+
+  protected static void copyResource(org.hl7.fhir.r4.model.Resource src, org.hl7.fhir.r5.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setIdElement(convertId(src.getIdElement()));
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRulesElement(convertUri(src.getImplicitRulesElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+  }
+
+  protected static void copyResource(org.hl7.fhir.r5.model.Resource src, org.hl7.fhir.r4.model.Resource tgt) throws FHIRException {
+    if (src.hasId()) tgt.setIdElement(convertId(src.getIdElement()));
+    if (src.hasMeta()) tgt.setMeta(convertMeta(src.getMeta()));
+    if (src.hasImplicitRules()) tgt.setImplicitRulesElement(convertUri(src.getImplicitRulesElement()));
+    if (src.hasLanguage()) tgt.setLanguageElement(convertCode(src.getLanguageElement()));
+  }
+
+  public static org.hl7.fhir.r5.model.Resource convertResource(org.hl7.fhir.r4.model.Resource src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r4.model.Parameters)
+      return Parameters40_50.convertParameters((org.hl7.fhir.r4.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r4.model.Account)
+      return Account40_50.convertAccount((org.hl7.fhir.r4.model.Account) src);
+    if (src instanceof org.hl7.fhir.r4.model.ActivityDefinition)
+      return ActivityDefinition40_50.convertActivityDefinition((org.hl7.fhir.r4.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.AllergyIntolerance)
+      return AllergyIntolerance40_50.convertAllergyIntolerance((org.hl7.fhir.r4.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Appointment)
+      return Appointment40_50.convertAppointment((org.hl7.fhir.r4.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r4.model.AppointmentResponse)
+      return AppointmentResponse40_50.convertAppointmentResponse((org.hl7.fhir.r4.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.AuditEvent)
+      return AuditEvent40_50.convertAuditEvent((org.hl7.fhir.r4.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r4.model.Basic) return Basic40_50.convertBasic((org.hl7.fhir.r4.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r4.model.Binary)
+      return Binary40_50.convertBinary((org.hl7.fhir.r4.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r4.model.BiologicallyDerivedProduct)
+      return BiologicallyDerivedProduct40_50.convertBiologicallyDerivedProduct((org.hl7.fhir.r4.model.BiologicallyDerivedProduct) src);
+    if (src instanceof org.hl7.fhir.r4.model.BodyStructure)
+      return BodyStructure40_50.convertBodyStructure((org.hl7.fhir.r4.model.BodyStructure) src);
+    if (src instanceof org.hl7.fhir.r4.model.Bundle)
+      return Bundle40_50.convertBundle((org.hl7.fhir.r4.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r4.model.CapabilityStatement)
+      return CapabilityStatement40_50.convertCapabilityStatement((org.hl7.fhir.r4.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.CarePlan)
+      return CarePlan40_50.convertCarePlan((org.hl7.fhir.r4.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r4.model.CareTeam)
+      return CareTeam40_50.convertCareTeam((org.hl7.fhir.r4.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.r4.model.ChargeItem)
+      return ChargeItem40_50.convertChargeItem((org.hl7.fhir.r4.model.ChargeItem) src);
+    if (src instanceof org.hl7.fhir.r4.model.ChargeItemDefinition)
+      return ChargeItemDefinition40_50.convertChargeItemDefinition((org.hl7.fhir.r4.model.ChargeItemDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Claim) return Claim40_50.convertClaim((org.hl7.fhir.r4.model.Claim) src);
+    if (src instanceof org.hl7.fhir.r4.model.ClaimResponse)
+      return ClaimResponse40_50.convertClaimResponse((org.hl7.fhir.r4.model.ClaimResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.ClinicalImpression)
+      return ClinicalImpression40_50.convertClinicalImpression((org.hl7.fhir.r4.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.r4.model.CodeSystem)
+      return CodeSystem40_50.convertCodeSystem((org.hl7.fhir.r4.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.Communication)
+      return Communication40_50.convertCommunication((org.hl7.fhir.r4.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r4.model.CommunicationRequest)
+      return CommunicationRequest40_50.convertCommunicationRequest((org.hl7.fhir.r4.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.CompartmentDefinition)
+      return CompartmentDefinition40_50.convertCompartmentDefinition((org.hl7.fhir.r4.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Composition)
+      return Composition40_50.convertComposition((org.hl7.fhir.r4.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r4.model.ConceptMap)
+      return ConceptMap40_50.convertConceptMap((org.hl7.fhir.r4.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.Condition)
+      return Condition40_50.convertCondition((org.hl7.fhir.r4.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Consent)
+      return Consent40_50.convertConsent((org.hl7.fhir.r4.model.Consent) src);
+    if (src instanceof org.hl7.fhir.r4.model.Contract)
+      return Contract40_50.convertContract((org.hl7.fhir.r4.model.Contract) src);
+    if (src instanceof org.hl7.fhir.r4.model.Coverage)
+      return Coverage40_50.convertCoverage((org.hl7.fhir.r4.model.Coverage) src);
+    if (src instanceof org.hl7.fhir.r4.model.CoverageEligibilityRequest)
+      return CoverageEligibilityRequest40_50.convertCoverageEligibilityRequest((org.hl7.fhir.r4.model.CoverageEligibilityRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.CoverageEligibilityResponse)
+      return CoverageEligibilityResponse40_50.convertCoverageEligibilityResponse((org.hl7.fhir.r4.model.CoverageEligibilityResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.DetectedIssue)
+      return DetectedIssue40_50.convertDetectedIssue((org.hl7.fhir.r4.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r4.model.Device)
+      return Device40_50.convertDevice((org.hl7.fhir.r4.model.Device) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceDefinition)
+      return DeviceDefinition40_50.convertDeviceDefinition((org.hl7.fhir.r4.model.DeviceDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceMetric)
+      return DeviceMetric40_50.convertDeviceMetric((org.hl7.fhir.r4.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceRequest)
+      return DeviceRequest40_50.convertDeviceRequest((org.hl7.fhir.r4.model.DeviceRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.DeviceUseStatement)
+      return DeviceUseStatement40_50.convertDeviceUseStatement((org.hl7.fhir.r4.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.DiagnosticReport)
+      return DiagnosticReport40_50.convertDiagnosticReport((org.hl7.fhir.r4.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.DocumentManifest)
+      return DocumentManifest40_50.convertDocumentManifest((org.hl7.fhir.r4.model.DocumentManifest) src);
+    if (src instanceof org.hl7.fhir.r4.model.DocumentReference)
+      return DocumentReference40_50.convertDocumentReference((org.hl7.fhir.r4.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r4.model.Encounter)
+      return Encounter40_50.convertEncounter((org.hl7.fhir.r4.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r4.model.Endpoint)
+      return Endpoint40_50.convertEndpoint((org.hl7.fhir.r4.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.r4.model.EnrollmentRequest)
+      return EnrollmentRequest40_50.convertEnrollmentRequest((org.hl7.fhir.r4.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.EnrollmentResponse)
+      return EnrollmentResponse40_50.convertEnrollmentResponse((org.hl7.fhir.r4.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.EpisodeOfCare)
+      return EpisodeOfCare40_50.convertEpisodeOfCare((org.hl7.fhir.r4.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r4.model.EventDefinition)
+      return EventDefinition40_50.convertEventDefinition((org.hl7.fhir.r4.model.EventDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.ExampleScenario)
+      return ExampleScenario40_50.convertExampleScenario((org.hl7.fhir.r4.model.ExampleScenario) src);
+    if (src instanceof org.hl7.fhir.r4.model.ExplanationOfBenefit)
+      return ExplanationOfBenefit40_50.convertExplanationOfBenefit((org.hl7.fhir.r4.model.ExplanationOfBenefit) src);
+    if (src instanceof org.hl7.fhir.r4.model.FamilyMemberHistory)
+      return FamilyMemberHistory40_50.convertFamilyMemberHistory((org.hl7.fhir.r4.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r4.model.Flag) return Flag40_50.convertFlag((org.hl7.fhir.r4.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r4.model.Goal) return Goal40_50.convertGoal((org.hl7.fhir.r4.model.Goal) src);
+    if (src instanceof org.hl7.fhir.r4.model.GraphDefinition)
+      return GraphDefinition40_50.convertGraphDefinition((org.hl7.fhir.r4.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Group) return Group40_50.convertGroup((org.hl7.fhir.r4.model.Group) src);
+    if (src instanceof org.hl7.fhir.r4.model.GuidanceResponse)
+      return GuidanceResponse40_50.convertGuidanceResponse((org.hl7.fhir.r4.model.GuidanceResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.HealthcareService)
+      return HealthcareService40_50.convertHealthcareService((org.hl7.fhir.r4.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImagingStudy)
+      return ImagingStudy40_50.convertImagingStudy((org.hl7.fhir.r4.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.r4.model.Immunization)
+      return Immunization40_50.convertImmunization((org.hl7.fhir.r4.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImmunizationEvaluation)
+      return ImmunizationEvaluation40_50.convertImmunizationEvaluation((org.hl7.fhir.r4.model.ImmunizationEvaluation) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImmunizationRecommendation)
+      return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r4.model.ImmunizationRecommendation) src);
+    if (src instanceof org.hl7.fhir.r4.model.ImplementationGuide)
+      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r4.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r4.model.InsurancePlan)
+      return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r4.model.InsurancePlan) src);
+    if (src instanceof org.hl7.fhir.r4.model.Invoice)
+      return Invoice40_50.convertInvoice((org.hl7.fhir.r4.model.Invoice) src);
+    if (src instanceof org.hl7.fhir.r4.model.Library)
+      return Library40_50.convertLibrary((org.hl7.fhir.r4.model.Library) src);
+    if (src instanceof org.hl7.fhir.r4.model.Linkage)
+      return Linkage40_50.convertLinkage((org.hl7.fhir.r4.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.r4.model.ListResource)
+      return ListResource40_50.convertListResource((org.hl7.fhir.r4.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r4.model.Location)
+      return Location40_50.convertLocation((org.hl7.fhir.r4.model.Location) src);
+    if (src instanceof org.hl7.fhir.r4.model.Measure)
+      return Measure40_50.convertMeasure((org.hl7.fhir.r4.model.Measure) src);
+    if (src instanceof org.hl7.fhir.r4.model.MeasureReport)
+      return MeasureReport40_50.convertMeasureReport((org.hl7.fhir.r4.model.MeasureReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.Media) return Media40_50.convertMedia((org.hl7.fhir.r4.model.Media) src);
+    if (src instanceof org.hl7.fhir.r4.model.Medication)
+      return Medication40_50.convertMedication((org.hl7.fhir.r4.model.Medication) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationAdministration)
+      return MedicationAdministration40_50.convertMedicationAdministration((org.hl7.fhir.r4.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationDispense)
+      return MedicationDispense40_50.convertMedicationDispense((org.hl7.fhir.r4.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationKnowledge)
+      return MedicationKnowledge40_50.convertMedicationKnowledge((org.hl7.fhir.r4.model.MedicationKnowledge) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationRequest)
+      return MedicationRequest40_50.convertMedicationRequest((org.hl7.fhir.r4.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicationStatement)
+      return MedicationStatement40_50.convertMedicationStatement((org.hl7.fhir.r4.model.MedicationStatement) src);
+    if (src instanceof org.hl7.fhir.r4.model.MedicinalProduct)
+      return MedicinalProductDefinition40_50.convertMedicinalProduct((org.hl7.fhir.r4.model.MedicinalProduct) src);
+    if (src instanceof org.hl7.fhir.r4.model.MessageDefinition)
+      return MessageDefinition40_50.convertMessageDefinition((org.hl7.fhir.r4.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.MessageHeader)
+      return MessageHeader40_50.convertMessageHeader((org.hl7.fhir.r4.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r4.model.MolecularSequence)
+      return MolecularSequence40_50.convertMolecularSequence((org.hl7.fhir.r4.model.MolecularSequence) src);
+    if (src instanceof org.hl7.fhir.r4.model.NamingSystem)
+      return NamingSystem40_50.convertNamingSystem((org.hl7.fhir.r4.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r4.model.NutritionOrder)
+      return NutritionOrder40_50.convertNutritionOrder((org.hl7.fhir.r4.model.NutritionOrder) src);
+    if (src instanceof org.hl7.fhir.r4.model.Observation)
+      return Observation40_50.convertObservation((org.hl7.fhir.r4.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r4.model.ObservationDefinition)
+      return ObservationDefinition40_50.convertObservationDefinition((org.hl7.fhir.r4.model.ObservationDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationDefinition)
+      return OperationDefinition40_50.convertOperationDefinition((org.hl7.fhir.r4.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.OperationOutcome)
+      return OperationOutcome40_50.convertOperationOutcome((org.hl7.fhir.r4.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r4.model.Organization)
+      return Organization40_50.convertOrganization((org.hl7.fhir.r4.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r4.model.OrganizationAffiliation)
+      return OrganizationAffiliation40_50.convertOrganizationAffiliation((org.hl7.fhir.r4.model.OrganizationAffiliation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Patient)
+      return Patient40_50.convertPatient((org.hl7.fhir.r4.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r4.model.PaymentNotice)
+      return PaymentNotice40_50.convertPaymentNotice((org.hl7.fhir.r4.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.r4.model.PaymentReconciliation)
+      return PaymentReconciliation40_50.convertPaymentReconciliation((org.hl7.fhir.r4.model.PaymentReconciliation) src);
+    if (src instanceof org.hl7.fhir.r4.model.Person)
+      return Person40_50.convertPerson((org.hl7.fhir.r4.model.Person) src);
+    if (src instanceof org.hl7.fhir.r4.model.PlanDefinition)
+      return PlanDefinition40_50.convertPlanDefinition((org.hl7.fhir.r4.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.Practitioner)
+      return Practitioner40_50.convertPractitioner((org.hl7.fhir.r4.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r4.model.PractitionerRole)
+      return PractitionerRole40_50.convertPractitionerRole((org.hl7.fhir.r4.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.r4.model.Procedure)
+      return Procedure40_50.convertProcedure((org.hl7.fhir.r4.model.Procedure) src);
+    if (src instanceof org.hl7.fhir.r4.model.Provenance)
+      return Provenance40_50.convertProvenance((org.hl7.fhir.r4.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.r4.model.Questionnaire)
+      return Questionnaire40_50.convertQuestionnaire((org.hl7.fhir.r4.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r4.model.QuestionnaireResponse)
+      return QuestionnaireResponse40_50.convertQuestionnaireResponse((org.hl7.fhir.r4.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r4.model.RelatedPerson)
+      return RelatedPerson40_50.convertRelatedPerson((org.hl7.fhir.r4.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.r4.model.RequestGroup)
+      return RequestGroup40_50.convertRequestGroup((org.hl7.fhir.r4.model.RequestGroup) src);
+    if (src instanceof org.hl7.fhir.r4.model.ResearchStudy)
+      return ResearchStudy40_50.convertResearchStudy((org.hl7.fhir.r4.model.ResearchStudy) src);
+    if (src instanceof org.hl7.fhir.r4.model.ResearchSubject)
+      return ResearchSubject40_50.convertResearchSubject((org.hl7.fhir.r4.model.ResearchSubject) src);
+    if (src instanceof org.hl7.fhir.r4.model.RiskAssessment)
+      return RiskAssessment40_50.convertRiskAssessment((org.hl7.fhir.r4.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r4.model.Schedule)
+      return Schedule40_50.convertSchedule((org.hl7.fhir.r4.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r4.model.SearchParameter)
+      return SearchParameter40_50.convertSearchParameter((org.hl7.fhir.r4.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r4.model.ServiceRequest)
+      return ServiceRequest40_50.convertServiceRequest((org.hl7.fhir.r4.model.ServiceRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.Slot) return Slot40_50.convertSlot((org.hl7.fhir.r4.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r4.model.Specimen)
+      return Specimen40_50.convertSpecimen((org.hl7.fhir.r4.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.r4.model.SpecimenDefinition)
+      return SpecimenDefinition40_50.convertSpecimenDefinition((org.hl7.fhir.r4.model.SpecimenDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureDefinition)
+      return StructureDefinition40_50.convertStructureDefinition((org.hl7.fhir.r4.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r4.model.StructureMap)
+      return StructureMap40_50.convertStructureMap((org.hl7.fhir.r4.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r4.model.Substance)
+      return Substance40_50.convertSubstance((org.hl7.fhir.r4.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstanceNucleicAcid)
+      return SubstanceNucleicAcid40_50.convertSubstanceNucleicAcid((org.hl7.fhir.r4.model.SubstanceNucleicAcid) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstancePolymer)
+      return SubstancePolymer40_50.convertSubstancePolymer((org.hl7.fhir.r4.model.SubstancePolymer) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstanceProtein)
+      return SubstanceProtein40_50.convertSubstanceProtein((org.hl7.fhir.r4.model.SubstanceProtein) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstanceReferenceInformation)
+      return SubstanceReferenceInformation40_50.convertSubstanceReferenceInformation((org.hl7.fhir.r4.model.SubstanceReferenceInformation) src);
+    if (src instanceof org.hl7.fhir.r4.model.SubstanceSourceMaterial)
+      return SubstanceSourceMaterial40_50.convertSubstanceSourceMaterial((org.hl7.fhir.r4.model.SubstanceSourceMaterial) src);
+    if (src instanceof org.hl7.fhir.r4.model.SupplyDelivery)
+      return SupplyDelivery40_50.convertSupplyDelivery((org.hl7.fhir.r4.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r4.model.SupplyRequest)
+      return SupplyRequest40_50.convertSupplyRequest((org.hl7.fhir.r4.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.r4.model.Task) return Task40_50.convertTask((org.hl7.fhir.r4.model.Task) src);
+    if (src instanceof org.hl7.fhir.r4.model.TerminologyCapabilities)
+      return TerminologyCapabilities40_50.convertTerminologyCapabilities((org.hl7.fhir.r4.model.TerminologyCapabilities) src);
+    if (src instanceof org.hl7.fhir.r4.model.TestReport)
+      return TestReport40_50.convertTestReport((org.hl7.fhir.r4.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.r4.model.TestScript)
+      return TestScript40_50.convertTestScript((org.hl7.fhir.r4.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r4.model.ValueSet)
+      return ValueSet40_50.convertValueSet((org.hl7.fhir.r4.model.ValueSet) src);
+    if (src instanceof org.hl7.fhir.r4.model.VerificationResult)
+      return VerificationResult40_50.convertVerificationResult((org.hl7.fhir.r4.model.VerificationResult) src);
+    if (src instanceof org.hl7.fhir.r4.model.VisionPrescription)
+      return VisionPrescription40_50.convertVisionPrescription((org.hl7.fhir.r4.model.VisionPrescription) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  public static org.hl7.fhir.r4.model.Resource convertResource(org.hl7.fhir.r5.model.Resource src) throws FHIRException {
+    if (src == null) return null;
+    if (src instanceof org.hl7.fhir.r5.model.Parameters)
+      return Parameters40_50.convertParameters((org.hl7.fhir.r5.model.Parameters) src);
+    if (src instanceof org.hl7.fhir.r5.model.Account)
+      return Account40_50.convertAccount((org.hl7.fhir.r5.model.Account) src);
+    if (src instanceof org.hl7.fhir.r5.model.ActivityDefinition)
+      return ActivityDefinition40_50.convertActivityDefinition((org.hl7.fhir.r5.model.ActivityDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.AllergyIntolerance)
+      return AllergyIntolerance40_50.convertAllergyIntolerance((org.hl7.fhir.r5.model.AllergyIntolerance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Appointment)
+      return Appointment40_50.convertAppointment((org.hl7.fhir.r5.model.Appointment) src);
+    if (src instanceof org.hl7.fhir.r5.model.AppointmentResponse)
+      return AppointmentResponse40_50.convertAppointmentResponse((org.hl7.fhir.r5.model.AppointmentResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.AuditEvent)
+      return AuditEvent40_50.convertAuditEvent((org.hl7.fhir.r5.model.AuditEvent) src);
+    if (src instanceof org.hl7.fhir.r5.model.Basic) return Basic40_50.convertBasic((org.hl7.fhir.r5.model.Basic) src);
+    if (src instanceof org.hl7.fhir.r5.model.Binary)
+      return Binary40_50.convertBinary((org.hl7.fhir.r5.model.Binary) src);
+    if (src instanceof org.hl7.fhir.r5.model.BiologicallyDerivedProduct)
+      return BiologicallyDerivedProduct40_50.convertBiologicallyDerivedProduct((org.hl7.fhir.r5.model.BiologicallyDerivedProduct) src);
+    if (src instanceof org.hl7.fhir.r5.model.BodyStructure)
+      return BodyStructure40_50.convertBodyStructure((org.hl7.fhir.r5.model.BodyStructure) src);
+    if (src instanceof org.hl7.fhir.r5.model.Bundle)
+      return Bundle40_50.convertBundle((org.hl7.fhir.r5.model.Bundle) src);
+    if (src instanceof org.hl7.fhir.r5.model.CapabilityStatement)
+      return CapabilityStatement40_50.convertCapabilityStatement((org.hl7.fhir.r5.model.CapabilityStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.CarePlan)
+      return CarePlan40_50.convertCarePlan((org.hl7.fhir.r5.model.CarePlan) src);
+    if (src instanceof org.hl7.fhir.r5.model.CareTeam)
+      return CareTeam40_50.convertCareTeam((org.hl7.fhir.r5.model.CareTeam) src);
+    if (src instanceof org.hl7.fhir.r5.model.ChargeItem)
+      return ChargeItem40_50.convertChargeItem((org.hl7.fhir.r5.model.ChargeItem) src);
+    if (src instanceof org.hl7.fhir.r5.model.ChargeItemDefinition)
+      return ChargeItemDefinition40_50.convertChargeItemDefinition((org.hl7.fhir.r5.model.ChargeItemDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Claim) return Claim40_50.convertClaim((org.hl7.fhir.r5.model.Claim) src);
+    if (src instanceof org.hl7.fhir.r5.model.ClaimResponse)
+      return ClaimResponse40_50.convertClaimResponse((org.hl7.fhir.r5.model.ClaimResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.ClinicalImpression)
+      return ClinicalImpression40_50.convertClinicalImpression((org.hl7.fhir.r5.model.ClinicalImpression) src);
+    if (src instanceof org.hl7.fhir.r5.model.CodeSystem)
+      return CodeSystem40_50.convertCodeSystem((org.hl7.fhir.r5.model.CodeSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.Communication)
+      return Communication40_50.convertCommunication((org.hl7.fhir.r5.model.Communication) src);
+    if (src instanceof org.hl7.fhir.r5.model.CommunicationRequest)
+      return CommunicationRequest40_50.convertCommunicationRequest((org.hl7.fhir.r5.model.CommunicationRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.CompartmentDefinition)
+      return CompartmentDefinition40_50.convertCompartmentDefinition((org.hl7.fhir.r5.model.CompartmentDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Composition)
+      return Composition40_50.convertComposition((org.hl7.fhir.r5.model.Composition) src);
+    if (src instanceof org.hl7.fhir.r5.model.ConceptMap)
+      return ConceptMap40_50.convertConceptMap((org.hl7.fhir.r5.model.ConceptMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.Condition)
+      return Condition40_50.convertCondition((org.hl7.fhir.r5.model.Condition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Consent)
+      return Consent40_50.convertConsent((org.hl7.fhir.r5.model.Consent) src);
+    if (src instanceof org.hl7.fhir.r5.model.Contract)
+      return Contract40_50.convertContract((org.hl7.fhir.r5.model.Contract) src);
+    if (src instanceof org.hl7.fhir.r5.model.Coverage)
+      return Coverage40_50.convertCoverage((org.hl7.fhir.r5.model.Coverage) src);
+    if (src instanceof org.hl7.fhir.r5.model.CoverageEligibilityRequest)
+      return CoverageEligibilityRequest40_50.convertCoverageEligibilityRequest((org.hl7.fhir.r5.model.CoverageEligibilityRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.CoverageEligibilityResponse)
+      return CoverageEligibilityResponse40_50.convertCoverageEligibilityResponse((org.hl7.fhir.r5.model.CoverageEligibilityResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.DetectedIssue)
+      return DetectedIssue40_50.convertDetectedIssue((org.hl7.fhir.r5.model.DetectedIssue) src);
+    if (src instanceof org.hl7.fhir.r5.model.Device)
+      return Device40_50.convertDevice((org.hl7.fhir.r5.model.Device) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceDefinition)
+      return DeviceDefinition40_50.convertDeviceDefinition((org.hl7.fhir.r5.model.DeviceDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceMetric)
+      return DeviceMetric40_50.convertDeviceMetric((org.hl7.fhir.r5.model.DeviceMetric) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceRequest)
+      return DeviceRequest40_50.convertDeviceRequest((org.hl7.fhir.r5.model.DeviceRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.DeviceUseStatement)
+      return DeviceUseStatement40_50.convertDeviceUseStatement((org.hl7.fhir.r5.model.DeviceUseStatement) src);
+    if (src instanceof org.hl7.fhir.r5.model.DiagnosticReport)
+      return DiagnosticReport40_50.convertDiagnosticReport((org.hl7.fhir.r5.model.DiagnosticReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentManifest)
+      return DocumentManifest40_50.convertDocumentManifest((org.hl7.fhir.r5.model.DocumentManifest) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
+      return DocumentReference40_50.convertDocumentReference((org.hl7.fhir.r5.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r5.model.Encounter)
+      return Encounter40_50.convertEncounter((org.hl7.fhir.r5.model.Encounter) src);
+    if (src instanceof org.hl7.fhir.r5.model.Endpoint)
+      return Endpoint40_50.convertEndpoint((org.hl7.fhir.r5.model.Endpoint) src);
+    if (src instanceof org.hl7.fhir.r5.model.EnrollmentRequest)
+      return EnrollmentRequest40_50.convertEnrollmentRequest((org.hl7.fhir.r5.model.EnrollmentRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.EnrollmentResponse)
+      return EnrollmentResponse40_50.convertEnrollmentResponse((org.hl7.fhir.r5.model.EnrollmentResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.EpisodeOfCare)
+      return EpisodeOfCare40_50.convertEpisodeOfCare((org.hl7.fhir.r5.model.EpisodeOfCare) src);
+    if (src instanceof org.hl7.fhir.r5.model.EventDefinition)
+      return EventDefinition40_50.convertEventDefinition((org.hl7.fhir.r5.model.EventDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.ExampleScenario)
+      return ExampleScenario40_50.convertExampleScenario((org.hl7.fhir.r5.model.ExampleScenario) src);
+    if (src instanceof org.hl7.fhir.r5.model.ExplanationOfBenefit)
+      return ExplanationOfBenefit40_50.convertExplanationOfBenefit((org.hl7.fhir.r5.model.ExplanationOfBenefit) src);
+    if (src instanceof org.hl7.fhir.r5.model.FamilyMemberHistory)
+      return FamilyMemberHistory40_50.convertFamilyMemberHistory((org.hl7.fhir.r5.model.FamilyMemberHistory) src);
+    if (src instanceof org.hl7.fhir.r5.model.Flag) return Flag40_50.convertFlag((org.hl7.fhir.r5.model.Flag) src);
+    if (src instanceof org.hl7.fhir.r5.model.Goal) return Goal40_50.convertGoal((org.hl7.fhir.r5.model.Goal) src);
+    if (src instanceof org.hl7.fhir.r5.model.GraphDefinition)
+      return GraphDefinition40_50.convertGraphDefinition((org.hl7.fhir.r5.model.GraphDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Group) return Group40_50.convertGroup((org.hl7.fhir.r5.model.Group) src);
+    if (src instanceof org.hl7.fhir.r5.model.GuidanceResponse)
+      return GuidanceResponse40_50.convertGuidanceResponse((org.hl7.fhir.r5.model.GuidanceResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.HealthcareService)
+      return HealthcareService40_50.convertHealthcareService((org.hl7.fhir.r5.model.HealthcareService) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImagingStudy)
+      return ImagingStudy40_50.convertImagingStudy((org.hl7.fhir.r5.model.ImagingStudy) src);
+    if (src instanceof org.hl7.fhir.r5.model.Immunization)
+      return Immunization40_50.convertImmunization((org.hl7.fhir.r5.model.Immunization) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImmunizationEvaluation)
+      return ImmunizationEvaluation40_50.convertImmunizationEvaluation((org.hl7.fhir.r5.model.ImmunizationEvaluation) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImmunizationRecommendation)
+      return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r5.model.ImmunizationRecommendation) src);
+    if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
+      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
+    if (src instanceof org.hl7.fhir.r5.model.InsurancePlan)
+      return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r5.model.InsurancePlan) src);
+    if (src instanceof org.hl7.fhir.r5.model.Invoice)
+      return Invoice40_50.convertInvoice((org.hl7.fhir.r5.model.Invoice) src);
+    if (src instanceof org.hl7.fhir.r5.model.Library)
+      return Library40_50.convertLibrary((org.hl7.fhir.r5.model.Library) src);
+    if (src instanceof org.hl7.fhir.r5.model.Linkage)
+      return Linkage40_50.convertLinkage((org.hl7.fhir.r5.model.Linkage) src);
+    if (src instanceof org.hl7.fhir.r5.model.ListResource)
+      return ListResource40_50.convertListResource((org.hl7.fhir.r5.model.ListResource) src);
+    if (src instanceof org.hl7.fhir.r5.model.Location)
+      return Location40_50.convertLocation((org.hl7.fhir.r5.model.Location) src);
+    if (src instanceof org.hl7.fhir.r5.model.Measure)
+      return Measure40_50.convertMeasure((org.hl7.fhir.r5.model.Measure) src);
+    if (src instanceof org.hl7.fhir.r5.model.MeasureReport)
+      return MeasureReport40_50.convertMeasureReport((org.hl7.fhir.r5.model.MeasureReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.DocumentReference)
+      return Media40_50.convertMedia((org.hl7.fhir.r5.model.DocumentReference) src);
+    if (src instanceof org.hl7.fhir.r5.model.Medication)
+      return Medication40_50.convertMedication((org.hl7.fhir.r5.model.Medication) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationAdministration)
+      return MedicationAdministration40_50.convertMedicationAdministration((org.hl7.fhir.r5.model.MedicationAdministration) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationDispense)
+      return MedicationDispense40_50.convertMedicationDispense((org.hl7.fhir.r5.model.MedicationDispense) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationKnowledge)
+      return MedicationKnowledge40_50.convertMedicationKnowledge((org.hl7.fhir.r5.model.MedicationKnowledge) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationRequest)
+      return MedicationRequest40_50.convertMedicationRequest((org.hl7.fhir.r5.model.MedicationRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicationUsage)
+      return MedicationStatement40_50.convertMedicationStatement((org.hl7.fhir.r5.model.MedicationUsage) src);
+    if (src instanceof org.hl7.fhir.r5.model.MedicinalProductDefinition)
+      return MedicinalProductDefinition40_50.convertMedicinalProductDefinition((org.hl7.fhir.r5.model.MedicinalProductDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.MessageDefinition)
+      return MessageDefinition40_50.convertMessageDefinition((org.hl7.fhir.r5.model.MessageDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.MessageHeader)
+      return MessageHeader40_50.convertMessageHeader((org.hl7.fhir.r5.model.MessageHeader) src);
+    if (src instanceof org.hl7.fhir.r5.model.MolecularSequence)
+      return MolecularSequence40_50.convertMolecularSequence((org.hl7.fhir.r5.model.MolecularSequence) src);
+    if (src instanceof org.hl7.fhir.r5.model.NamingSystem)
+      return NamingSystem40_50.convertNamingSystem((org.hl7.fhir.r5.model.NamingSystem) src);
+    if (src instanceof org.hl7.fhir.r5.model.NutritionOrder)
+      return NutritionOrder40_50.convertNutritionOrder((org.hl7.fhir.r5.model.NutritionOrder) src);
+    if (src instanceof org.hl7.fhir.r5.model.Observation)
+      return Observation40_50.convertObservation((org.hl7.fhir.r5.model.Observation) src);
+    if (src instanceof org.hl7.fhir.r5.model.ObservationDefinition)
+      return ObservationDefinition40_50.convertObservationDefinition((org.hl7.fhir.r5.model.ObservationDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationDefinition)
+      return OperationDefinition40_50.convertOperationDefinition((org.hl7.fhir.r5.model.OperationDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.OperationOutcome)
+      return OperationOutcome40_50.convertOperationOutcome((org.hl7.fhir.r5.model.OperationOutcome) src);
+    if (src instanceof org.hl7.fhir.r5.model.Organization)
+      return Organization40_50.convertOrganization((org.hl7.fhir.r5.model.Organization) src);
+    if (src instanceof org.hl7.fhir.r5.model.OrganizationAffiliation)
+      return OrganizationAffiliation40_50.convertOrganizationAffiliation((org.hl7.fhir.r5.model.OrganizationAffiliation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Patient)
+      return Patient40_50.convertPatient((org.hl7.fhir.r5.model.Patient) src);
+    if (src instanceof org.hl7.fhir.r5.model.PaymentNotice)
+      return PaymentNotice40_50.convertPaymentNotice((org.hl7.fhir.r5.model.PaymentNotice) src);
+    if (src instanceof org.hl7.fhir.r5.model.PaymentReconciliation)
+      return PaymentReconciliation40_50.convertPaymentReconciliation((org.hl7.fhir.r5.model.PaymentReconciliation) src);
+    if (src instanceof org.hl7.fhir.r5.model.Person)
+      return Person40_50.convertPerson((org.hl7.fhir.r5.model.Person) src);
+    if (src instanceof org.hl7.fhir.r5.model.PlanDefinition)
+      return PlanDefinition40_50.convertPlanDefinition((org.hl7.fhir.r5.model.PlanDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.Practitioner)
+      return Practitioner40_50.convertPractitioner((org.hl7.fhir.r5.model.Practitioner) src);
+    if (src instanceof org.hl7.fhir.r5.model.PractitionerRole)
+      return PractitionerRole40_50.convertPractitionerRole((org.hl7.fhir.r5.model.PractitionerRole) src);
+    if (src instanceof org.hl7.fhir.r5.model.Procedure)
+      return Procedure40_50.convertProcedure((org.hl7.fhir.r5.model.Procedure) src);
+    if (src instanceof org.hl7.fhir.r5.model.Provenance)
+      return Provenance40_50.convertProvenance((org.hl7.fhir.r5.model.Provenance) src);
+    if (src instanceof org.hl7.fhir.r5.model.Questionnaire)
+      return Questionnaire40_50.convertQuestionnaire((org.hl7.fhir.r5.model.Questionnaire) src);
+    if (src instanceof org.hl7.fhir.r5.model.QuestionnaireResponse)
+      return QuestionnaireResponse40_50.convertQuestionnaireResponse((org.hl7.fhir.r5.model.QuestionnaireResponse) src);
+    if (src instanceof org.hl7.fhir.r5.model.RelatedPerson)
+      return RelatedPerson40_50.convertRelatedPerson((org.hl7.fhir.r5.model.RelatedPerson) src);
+    if (src instanceof org.hl7.fhir.r5.model.RequestGroup)
+      return RequestGroup40_50.convertRequestGroup((org.hl7.fhir.r5.model.RequestGroup) src);
+    if (src instanceof org.hl7.fhir.r5.model.ResearchStudy)
+      return ResearchStudy40_50.convertResearchStudy((org.hl7.fhir.r5.model.ResearchStudy) src);
+    if (src instanceof org.hl7.fhir.r5.model.ResearchSubject)
+      return ResearchSubject40_50.convertResearchSubject((org.hl7.fhir.r5.model.ResearchSubject) src);
+    if (src instanceof org.hl7.fhir.r5.model.RiskAssessment)
+      return RiskAssessment40_50.convertRiskAssessment((org.hl7.fhir.r5.model.RiskAssessment) src);
+    if (src instanceof org.hl7.fhir.r5.model.Schedule)
+      return Schedule40_50.convertSchedule((org.hl7.fhir.r5.model.Schedule) src);
+    if (src instanceof org.hl7.fhir.r5.model.SearchParameter)
+      return SearchParameter40_50.convertSearchParameter((org.hl7.fhir.r5.model.SearchParameter) src);
+    if (src instanceof org.hl7.fhir.r5.model.ServiceRequest)
+      return ServiceRequest40_50.convertServiceRequest((org.hl7.fhir.r5.model.ServiceRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.Slot) return Slot40_50.convertSlot((org.hl7.fhir.r5.model.Slot) src);
+    if (src instanceof org.hl7.fhir.r5.model.Specimen)
+      return Specimen40_50.convertSpecimen((org.hl7.fhir.r5.model.Specimen) src);
+    if (src instanceof org.hl7.fhir.r5.model.SpecimenDefinition)
+      return SpecimenDefinition40_50.convertSpecimenDefinition((org.hl7.fhir.r5.model.SpecimenDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureDefinition)
+      return StructureDefinition40_50.convertStructureDefinition((org.hl7.fhir.r5.model.StructureDefinition) src);
+    if (src instanceof org.hl7.fhir.r5.model.StructureMap)
+      return StructureMap40_50.convertStructureMap((org.hl7.fhir.r5.model.StructureMap) src);
+    if (src instanceof org.hl7.fhir.r5.model.Substance)
+      return Substance40_50.convertSubstance((org.hl7.fhir.r5.model.Substance) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstanceNucleicAcid)
+      return SubstanceNucleicAcid40_50.convertSubstanceNucleicAcid((org.hl7.fhir.r5.model.SubstanceNucleicAcid) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstancePolymer)
+      return SubstancePolymer40_50.convertSubstancePolymer((org.hl7.fhir.r5.model.SubstancePolymer) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstanceProtein)
+      return SubstanceProtein40_50.convertSubstanceProtein((org.hl7.fhir.r5.model.SubstanceProtein) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstanceReferenceInformation)
+      return SubstanceReferenceInformation40_50.convertSubstanceReferenceInformation((org.hl7.fhir.r5.model.SubstanceReferenceInformation) src);
+    if (src instanceof org.hl7.fhir.r5.model.SubstanceSourceMaterial)
+      return SubstanceSourceMaterial40_50.convertSubstanceSourceMaterial((org.hl7.fhir.r5.model.SubstanceSourceMaterial) src);
+    if (src instanceof org.hl7.fhir.r5.model.SupplyDelivery)
+      return SupplyDelivery40_50.convertSupplyDelivery((org.hl7.fhir.r5.model.SupplyDelivery) src);
+    if (src instanceof org.hl7.fhir.r5.model.SupplyRequest)
+      return SupplyRequest40_50.convertSupplyRequest((org.hl7.fhir.r5.model.SupplyRequest) src);
+    if (src instanceof org.hl7.fhir.r5.model.Task) return Task40_50.convertTask((org.hl7.fhir.r5.model.Task) src);
+    if (src instanceof org.hl7.fhir.r5.model.TerminologyCapabilities)
+      return TerminologyCapabilities40_50.convertTerminologyCapabilities((org.hl7.fhir.r5.model.TerminologyCapabilities) src);
+    if (src instanceof org.hl7.fhir.r5.model.TestReport)
+      return TestReport40_50.convertTestReport((org.hl7.fhir.r5.model.TestReport) src);
+    if (src instanceof org.hl7.fhir.r5.model.TestScript)
+      return TestScript40_50.convertTestScript((org.hl7.fhir.r5.model.TestScript) src);
+    if (src instanceof org.hl7.fhir.r5.model.ValueSet)
+      return ValueSet40_50.convertValueSet((org.hl7.fhir.r5.model.ValueSet) src);
+    if (src instanceof org.hl7.fhir.r5.model.VerificationResult)
+      return VerificationResult40_50.convertVerificationResult((org.hl7.fhir.r5.model.VerificationResult) src);
+    if (src instanceof org.hl7.fhir.r5.model.VisionPrescription)
+      return VisionPrescription40_50.convertVisionPrescription((org.hl7.fhir.r5.model.VisionPrescription) src);
+    throw new FHIRException("Unknown resource " + src.fhirType());
+  }
+
+  protected static org.hl7.fhir.r5.model.CodeType convertResourceEnum(org.hl7.fhir.r4.model.CodeType src) {
+    return convertCode(src);
+  }
+
+  protected static org.hl7.fhir.r4.model.CodeType convertResourceEnum(org.hl7.fhir.r5.model.CodeType src) {
+    return convertCode(src);
+  }
+
+  protected static CodeableReference convertReferenceToCodeableReference(org.hl7.fhir.r4.model.Reference src) {
+    CodeableReference tgt = new CodeableReference();
+    tgt.setReference(convertReference(src));
+    return tgt;
+  }
+
+  protected static CodeableReference convertCodeableConceptToCodeableReference(org.hl7.fhir.r4.model.CodeableConcept src) {
+    CodeableReference tgt = new CodeableReference();
+    tgt.setConcept(convertCodeableConcept(src));
+    return tgt;
+  }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/AdministrativeGender10_30Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/AdministrativeGender10_30Test.java
@@ -1,0 +1,27 @@
+package org.hl7.fhir.convertors.conv10_30;
+
+import org.hl7.fhir.convertors.VersionConvertorAdvisor30;
+import org.hl7.fhir.convertors.VersionConvertor_10_30;
+import org.hl7.fhir.convertors.loaders.R2ToR3Loader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+public class AdministrativeGender10_30Test {
+
+    @Test
+    @DisplayName("Test 10_30 extension present, value is not")
+    public void testMedicationRequestConversion() throws IOException {
+        InputStream dstu2_input = this.getClass().getResourceAsStream("/administrative_gender_null.json");
+        org.hl7.fhir.dstu2.model.Patient dstu2 = (org.hl7.fhir.dstu2.model.Patient) new org.hl7.fhir.dstu2.formats.JsonParser().parse(dstu2_input);
+        VersionConvertorAdvisor30 advisor = new R2ToR3Loader();
+        org.hl7.fhir.dstu3.model.Resource stu_actual = VersionConvertor_10_30.convertResource(dstu2, advisor);
+    }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/administrative_gender_null.json
+++ b/org.hl7.fhir.convertors/src/test/resources/administrative_gender_null.json
@@ -1,0 +1,94 @@
+{
+  "resourceType": "Patient",
+  "id": "12743884",
+  "meta": {
+    "versionId": "0",
+    "lastUpdated": "2020-09-15T06:35:01.000Z"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Patient</b></p><p><b>Name</b>: Dawg, Joel</p><p><b>DOB</b>: Nov 11, 1991</p><p><b>Status</b>: Active</p></div>"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "MR",
+            "display": "Medical record number",
+            "userSelected": false
+          }
+        ],
+        "text": "MRN"
+      },
+      "system": "urn:oid:2.16.840.1.113883.6.1000",
+      "value": "7690",
+      "_value": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/rendered-value",
+            "valueString": "00000007690"
+          }
+        ]
+      },
+      "period": {
+        "start": "2020-09-15T06:35:01.000Z"
+      }
+    },
+    {
+      "use": "usual",
+      "type": {
+        "text": "Military Id"
+      },
+      "system": "urn:oid:2.16.840.1.113883.3.42.10001.100001.12",
+      "value": "10050007740",
+      "_value": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/rendered-value",
+            "valueString": "10050007740"
+          }
+        ]
+      },
+      "period": {
+        "start": "2020-09-15T06:35:01.000Z"
+      }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "text": "Dawg, Joel",
+      "family": [
+        "Dawg"
+      ],
+      "given": [
+        "Joel"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "3075557575",
+      "use": "home"
+    },
+    {
+      "system": "email",
+      "value": "amitabhp@mindfiresolutions.com",
+      "use": "work"
+    }
+  ],
+  "_gender": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  },
+  "birthDate": "1991-11-11"
+}


### PR DESCRIPTION
Related issue: https://github.com/hapifhir/org.hl7.fhir.core/issues/373

In conversion, we do a check for all enumerated values to ensure that if (src == null || src.isEmpty()) we return a null value for that enum, under the assumption that it is not set.

However, there exist cases where the convertor might be passed an enum where there is an extension defined, but no value. This causes the initial check to pass, and a null pointer exception to be thrown when parsing the value of the enum to convert to the new version.

To get around this, all enum checks are now wrapped in a check `(src.getValue() == null)`, where if true, we return the defined NULL value for the given enum, instead of just null.

All convertors have been updated with this change.
