### PR TITLE
adjust hostContext in Bundle for conformsTo

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -308,7 +308,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
         if (e.getName().equals("contained")) {
           self.validateResource(new ValidatorHostContext(ctxt.getAppContext(), e, ctxt.getRootResource()), valerrors, e, e, sd, IdStatus.OPTIONAL, new NodeStack(context, null, e, validationLanguage));          
         } else {
-          self.validateResource(new ValidatorHostContext(ctxt.getAppContext(), e), valerrors, e, e, sd, IdStatus.OPTIONAL, new NodeStack(context, null, e, validationLanguage));
+          self.validateResource(new ValidatorHostContext(("Bundle".equals(ctxt.getRootResource().getName()) ? ctxt.getRootResource() : ctxt.getAppContext()), e), valerrors, e, e, sd, IdStatus.OPTIONAL, new NodeStack(context, null, e, validationLanguage));
         }
       } else
         throw new NotImplementedException(context.formatMessage(I18nConstants.NOT_DONE_YET_VALIDATORHOSTSERVICESCONFORMSTOPROFILE_WHEN_ITEM_IS_NOT_AN_ELEMENT));


### PR DESCRIPTION
we experienced a very strange issue. we have a [FHIR document profile](http://fhir.ch/ig/ch-emed/StructureDefinition-ch-emed-document-medicationcard.html) which requires that the composition.subject is a patient and the patient needs to have one identifier. We have [an incorrect example](http://build.fhir.org/ig/ehealthsuisse/ch-emed/branches/validation/qa.html#_scratch_ig-build-temp-CHRP4N_repo_input_examples_bundle_medicationcard) without a Patient identifier and the IGPubliser correctly shows the failing in the reasoning (what a cool feature, btw):

```
This element does not match any known slicedefined_in_the_profilehttp://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-document-medicationcard
Bundle.entry[0]: discriminator = true and resource.conformsTo('http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-composition-medicationcard')
,
Bundle.entry[0]: Profile http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-composition-medicationcard does not match for Bundle because of the following profile issues:
Bundle.entry[0].resource.subject: Unable to find a match for profile Patient/65788 among choices: http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient-epr
,
Bundle.entry[0].resource.subject:
Bundle.entry[1].resource.ofType(Patient): Patient.identifier: minimum required = 1, but only found 0 (from http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient-epr)
``` 
however when we validate the same document with the FHIR validator we do not get an error:

```
java -jar validator_cli.jar -version 4.0.1 -ig ch.fhir.ig.ch-emed#1.0.0 -profile http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-document-medicationcard http://build.fhir.org/ig/ehealthsuisse/ch-emed/branches/validation/Bundle-medicationcard.json
...
Success: 0 errors, 9 warnings, 6 notes
  Information @ Bundle.entry[1] (line 124, col6): This element does not match any known slice defined in the profile http://fhir.ch/ig/ch-emed/StructureDefinition/ch-emed-document-medicationcard
```
trying to debug it, there is a comment in [InstanceValidator](https://github.com/hapifhir/org.hl7.fhir.core/blob/41b7a0566c2059c947fa27226247644c40cee55a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java#L3475) that the conformsTo breaks the stack and you end up there, but the code is not entered because hostContext is null 

if i adjust the hostContext that is provided as a bundle I get back the validation error, but I'am a bit puzzled why the InstanceValidator is needing an adjustment, but the same is working for the IG Publisher. 

see also zulip thread: https://chat.fhir.org/#narrow/stream/179177-conformance/topic/differences.20in.20Validator.20and.20IGPublisher