### PR TITLE
disabled experimental support for Evidence, EvidenceVariable resources

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Evidence.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Evidence.java
@@ -6058,6 +6058,11 @@ public class Evidence extends MetadataResource {
    */
   public static final ca.uhn.fhir.rest.gclient.TokenClientParam VERSION = new ca.uhn.fhir.rest.gclient.TokenClientParam(SP_VERSION);
 
+  // Manual code
+  public boolean supportsExperimental() {
+    return false;
+  }
 
+// end addition
 }
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceVariable.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceVariable.java
@@ -4531,6 +4531,11 @@ public class EvidenceVariable extends MetadataResource {
    */
   public static final ca.uhn.fhir.rest.gclient.TokenClientParam VERSION = new ca.uhn.fhir.rest.gclient.TokenClientParam(SP_VERSION);
 
+  // Manual code
+  public boolean supportsExperimental() {
+    return false;
+  }
 
+// end addition
 }
 


### PR DESCRIPTION
The EBMonFHIR resources [Evidence](http://hl7.org/fhir/5.0.0-snapshot1/evidence.html) and [EvidenceVariable](http://hl7.org/fhir/5.0.0-snapshot1/evidencevariable.html) do not support the experimental field (in 5.0.0-snapshot1) . For the IG publisher to work properly, the respective classes need to override the `supportsExperimental()` function to return `false`.