### PR TITLE
Validation sessions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
 * add test for Observation conversion from 10 to 40
 * add procedures conversion form dstu2 to r4
 * add medication conversion from dstu2 to r4
+* adding caching for ValidationEngine

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,1 @@
-* add test for Observation conversion from 10 to 40
-* add procedures conversion form dstu2 to r4
-* add medication conversion from dstu2 to r4
-* adding caching for ValidationEngine
 * adding session ids to validator service

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.fhir</groupId>
             <artifactId>ucum</artifactId>
             <version>1.0.3</version>

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -149,6 +149,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
   @Getter @Setter private QuestionnaireMode questionnaireMode;
   @Getter @Setter private FHIRPathEngine fhirPathEngine;
   @Getter @Setter private IgLoader igLoader;
+  @Getter @Setter private String sessionId;
 
   /**
    * Systems that host the ValidationEngine can use this to control what validation the validator performs.
@@ -193,7 +194,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IPackageInst
     igLoader = new IgLoader(getPcm(), getContext(), getVersion(), isDebug());
   }
 
-  public ValidationEngine(String src, FhirPublication version, String vString, TimeTracker tt) throws FHIRException, IOException, URISyntaxException {
+  public ValidationEngine(String src, String vString, TimeTracker tt) throws FHIRException, IOException, URISyntaxException {
     loadCoreDefinitions(src, false, tt);
     setVersion(vString);
     igLoader = new IgLoader(getPcm(), getContext(), getVersion(), isDebug());

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -94,6 +94,8 @@ public class ValidatorCli {
   public static final String JAVA_DISABLED_PROXY_SCHEMES = "jdk.http.auth.proxying.disabledSchemes";
   public static final String JAVA_USE_SYSTEM_PROXIES = "java.net.useSystemProxies";
 
+  private static ValidationService validationService = new ValidationService();
+
   public static void main(String[] args) throws Exception {
     TimeTracker tt = new TimeTracker();
     TimeTracker.Session tts = tt.start("Loading");
@@ -181,42 +183,42 @@ public class ValidatorCli {
   private static void doLeftRightComparison(String[] args, CliContext cliContext, TimeTracker tt) throws Exception {
     Display.printCliArgumentsAndInfo(args);
     if (cliContext.getSv() == null) {
-      cliContext.setSv(ValidationService.determineVersion(cliContext));
+      cliContext.setSv(validationService.determineVersion(cliContext));
     }
     String v = VersionUtilities.getCurrentVersion(cliContext.getSv());
     String definitions = VersionUtilities.packageForVersion(v) + "#" + v;
-    ValidationEngine validator = ValidationService.getValidator(cliContext, definitions, tt);
+    ValidationEngine validator = validationService.getValidator(cliContext, definitions, tt);
     ComparisonService.doLeftRightComparison(args, Params.getParam(args, Params.DESTINATION), validator);
   }
 
   private static void doValidation(TimeTracker tt, TimeTracker.Session tts, CliContext cliContext) throws Exception {
     if (cliContext.getSv() == null) {
-      cliContext.setSv(ValidationService.determineVersion(cliContext));
+      cliContext.setSv(validationService.determineVersion(cliContext));
     }
     System.out.println("Loading");
     // Comment this out because definitions filename doesn't necessarily contain version (and many not even be 14 characters long).
     // Version gets spit out a couple of lines later after we've loaded the context
     String definitions = VersionUtilities.packageForVersion(cliContext.getSv()) + "#" + VersionUtilities.getCurrentVersion(cliContext.getSv());
-    ValidationEngine validator = ValidationService.getValidator(cliContext, definitions, tt);
+    ValidationEngine validator = validationService.getValidator(cliContext, definitions, tt);
     tts.end();
     switch (cliContext.getMode()) {
       case TRANSFORM:
-        ValidationService.transform(cliContext, validator);
+        validationService.transform(cliContext, validator);
         break;
       case NARRATIVE:
-        ValidationService.generateNarrative(cliContext, validator);
+        validationService.generateNarrative(cliContext, validator);
         break;
       case SNAPSHOT:
-        ValidationService.generateSnapshot(cliContext, validator);
+        validationService.generateSnapshot(cliContext, validator);
         break;
       case CONVERT:
-        ValidationService.convertSources(cliContext, validator);
+        validationService.convertSources(cliContext, validator);
         break;
       case FHIRPATH:
-        ValidationService.evaluateFhirpath(cliContext, validator);
+        validationService.evaluateFhirpath(cliContext, validator);
         break;
       case VERSION:
-        ValidationService.transformVersion(cliContext, validator);
+        validationService.transformVersion(cliContext, validator);
         break;
       case VALIDATION:
       case SCAN:
@@ -232,7 +234,7 @@ public class ValidatorCli {
           Scanner validationScanner = new Scanner(validator.getContext(), validator.getValidator(), validator.getIgLoader(), validator.getFhirPathEngine());
           validationScanner.validateScan(cliContext.getOutput(), cliContext.getSources());
         } else {
-          ValidationService.validateSources(cliContext, validator);
+          validationService.validateSources(cliContext, validator);
         }
         break;
     }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -187,7 +187,7 @@ public class ValidatorCli {
     }
     String v = VersionUtilities.getCurrentVersion(cliContext.getSv());
     String definitions = VersionUtilities.packageForVersion(v) + "#" + v;
-    ValidationEngine validator = validationService.getValidator(cliContext, definitions, tt);
+    ValidationEngine validator = validationService.initializeValidator(cliContext, definitions, tt);
     ComparisonService.doLeftRightComparison(args, Params.getParam(args, Params.DESTINATION), validator);
   }
 
@@ -199,7 +199,7 @@ public class ValidatorCli {
     // Comment this out because definitions filename doesn't necessarily contain version (and many not even be 14 characters long).
     // Version gets spit out a couple of lines later after we've loaded the context
     String definitions = VersionUtilities.packageForVersion(cliContext.getSv()) + "#" + VersionUtilities.getCurrentVersion(cliContext.getSv());
-    ValidationEngine validator = validationService.getValidator(cliContext, definitions, tt);
+    ValidationEngine validator = validationService.initializeValidator(cliContext, definitions, tt);
     tts.end();
     switch (cliContext.getMode()) {
       case TRANSFORM:

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationRequest.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationRequest.java
@@ -18,11 +18,19 @@ public class ValidationRequest {
     return cliContext;
   }
 
+  @JsonProperty("sessionToken")
+  public String sessionToken;
+
   public ValidationRequest() {}
 
   public ValidationRequest(CliContext cliContext, List<FileInfo> filesToValidate) {
+    this(cliContext, filesToValidate, null);
+  }
+
+  public ValidationRequest(CliContext cliContext, List<FileInfo> filesToValidate, String sessionToken) {
     this.cliContext = cliContext;
     this.filesToValidate = filesToValidate;
+    this.sessionToken = sessionToken;
   }
 
   @JsonProperty("cliContext")
@@ -39,6 +47,17 @@ public class ValidationRequest {
   @JsonProperty("filesToValidate")
   public ValidationRequest setFilesToValidate(List<FileInfo> filesToValidate) {
     this.filesToValidate = filesToValidate;
+    return this;
+  }
+
+  @JsonProperty("sessionToken")
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  @JsonProperty("sessionToken")
+  public ValidationRequest setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
     return this;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationRequest.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationRequest.java
@@ -18,8 +18,8 @@ public class ValidationRequest {
     return cliContext;
   }
 
-  @JsonProperty("sessionToken")
-  public String sessionToken;
+  @JsonProperty("sessionId")
+  public String sessionId;
 
   public ValidationRequest() {}
 
@@ -30,7 +30,7 @@ public class ValidationRequest {
   public ValidationRequest(CliContext cliContext, List<FileInfo> filesToValidate, String sessionToken) {
     this.cliContext = cliContext;
     this.filesToValidate = filesToValidate;
-    this.sessionToken = sessionToken;
+    this.sessionId = sessionToken;
   }
 
   @JsonProperty("cliContext")
@@ -50,14 +50,14 @@ public class ValidationRequest {
     return this;
   }
 
-  @JsonProperty("sessionToken")
-  public String getSessionToken() {
-    return sessionToken;
+  @JsonProperty("sessionId")
+  public String getSessionId() {
+    return sessionId;
   }
 
-  @JsonProperty("sessionToken")
-  public ValidationRequest setSessionToken(String sessionToken) {
-    this.sessionToken = sessionToken;
+  @JsonProperty("sessionId")
+  public ValidationRequest setSessionId(String sessionId) {
+    this.sessionId = sessionId;
     return this;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
@@ -10,10 +10,18 @@ public class ValidationResponse {
   @JsonProperty("outcomes")
   public List<ValidationOutcome> outcomes = new ArrayList<>();
 
+  @JsonProperty("sessionToken")
+  public String sessionToken;
+
   public ValidationResponse() {}
 
   public ValidationResponse(List<ValidationOutcome> outcomes) {
+    this(outcomes, null);
+  }
+
+  public ValidationResponse(List<ValidationOutcome> outcomes, String sessionToken) {
     this.outcomes = outcomes;
+    this.sessionToken = sessionToken;
   }
 
   @JsonProperty("outcomes")
@@ -24,6 +32,17 @@ public class ValidationResponse {
   @JsonProperty("outcomes")
   public ValidationResponse setOutcomes(List<ValidationOutcome> outcomes) {
     this.outcomes = outcomes;
+    return this;
+  }
+
+  @JsonProperty("sessionToken")
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  @JsonProperty("sessionToken")
+  public ValidationResponse setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
     return this;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -3,6 +3,7 @@ package org.hl7.fhir.validation.cli.services;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.hl7.fhir.validation.ValidationEngine;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class SessionCache {
@@ -10,7 +11,40 @@ public class SessionCache {
   private static final long TIME_TO_LIVE = 60;
   private static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
 
-  private PassiveExpiringMap<String, ValidationEngine> cachedSessions = new PassiveExpiringMap<>();
+  private final PassiveExpiringMap<String, ValidationEngine> cachedSessions;
 
+  public SessionCache() {
+    cachedSessions = new PassiveExpiringMap<>(TIME_TO_LIVE, TIME_UNIT);
+  }
 
+  public SessionCache(long sessionLength, TimeUnit sessionLengthUnit) {
+    cachedSessions = new PassiveExpiringMap<>(sessionLength, sessionLengthUnit);
+  }
+
+  public String cacheSession(ValidationEngine validator) {
+    String generatedId = generateID();
+    cachedSessions.put(generatedId, validator);
+    return generatedId;
+  }
+
+  public String cacheSession(String sessionId, ValidationEngine validator) {
+    if(sessionId == null) {
+      sessionId = cacheSession(validator);
+    } else {
+      cachedSessions.put(sessionId, validator);
+    }
+    return sessionId;
+  }
+
+  public boolean sessionExists(String sessionId) {
+    return cachedSessions.containsKey(sessionId);
+  }
+
+  public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
+    return cachedSessions.get(sessionId);
+  }
+
+  private String generateID() {
+    return UUID.randomUUID().toString();
+  }
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -7,6 +7,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * SessionCache for storing and retrieving ValidationEngine instances, so callers do not have to re-instantiate a new
+ * instance for each validation request.
+ */
 public class SessionCache {
 
   protected static final long TIME_TO_LIVE = 60;
@@ -18,37 +22,73 @@ public class SessionCache {
     cachedSessions = new PassiveExpiringMap<>(TIME_TO_LIVE, TIME_UNIT);
   }
 
+  /**
+   * @param sessionLength the constant amount of time an entry is available before it expires. A negative value results
+   *                      in entries that NEVER expire. A zero value results in entries that ALWAYS expire.
+   * @param sessionLengthUnit the unit of time for the timeToLive parameter, must not be null
+   */
   public SessionCache(long sessionLength, TimeUnit sessionLengthUnit) {
     cachedSessions = new PassiveExpiringMap<>(sessionLength, sessionLengthUnit);
   }
 
-  public String cacheSession(ValidationEngine validator) {
+  /**
+   * Stores the initialized {@link ValidationEngine} in the cache. Returns the session id that will be associated with
+   * this instance.
+   * @param validationEngine {@link ValidationEngine}
+   * @return The {@link String} id associated with the stored instance.
+   */
+  public String cacheSession(ValidationEngine validationEngine) {
     String generatedId = generateID();
-    cachedSessions.put(generatedId, validator);
+    cachedSessions.put(generatedId, validationEngine);
     return generatedId;
   }
 
-  public String cacheSession(String sessionId, ValidationEngine validator) {
+  /**
+   * Stores the initialized {@link ValidationEngine} in the cache with the passed in id as the key. If a null key is
+   * passed in, a new key is generated and returned.
+   * @param sessionId The {@link String} key to associate with this stored {@link ValidationEngine}
+   * @param validationEngine The {@link ValidationEngine} instance to cache.
+   * @return The {@link String} id that will be associated with the stored {@link ValidationEngine}
+   */
+  public String cacheSession(String sessionId, ValidationEngine validationEngine) {
     if(sessionId == null) {
-      sessionId = cacheSession(validator);
+      sessionId = cacheSession(validationEngine);
     } else {
-      cachedSessions.put(sessionId, validator);
+      cachedSessions.put(sessionId, validationEngine);
     }
     return sessionId;
   }
 
+  /**
+   * Checks if the passed in {@link String} id exists in the set of stored session id.
+   * @param sessionId The {@link String} id to search for.
+   * @return {@link Boolean#TRUE} if such id exists.
+   */
   public boolean sessionExists(String sessionId) {
     return cachedSessions.containsKey(sessionId);
   }
 
+  /**
+   * Returns the stored {@link ValidationEngine} associated with the passed in session id, if one such instance exists.
+   * @param sessionId The {@link String} session id.
+   * @return The {@link ValidationEngine} associated with the passed in id, or null if none exists.
+   */
   public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
     return cachedSessions.get(sessionId);
   }
 
+  /**
+   * Returns the set of stored session ids.
+   * @return {@link Set} of session ids.
+   */
   public Set<String> getSessionIds() {
     return cachedSessions.keySet();
   }
 
+  /**
+   * Session ids generated internally are UUID {@link String}.
+   * @return A new {@link String} session id.
+   */
   private String generateID() {
     return UUID.randomUUID().toString();
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -1,0 +1,16 @@
+package org.hl7.fhir.validation.cli.services;
+
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.hl7.fhir.validation.ValidationEngine;
+
+import java.util.concurrent.TimeUnit;
+
+public class SessionCache {
+
+  private static final long TIME_TO_LIVE = 60;
+  private static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
+
+  private PassiveExpiringMap<String, ValidationEngine> cachedSessions = new PassiveExpiringMap<>();
+
+
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -3,13 +3,14 @@ package org.hl7.fhir.validation.cli.services;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.hl7.fhir.validation.ValidationEngine;
 
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class SessionCache {
 
-  private static final long TIME_TO_LIVE = 60;
-  private static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
+  protected static final long TIME_TO_LIVE = 60;
+  protected static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
 
   private final PassiveExpiringMap<String, ValidationEngine> cachedSessions;
 
@@ -42,6 +43,10 @@ public class SessionCache {
 
   public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
     return cachedSessions.get(sessionId);
+  }
+
+  public Set<String> getSessionIds() {
+    return cachedSessions.keySet();
   }
 
   private String generateID() {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -40,8 +40,6 @@ public class ValidationService {
   }
 
   public ValidationResponse validateSources(ValidationRequest request) throws Exception {
-    // have to consolidate the calls to validator engine init
-    // it's done twice, once in the scan and once more below
     if (request.getCliContext().getSv() == null) {
       String sv = determineVersion(request.getCliContext(), request.sessionId);
       request.getCliContext().setSv(sv);
@@ -247,7 +245,7 @@ public class ValidationService {
       validator.prepare(); // generate any missing snapshots
       System.out.println(" go (" + tt.milestone() + ")");
     } else {
-      System.out.println("Cached session exists for session id " + sessionId + ", returning stored validator.");
+      System.out.println("Cached session exists for session id " + sessionId + ", returning stored validator session id.");
     }
     return sessionId;
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Common.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Common.java
@@ -87,7 +87,7 @@ public class Common {
 
   public static ValidationEngine getValidationEngine(String version, String txServer, String definitions, String txLog, TimeTracker tt) throws Exception {
     System.out.println("Loading (v = " + version + ", tx server -> " + txServer + ")");
-    ValidationEngine ve = new ValidationEngine(definitions, FhirPublication.fromCode(version), version, tt);
+    ValidationEngine ve = new ValidationEngine(definitions, version, tt);
     ve.connectToTSServer(txServer, txLog, FhirPublication.fromCode(version));
     return ve;
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/VersionSourceInformation.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/VersionSourceInformation.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public class VersionSourceInformation {
 
-  private List<String> report = new ArrayList<>();
-  private List<String> versions = new ArrayList<>();
+  private final List<String> report = new ArrayList<>();
+  private final List<String> versions = new ArrayList<>();
 
   public void see(String version, String src) {
     version = VersionUtilities.getMajMin(version);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/SessionCacheTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/SessionCacheTest.java
@@ -1,32 +1,51 @@
 package org.hl7.fhir.validation.cli.services;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.hl7.fhir.validation.ValidationEngine;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import sun.security.validator.ValidatorException;
 
+import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class SessionCacheTest {
 
-  @BeforeEach
-  void setUp() {
-  }
-
-  @AfterEach
-  void tearDown() {
+  @Test
+  @DisplayName("test session expiration works")
+  void expiredSession() throws IOException, InterruptedException {
+    final long EXPIRE_TIME = 5L;
+    SessionCache cache = new SessionCache(EXPIRE_TIME, TimeUnit.SECONDS);
+    ValidationEngine testEngine = new ValidationEngine();
+    String sessionId = cache.cacheSession(testEngine);
+    TimeUnit.SECONDS.sleep(EXPIRE_TIME + 1L);
+    Assertions.assertNull(cache.fetchSessionValidatorEngine(sessionId));
   }
 
   @Test
-  @DisplayName("Test session expiration works.")
-  void expiredSession() {
-    SessionCache cache = new SessionCache(5L, TimeUnit.SECONDS);
+  @DisplayName("test session caching works")
+  void cachedSession() throws IOException {
+    final long EXPIRE_TIME = 5L;
+    SessionCache cache = new SessionCache(EXPIRE_TIME, TimeUnit.SECONDS);
+    ValidationEngine testEngine = new ValidationEngine();
+    String sessionId = cache.cacheSession(testEngine);
+    Assertions.assertEquals(testEngine, cache.fetchSessionValidatorEngine(sessionId));
   }
 
   @Test
-  void fetchSessionValidatorEngine() {
+  @DisplayName("test session exists")
+  void sessionExists() throws IOException {
+    SessionCache cache = new SessionCache();
+    ValidationEngine testEngine = new ValidationEngine();
+    String sessionId = cache.cacheSession(testEngine);
+    Assertions.assertTrue(cache.sessionExists(sessionId));
+    Assertions.assertFalse(cache.sessionExists(UUID.randomUUID().toString()));
+  }
+
+  @Test
+  @DisplayName("test null session test id returns false")
+  void testNullSessionExists() {
+    SessionCache cache = new SessionCache();
+    Assertions.assertFalse(cache.sessionExists(null));
   }
 }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/SessionCacheTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/SessionCacheTest.java
@@ -1,0 +1,32 @@
+package org.hl7.fhir.validation.cli.services;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sun.security.validator.ValidatorException;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionCacheTest {
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @AfterEach
+  void tearDown() {
+  }
+
+  @Test
+  @DisplayName("Test session expiration works.")
+  void expiredSession() {
+    SessionCache cache = new SessionCache(5L, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void fetchSessionValidatorEngine() {
+  }
+}

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -1,0 +1,67 @@
+package org.hl7.fhir.validation.cli.services;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.validation.ValidationEngine;
+import org.hl7.fhir.validation.cli.model.CliContext;
+import org.hl7.fhir.validation.cli.model.FileInfo;
+import org.hl7.fhir.validation.cli.model.ValidationRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationServiceTest {
+
+  @Test
+  void validateSources() throws Exception {
+    SessionCache sessionCache = Mockito.spy(new SessionCache());
+    ValidationService myService = new ValidationService(sessionCache);
+
+    String resource = IOUtils.toString(getFileFromResourceAsStream("detected_issues.json"), StandardCharsets.UTF_8);
+    List<FileInfo> filesToValidate = new ArrayList<>();
+    filesToValidate.add(new FileInfo().setFileName("test_resource.json").setFileContent(resource).setFileType(Manager.FhirFormat.JSON.getExtension()));
+
+    ValidationRequest request = new ValidationRequest().setCliContext(new CliContext()).setFilesToValidate(filesToValidate);
+    // Validation run 1...nothing cached yet
+    myService.validateSources(request);
+    Mockito.verify(sessionCache, Mockito.times(1)).cacheSession(ArgumentMatchers.any(ValidationEngine.class));
+
+    Set<String> sessionIds = sessionCache.getSessionIds();
+    if (sessionIds.stream().findFirst().isPresent()) {
+      // Verify that after 1 run there is only one entry within the cache
+      Assertions.assertEquals(1, sessionIds.size());
+      myService.validateSources(request);
+      // Verify that the cache has been called on once with the id created in the first run
+      Mockito.verify(sessionCache, Mockito.times(1)).fetchSessionValidatorEngine(sessionIds.stream().findFirst().get());
+    } else {
+      // If no sessions exist within the cache after a run, we auto-fail.
+      fail();
+    }
+  }
+
+  private InputStream getFileFromResourceAsStream(String fileName) {
+    // The class loader that loaded the class
+    ClassLoader classLoader = getClass().getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream(fileName);
+
+    // the stream holding the file content
+    if (inputStream == null) {
+      throw new IllegalArgumentException("file not found! " + fileName);
+    } else {
+      return inputStream;
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/test/resources/detected_issues.json
+++ b/org.hl7.fhir.validation/src/test/resources/detected_issues.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "DetectedIssue",
+  "identifier": [ {
+    "system": "http://covidcare.au/app/checkin",
+    "value": "7"
+  } ],
+  "status": "final",
+  "patient": "Patient/4912",
+  "identifiedDateTime": "3020-10-27T13:33:15+11:00",
+  "code": {
+    "coding": [ {
+      "system": "http://covidcare.au/app/alert",
+      "code": "trendNegative",
+      "display": "CovidCare: Vital signs trend negative alert: re-check recommended"
+    } ],
+    "text": "CovidCare alert"
+  }
+}


### PR DESCRIPTION
Added sessions to validation process. All validations done through the ValidationService class now return a session id (long) as part of the response. If passed in with a ValidationRequest, the validator will not re-instantiate a new ValidationEngine to run validation. This should save considerably on back to back validation times.