### PR TITLE
Fix intermittent failures in NarrativeGenerationTests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,4 +4,4 @@
 
 ## Other code changes
 
-* no changes
+* Fix to r5 TestingUtilities to allow NarrativeGenerationTests to pass. 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -239,7 +239,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 
     public SimpleWorkerContext fromPackage(NpmPackage pi, IContextResourceLoader loader) throws IOException, FHIRException {
       SimpleWorkerContext context = getSimpleWorkerContextInstance();
-      context.setAllowLoadingDuplicates(true);
+      context.setAllowLoadingDuplicates(allowLoadingDuplicates);
       context.version = pi.getNpm().get("version").getAsString();
       context.loadFromPackage(pi, loader);
       context.finishLoading();

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
@@ -75,11 +75,23 @@ public class TestingUtilities extends BaseTestingUtilities {
 
   static public Map<String, IWorkerContext> fcontexts;
 
-  public static IWorkerContext context() {
-    return context("4.0.1");
+  final static public String DEFAULT_CONTEXT_VERSION = "4.0.1";
+
+  /** Get an existing instantiation of a WorkerContext if available
+   *
+   * This uses the DEFAULT_CONTEXT_VERSION
+   * */
+  public static IWorkerContext getSharedWorkerContext() {
+    return getSharedWorkerContext(DEFAULT_CONTEXT_VERSION);
   }
 
-  public static IWorkerContext context(String version) {
+  /**
+   * Get an existing instantiation of a WorkerContext if available
+   *
+   * @param version FHIR Version to get context for
+   * @return
+   */
+  public static IWorkerContext getSharedWorkerContext(String version) {
     if ("4.5.0".equals(version)) {
       version = "4.4.0"; // temporary work around
     }
@@ -89,33 +101,35 @@ public class TestingUtilities extends BaseTestingUtilities {
       fcontexts = new HashMap<>();
     }
     if (!fcontexts.containsKey(v)) {
-      FilesystemPackageCacheManager pcm;
-      try {
-        pcm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
-        IWorkerContext fcontext = getWorkerContext(pcm.loadPackage(VersionUtilities.packageForVersion(version), version));
-        fcontext.setUcumService(new UcumEssenceService(TestingUtilities.loadTestResourceStream("ucum", "ucum-essence.xml")));
-        fcontext.setExpansionProfile(new Parameters());
-//        ((SimpleWorkerContext) fcontext).connectToTSServer(new TerminologyClientR5("http://tx.fhir.org/r4"), null);
+        IWorkerContext fcontext = getWorkerContext(version);
         fcontexts.put(v, fcontext);
-      } catch (Exception e) {
-        e.printStackTrace();
-        throw new Error(e);
-      }
     }
     return fcontexts.get(v);
   }
 
+  public static IWorkerContext getWorkerContext(String version) {
+    FilesystemPackageCacheManager pcm;
+    try {
+      pcm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+      IWorkerContext fcontext = getWorkerContext(pcm.loadPackage(VersionUtilities.packageForVersion(version), version));
+      fcontext.setUcumService(new UcumEssenceService(TestingUtilities.loadTestResourceStream("ucum", "ucum-essence.xml")));
+      fcontext.setExpansionProfile(new Parameters());
+      return fcontext;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new Error(e);
+    }
+  }
+
   public static SimpleWorkerContext getWorkerContext(NpmPackage npmPackage) throws Exception {
-    SimpleWorkerContext swc = new SimpleWorkerContext.SimpleWorkerContextBuilder().withUserAgent(TestConstants.USER_AGENT).withTerminologyCachePath(TestConstants.TX_CACHE).fromPackage(npmPackage);
+    SimpleWorkerContext swc = new SimpleWorkerContext.SimpleWorkerContextBuilder().withAllowLoadingDuplicates(true).withUserAgent(TestConstants.USER_AGENT).withTerminologyCachePath(TestConstants.TX_CACHE).fromPackage(npmPackage);
     TerminologyCache.setCacheErrors(true);
-    swc.setAllowLoadingDuplicates(true);
     return swc;
   }
 
   public static SimpleWorkerContext getWorkerContext(NpmPackage npmPackage, IWorkerContext.IContextResourceLoader loader) throws Exception {
-    SimpleWorkerContext swc = new SimpleWorkerContext.SimpleWorkerContextBuilder().withUserAgent(TestConstants.USER_AGENT).withTerminologyCachePath(TestConstants.TX_CACHE).fromPackage(npmPackage, loader);
+    SimpleWorkerContext swc = new SimpleWorkerContext.SimpleWorkerContextBuilder().withAllowLoadingDuplicates(true).withUserAgent(TestConstants.USER_AGENT).withTerminologyCachePath(TestConstants.TX_CACHE).fromPackage(npmPackage, loader);
     TerminologyCache.setCacheErrors(true);
-    swc.setAllowLoadingDuplicates(true);
     return swc;
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CDARoundTripTests.java
@@ -257,7 +257,7 @@ public class CDARoundTripTests {
 	  value.setValue("öé");
 	  
 	  ByteArrayOutputStream baosXml = new ByteArrayOutputStream();
-	  Manager.compose(TestingUtilities.context(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
+	  Manager.compose(TestingUtilities.getSharedWorkerContext(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
 	  String cdaSerialised = baosXml.toString("UTF-8");
     Assertions.assertTrue(cdaSerialised.indexOf("öé") > 0);
 	}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -93,7 +93,7 @@ public class FHIRPathTests {
 
     @Override
     public ValueSet resolveValueSet(Object appContext, String url) {
-      return TestingUtilities.context().fetchResource(ValueSet.class, url);
+      return TestingUtilities.getSharedWorkerContext().fetchResource(ValueSet.class, url);
     }
 
   }
@@ -103,7 +103,7 @@ public class FHIRPathTests {
 
   @BeforeAll
   public static void setUp() {
-    fp = new FHIRPathEngine(TestingUtilities.context());
+    fp = new FHIRPathEngine(TestingUtilities.getSharedWorkerContext());
   }
 
   public static Stream<Arguments> data() throws ParserConfigurationException, SAXException, IOException {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/GraphQLEngineTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/GraphQLEngineTests.java
@@ -65,7 +65,7 @@ public class GraphQLEngineTests implements IGraphQLStorageServices {
         stream = TestingUtilities.loadTestResourceStream("r5", parts[0].toLowerCase()+"-"+parts[1].toLowerCase()+".xml");
     }
 
-    GraphQLEngine gql = new GraphQLEngine(TestingUtilities.context());
+    GraphQLEngine gql = new GraphQLEngine(TestingUtilities.getSharedWorkerContext());
     gql.setServices(this);
     if (stream != null)
       gql.setFocus(new XmlParser().parse(stream));

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/LiquidEngineTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/LiquidEngineTests.java
@@ -37,7 +37,7 @@ public class LiquidEngineTests implements ILiquidEngineIncludeResolver {
 
   @BeforeEach
   public void setUp() throws Exception {
-    engine = new LiquidEngine(TestingUtilities.context(), null);
+    engine = new LiquidEngine(TestingUtilities.getSharedWorkerContext(), null);
     engine.setIncludeResolver(this);
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/NarrativeGenerationTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/NarrativeGenerationTests.java
@@ -103,7 +103,7 @@ public class NarrativeGenerationTests {
 
   @BeforeAll
   public static void setUp() {
-    context = TestingUtilities.context();
+    context = TestingUtilities.getSharedWorkerContext();
   }
 
   @ParameterizedTest(name = "{index}: file {0}")

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/NarrativeGeneratorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/NarrativeGeneratorTests.java
@@ -34,7 +34,7 @@ public class NarrativeGeneratorTests {
 
   @BeforeAll
   public static void setUp() throws FHIRException {
-    rc = new RenderingContext(TestingUtilities.context(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
+    rc = new RenderingContext(TestingUtilities.getSharedWorkerContext(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/OpenApiGeneratorTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/OpenApiGeneratorTest.java
@@ -32,7 +32,7 @@ public class OpenApiGeneratorTest {
   public void run(InputStream sfn, String dfn) throws IOException, FHIRFormatError, FileNotFoundException {
     CapabilityStatement cs = (CapabilityStatement) new JsonParser().parse(sfn);
     Writer oa = new Writer(new FileOutputStream(dfn));
-    OpenApiGenerator gen = new OpenApiGenerator(TestingUtilities.context(), cs, oa);
+    OpenApiGenerator gen = new OpenApiGenerator(TestingUtilities.getSharedWorkerContext(), cs, oa);
     gen.generate("test-lic", "http://spdx.org/licenses/test-lic.html");
     oa.commit();
   }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ProfileUtilitiesTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ProfileUtilitiesTests.java
@@ -29,13 +29,13 @@ public class ProfileUtilitiesTests {
   public void testSimple() throws FHIRException {
 
     StructureDefinition focus = new StructureDefinition();
-    StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient").copy();
+    StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient").copy();
     focus.setUrl(Utilities.makeUuidUrn());
     focus.setBaseDefinition(base.getUrl());
     focus.setType("Patient");
     focus.setDerivation(TypeDerivationRule.CONSTRAINT);
     List<ValidationMessage> messages = new ArrayList<>();
-    new ProfileUtilities(TestingUtilities.context(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org/test", "Simple Test");
+    new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org/test", "Simple Test");
 
     boolean ok = base.getSnapshot().getElement().size() == focus.getSnapshot().getElement().size();
     for (int i = 0; i < base.getSnapshot().getElement().size(); i++) {
@@ -70,13 +70,13 @@ public class ProfileUtilitiesTests {
 //   */
   @Test
   public void testSimple2() {
-    StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet").copy();
+    StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet").copy();
     StructureDefinition focus = base.copy();
     focus.setUrl(Utilities.makeUuidUrn());
     focus.setSnapshot(null);
     focus.setDifferential(null);
     List<ValidationMessage> messages = new ArrayList<>();
-    new ProfileUtilities(TestingUtilities.context(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
+    new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
 
     boolean ok = base.getSnapshot().getElement().size() == focus.getSnapshot().getElement().size();
     for (int i = 0; i < base.getSnapshot().getElement().size(); i++) {
@@ -110,7 +110,7 @@ public class ProfileUtilitiesTests {
   @Test
   void testCardinalityChange() {
     StructureDefinition focus = new StructureDefinition();
-    StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient").copy();
+    StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient").copy();
     focus.setUrl(Utilities.makeUuidUrn());
     focus.setBaseDefinition(base.getUrl());
     focus.setType(base.getType());
@@ -119,7 +119,7 @@ public class ProfileUtilitiesTests {
     id.setPath("Patient.identifier");
     id.setMin(1);
     List<ValidationMessage> messages = new ArrayList<>();
-    new ProfileUtilities(TestingUtilities.context(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
+    new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
 
     boolean ok = base.getSnapshot().getElement().size() == focus.getSnapshot().getElement().size();
     for (int i = 0; i < base.getSnapshot().getElement().size(); i++) {
@@ -155,7 +155,7 @@ public class ProfileUtilitiesTests {
   void testMinValueChange() {
     // Given
     StructureDefinition focus = new StructureDefinition();
-    StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Appointment").copy();
+    StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Appointment").copy();
     focus.setUrl(Utilities.makeUuidUrn());
     focus.setBaseDefinition(base.getUrl());
     focus.setType(base.getType());
@@ -165,7 +165,7 @@ public class ProfileUtilitiesTests {
     id.setMinValue(new IntegerType(1));
     List<ValidationMessage> messages = new ArrayList<>();
     // When
-    new ProfileUtilities(TestingUtilities.context(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
+    new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
     // Then
     boolean ok = base.getSnapshot().getElement().size() == focus.getSnapshot().getElement().size();
     for (int i = 0; i < base.getSnapshot().getElement().size(); i++) {
@@ -202,7 +202,7 @@ public class ProfileUtilitiesTests {
   void testMaxValueChange() {
     // Given
     StructureDefinition focus = new StructureDefinition();
-    StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Appointment").copy();
+    StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Appointment").copy();
     focus.setUrl(Utilities.makeUuidUrn());
     focus.setBaseDefinition(base.getUrl());
     focus.setType(base.getType());
@@ -212,7 +212,7 @@ public class ProfileUtilitiesTests {
     id.setMaxValue(new IntegerType(1));
     List<ValidationMessage> messages = new ArrayList<>();
     // When
-    new ProfileUtilities(TestingUtilities.context(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
+    new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null).generateSnapshot(base, focus, focus.getUrl(), "http://test.org", "Simple Test");
     // Then
     boolean ok = base.getSnapshot().getElement().size() == focus.getSnapshot().getElement().size();
     for (int i = 0; i < base.getSnapshot().getElement().size(); i++) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ResourceRoundTripTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ResourceRoundTripTests.java
@@ -33,7 +33,7 @@ public class ResourceRoundTripTests {
   @Test
   public void test() throws IOException, FHIRException, EOperationOutcome {
     DomainResource res = (DomainResource) new XmlParser().parse(TestingUtilities.loadTestResourceStream("r5", "unicode.xml"));
-    RenderingContext rc = new RenderingContext(TestingUtilities.context(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
+    RenderingContext rc = new RenderingContext(TestingUtilities.getSharedWorkerContext(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
     RendererFactory.factory(res, rc).render(res);
     IOUtils.copy(TestingUtilities.loadTestResourceStream("r5", "unicode.xml"), new FileOutputStream(TestingUtilities.tempFile("gen", "unicode.xml")));
     new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(new FileOutputStream(TestingUtilities.tempFile("gen", "unicode.out.xml")), res);
@@ -64,7 +64,7 @@ public class ResourceRoundTripTests {
    * verify that umlaut like äö etc are not encoded in UTF-8 in attributes
    */
   public void testSerializeUmlaut() throws IOException {
-    Element xml = Manager.parseSingle(TestingUtilities.context(), TestingUtilities.loadTestResourceStream("r5", "unicode.xml"),
+    Element xml = Manager.parseSingle(TestingUtilities.getSharedWorkerContext(), TestingUtilities.loadTestResourceStream("r5", "unicode.xml"),
         FhirFormat.XML);
     List<Element> concept = xml.getChildrenByName("concept");
     assertTrue(concept!=null && concept.size()==1);
@@ -72,7 +72,7 @@ public class ResourceRoundTripTests {
     assertTrue(code!=null && code.size()==1);
     code.get(0).setValue("ö");
     ByteArrayOutputStream baosXml = new  ByteArrayOutputStream();
-    Manager.compose(TestingUtilities.context(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
+    Manager.compose(TestingUtilities.getSharedWorkerContext(), xml, baosXml, FhirFormat.XML, OutputStyle.PRETTY, null);
     String cdaSerialised = baosXml.toString("UTF-8");
     assertTrue(cdaSerialised.indexOf("ö")>0); 
   }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ShexGeneratorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ShexGeneratorTests.java
@@ -18,12 +18,12 @@ import org.junit.jupiter.api.Test;
 public class ShexGeneratorTests {
 
   private void doTest(String name) throws FileNotFoundException, IOException, FHIRException, UcumException {
-    StructureDefinition sd = TestingUtilities.context().fetchResource(StructureDefinition.class, ProfileUtilities.sdNs(name, null));
+    StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, ProfileUtilities.sdNs(name, null));
     if (sd == null) {
       throw new FHIRException("StructuredDefinition for " + name + "was null");
     }
     Path outPath = FileSystems.getDefault().getPath(System.getProperty("java.io.tmpdir"), name.toLowerCase() + ".shex");
-    TextFile.stringToFile(new ShExGenerator(TestingUtilities.context()).generate(HTMLLinkPolicy.NONE, sd), outPath.toString());
+    TextFile.stringToFile(new ShExGenerator(TestingUtilities.getSharedWorkerContext()).generate(HTMLLinkPolicy.NONE, sd), outPath.toString());
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
@@ -211,13 +211,13 @@ public class SnapShotGenerationTests {
 
     @Override
     public boolean isDatatype(String name) {
-      StructureDefinition sd = TestingUtilities.context().fetchTypeDefinition(name);
+      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchTypeDefinition(name);
       return (sd != null) && (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION) && (sd.getKind() == StructureDefinitionKind.PRIMITIVETYPE || sd.getKind() == StructureDefinitionKind.COMPLEXTYPE);
     }
 
     @Override
     public boolean isResource(String typeSimple) {
-      StructureDefinition sd = TestingUtilities.context().fetchTypeDefinition(typeSimple);
+      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchTypeDefinition(typeSimple);
       return (sd != null) && (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION) && (sd.getKind() == StructureDefinitionKind.RESOURCE);
     }
 
@@ -249,7 +249,7 @@ public class SnapShotGenerationTests {
 
     @Override
     public String getLinkForProfile(StructureDefinition profile, String url) {
-      StructureDefinition sd = TestingUtilities.context().fetchResource(StructureDefinition.class, url);
+      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, url);
       if (sd == null)
         return url + "|" + url;
       else
@@ -275,15 +275,15 @@ public class SnapShotGenerationTests {
     public Resource fetchFixture(String id) {
       TestFetchMode mode = TestFetchMode.INPUT;
       if (id.equals("patient"))
-        return TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient");
+        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient");
       if (id.equals("valueset"))
-        return TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet");
+        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet");
       if (id.equals("organization"))
-        return TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Organization");
+        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Organization");
       if (id.equals("operationoutcome"))
-        return TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/OperationOutcome");
+        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/OperationOutcome");
       if (id.equals("parameters"))
-        return TestingUtilities.context().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Parameters");
+        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Parameters");
 
       if (id.contains("-")) {
         String[] p = id.split("\\-");
@@ -339,7 +339,7 @@ public class SnapShotGenerationTests {
     @Override
     public TypeDetails checkFunction(Object appContext, String functionName, List<TypeDetails> parameters) throws PathEngineException {
       if ("fixture".equals(functionName))
-        return new TypeDetails(CollectionStatus.SINGLETON, TestingUtilities.context().getResourceNamesAsSet());
+        return new TypeDetails(CollectionStatus.SINGLETON, TestingUtilities.getSharedWorkerContext().getResourceNamesAsSet());
       return null;
     }
 
@@ -366,7 +366,7 @@ public class SnapShotGenerationTests {
 
     @Override
     public boolean conformsToProfile(Object appContext, Base item, String url) throws FHIRException {
-      IResourceValidator val = TestingUtilities.context().newValidator();
+      IResourceValidator val = TestingUtilities.getSharedWorkerContext().newValidator();
       List<ValidationMessage> valerrors = new ArrayList<ValidationMessage>();
       if (item instanceof Resource) {
         val.validate(appContext, valerrors, (Resource) item, url);
@@ -404,7 +404,7 @@ public class SnapShotGenerationTests {
 
   @BeforeAll
   public static void setUp() {
-    fp = new FHIRPathEngine(TestingUtilities.context());
+    fp = new FHIRPathEngine(TestingUtilities.getSharedWorkerContext());
   }
 
   public static Stream<Arguments> data() throws ParserConfigurationException, IOException, FHIRFormatError, SAXException {
@@ -462,7 +462,7 @@ public class SnapShotGenerationTests {
   private void testSort(TestDetails test, SnapShotGenerationTestsContext context) throws DefinitionException, FHIRException, IOException {
     StructureDefinition base = getSD(test.getSource().getBaseDefinition(), context);
     test.setOutput(test.getSource().copy());
-    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.context(), null, null);
+    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), null, null);
     pu.setIds(test.getSource(), false);
     List<String> errors = new ArrayList<String>();
     pu.sortDifferential(base, test.getOutput(), test.getOutput().getUrl(), errors, false);
@@ -476,17 +476,17 @@ public class SnapShotGenerationTests {
   private void testGen(boolean fail, TestDetails test, SnapShotGenerationTestsContext context) throws Exception {
     if (!Utilities.noString(test.register)) {
       List<ValidationMessage> messages = new ArrayList<ValidationMessage>();
-      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.context(), messages, null);
+      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null);
       pu.setNewSlicingProcessing(true);
       for (StructureDefinition sd : test.included) {
         pu.setIds(sd, false);
       }
       for (StructureDefinition sd : test.included) {
-        if (!TestingUtilities.context().hasResource(StructureDefinition.class, sd.getUrl())) {
-          TestingUtilities.context().cacheResource(sd);
+        if (!TestingUtilities.getSharedWorkerContext().hasResource(StructureDefinition.class, sd.getUrl())) {
+          TestingUtilities.getSharedWorkerContext().cacheResource(sd);
         }
       }
-      StructureDefinition base = TestingUtilities.context().fetchResource(StructureDefinition.class, test.included.get(0).getBaseDefinition());
+      StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, test.included.get(0).getBaseDefinition());
       if (base != null) {
         pu.generateSnapshot(base, test.included.get(0), test.included.get(0).getUrl(), "http://test.org/profile", test.included.get(0).getName());
       }
@@ -505,16 +505,16 @@ public class SnapShotGenerationTests {
       throw new Exception("URL mismatch on base: " + base.getUrl() + " wanting " + test.getSource().getBaseDefinition());
 
     StructureDefinition output = test.getSource().copy();
-    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.context(), messages, new TestPKP());
+    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, new TestPKP());
     pu.setNewSlicingProcessing(test.isNewSliceProcessing());
     pu.setThrowException(false);
     pu.setDebug(test.isDebug());
     pu.setIds(test.getSource(), false);
-    if (!TestingUtilities.context().hasPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER)) {
+    if (!TestingUtilities.getSharedWorkerContext().hasPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER)) {
       NpmPackage npm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).loadPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER);
-      TestingUtilities.context().loadFromPackage(npm, new TestPackageLoader(new String[]{"StructureDefinition"}), new String[]{"StructureDefinition"});
+      TestingUtilities.getSharedWorkerContext().loadFromPackage(npm, new TestPackageLoader(new String[]{"StructureDefinition"}), new String[]{"StructureDefinition"});
     }
-    pu.setXver(new XVerExtensionManager(TestingUtilities.context()));
+    pu.setXver(new XVerExtensionManager(TestingUtilities.getSharedWorkerContext()));
     if (test.isSort()) {
       List<String> errors = new ArrayList<String>();
       int lastCount = output.getDifferential().getElement().size();
@@ -539,14 +539,14 @@ public class SnapShotGenerationTests {
       throw e;
     }
     if (output.getDifferential().hasElement()) {
-      RenderingContext rc = new RenderingContext(TestingUtilities.context(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
+      RenderingContext rc = new RenderingContext(TestingUtilities.getSharedWorkerContext(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
       rc.setDestDir(Utilities.path("[tmp]", "snapshot"));
-      rc.setProfileUtilities(new ProfileUtilities(TestingUtilities.context(), null, new TestPKP()));
+      rc.setProfileUtilities(new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), null, new TestPKP()));
       RendererFactory.factory(output, rc).render(output);
     }
     if (!fail) {
       test.output = output;
-      TestingUtilities.context().cacheResource(output);
+      TestingUtilities.getSharedWorkerContext().cacheResource(output);
       File dst = new File(TestingUtilities.tempFile("snapshot", test.getId() + "-expected.xml"));
       if (dst.exists())
         dst.delete();
@@ -563,14 +563,14 @@ public class SnapShotGenerationTests {
   private StructureDefinition getSD(String url, SnapShotGenerationTestsContext context) throws DefinitionException, FHIRException, IOException {
     StructureDefinition sd = context.getByUrl(url);
     if (sd == null) {
-      sd = TestingUtilities.context().fetchResource(StructureDefinition.class, url);
+      sd = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, url);
     } 
     if (sd == null) {
       throw new DefinitionException("Unable to find profile "+url);
     }
     if (!sd.hasSnapshot()) {
       StructureDefinition base = getSD(sd.getBaseDefinition(), context);
-      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.context(), messages, new TestPKP());
+      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, new TestPKP());
       pu.setNewSlicingProcessing(true);
       List<String> errors = new ArrayList<String>();
       pu.sortDifferential(base, sd, url, errors, false);

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/VocabTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/VocabTests.java
@@ -24,6 +24,7 @@ import org.hl7.fhir.r5.renderers.utils.RenderingContext.ITypeParser;
 import org.hl7.fhir.r5.terminologies.ValueSetExpander.ValueSetExpansionOutcome;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.utilities.TextFile;
+import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.npm.ToolsVersion;
@@ -104,8 +105,11 @@ public class VocabTests {
   }
 
   @BeforeAll
-  public static void setUp() throws FileNotFoundException, FHIRException, IOException {
-    context = TestingUtilities.context();
+  public static void setUp() throws FHIRException, IOException {
+    /* Do NOT get a shared worker context from Testing Utilities or else the terminology package loaded below
+       will appear in tests where it causes failures.
+     */
+    context = TestingUtilities.getWorkerContext(VersionUtilities.getMajMin(TestingUtilities.DEFAULT_CONTEXT_VERSION));
     if (!context.hasPackage("hl7.terminology", null)) {
   
       NpmPackage utg = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).loadPackage("hl7.terminology");

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/misc/ResourceTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/misc/ResourceTest.java
@@ -86,9 +86,9 @@ public class ResourceTest {
   }
 
   public Element testEM() throws Exception {
-  	Element resource = Manager.parseSingle(TestingUtilities.context(), new FileInputStream(source), isJson() ? FhirFormat.JSON : FhirFormat.XML);
-  	Manager.compose(TestingUtilities.context(), resource, new FileOutputStream(source.getAbsoluteFile()+".out.json"), FhirFormat.JSON, OutputStyle.PRETTY, null);
-  	Manager.compose(TestingUtilities.context(), resource, new FileOutputStream(source.getAbsoluteFile()+".out.json"), FhirFormat.XML, OutputStyle.PRETTY, null);
+  	Element resource = Manager.parseSingle(TestingUtilities.getSharedWorkerContext(), new FileInputStream(source), isJson() ? FhirFormat.JSON : FhirFormat.XML);
+  	Manager.compose(TestingUtilities.getSharedWorkerContext(), resource, new FileOutputStream(source.getAbsoluteFile()+".out.json"), FhirFormat.JSON, OutputStyle.PRETTY, null);
+  	Manager.compose(TestingUtilities.getSharedWorkerContext(), resource, new FileOutputStream(source.getAbsoluteFile()+".out.json"), FhirFormat.XML, OutputStyle.PRETTY, null);
   	return resource;
   }
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/comparison/tests/ComparisonTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/comparison/tests/ComparisonTests.java
@@ -108,7 +108,7 @@ public class ComparisonTests {
 
     if (context == null) {
       System.out.println("---- Load R5 ----------------------------------------------------------------");
-      context = TestingUtilities.context();
+      context = TestingUtilities.getSharedWorkerContext();
       FilesystemPackageCacheManager pcm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
       NpmPackage npm = pcm.loadPackage("hl7.fhir.us.core#3.1.0");
       BaseWorkerContext bc = (BaseWorkerContext) context;

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/conversion/tests/SnapShotGenerationXTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/conversion/tests/SnapShotGenerationXTests.java
@@ -522,9 +522,9 @@ public class SnapShotGenerationXTests {
       throw e;
     }
     if (output.getDifferential().hasElement()) {
-      RenderingContext rc = new RenderingContext(TestingUtilities.context(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
+      RenderingContext rc = new RenderingContext(TestingUtilities.getSharedWorkerContext(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
       rc.setDestDir(makeTempDir());
-      rc.setProfileUtilities(new ProfileUtilities(TestingUtilities.context(), null, new TestPKP()));
+      rc.setProfileUtilities(new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), null, new TestPKP()));
       RendererFactory.factory(output, rc).render(output);
     }
     if (!fail) {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
@@ -350,9 +350,9 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
 
   public StructureDefinition loadProfile(String filename, String contents, List<ValidationMessage> messages) throws IOException, FHIRFormatError, FileNotFoundException, FHIRException, DefinitionException {
     StructureDefinition sd = (StructureDefinition) loadResource(filename, contents);
-    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.context(version), messages, null);
+    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(version), messages, null);
     if (!sd.hasSnapshot()) {
-      StructureDefinition base = TestingUtilities.context(version).fetchResource(StructureDefinition.class, sd.getBaseDefinition());
+      StructureDefinition base = TestingUtilities.getSharedWorkerContext(version).fetchResource(StructureDefinition.class, sd.getBaseDefinition());
       pu.generateSnapshot(base, sd, sd.getUrl(), null, sd.getTitle());
 // (debugging)      new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(new FileOutputStream(Utilities.path("[tmp]", sd.getId()+".xml")), sd);
     }
@@ -360,7 +360,7 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
       if (r instanceof StructureDefinition) {
         StructureDefinition childSd = (StructureDefinition) r;
         if (!childSd.hasSnapshot()) {
-          StructureDefinition base = TestingUtilities.context(version).fetchResource(StructureDefinition.class, childSd.getBaseDefinition());
+          StructureDefinition base = TestingUtilities.getSharedWorkerContext(version).fetchResource(StructureDefinition.class, childSd.getBaseDefinition());
           pu.generateSnapshot(base, childSd, childSd.getUrl(), null, childSd.getTitle());
         }
       }
@@ -427,7 +427,7 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
         }
       }
     }
-    if (!TestingUtilities.context(version).isNoTerminologyServer() || !focus.has("tx-dependent")) {
+    if (!TestingUtilities.getSharedWorkerContext(version).isNoTerminologyServer() || !focus.has("tx-dependent")) {
       Assert.assertEquals("Test " + name + (profile == null ? "" : " profile: "+ profile) + ": Expected " + Integer.toString(java.get("errorCount").getAsInt()) + " errors, but found " + Integer.toString(ec) + ".", java.get("errorCount").getAsInt(), ec);
       if (java.has("warningCount")) {
         Assert.assertEquals( "Test " + name + (profile == null ? "" : " profile: "+ profile) + ": Expected " + Integer.toString(java.get("warningCount").getAsInt()) + " warnings, but found " + Integer.toString(wc) + ".", java.get("warningCount").getAsInt(), wc);
@@ -501,18 +501,18 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
   public Element fetch(IResourceValidator validator, Object appContext, String url) throws FHIRFormatError, DefinitionException, IOException, FHIRException {
     Element res = null;
     if (url.equals("Patient/test")) {
-      res = new ObjectConverter(TestingUtilities.context(version)).convert(new Patient());
+      res = new ObjectConverter(TestingUtilities.getSharedWorkerContext(version)).convert(new Patient());
     } else if (TestingUtilities.findTestResource("validator", url.replace("/", "-").toLowerCase() + ".json")) {
-      res = Manager.makeParser(TestingUtilities.context(version), FhirFormat.JSON).parseSingle(TestingUtilities.loadTestResourceStream("validator", url.replace("/", "-").toLowerCase() + ".json"));
+      res = Manager.makeParser(TestingUtilities.getSharedWorkerContext(version), FhirFormat.JSON).parseSingle(TestingUtilities.loadTestResourceStream("validator", url.replace("/", "-").toLowerCase() + ".json"));
     } else if (TestingUtilities.findTestResource("validator", url.replace("/", "-").toLowerCase() + ".xml")) {
-      res = Manager.makeParser(TestingUtilities.context(version), FhirFormat.XML).parseSingle(TestingUtilities.loadTestResourceStream("validator", url.replace("/", "-").toLowerCase() + ".xml"));
+      res = Manager.makeParser(TestingUtilities.getSharedWorkerContext(version), FhirFormat.XML).parseSingle(TestingUtilities.loadTestResourceStream("validator", url.replace("/", "-").toLowerCase() + ".xml"));
     }
     if (res == null && url.contains("/")) {
       String tail = url.substring(url.indexOf("/") + 1);
       if (TestingUtilities.findTestResource("validator", tail.replace("/", "-").toLowerCase() + ".json")) {
-        res = Manager.makeParser(TestingUtilities.context(version), FhirFormat.JSON).parseSingle(TestingUtilities.loadTestResourceStream("validator", tail.replace("/", "-").toLowerCase() + ".json"));
+        res = Manager.makeParser(TestingUtilities.getSharedWorkerContext(version), FhirFormat.JSON).parseSingle(TestingUtilities.loadTestResourceStream("validator", tail.replace("/", "-").toLowerCase() + ".json"));
       } else if (TestingUtilities.findTestResource("validator", tail.replace("/", "-").toLowerCase() + ".xml")) {
-        res = Manager.makeParser(TestingUtilities.context(version), FhirFormat.XML).parseSingle(TestingUtilities.loadTestResourceStream("validator", tail.replace("/", "-").toLowerCase() + ".xml"));
+        res = Manager.makeParser(TestingUtilities.getSharedWorkerContext(version), FhirFormat.XML).parseSingle(TestingUtilities.loadTestResourceStream("validator", tail.replace("/", "-").toLowerCase() + ".xml"));
       }
     }
     return res;
@@ -558,7 +558,7 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
 
   @Override
   public boolean conformsToProfile(Object appContext, Base item, String url) throws FHIRException {
-    IResourceValidator val = TestingUtilities.context(version).newValidator();
+    IResourceValidator val = TestingUtilities.getSharedWorkerContext(version).newValidator();
     List<ValidationMessage> valerrors = new ArrayList<ValidationMessage>();
     if (item instanceof Resource) {
       val.validate(appContext, valerrors, (Resource) item, url);


### PR DESCRIPTION

The WorkerContext used in the VocabTests was adding terminology that was then used by other tests, since the instance would persist in TestingUtilities. This primarily impacted NarrativeGenerationTests, causing intermittent failures if VocabTests was run prior to NarrativeGenerationTests.