### PR TITLE
Updated the info.cqframework dependency versions

### DIFF
--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -110,32 +110,32 @@
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>model</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>elm</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>quick</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>qdm</artifactId>
-            <version>1.4.9</version>
+            <version>${info_cqframework_version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,7 @@
         <junit_jupiter_version>5.6.2</junit_jupiter_version>
         <maven_surefire_version>3.0.0-M4</maven_surefire_version>
         <jacoco_version>0.8.5</jacoco_version>
-        <!-- FIXME KBD - Update this once Jonathan/Bryn release the latest version of their cqframework code -->
-        <info_cqframework_version>1.5.2-SNAPSHOT</info_cqframework_version>
+        <info_cqframework_version>1.5.1</info_cqframework_version>
     </properties>
 
     <name>HL7 Core Artifacts</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <junit_jupiter_version>5.6.2</junit_jupiter_version>
         <maven_surefire_version>3.0.0-M4</maven_surefire_version>
         <jacoco_version>0.8.5</jacoco_version>
+        <!-- FIXME KBD - Update this once Jonathan/Bryn release the latest version of their cqframework code -->
+        <info_cqframework_version>1.5.2-SNAPSHOT</info_cqframework_version>
     </properties>
 
     <name>HL7 Core Artifacts</name>


### PR DESCRIPTION
@markiantorno 
The existing v1.4.9 `info.cqframework` libraries are no longer available, so this PR will upgrade those libraries to the latest version.
