### PR TITLE
Validate MeasureReport groups only if Measure has groups

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/MeasureValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/MeasureValidator.java
@@ -244,6 +244,11 @@ public class MeasureValidator extends BaseValidator {
   }
 
   private void validateMeasureReportGroups(ValidatorHostContext hostContext, MeasureContext m, List<ValidationMessage> errors, Element mr, NodeStack stack, boolean inProgress) {
+    if (m.groups().size() == 0) {
+      // only validate the report groups if the measure has groups.
+      return;
+    }
+
     List<MeasureGroupComponent> groups = new ArrayList<MeasureGroupComponent>();
 
     List<Element> glist = mr.getChildrenByName("group");


### PR DESCRIPTION
Ref Zulip https://chat.fhir.org/#narrow/stream/179165-committers/topic/MeasureReport.2Egroup.20validation.

Tested locally that it addresses the issue.

Tested locally that issues that were detected prior to the update still are.
Pre update:
![image](https://user-images.githubusercontent.com/13257640/138472857-02f35e2e-71b1-4fa6-b2eb-d379a6624284.png)

Post update:
![image](https://user-images.githubusercontent.com/13257640/138473606-2fb95529-1b29-4cfa-83bf-18d1e527a91c.png)
