### PR TITLE
Fix kotlin ref in r4b build.

### DIFF
--- a/org.hl7.fhir.r4b/.project
+++ b/org.hl7.fhir.r4b/.project
@@ -6,11 +6,6 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.jetbrains.kotlin.ui.kotlinBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -22,15 +17,7 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.jetbrains.kotlin.core.kotlinNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
-	<linkedResources>
-		<link>
-			<name>kotlin_bin</name>
-			<type>2</type>
-			<locationURI>org.jetbrains.kotlin.core.filesystem:/org.hl7.fhir.r4b/kotlin_bin</locationURI>
-		</link>
-	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Sneaky kotlin. There's a reference to kotlinBuilder in the r4b project, likely autogenerated and committed, that breaks the build on systems without that specific kotlin setup.