### PR TITLE
https://github.com/hapifhir/org.hl7.fhir.core/issues/564

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -61,14 +61,7 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 /**
@@ -141,6 +134,11 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       names.add(s);
     Collections.sort(names);
     return names;
+  }
+
+  private List<String> reverseSorted(String[] keys) {
+    Arrays.sort(keys, Collections.reverseOrder());
+    return Arrays.asList(keys);
   }
 
   private NpmPackage loadPackageInfo(String path) throws IOException {
@@ -316,7 +314,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     }
     String foundPackage = null;
     String foundVersion = null;
-    for (String f : sorted(new File(cacheFolder).list())) {
+    for (String f : reverseSorted(new File(cacheFolder).list())) {
       File cf = new File(Utilities.path(cacheFolder, f));
       if (cf.isDirectory()) {
         if (f.equals(id + "#" + version) || (Utilities.noString(version) && f.startsWith(id + "#"))) {
@@ -475,6 +473,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       version = id.substring(id.indexOf("#")+1);
       id = id.substring(0, id.indexOf("#"));
     }
+
     NpmPackage p = loadPackageFromCacheOnly(id, version);
     if (p != null) {
       if ("current".equals(version)) {

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -28,6 +28,10 @@ The following parameters are supported:
      the URL of an implementation guide or a package ([id]-[ver]) for
      a built implementation guide or a local folder that contains a
      set of conformance resources.
+     If you would like to load the latest version of the implementation guide or package,
+     please define the version as '#current'. If no version is provided, the latest version
+     in the package cache will be used, or if no such cached package is available, the
+     PackageCacheManager will load the latest from the the online package repo.
      No default value. This parameter can appear any number of times
 -tx [url]: the [base] url of a FHIR terminology service
      Default value is http://tx.fhir.org. This parameter can appear once


### PR DESCRIPTION
Updating validator cli instructions to better outline the behaviour around caching packages.

Changed caching behaviour to sort currently cached packages from newest release to oldest release.

https://github.com/hapifhir/org.hl7.fhir.core/issues/564