### PR TITLE
Fix FHIRPathEngine funcReplace parameters

### DIFF
--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/FHIRPathEngine.java
@@ -2219,7 +2219,7 @@ public class FHIRPathEngine {
 
       if (!Utilities.noString(f)) {
 
-        if (exp.getParameters().size() != 2) {
+        if (exp.getParameters().size() == 2) {
 
           String t = convertToString(execute(context, focus, exp.getParameters().get(0), true));
           String r = convertToString(execute(context, focus, exp.getParameters().get(1), true));

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
@@ -1,14 +1,21 @@
 package org.hl7.fhir.dstu3.utils;
 
-
 import org.hl7.fhir.dstu3.context.IWorkerContext;
 import org.hl7.fhir.dstu3.model.Base;
 import org.hl7.fhir.dstu3.model.ExpressionNode;
+import org.hl7.fhir.dstu3.model.StringType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class FhirPathTests {
@@ -43,7 +50,12 @@ public class FhirPathTests {
 
     expressionNode.getParameters().add(expressionNodeB);
     expressionNode.getParameters().add(expressionNodeC);
-    engine.evaluate(appContext, resource, base, expressionNode);
+    List<Base> result = engine.evaluate(appContext, resource, base, expressionNode);
 
+    assertEquals(1, result.size());
+    Base onlyResult = result.get(0);
+    assertTrue(onlyResult instanceof StringType);
+    assertEquals("base", ((StringType)result.get(0)).asStringValue());
+    Mockito.verify(engine, times(2)).convertToString(any());
   }
 }

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
@@ -1,0 +1,49 @@
+package org.hl7.fhir.dstu3.utils;
+
+
+import org.hl7.fhir.dstu3.context.IWorkerContext;
+import org.hl7.fhir.dstu3.model.Base;
+import org.hl7.fhir.dstu3.model.ExpressionNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FhirPathTests {
+
+  @Mock
+  IWorkerContext iWorkerContext;
+
+  @Mock
+  Object appContext;
+
+  @Mock
+  Base resource;
+
+  @Mock
+  Base base;
+
+  @Test
+  public void testFuncReplaceParamSize() {
+    FHIRPathEngine engine = Mockito.spy(new FHIRPathEngine(iWorkerContext));
+
+    ExpressionNode expressionNode = new ExpressionNode(0);
+    expressionNode.setKind(ExpressionNode.Kind.Function);
+    expressionNode.setFunction(ExpressionNode.Function.Replace);
+
+    ExpressionNode expressionNodeB = new ExpressionNode(1);
+    expressionNodeB.setKind(ExpressionNode.Kind.Function);
+    expressionNodeB.setFunction(ExpressionNode.Function.Empty);
+
+    ExpressionNode expressionNodeC = new ExpressionNode(2);
+    expressionNodeC.setKind(ExpressionNode.Kind.Function);
+    expressionNodeC.setFunction(ExpressionNode.Function.Empty);
+
+    expressionNode.getParameters().add(expressionNodeB);
+    expressionNode.getParameters().add(expressionNodeC);
+    engine.evaluate(appContext, resource, base, expressionNode);
+
+  }
+}


### PR DESCRIPTION
FHIRPathEngine funcReplace requires two parameters, but incorrectly throws an exception when two parameters are provided.