### PR TITLE
Load context from classpath allowing duplicates

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -243,10 +243,14 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 	}
 
 	 public static SimpleWorkerContext fromClassPath(String name) throws IOException, FHIRException {
-	   InputStream s = SimpleWorkerContext.class.getResourceAsStream("/"+name);
-	    SimpleWorkerContext res = new SimpleWorkerContext();
+	    return fromClassPath(name, false);
+	  }
+	 public static SimpleWorkerContext fromClassPath(String name, boolean allowDuplicates) throws IOException, FHIRException {
+	   InputStream s = SimpleWorkerContext.class.getResourceAsStream("/" + name);
+     SimpleWorkerContext res = new SimpleWorkerContext();
+     res.setAllowLoadingDuplicates(allowDuplicates);
 	   res.loadFromStream(s, null);
-	    return res;
+     return res;
 	  }
 
 //	public static SimpleWorkerContext fromDefinitions(Map<String, byte[]> source) throws IOException, FHIRException {


### PR DESCRIPTION
Added ability to specify whether to allow duplicates when loading context from classpath. In similar fashion to loading from package.