### PR TITLE
Memory and Performance enhancements

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
@@ -330,6 +330,18 @@ public class ProfileUtilities extends TranslatingUtilities {
   private boolean autoFixSliceNames;
   private XVerExtensionManager xver;
 
+  public ProfileUtilities(IWorkerContext context, List<ValidationMessage> messages, ProfileKnowledgeProvider pkp, FHIRPathEngine fpe) {
+    super();
+    this.context = context;
+    this.messages = messages;
+    this.pkp = pkp;
+
+    this.fpe = fpe;
+    if (context != null && this.fpe == null) {
+      this.fpe = new FHIRPathEngine(context, this);
+    }
+  }
+
   public ProfileUtilities(IWorkerContext context, List<ValidationMessage> messages, ProfileKnowledgeProvider pkp) {
     super();
     this.context = context;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/JsonParser.java
@@ -53,6 +53,7 @@ import org.hl7.fhir.r5.formats.JsonCreator;
 import org.hl7.fhir.r5.formats.JsonCreatorCanonical;
 import org.hl7.fhir.r5.formats.JsonCreatorGson;
 import org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent;
+import org.hl7.fhir.r5.utils.FHIRPathEngine;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
@@ -75,8 +76,14 @@ public class JsonParser extends ParserBase {
 	private Map<JsonElement, LocationData> map;
 	private boolean allowComments;
 
+  private FHIRPathEngine fpe;
+  private ProfileUtilities profileUtilities;
+
 	public JsonParser(IWorkerContext context) {
 		super(context);
+    
+    this.fpe = new FHIRPathEngine(this.context);
+    this.profileUtilities = new ProfileUtilities(this.context, null, null, this.fpe);
 	}
 
 	public Element parse(String source, String type) throws Exception {
@@ -86,7 +93,7 @@ public class JsonParser extends ParserBase {
     if (sd == null)
       return null;
 
-    Element result = new Element(type, new Property(context, sd.getSnapshot().getElement().get(0), sd));
+    Element result = new Element(type, new Property(context, sd.getSnapshot().getElement().get(0), sd, this.profileUtilities));
     checkObject(obj, path);
     result.setType(type);
     parseChildren(path, obj, result, true);
@@ -135,7 +142,7 @@ public class JsonParser extends ParserBase {
 			if (sd == null)
 				return null;
 
-			Element result = new Element(name, new Property(context, sd.getSnapshot().getElement().get(0), sd));
+			Element result = new Element(name, new Property(context, sd.getSnapshot().getElement().get(0), sd, this.profileUtilities));
 			checkObject(object, path);
 			result.markLocation(line(object), col(object));
 			result.setType(name);
@@ -357,7 +364,7 @@ public class JsonParser extends ParserBase {
 			StructureDefinition sd = context.fetchResource(StructureDefinition.class, ProfileUtilities.sdNs(name, context.getOverrideVersionNs()));
 			if (sd == null)
 				throw new FHIRFormatError(context.formatMessage(I18nConstants.CONTAINED_RESOURCE_DOES_NOT_APPEAR_TO_BE_A_FHIR_RESOURCE_UNKNOWN_NAME_, name));
-			parent.updateProperty(new Property(context, sd.getSnapshot().getElement().get(0), sd), SpecialElement.fromProperty(parent.getProperty()), elementProperty);
+			parent.updateProperty(new Property(context, sd.getSnapshot().getElement().get(0), sd, this.profileUtilities), SpecialElement.fromProperty(parent.getProperty()), elementProperty);
 			parent.setType(name);
 			parseChildren(npath, res, parent, true);
 		}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Property.java
@@ -57,11 +57,16 @@ public class Property {
 	private Boolean canBePrimitive;
   private ProfileUtilities profileUtilities; 
 
-	public Property(IWorkerContext context, ElementDefinition definition, StructureDefinition structure) {
+  public Property(IWorkerContext context, ElementDefinition definition, StructureDefinition structure, ProfileUtilities profileUtilities) {
 		this.context = context;
 		this.definition = definition;
 		this.structure = structure;
-    profileUtilities = new ProfileUtilities(context, null, null); 
+    this.profileUtilities = profileUtilities;
+	}
+
+
+	public Property(IWorkerContext context, ElementDefinition definition, StructureDefinition structure) {
+    this(context, definition, structure, new ProfileUtilities(context, null, null));
 	}
 
 	public String getName() {
@@ -354,7 +359,7 @@ public class Property {
     }
     List<Property> properties = new ArrayList<Property>();
     for (ElementDefinition child : children) {
-      properties.add(new Property(context, child, sd));
+      properties.add(new Property(context, child, sd, this.profileUtilities));
     }
     return properties;
   }
@@ -393,7 +398,7 @@ public class Property {
     }
     List<Property> properties = new ArrayList<Property>();
     for (ElementDefinition child : children) {
-      properties.add(new Property(context, child, sd));
+      properties.add(new Property(context, child, sd, this.profileUtilities));
     }
     return properties;
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
@@ -309,17 +309,7 @@ public class FHIRPathEngine {
    * @param worker - used when validating paths (@check), and used doing value set membership when executing tests (once that's defined)
    */
   public FHIRPathEngine(IWorkerContext worker) {
-    super();
-    this.worker = worker;
-    profileUtilities = new ProfileUtilities(worker, null, null); 
-    for (StructureDefinition sd : worker.getStructures()) {
-      if (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION && sd.getKind() != StructureDefinitionKind.LOGICAL) {
-        allTypes.put(sd.getName(), sd);
-      }
-      if (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION && sd.getKind() == StructureDefinitionKind.PRIMITIVETYPE) { 
-        primitiveTypes.add(sd.getName());
-      }
-    }
+    this(worker, new ProfileUtilities(worker, null, null));
   }
 
   public FHIRPathEngine(IWorkerContext worker, ProfileUtilities utilities) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -207,6 +207,8 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
   private Map<String, ValidationControl> validationControl = new HashMap<>();
   private QuestionnaireMode questionnaireMode;
 
+  private FHIRPathEngine fpe;
+
   public ValidationEngine() throws IOException {
     pcm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
     context = SimpleWorkerContext.fromNothing();
@@ -269,6 +271,8 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
     }
     NpmPackage npmX = pcm.loadPackage("hl7.fhir.xver-extensions", "0.0.4");
     context.loadFromPackage(npmX, null);
+
+    this.fpe = new FHIRPathEngine(context);
   }
 
   private IContextResourceLoader loaderForVersion() {
@@ -1310,7 +1314,6 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
   private OperationOutcome messagesToOutcome(List<ValidationMessage> messages) throws IOException, FHIRException, EOperationOutcome {
     OperationOutcome op = new OperationOutcome();
     for (ValidationMessage vm : filterMessages(messages)) {
-      FHIRPathEngine fpe = new FHIRPathEngine(context);
       try {
         fpe.parse(vm.getLocation());
       } catch (Exception e) {
@@ -1387,7 +1390,6 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
 
   public String evaluateFhirPath(String source, String expression) throws FHIRException, IOException {
     Content cnt = loadContent(source, "validate", false);
-    FHIRPathEngine fpe = new FHIRPathEngine(context);
     Element e = Manager.parse(context, new ByteArrayInputStream(cnt.focus), cnt.cntType);
     return fpe.evaluateToString(e, expression);
   }


### PR DESCRIPTION
The motivation for this PR is to speed up the IG Publisher builds and reduce its memory usage. It was tested and benchmarked by building the [opioid-cds-r4](https://github.com/cqframework/opioid-cds-r4) IG.

The core change is to reuse the same instance of the FHIRPathEngine where possible in the JSONParser. This necessitated some changes in the FHIRPathEngine and supporting classes. All the changes were made to be backwards compatible.

In benchmarking, overall memory usage of the publisher was reduced by ~60% and the "Load Content" portion of the IG Build is about 6x faster, reducing overall build time by about 2 minutes.

Before:
Sending Usage Stats to Server (06:43.0788)
Memory (MB): Use = 6262, Free = 3628, Total = 9890, Max =11264

After:
Sending Usage Stats to Server (04:33.0507)
Memory (MB): Use = 2660, Free = 962, Total = 3623, Max =11264