### PR TITLE
Fix GraphQLSchemaGenerator to produce valid GraphQL schemas

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,12 @@ public class GraphQLSchemaGenerator {
   public enum FHIROperationType {READ, SEARCH, CREATE, UPDATE, DELETE};
   
   private static final String INNER_TYPE_NAME = "gql.type.name";
+  private static final Set<String> JSON_NUMBER_TYPES = new HashSet<String>() {{
+    add("decimal");
+    add("positiveInt");
+    add("unsignedInt");
+  }};
+
   IWorkerContext context;
 
   public GraphQLSchemaGenerator(IWorkerContext context) {
@@ -411,7 +418,7 @@ public class GraphQLSchemaGenerator {
     if (gqlName.equals(name)) { 
       writer.write("scalar ");
       writer.write(name);
-      writer.write(" # JSON Format: String");
+      writer.write(" # JSON Format: string");
     } else  {
       writer.write("# Search Param ");
       writer.write(name);
@@ -426,7 +433,12 @@ public class GraphQLSchemaGenerator {
       if (!ed.getType().isEmpty() &&  ed.getType().get(0).getCodeElement().hasExtension("http://hl7.org/fhir/StructureDefinition/structuredefinition-json-type"))
         return ed.getType().get(0).getCodeElement().getExtensionString("http://hl7.org/fhir/StructureDefinition/structuredefinition-json-type");
     }
-    return "??";
+    // all primitives but JSON_NUMBER_TYPES are represented as JSON strings
+    if (JSON_NUMBER_TYPES.contains(sd.getName())) {
+      return "number";
+    } else {
+      return "string";
+    }
   }
 
   private String getGqlname(String name) {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -113,7 +113,7 @@ public class GraphQLSchemaGenerator {
   public void generateResource(OutputStream stream, StructureDefinition sd, List<SearchParameter> parameters, EnumSet<FHIROperationType> operations) throws IOException, FHIRException {
     BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream));
     writer.write("# FHIR GraphQL Schema. Version "+Constants.VERSION+"\r\n\r\n");
-    writer.write("# import the types from 'types.graphql'\r\n\r\n");
+    writer.write("# import * from 'types.graphql'\r\n\r\n");
     generateType(writer, sd);
     if (operations.contains(FHIROperationType.READ))
       generateIdAccess(writer, sd.getName());

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -409,7 +409,7 @@ public class GraphQLSchemaGenerator {
   private void generateSearchParamType(BufferedWriter writer, String name) throws IOException, FHIRException {
     String gqlName = getGqlname(name);
     if (gqlName.equals(name)) { 
-      writer.write("Scalar ");
+      writer.write("scalar ");
       writer.write(name);
       writer.write(" # JSON Format: String");
     } else  {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -247,6 +247,11 @@ public class GraphQLSchemaGenerator {
     writer.write("}\r\n");
     writer.write("\r\n");
     
+    writer.write("input ElementBaseInput {\r\n");
+    writer.write("  id : ID\r\n");
+    writer.write("  extension: [ExtensionInput]\r\n");
+    writer.write("}\r\n");
+    writer.write("\r\n");
   }
 
   private void generateType(BufferedWriter writer, StructureDefinition sd) throws IOException {
@@ -326,10 +331,15 @@ public class GraphQLSchemaGenerator {
         b.append(tail(child.getPath(), suffix));
         if (suffix)
           b.append(Utilities.capitalize(typeDetails.getWorkingCode()));
-        if (!child.getMax().equals("1"))
-          b.append(": [ElementBase]\r\n");
-        else
-          b.append(": ElementBase\r\n");
+        if (!child.getMax().equals("1")) {
+          b.append(": [ElementBase");
+          b.append(suffixS);
+          b.append("]\r\n");
+        } else {
+          b.append(": ElementBase");
+          b.append(suffixS);
+          b.append("\r\n");
+        }
       } else
         b.append("\r\n");
     } else {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -415,11 +415,15 @@ public class GraphQLSchemaGenerator {
 
   private void generateSearchParamType(BufferedWriter writer, String name) throws IOException, FHIRException {
     String gqlName = getGqlname(name);
-    if (gqlName.equals(name)) { 
+    if (gqlName.equals("date")) {
+      writer.write("# Search Param ");
+      writer.write(name);
+      writer.write(": already defined as Primitive with JSON Format: string ");
+    } else if (gqlName.equals(name)) { 
       writer.write("scalar ");
       writer.write(name);
       writer.write(" # JSON Format: string");
-    } else  {
+    } else {
       writer.write("# Search Param ");
       writer.write(name);
       writer.write(": use GraphQL Scalar type ");

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -116,7 +116,7 @@ public class GraphQLSchemaGenerator {
   public void generateResource(OutputStream stream, StructureDefinition sd, List<SearchParameter> parameters, EnumSet<FHIROperationType> operations) throws IOException, FHIRException {
     BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream));
     writer.write("# FHIR GraphQL Schema. Version "+version+"\r\n\r\n");
-    writer.write("# import the types from 'types.graphql'\r\n\r\n");
+    writer.write("# import * from 'types.graphql'\r\n\r\n");
     generateType(writer, sd);
     if (operations.contains(FHIROperationType.READ))
       generateIdAccess(writer, sd.getName());

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -250,6 +250,11 @@ public class GraphQLSchemaGenerator {
     writer.write("}\r\n");
     writer.write("\r\n");
     
+    writer.write("input ElementBaseInput {\r\n");
+    writer.write("  id : ID\r\n");
+    writer.write("  extension: [ExtensionInput]\r\n");
+    writer.write("}\r\n");
+    writer.write("\r\n");
   }
 
   private void generateType(BufferedWriter writer, StructureDefinition sd) throws IOException {
@@ -329,10 +334,15 @@ public class GraphQLSchemaGenerator {
         b.append(tail(child.getPath(), suffix));
         if (suffix)
           b.append(Utilities.capitalize(typeDetails.getWorkingCode()));
-        if (!child.getMax().equals("1"))
-          b.append(": [ElementBase]\r\n");
-        else
-          b.append(": ElementBase\r\n");
+          if (!child.getMax().equals("1")) {
+            b.append(": [ElementBase");
+            b.append(suffixS);
+            b.append("]\r\n");
+          } else {
+            b.append(": ElementBase");
+            b.append(suffixS);
+            b.append("\r\n");
+          }
       } else
         b.append("\r\n");
     } else {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -418,7 +418,11 @@ public class GraphQLSchemaGenerator {
 
   private void generateSearchParamType(BufferedWriter writer, String name) throws IOException, FHIRException {
     String gqlName = getGqlname(name);
-    if (gqlName.equals(name)) { 
+    if (gqlName.equals("date")) {
+      writer.write("# Search Param ");
+      writer.write(name);
+      writer.write(": already defined as Primitive with JSON Format: string ");
+    } else if (gqlName.equals(name)) { 
       writer.write("scalar ");
       writer.write(name);
       writer.write(" # JSON Format: string");

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -413,7 +413,7 @@ public class GraphQLSchemaGenerator {
   private void generateSearchParamType(BufferedWriter writer, String name) throws IOException, FHIRException {
     String gqlName = getGqlname(name);
     if (gqlName.equals(name)) { 
-      writer.write("Scalar ");
+      writer.write("scalar ");
       writer.write(name);
       writer.write(" # JSON Format: String");
     } else  {


### PR DESCRIPTION
The schemas generated by the R4 and R5 (https://build.fhir.org/fhir.schema.graphql.zip) `GraphQLSchemaGenerator`s are no valid GraphQL schemas.

This PR contains the following fixes:

- The `scalar` keyword generated for parameter types used to be capitalized (e.g. `Scalar number` instead of `scalar number`). Only `scalar` is a valid keyword in GraphQL.
- Two scalars with the name `date` were generated (one for primitives and one for parameters). As both use a JSON representation of type string, this fix replaces the second scalar with the comment `# Search Param date: already defined as Primitive with JSON Format: string `
- Various input types had properties of type `ElementBase` which is not an input type. Input types can only use other input types. A new input type `ElementBaseInput` was added. `ElementBase` was changed to `ElementBaseInput` for all input types.

As well as some minor enhancements:

- All scalars were already followed by a comment specifying the actual JSON type. However, for most of them a placeholder `??` was printed. This PR changes `??` to the JSON type as specified in https://www.hl7.org/fhir/datatypes.html.
  (e.g. `scalar date # JSON Format: string` instead of `scalar date # JSON Format: ??`)
- The comment `# import the types from 'types.graphql'` was changed to `# import * from 'types.graphql'`. This makes it easier to work with the schema using *graphql-tools* which is a very common GraphQL library in the NodeJS ecosystem (https://www.graphql-tools.com/docs/schema-loading). 


I am actually not sure how to really test this. There does not seem to be any GraphQLSchemaGenerator related tests in this repo. I tried building https://github.com/HL7/fhir with my local changes to https://github.com/hapifhir/org.hl7.fhir.core but were not succesful yet.
However, since the generated schemas were no valid GraphQL anyway, there is at least no way to break anything.