### PR TITLE
fixing procedure conversion from dstu2 to r4

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/Procedure10_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/Procedure10_40.java
@@ -15,8 +15,8 @@ public class Procedure10_40 {
         for (org.hl7.fhir.dstu2.model.Identifier t : src.getIdentifier()) tgt.addIdentifier(VersionConvertor_10_40.convertIdentifier(t));
         if (src.hasSubject())
             tgt.setSubject(VersionConvertor_10_40.convertReference(src.getSubject()));
-        if (src.hasStatus() && src.hasNotPerformed()) {
-            if (src.getNotPerformed()) {
+        if (src.hasStatus()) {
+            if (src.hasNotPerformed() && src.getNotPerformed()) {
                 tgt.setStatus(Procedure.ProcedureStatus.NOTDONE);
             } else {
                 tgt.setStatus(convertProcedureStatus(src.getStatus()));


### PR DESCRIPTION
the field dstu2.Procedure.notPerformed is optional. fixing a bug in convert for procedure which didn't convert the status field if notPerformed was not given