### PR TITLE
Fixed issue where when validating with no terminology server and a va…

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
@@ -489,19 +489,31 @@ public class ValueSetCheckerSimple extends ValueSetWorker implements ValueSetChe
         }
       }
     } else if (valueset.hasExpansion()) {
-      for (ValueSetExpansionContainsComponent c: valueset.getExpansion().getContains()) {
-        if (c.getCode().equals(code)) {
-          if (sys == null)
-            sys = c.getSystem(); 
-          else
-            return null;
-        }
-      }
+      // Retrieve a list of all systems associated with this code in the expansion
+      List<String> systems = new ArrayList<String>();
+      checkSystems(valueset.getExpansion().getContains(), code, systems);
+      if (systems.size()==1)
+        sys = systems.get(0);
     }
 
     return sys;  
   }
 
+  /*
+   * Recursively go through all codes in the expansion and for any coding that matches the specified code, add the system for that coding
+   * to the passed list. 
+   */
+  private void checkSystems(List<ValueSetExpansionContainsComponent> contains, String code, List<String> systems) {
+    for (ValueSetExpansionContainsComponent c: contains) {
+      if (c.getCode().equals(code)) {
+        if (!systems.contains(c.getSystem()))
+          systems.add(c.getSystem());
+      }
+      if (c.hasContains())
+        checkSystems(c.getContains(), code, systems);
+    }
+  }
+  
   @Override
   public Boolean codeInValueSet(String system, String code) throws FHIRException {
     Boolean result = false;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetCheckerSimple.java
@@ -488,6 +488,15 @@ public class ValueSetCheckerSimple extends ValueSetWorker implements ValueSetChe
           }
         }
       }
+    } else if (valueset.hasExpansion()) {
+      for (ValueSetExpansionContainsComponent c: valueset.getExpansion().getContains()) {
+        if (c.getCode().equals(code)) {
+          if (sys == null)
+            sys = c.getSystem(); 
+          else
+            return null;
+        }
+      }
     }
 
     return sys;  


### PR DESCRIPTION
…lue set with only an expansion (no compose), the 'inferred' code system wasn't being populated and validation was then failing on a coding with no specified code system