### PR TITLE
Fix the #current version to drive off a specific git file instead of …

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -522,8 +522,8 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   private InputStreamWithSrc loadFromCIBuild(String id) throws IOException {
     checkBuildLoaded();
     if (packageRepos.containsKey(id)) {
-      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL((String)packageRepos.get(id), "package.tgz"), false);
-      return new InputStreamWithSrc(stream, Utilities.pathURL((String)packageRepos.get(id), "package.tgz"), "current");
+      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(packageRepos.get(id), "package.tgz"), false);
+      return new InputStreamWithSrc(stream, Utilities.pathURL(packageRepos.get(id), "package.tgz"), "current");
     } else if (id.startsWith("hl7.fhir.r5")) {
       InputStream stream = fetchFromUrlSpecific(Utilities.pathURL("http://build.fhir.org", id + ".tgz"), false);
       return new InputStreamWithSrc(stream, Utilities.pathURL("http://build.fhir.org", id + ".tgz"), "current");
@@ -534,7 +534,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
 
   private String getPackageUrlFromBuildList(String packageId) throws IOException {
     checkBuildLoaded();
-    return (String)packageRepos.get(packageId);
+    return packageRepos.get(packageId);
   }
 
   private void addCIBuildSpecs(Map<String, String> specList) throws IOException {
@@ -606,7 +606,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     checkBuildLoaded();
     // special case: current versions roll over, and we have to check their currency
     try {
-      String url = (String)packageRepos.get(id);
+      String url = packageRepos.get(id);
       JsonObject json = fetchJson(Utilities.pathURL(url, "package.manifest.json"));
       String currDate = JSONUtil.str(json, "date");
       String packDate = p.date();
@@ -647,28 +647,8 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       String repo = o.get("repo").getAsString();
       packageRepos.put(packageId, repo);
     }
-/*    for (BuildRecord bld : builds) {
-      if (!ciList.containsKey(bld.getPackageId())) {
-        ciList.put(bld.getPackageId(), "https://build.fhir.org/ig/" + bld.getRepo());
-      }
-    }*/
     buildLoaded = true; // whether it succeeds or not
   }
-
-/*  private String getRepo(String path) {
-    String[] p = path.split("\\/");
-    return p[0] + "/" + p[1];
-  }
-
-  private Date readDate(String s) {
-    SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM, yyyy HH:mm:ss Z", new Locale("en", "US"));
-    try {
-      return sdf.parse(s);
-    } catch (ParseException e) {
-      e.printStackTrace();
-      return new Date();
-    }
-  }*/
 
   // ----- the old way, from before package server, while everything gets onto the package server
   private InputStreamWithSrc fetchTheOldWay(String id, String v) {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -99,8 +99,8 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   private boolean progress = true;
   private List<NpmPackage> temporaryPackages = new ArrayList<>();
   private boolean buildLoaded = false;
-  private Map<String, String> ciList = new HashMap<String, String>();
   private JsonArray buildInfo;
+  private HashMap<String,String> packageRepos;
 
   /**
    * Constructor
@@ -521,26 +521,20 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
 
   private InputStreamWithSrc loadFromCIBuild(String id) throws IOException {
     checkBuildLoaded();
-    if (ciList.containsKey(id)) {
-      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(ciList.get(id), "package.tgz"), false);
-      return new InputStreamWithSrc(stream, Utilities.pathURL(ciList.get(id), "package.tgz"), "current");
+    if (packageRepos.containsKey(id)) {
+      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL((String)packageRepos.get(id), "package.tgz"), false);
+      return new InputStreamWithSrc(stream, Utilities.pathURL((String)packageRepos.get(id), "package.tgz"), "current");
     } else if (id.startsWith("hl7.fhir.r5")) {
       InputStream stream = fetchFromUrlSpecific(Utilities.pathURL("http://build.fhir.org", id + ".tgz"), false);
       return new InputStreamWithSrc(stream, Utilities.pathURL("http://build.fhir.org", id + ".tgz"), "current");
     } else {
-      throw new FHIRException("The package '" + id + "' has no entry on the current build server");
+      throw new FHIRException("The package '" + id + "' has no entry on https://github.com/hl7/package-info and an entry is required to use #current.  Please submit a pull request against the package-info.json file.");
     }
   }
 
   private String getPackageUrlFromBuildList(String packageId) throws IOException {
     checkBuildLoaded();
-    for (JsonElement n : buildInfo) {
-      JsonObject o = (JsonObject) n;
-      if (packageId.equals(JSONUtil.str(o, "package-id"))) {
-        return JSONUtil.str(o, "url");
-      }
-    }
-    return null;
+    return (String)packageRepos.get(packageId);
   }
 
   private void addCIBuildSpecs(Map<String, String> specList) throws IOException {
@@ -612,7 +606,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     checkBuildLoaded();
     // special case: current versions roll over, and we have to check their currency
     try {
-      String url = ciList.get(id);
+      String url = (String)packageRepos.get(id);
       JsonObject json = fetchJson(Utilities.pathURL(url, "package.manifest.json"));
       String currDate = JSONUtil.str(json, "date");
       String packDate = p.date();
@@ -637,7 +631,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   }
 
   private void loadFromBuildServer() throws IOException {
-    URL url = new URL("https://build.fhir.org/ig/qas.json?nocache=" + System.currentTimeMillis());
+    URL url = new URL("https://raw.githubusercontent.com/HL7/package-info/main/package-info.json?nocache=" + System.currentTimeMillis());
     SSLCertTruster.trustAllHosts();
     HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
     connection.setHostnameVerifier(SSLCertTruster.DO_NOT_VERIFY);
@@ -645,27 +639,23 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     InputStream json = connection.getInputStream();
     buildInfo = (JsonArray) new com.google.gson.JsonParser().parse(TextFile.streamToString(json));
 
-    List<BuildRecord> builds = new ArrayList<>();
+    packageRepos = new HashMap<String,String>();
 
     for (JsonElement n : buildInfo) {
       JsonObject o = (JsonObject) n;
-      if (o.has("url") && o.has("package-id") && o.get("package-id").getAsString().contains(".")) {
-        String u = o.get("url").getAsString();
-        if (u.contains("/ImplementationGuide/"))
-          u = u.substring(0, u.indexOf("/ImplementationGuide/"));
-        builds.add(new BuildRecord(u, o.get("package-id").getAsString(), getRepo(o.get("repo").getAsString()), readDate(o.get("date").getAsString())));
-      }
+      String packageId = o.get("package-id").getAsString();
+      String repo = o.get("repo").getAsString();
+      packageRepos.put(packageId, repo);
     }
-    Collections.sort(builds, new BuildRecordSorter());
-    for (BuildRecord bld : builds) {
+/*    for (BuildRecord bld : builds) {
       if (!ciList.containsKey(bld.getPackageId())) {
         ciList.put(bld.getPackageId(), "https://build.fhir.org/ig/" + bld.getRepo());
       }
-    }
+    }*/
     buildLoaded = true; // whether it succeeds or not
   }
 
-  private String getRepo(String path) {
+/*  private String getRepo(String path) {
     String[] p = path.split("\\/");
     return p[0] + "/" + p[1];
   }
@@ -678,7 +668,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       e.printStackTrace();
       return new Date();
     }
-  }
+  }*/
 
   // ----- the old way, from before package server, while everything gets onto the package server
   private InputStreamWithSrc fetchTheOldWay(String id, String v) {
@@ -787,32 +777,10 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     T get() throws IOException;
   }
 
-  public class BuildRecordSorter implements Comparator<BuildRecord> {
-
-    @Override
-    public int compare(BuildRecord arg0, BuildRecord arg1) {
-      return arg1.date.compareTo(arg0.date);
-    }
-  }
-
   public class BuildRecord {
 
-    private String url;
     private String packageId;
     private String repo;
-    private Date date;
-
-    public BuildRecord(String url, String packageId, String repo, Date date) {
-      super();
-      this.url = url;
-      this.packageId = packageId;
-      this.repo = repo;
-      this.date = date;
-    }
-
-    public String getUrl() {
-      return url;
-    }
 
     public String getPackageId() {
       return packageId;
@@ -821,15 +789,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
     public String getRepo() {
       return repo;
     }
-
-    public Date getDate() {
-      return date;
-    }
-
-
   }
-
-
 
   public class VersionHistory {
     private String id;


### PR DESCRIPTION
…the file used to manage the list of CI builds - as the former doesn't ensure that only the 'authoritative' project can be the 'current' version for a given IG.  (This is a temporary measure until we update the package server to manage #current.)