### PR TITLE
Fix R5 (and R4B) validation issues

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/SpecialExtensions.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/SpecialExtensions.java
@@ -24,6 +24,8 @@ public class SpecialExtensions {
         "http://hl7.org/fhir/StructureDefinition/instance-name",
         "http://hl7.org/fhir/StructureDefinition/instance-description",
         "http://hl7.org/fhir/build/StructureDefinition/definition", // wrongly defined in used in early R4B/R5 builds - changed to http://hl7.org/build/fhir/StructureDefinition/binding-definition
+        "http://hl7.org/fhir/build/StructureDefinition/binding-definition",
+        "http://hl7.org/fhir/build/StructureDefinition/no-binding",
         "http://hl7.org/fhir/StructureDefinition/codesystem-properties-mode",
         "http://hl7.org/fhir/StructureDefinition/structuredefinition-rdf-type",
         "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom", // this is defined in R5, but needed earlier

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
@@ -355,7 +355,7 @@ public class StructureDefinitionValidator extends BaseValidator {
   private void validateTargetProfile(List<ValidationMessage> errors, Element profile, String code, NodeStack stack, String path) {
     String p = profile.primitiveValue();
     StructureDefinition sd = context.fetchResource(StructureDefinition.class, p);
-    if (code.equals("Reference")) {
+    if (code.equals("Reference") || code.equals("CodeableReference")) {
       if (warning(errors, IssueType.EXCEPTION, stack.getLiteralPath(), sd != null, I18nConstants.SD_ED_TYPE_PROFILE_UNKNOWN, p)) {
         StructureDefinition t = determineBaseType(sd);
         if (t == null) {


### PR DESCRIPTION
- don't yell about new 'build' extensions
- allow CodeableReference as a reference type