### PR TITLE
Fix for UnknownHostException

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -559,8 +559,10 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   public String getPackageId(String canonicalUrl) throws IOException {
     String retVal = findCanonicalInLocalCache(canonicalUrl);
     
-    retVal = super.getPackageId(canonicalUrl);
-
+    if(retVal == null) {
+      retVal = super.getPackageId(canonicalUrl);
+    }
+    
     if (retVal == null) {
       retVal = getPackageIdFromBuildList(canonicalUrl);
     }


### PR DESCRIPTION
Error connecting to build server - running without build (build.fhir.org)
java.net.UnknownHostException: build.fhir.org
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:220)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:403)
	at java.base/java.net.Socket.connect(Socket.java:608)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:285)
	at java.base/sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:173)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:182)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:569)
	at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:265)
	at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:372)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1187)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1081)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1592)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
	at org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager.loadFromBuildServer(FilesystemPackageCacheManager.java:645)
	at org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager.checkBuildLoaded(FilesystemPackageCacheManager.java:631)
	at org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager.getPackageIdFromBuildList(FilesystemPackageCacheManager.java:593)
	at org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager.getPackageId(FilesystemPackageCacheManager.java:565)
	at org.hl7.fhir.validation.cli.services.StandAloneValidatorFetcher.resolveURL(StandAloneValidatorFetcher.java:87)
	at org.hl7.fhir.validation.ValidationEngine.resolveURL(ValidationEngine.java:1738)
	at org.hl7.fhir.validation.instance.InstanceValidator.checkPrimitive(InstanceValidator.java:1954)