### PR TITLE
remove unnecessary (& problem causing) Fragment-Host from OSGi manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,9 +270,13 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Fragment-Host>
-                            ca.uhn.hapi.fhir.hapi-fhir-base
-                        </Fragment-Host>
+                        <_nouses>true</_nouses>
+                        <_removeheaders>Built-By, Include-Resource, Private-Package, Require-Capability</_removeheaders>
+                        <!-- No need to disable normal OSGi class loading
+						<Fragment-Host>
+							ca.uhn.hapi.fhir.hapi-fhir-base
+						</Fragment-Host>
+						-->
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Adding "Fragment-Host" to the OSGi manifest is not needed and it short-circuits the normal OSGi class loading architecture. This has been creating issues for the few of us that are trying to build OSGi-based solutions for FHIR