### PR TITLE
Update BaseWorkerContext.java HashMap to TreeMap to avoid null keys

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.Set;
 
 import lombok.Getter;
@@ -199,7 +200,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   private int serverQueryCount = 0;
   private final Set<String> cached = new HashSet<>();
   
-  private Map<String, Map<String, ResourceProxy>> allResourcesById = new HashMap<String, Map<String, ResourceProxy>>();
+  private Map<String, Map<String, ResourceProxy>> allResourcesById = new TreeMap<String, Map<String, ResourceProxy>>();
   // all maps are to the full URI
   private CanonicalResourceManager<CodeSystem> codeSystems = new CanonicalResourceManager<CodeSystem>(false);
   private final Set<String> supportedCodeSystems = new HashSet<String>();
@@ -312,7 +313,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     synchronized (lock) {
       Map<String, ResourceProxy> map = allResourcesById.get(r.getType());
       if (map == null) {
-        map = new HashMap<String, ResourceProxy>();
+        map = new TreeMap<String, ResourceProxy>();
         allResourcesById.put(r.getType(), map);
       }
       if ((packageInfo == null || !packageInfo.isExamplesPackage()) || !map.containsKey(r.getId())) {
@@ -382,7 +383,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     synchronized (lock) {
       Map<String, ResourceProxy> map = allResourcesById.get(r.fhirType());
       if (map == null) {
-        map = new HashMap<String, ResourceProxy>();
+        map = new TreeMap<String, ResourceProxy>();
         allResourcesById.put(r.fhirType(), map);
       }
       if ((packageInfo == null || !packageInfo.isExamplesPackage()) || !map.containsKey(r.getId())) {


### PR DESCRIPTION
HashMap accepts null keys, TreeMap doesn't. The map allResourcesById is used to store FHIR resources with unique ID keys (their unique URIs), a null key must therefore be wrong. 
Currently the HashMap masks the fact that a number of FHIR resources are parsed with null IDs and overwrite one another when being stored in the HashMap under a null key, f.e. there are 301 naming systems in the R4 core definitions on Simplifier but only 293 end up being loaded and available for the validator, 8 have null IDs and therefore null keys, so they have to be loaded from the server and parsed by instantiating the huge JsonParser for each FHIR instance to be validate because they cannot be found in the map.