### PR TITLE
Fix Issue 618 | NPE bundle validation

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/BundleValidator.java
@@ -143,7 +143,7 @@ public class BundleValidator extends BaseValidator{
     }
 
     Boolean searchMode = readHasSearchMode(entries);
-    if (searchMode == false) { // if no resources have search mode
+    if (searchMode != null && searchMode == false) { // if no resources have search mode
       boolean typeProblem = false;
       String rtype = null;
       int count = 0;


### PR DESCRIPTION
When validating a bundle, with the type, searchset, a NPE would be
thrown if some but not all entities contained a search mode.

Fixes #618 