### PR TITLE
allow "resource:#" as valid Reference.value

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -831,7 +831,7 @@ public class BaseValidator {
     String targetUrl = null;
     String version = "";
     String resourceType = null;
-    if (ref.startsWith("http") || ref.startsWith("urn")) {
+    if (ref.startsWith("http") || ref.startsWith("urn") || ref.startsWith("resource")) {
       // We've got an absolute reference, no need to calculate
       if (ref.contains("/_history/")) {
         targetUrl = ref.substring(0, ref.indexOf("/_history/") - 1);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -4885,7 +4885,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       if (method == null) {
         if (fullUrl == null)
           return IdStatus.REQUIRED;
-        else if (fullUrl.primitiveValue().startsWith("urn:uuid:") || fullUrl.primitiveValue().startsWith("urn:oid:"))
+        else if (fullUrl.primitiveValue().startsWith("urn:uuid:") || fullUrl.primitiveValue().startsWith("urn:oid:") || fullUrl.primitiveValue().startsWith("resource:"))
           return IdStatus.OPTIONAL;
         else
           return IdStatus.REQUIRED;


### PR DESCRIPTION
The changes allows "resource:#" as valid URI in Reference.value. This is fixed for SMART Health Card / VCI Implementation Guide