### PR TITLE
Fixed issue where validator fails to detect invariant issue when ther…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+Fixed issue where validator fails to detect invariant issue when there are multiple profiles that use the same invariant on the same element. Also addressed issue revealed by the fix where the context resource wasn't being set properly when checking certain invariants (identified by one of the existing test cases).

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -4528,10 +4528,6 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     String thisExtension = null;
     boolean checkDisplay = true;
 
-    // Lloyd: Changed onlyNonInherited to false because inherited invariants can be overridden and it's important to check both.  
-    // Caching logic should make checking inherited constraints more efficient now.
-    // Added choice around checkInvariants because azatadha/example-params-1 test was treating the '%resource' in the bdl-3 constraint for 
-    // evaluating the Bundle rule as Parameters, not Bundle
     SpecialElement special = ei.getElement().getSpecial();
     if (special == SpecialElement.BUNDLE_ENTRY || special == SpecialElement.BUNDLE_OUTCOME || special == SpecialElement.PARAMETER) {
       checkInvariants(hostContext, errors, profile, typeDefn != null ? typeDefn : checkDefn, ei.getElement(), ei.getElement(), localStack, false);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -4528,7 +4528,16 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     String thisExtension = null;
     boolean checkDisplay = true;
 
-    checkInvariants(hostContext, errors, profile, typeDefn != null ? typeDefn : checkDefn, resource, ei.getElement(), localStack, true);
+    // Lloyd: Changed onlyNonInherited to false because inherited invariants can be overridden and it's important to check both.  
+    // Caching logic should make checking inherited constraints more efficient now.
+    // Added choice around checkInvariants because azatadha/example-params-1 test was treating the '%resource' in the bdl-3 constraint for 
+    // evaluating the Bundle rule as Parameters, not Bundle
+    SpecialElement special = ei.getElement().getSpecial();
+    if (special == SpecialElement.BUNDLE_ENTRY || special == SpecialElement.BUNDLE_OUTCOME || special == SpecialElement.PARAMETER) {
+      checkInvariants(hostContext, errors, profile, typeDefn != null ? typeDefn : checkDefn, ei.getElement(), ei.getElement(), localStack, false);
+    } else {
+      checkInvariants(hostContext, errors, profile, typeDefn != null ? typeDefn : checkDefn, resource, ei.getElement(), localStack, false);
+    }
 
     ei.getElement().markValidation(profile, checkDefn);
     boolean elementValidated = false;
@@ -5003,18 +5012,23 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     for (ElementDefinitionConstraintComponent inv : ed.getConstraint()) {
       if (inv.hasExpression() && (!onlyNonInherited || !inv.hasSource() || (!isInheritedProfile(profile, inv.getSource()) && !isInheritedProfile(ed.getType(), inv.getSource())) )) {
         @SuppressWarnings("unchecked")
-        Set<String> invList = executionId.equals(element.getUserString(EXECUTION_ID)) ? (Set<String>) element.getUserData(EXECUTED_CONSTRAINT_LIST) : null;
-        if (invList == null) {
-          invList = new HashSet<>();
-          element.setUserData(EXECUTED_CONSTRAINT_LIST, invList);
+        Map<String, List<ValidationMessage>> invMap = executionId.equals(element.getUserString(EXECUTION_ID)) ? (Map<String, List<ValidationMessage>>) element.getUserData(EXECUTED_CONSTRAINT_LIST) : null;
+        if (invMap == null) {
+          invMap = new HashMap<>();
+          element.setUserData(EXECUTED_CONSTRAINT_LIST, invMap);
           element.setUserData(EXECUTION_ID, executionId);
         }
-        if (!invList.contains(inv.getKey())) {
-          invList.add(inv.getKey());
-          checkInvariant(hostContext, errors, path, profile, resource, element, inv);
+        List<ValidationMessage> invErrors = null;
+        // We key based on inv.expression rather than inv.key because expressions can change in derived profiles and aren't guaranteed to be consistent across profiles.
+        String key = fixExpr(inv.getExpression(), inv.getKey());
+        if (!invMap.keySet().contains(key)) {
+          invErrors = new ArrayList<ValidationMessage>();
+          invMap.put(key, invErrors);
+          checkInvariant(hostContext, invErrors, path, profile, resource, element, inv);
         } else {
-          //System.out.println("Skip "+inv.getKey()+" on "+path);
+          invErrors = (ArrayList<ValidationMessage>)invMap.get(key);
         }
+        errors.addAll(invErrors);
       }
     }
   }


### PR DESCRIPTION
…e are multiple profiles that use the same invariant on the same element.  Also addressed issue revealed by the fix where the context resource wasn't being set properly when checking certain invariants (identified by one of the existing test cases).

See new test case in https://github.com/FHIR/fhir-test-cases/pull/93