### PR TITLE
Replace proprietary notnull with javax.annotation.Nonnull

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGPackConverter102.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGPackConverter102.java
@@ -41,7 +41,7 @@ import org.hl7.fhir.dstu3.model.ValueSet;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.model.FhirPublication;
 import org.hl7.fhir.utilities.Utilities;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGPackConverter102.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGPackConverter102.java
@@ -84,18 +84,18 @@ public class IGPackConverter102 extends BaseAdvisor_10_30 {
   }
 
   @Override
-  public boolean ignoreEntry(@NotNull BundleEntryComponent src, @NotNull FhirPublication publication) {
+  public boolean ignoreEntry(@Nonnull BundleEntryComponent src, @Nonnull FhirPublication publication) {
     return false;
   }
 
 
   @Override
-  public void handleCodeSystem(@NotNull CodeSystem tgtcs, @NotNull ValueSet vs) {
+  public void handleCodeSystem(@Nonnull CodeSystem tgtcs, @Nonnull ValueSet vs) {
     cslist.addEntry().setFullUrl(tgtcs.getUrl()).setResource(tgtcs);
   }
 
   @Override
-  public CodeSystem getCodeSystem(@NotNull ValueSet src) {
+  public CodeSystem getCodeSystem(@Nonnull ValueSet src) {
     return null;
   }
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 
 public class IGR2ConvertorAdvisor extends BaseAdvisor_10_40 {
   @Override
-  public void handleCodeSystem(@NotNull CodeSystem cs, @NotNull ValueSet vs) {
+  public void handleCodeSystem(@Nonnull CodeSystem cs, @Nonnull ValueSet vs) {
     cs.setId(vs.getId());
   }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor.java
@@ -32,7 +32,7 @@ package org.hl7.fhir.convertors.misc;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_10_40;
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.ValueSet;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public class IGR2ConvertorAdvisor extends BaseAdvisor_10_40 {
   @Override

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor5.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor5.java
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
 public class IGR2ConvertorAdvisor5 extends BaseAdvisor_10_50 {
 
   @Override
-  public void handleCodeSystem(@NotNull CodeSystem cs, @NotNull ValueSet vs) {
+  public void handleCodeSystem(@Nonnull CodeSystem cs, @Nonnull ValueSet vs) {
     cs.setId(vs.getId());
   }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor5.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/misc/IGR2ConvertorAdvisor5.java
@@ -33,7 +33,7 @@ package org.hl7.fhir.convertors.misc;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_10_50;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.ValueSet;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public class IGR2ConvertorAdvisor5 extends BaseAdvisor_10_50 {
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/network/RetryInterceptor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/network/RetryInterceptor.java
@@ -3,7 +3,7 @@ package org.hl7.fhir.r5.utils.client.network;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/network/RetryInterceptor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/network/RetryInterceptor.java
@@ -27,7 +27,7 @@ public class RetryInterceptor implements Interceptor {
   }
 
   @Override
-  public @NotNull Response intercept(Interceptor.Chain chain) throws IOException {
+  public Response intercept(Interceptor.Chain chain) throws IOException {
     Request request = chain.request();
     Response response = null;
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/NativeHostServices.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/NativeHostServices.java
@@ -78,7 +78,7 @@ import org.hl7.fhir.utilities.VersionUtilities;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * This class allows you to host the java validator in another service, and use the services it has in a wider context. The way it works is 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/NativeHostServices.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/NativeHostServices.java
@@ -106,10 +106,10 @@ public class NativeHostServices {
   
   private class NH_10_50_Advisor extends BaseAdvisor_10_50 {
     @Override
-    public void handleCodeSystem(@NotNull CodeSystem tgtcs, @NotNull ValueSet source) throws FHIRException {}
+    public void handleCodeSystem(@Nonnull CodeSystem tgtcs, @Nonnull ValueSet source) throws FHIRException {}
 
     @Override
-    public CodeSystem getCodeSystem(@NotNull ValueSet src) throws FHIRException {
+    public CodeSystem getCodeSystem(@Nonnull ValueSet src) throws FHIRException {
       throw new FHIRException("Code systems cannot be handled at this time"); // what to do? need thread local storage? 
     }
   }


### PR DESCRIPTION
* Prevents build issues upstream with projects that try to not rely on IDE-specific annotations. 