### PR TITLE
Fix for #701

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* fix bug for NullPointerException in Bundle convertors when resource is not available.

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_30/resources10_30/Bundle10_30.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_30/resources10_30/Bundle10_30.java
@@ -60,8 +60,8 @@ public class Bundle10_30 {
       tgt.addLink(convertBundleLinkComponent(t));
     if (src.hasFullUrlElement())
       tgt.setFullUrlElement(Uri10_30.convertUri(src.getFullUrlElement()));
-    org.hl7.fhir.dstu2.model.Resource res = ConversionContext10_30.INSTANCE.getVersionConvertor_10_30().convertResource(src.getResource());
-    tgt.setResource(res);
+    if (src.hasResource())
+      tgt.setResource(ConversionContext10_30.INSTANCE.getVersionConvertor_10_30().convertResource(src.getResource()));
     if (src.hasSearch())
       tgt.setSearch(convertBundleEntrySearchComponent(src.getSearch()));
     if (src.hasRequest())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/resources10_40/Bundle10_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/resources10_40/Bundle10_40.java
@@ -78,8 +78,8 @@ public class Bundle10_40 {
     for (org.hl7.fhir.r4.model.Bundle.BundleLinkComponent t : src.getLink()) tgt.addLink(convertBundleLinkComponent(t));
     if (src.hasFullUrlElement())
       tgt.setFullUrlElement(Uri10_40.convertUri(src.getFullUrlElement()));
-    org.hl7.fhir.dstu2.model.Resource res = ConversionContext10_40.INSTANCE.getVersionConvertor_10_40().convertResource(src.getResource());
-    tgt.setResource(res);
+    if (src.hasResource())
+      tgt.setResource(ConversionContext10_40.INSTANCE.getVersionConvertor_10_40().convertResource(src.getResource()));
     if (src.hasSearch())
       tgt.setSearch(convertBundleEntrySearchComponent(src.getSearch()));
     if (src.hasRequest())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_50/resources10_50/Bundle10_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_50/resources10_50/Bundle10_50.java
@@ -78,8 +78,8 @@ public class Bundle10_50 {
     for (org.hl7.fhir.r5.model.Bundle.BundleLinkComponent t : src.getLink()) tgt.addLink(convertBundleLinkComponent(t));
     if (src.hasFullUrlElement())
       tgt.setFullUrlElement(Uri10_50.convertUri(src.getFullUrlElement()));
-    org.hl7.fhir.dstu2.model.Resource res = ConversionContext10_50.INSTANCE.getVersionConvertor_10_50().convertResource(src.getResource());
-    tgt.setResource(res);
+    if (src.hasResource())
+      tgt.setResource(ConversionContext10_50.INSTANCE.getVersionConvertor_10_50().convertResource(src.getResource()));
     if (src.hasSearch())
       tgt.setSearch(convertBundleEntrySearchComponent(src.getSearch()));
     if (src.hasRequest())

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/Bundle10_30Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/Bundle10_30Test.java
@@ -1,0 +1,35 @@
+package org.hl7.fhir.convertors.conv10_30;
+
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_30;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class Bundle10_30Test {
+
+  @Test
+  @DisplayName("Test 10_30 bundle conversion when resource is null")
+  public void testNoResourceBundleConversion() throws IOException {
+    org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent bec = new org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent()
+      .setRequest(
+        new org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent()
+          .setMethod(org.hl7.fhir.dstu3.model.Bundle.HTTPVerb.DELETE)
+          .setUrl("Patient?identifier=123456")
+      );
+
+    org.hl7.fhir.dstu3.model.Bundle stu3Bundle = new org.hl7.fhir.dstu3.model.Bundle()
+      .addEntry(bec);
+
+    org.hl7.fhir.dstu2.model.Resource dstu2Resource = VersionConvertorFactory_10_30.convertResource(stu3Bundle);
+    Assertions.assertNotNull(dstu2Resource);
+    Assertions.assertTrue(dstu2Resource instanceof org.hl7.fhir.dstu2.model.Bundle);
+
+    org.hl7.fhir.dstu2.model.Bundle dstu2Bundle = (org.hl7.fhir.dstu2.model.Bundle) dstu2Resource;
+    Assertions.assertEquals(1, dstu2Bundle.getEntry().size());
+
+    Assertions.assertNull(dstu2Bundle.getEntry().get(0).getResource());
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_40/Bundle10_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_40/Bundle10_40Test.java
@@ -1,0 +1,34 @@
+package org.hl7.fhir.convertors.conv10_40;
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_40;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class Bundle10_40Test {
+
+  @Test
+  @DisplayName("Test 10_40 bundle conversion when resource is null")
+  public void testNoResourceBundleConversion() throws IOException {
+    org.hl7.fhir.r4.model.Bundle.BundleEntryComponent bec = new org.hl7.fhir.r4.model.Bundle.BundleEntryComponent()
+      .setRequest(
+        new org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent()
+          .setMethod(org.hl7.fhir.r4.model.Bundle.HTTPVerb.DELETE)
+          .setUrl("Patient?identifier=123456")
+      );
+
+    org.hl7.fhir.r4.model.Bundle r4Bundle = new org.hl7.fhir.r4.model.Bundle()
+      .addEntry(bec);
+
+    org.hl7.fhir.dstu2.model.Resource dstu2Resource = VersionConvertorFactory_10_40.convertResource(r4Bundle);
+    Assertions.assertNotNull(dstu2Resource);
+    Assertions.assertTrue(dstu2Resource instanceof org.hl7.fhir.dstu2.model.Bundle);
+
+    org.hl7.fhir.dstu2.model.Bundle dstu2Bundle = (org.hl7.fhir.dstu2.model.Bundle) dstu2Resource;
+    Assertions.assertEquals(1, dstu2Bundle.getEntry().size());
+
+    Assertions.assertNull(dstu2Bundle.getEntry().get(0).getResource());
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_50/Bundle10_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_50/Bundle10_50Test.java
@@ -1,0 +1,34 @@
+package org.hl7.fhir.convertors.conv10_50;
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_50;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class Bundle10_50Test {
+
+  @Test
+  @DisplayName("Test 10_50 bundle conversion when resource is null")
+  public void testNoResourceBundleConversion() throws IOException {
+    org.hl7.fhir.r5.model.Bundle.BundleEntryComponent bec = new org.hl7.fhir.r5.model.Bundle.BundleEntryComponent()
+      .setRequest(
+        new org.hl7.fhir.r5.model.Bundle.BundleEntryRequestComponent()
+          .setMethod(org.hl7.fhir.r5.model.Bundle.HTTPVerb.DELETE)
+          .setUrl("Patient?identifier=123456")
+      );
+
+    org.hl7.fhir.r5.model.Bundle r5Bundle = new org.hl7.fhir.r5.model.Bundle()
+      .addEntry(bec);
+
+    org.hl7.fhir.dstu2.model.Resource dstu2Resource = VersionConvertorFactory_10_50.convertResource(r5Bundle);
+    Assertions.assertNotNull(dstu2Resource);
+    Assertions.assertTrue(dstu2Resource instanceof org.hl7.fhir.dstu2.model.Bundle);
+
+    org.hl7.fhir.dstu2.model.Bundle dstu2Bundle = (org.hl7.fhir.dstu2.model.Bundle) dstu2Resource;
+    Assertions.assertEquals(1, dstu2Bundle.getEntry().size());
+
+    Assertions.assertNull(dstu2Bundle.getEntry().get(0).getResource());
+  }
+}


### PR DESCRIPTION
Fixes #701

Checks to see if src.hasResource() is true before attempting to convert to avoid a NullPointerException.

Conversion code was checked for instances of this error in all Bundle covertors:

- [x] conv10_30 _needed fixes_
- [x] conv10_40 _needed fixes_
- [x] conv10_50 _needed fixes_
- [x] conv14_30
- [x] conv14_40
- [x] conv14_50
- [x] conv30_40
- [x] conv30_50
- [x] conv40_50