### PR TITLE
fixes missing depencency: okhttp3/Request$Builder

### DIFF
--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -138,6 +138,13 @@
             <version>${info_cqframework_version}</version>
         </dependency>
 
+        <!-- OkHttpDependency -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.0</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.hl7.fhir.testcases</groupId>

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -143,6 +143,7 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.9.0</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
This PR adds the okhttp dependency to the validation module which is introduced in the R5 package as optional.

 Terminology server http://tx.fhir.orgException in thread "main" java.lang.NoClassDefFoundError: okhttp3/Request$Builder