### PR TITLE
fixed detection of FHIR R5 from version string

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
@@ -75,6 +75,10 @@ public class VersionUtilities {
     if (isR4BVer(v)) {
       return "hl7.fhir.r4b.core";
     }
+
+    if (isR5Ver(v)) {
+      return "hl7.fhir.r5.core";
+    }
     
     if ("current".equals(v)) {
       return "hl7.fhir.r5.core";
@@ -100,6 +104,9 @@ public class VersionUtilities {
     }
     if (isR4Ver(v)) {
       return "4.0.1";
+    }
+    if (isR5Ver(v)) {
+      return "5.0.0";
     }
     if (v != null && v.startsWith(CURRENT_VERSION)) {
       return "current";


### PR DESCRIPTION
The current version of the utilities does not correctly detect FHIR R5 (5.0.0-snapshot1) from version strings when running the validator using "-version 5.0.0" or "-version 5.0.0-snapshot1" parameter.

Although the appropriate functions to check for R5 were already implemented, they were not called in VersionUtilities.packageForVersion() and VersionUtilities.getCurrentVersion().
This PR adds the calls to these functions.