### PR TITLE
If there's an ampersand that doesn't actually have a closing semi-col…

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
@@ -885,6 +885,8 @@ private boolean elementIsOk(String name) throws FHIRFormatError  {
     // UInt16 w;
     readChar();
     String c = readUntil(";&'\"><");
+    if (c.isEmpty())
+      throw new FHIRFormatError("Invalid literal declaration following text: " + s);
     if (c.equals("apos"))
       s.append('\'');
     else if (c.equals("quot"))


### PR DESCRIPTION
…on, the process eventually runs out of characters and then fails doing a charAt(0).  Catch this issue and throw a useful exception.

Specific example within file that caused an issue:
            feedbackurl = feedbackurl + '&';
