### PR TITLE
changing JAVA_HOME to remove trailing slash

### DIFF
--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesTest.java
@@ -29,7 +29,7 @@ class UtilitiesTest {
   public static final String WIN_JAVA_HOME = System.getenv("JAVA_HOME") + "\\";
 
   public static final String OSX_USER_DIR = System.getProperty("user.home") + "/";
-  public static final String OSX_JAVA_HOME = System.getenv("JAVA_HOME") + "/";
+  public static final String OSX_JAVA_HOME = System.getenv("JAVA_HOME");
 
   @Test
   @DisplayName("Test Utilities.path maps temp directory correctly")


### PR DESCRIPTION
Utilities test fails Java Home location because of trailing slash.