### PR TITLE
[FHIR-28413]: noNamespace instead of default for Logical Models not having a namespace

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -188,7 +188,7 @@ public class XmlParser extends ParserBase {
     String name = element.getLocalName();
     String path = "/"+pathPrefix(ns)+name;
     
-    StructureDefinition sd = getDefinition(line(element), col(element), (ns == null ? "default" : ns), name);
+    StructureDefinition sd = getDefinition(line(element), col(element), (ns == null ? "noNamespace" : ns), name);
     if (sd == null)
       return null;
 
@@ -242,7 +242,7 @@ public class XmlParser extends ParserBase {
       String ns = prop.getXmlNamespace();
       String elementNs = element.getNamespaceURI();
       if (elementNs == null) {
-        elementNs = "default";
+        elementNs = "noNamespace";
       }
       if (!elementNs.equals(ns))
         logError(line(element), col(element), path, IssueType.INVALID, context.formatMessage(I18nConstants.WRONG_NAMESPACE__EXPECTED_, ns), IssueSeverity.ERROR);
@@ -544,7 +544,7 @@ public class XmlParser extends ParserBase {
     xml.setPretty(style == OutputStyle.PRETTY);
     xml.start();
     String ns = e.getProperty().getXmlNamespace();
-    if (ns!=null && !"default".equals(ns)) {
+    if (ns!=null && !"noNamespace".equals(ns)) {
       xml.setDefaultNamespace(ns);
     }
     if (hasTypeAttr(e))

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xml/XMLWriter.java
@@ -450,7 +450,7 @@ public class XMLWriter extends OutputStreamWriter implements IXMLWriter {
 		if ("http://www.w3.org/XML/1998/namespace".equals(namespace))
 			return "xml:";
 		
-		if (namespace == null || "".equals(namespace) || "default".equals(namespace))
+		if (namespace == null || "".equals(namespace) || "noNamespace".equals(namespace))
 			return "";
 		
 		XMLNamespace ns = findByNamespace(namespace);


### PR DESCRIPTION
[FHIR-28413](https://jira.hl7.org/browse/FHIR-28413) Additional documentation for extension for namespace definition

For logical models FHIR provides an extension to specify the XML namespace if it differs from the FHIR namespace http://hl7.org/fhir. There is currently no way to specify logical models where the xml lives in default unspecified xml namespace (aka no namespace, pre 2000 area).

Resolution of FHIR-28413 was to use noNamespace in the StructureDefinition instead of default. 

This PR changes the [exisition behavior](https://github.com/hapifhir/org.hl7.fhir.core/pull/321) to the resolution.

For the test-cases a corresponding PR has been made that the test runs through: https://github.com/FHIR/fhir-test-cases/pull/80