### PR TITLE
Update Azure Pipeline to Test Recent JDKs

### DIFF
--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -1,0 +1,56 @@
+jobs:
+  - ${{ each imageName in parameters.imageName }}:
+    - ${{ each jdkVersion in parameters.jdkVersion }}:
+      - job:
+        trigger: none
+        
+        pr:
+        - master
+        - release
+        
+        pool:
+          vmImage: $(imageName)
+        
+        variables:
+          currentImage: $(imageName)
+          codecov: $(CODECOV_TOKEN)
+          VERSION:
+
+        steps:
+          # Runs 'mvn clean package'
+          - task: Maven@3
+            inputs:
+              mavenPomFile: 'pom.xml'
+              mavenOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: $(jdkVersion)
+              jdkArchitectureOption: 'x64'
+              publishJUnitResults: true
+              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              goals: 'package'
+
+          - task: Maven@3
+            inputs:
+              mavenPomFile: 'pom.xml'
+              mavenOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: '$(jdkVersion)'
+              jdkArchitectureOption: 'x64'
+              options: '-pl org.hl7.fhir.validation.cli'
+              publishJUnitResults: false
+              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              goals: 'exec:exec'
+
+          # Upload test results to codecov    
+          - script: bash <(curl https://codecov.io/bash) -t $(codecov)
+            displayName: 'codecov Bash Uploader'
+            condition: eq(variables.currentImage, 'ubuntu-latest')
+
+          # Publishes the test results to build artifacts.
+          - task: PublishCodeCoverageResults@1
+            displayName: 'Publish JaCoCo test results'
+            condition: eq(variables.currentImage, 'ubuntu-latest')
+            inputs:
+              codeCoverageTool: 'JaCoCo'
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/jacoco.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/'

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -1,9 +1,3 @@
-trigger: none
-        
-pr:
-- master
-- release
-
 jobs:
   - ${{ each imageName in parameters.imageName }}:
     - ${{ each jdkVersion in parameters.jdkVersion }}:

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -4,10 +4,10 @@ jobs:
       - job:
         
         pool:
-          vmImage: $(imageName)
+          vmImage: ${{imageName}}
         
         variables:
-          currentImage: $(imageName)
+          currentImage: ${{imageName}}
           codecov: $(CODECOV_TOKEN)
           VERSION:
 
@@ -18,7 +18,7 @@ jobs:
               mavenPomFile: 'pom.xml'
               mavenOptions: '-Xmx3072m'
               javaHomeOption: 'JDKVersion'
-              jdkVersionOption: $(jdkVersion)
+              jdkVersionOption: '${{jdkVersion}}'
               jdkArchitectureOption: 'x64'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
@@ -29,7 +29,7 @@ jobs:
               mavenPomFile: 'pom.xml'
               mavenOptions: '-Xmx3072m'
               javaHomeOption: 'JDKVersion'
-              jdkVersionOption: '$(jdkVersion)'
+              jdkVersionOption: '${{jdkVersion}}'
               jdkArchitectureOption: 'x64'
               options: '-pl org.hl7.fhir.validation.cli'
               publishJUnitResults: false

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -1,12 +1,13 @@
+trigger: none
+        
+pr:
+- master
+- release
+
 jobs:
   - ${{ each imageName in parameters.imageName }}:
     - ${{ each jdkVersion in parameters.jdkVersion }}:
       - job:
-        trigger: none
-        
-        pr:
-        - master
-        - release
         
         pool:
           vmImage: $(imageName)

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -2,6 +2,8 @@ jobs:
   - ${{ each imageName in parameters.imageName }}:
     - ${{ each jdkVersion in parameters.jdkVersion }}:
       - job:
+
+        displayName: ${{imageName}}_${{jdkVersion}}
         
         pool:
           vmImage: ${{imageName}}

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -1,3 +1,8 @@
+trigger: none
+        
+pr:
+- master
+- release
 
 jobs:
 - template: pull-request-pipeline-parameterized.yml

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -1,5 +1,5 @@
 trigger: none
-        
+
 pr:
 - master
 - release

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -8,4 +8,4 @@ jobs:
 - template: pull-request-pipeline-parameterized.yml
   parameters:
     imageName: [ 'ubuntu-latest', 'macos-latest', 'windows-2019' ]
-    jdkVersion: [ '1.8', '1.11']
+    jdkVersion: [ '1.8', '1.11', '1.17']

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -1,63 +1,6 @@
-trigger: none
 
-pr:
-- master
-- release
-
-# Different users have different machine setups, we run the build three times, on ubuntu, osx, and windows
-strategy:
-  matrix:
-    linux:
-      imageName: 'ubuntu-latest'
-    mac:
-      imageName: "macos-latest"
-    windows:
-      imageName: "windows-2019"
-  maxParallel: 3
-
-pool:
-  vmImage: $(imageName)
-
-variables:
-  currentImage: $(imageName)
-  codecov: $(CODECOV_TOKEN)
-  VERSION:
-
-steps:
-  # Runs 'mvn clean package'
-  - task: Maven@3
-    inputs:
-      mavenPomFile: 'pom.xml'
-      mavenOptions: '-Xmx3072m'
-      javaHomeOption: 'JDKVersion'
-      jdkVersionOption: '1.11'
-      jdkArchitectureOption: 'x64'
-      publishJUnitResults: true
-      testResultsFiles: '**/surefire-reports/TEST-*.xml'
-      goals: 'package'
-
-  - task: Maven@3
-    inputs:
-      mavenPomFile: 'pom.xml'
-      mavenOptions: '-Xmx3072m'
-      javaHomeOption: 'JDKVersion'
-      jdkVersionOption: '1.11'
-      jdkArchitectureOption: 'x64'
-      options: '-pl org.hl7.fhir.validation.cli'
-      publishJUnitResults: false
-      testResultsFiles: '**/surefire-reports/TEST-*.xml'
-      goals: 'exec:exec'
-
-  # Upload test results to codecov    
-  - script: bash <(curl https://codecov.io/bash) -t $(codecov)
-    displayName: 'codecov Bash Uploader'
-    condition: eq(variables.currentImage, 'ubuntu-latest')
-
-  # Publishes the test results to build artifacts.
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish JaCoCo test results'
-    condition: eq(variables.currentImage, 'ubuntu-latest')
-    inputs:
-      codeCoverageTool: 'JaCoCo'
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/jacoco.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/'
+jobs:
+- template: pull-request-pipeline-parameterized.yml
+  parameters:
+    imageName: [ 'ubuntu-latest', 'macos-latest', 'windows-2019' ]
+    jdkVersion: [ '1.8', '1.11']


### PR DESCRIPTION
Making updates to the Azure Pipeline so that it tests PRs against multiple JDK Versions. I haven't used Azure Pipelines before, so there might be a better way to do this.

Currently, it [doesn't appear that Azure Pipelines support a cross-product matrix strategy like GitHub Actions, but there are some examples of how to replicate the functionality in Azure Pipelines](https://github.com/microsoft/azure-pipelines-yaml/issues/20).

[fhir-validator-wrapper/41](https://github.com/inferno-community/fhir-validator-wrapper/pull/41) highlighted a suspected issue that only appeared when using JDK 8 ([relevant zulip thread](https://chat.fhir.org/#narrow/stream/207835-IPS/topic/IPS.20support.20in.20the.20validator)).