### PR TITLE
Validator evaluate FHIRPath statements: Use FHIRPathEngine directly form validator

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -50,6 +50,8 @@ import org.hl7.fhir.validation.cli.model.ScanOutputItem;
 import org.hl7.fhir.validation.cli.services.StandAloneValidatorFetcher.IPackageInstaller;
 import org.hl7.fhir.validation.cli.utils.*;
 import org.hl7.fhir.validation.instance.InstanceValidator;
+import org.hl7.fhir.validation.instance.utils.NodeStack;
+import org.hl7.fhir.validation.instance.utils.ValidatorHostContext;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -1387,9 +1389,10 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
 
   public String evaluateFhirPath(String source, String expression) throws FHIRException, IOException {
     Content cnt = loadContent(source, "validate", false);
-    FHIRPathEngine fpe = new FHIRPathEngine(context);
+    FHIRPathEngine fpe = this.getValidator().getFHIRPathEngine();
     Element e = Manager.parse(context, new ByteArrayInputStream(cnt.focus), cnt.cntType);
-    return fpe.evaluateToString(e, expression);
+    ExpressionNode exp = fpe.parse(expression);
+    return fpe.evaluateToString(new ValidatorHostContext(context, e), e, e, e, exp);
   }
 
   public StructureDefinition snapshot(String source, String version) throws FHIRException, IOException {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -332,6 +332,10 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
   }
   private FHIRPathEngine fpe;
 
+  public FHIRPathEngine getFHIRPathEngine() {
+    return fpe;
+  }
+
   // configuration items
   private CheckDisplayOption checkDisplay;
   private boolean anyExtensionsAllowed;


### PR DESCRIPTION
The validator_cli.jar has a -fhirpath option to run fhirPath statements against resources. 

```
java -jar validator_cli.jar /Users/oliveregger/Documents/github/ch-orf/input/examples/bundle/referral-min-mapped.xml -version 4.0.1 -fhirpath 'entry[0].resource.subject.resolve().name.given'
````
However the FHIRPathEngine was currently not configured together with the validator, especially the resolve() function within a bundle does not work that way.

Bundle.entry[0].resource.subject.resolve().name.family
-> if the subject references a patient resource this should return the family name.

if the FHIRPathengine is used directly from the Validator the resolve function within a bundle is implemented and works.

This PR access the FHIRPathEnginge from the validator instead of creating a new one. 