### PR TITLE
Fix null exception for debug messages in BaseWorkerContext

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
@@ -77,6 +77,8 @@ import org.hl7.fhir.utilities.validation.ValidationOptions;
 
 import com.google.gson.JsonSyntaxException;
 
+import javax.annotation.Nonnull;
+
 
 /**
  * This is the standard interface used for access to underlying FHIR
@@ -802,7 +804,7 @@ public interface IWorkerContext {
     public void logDebugMessage(LogCategory category, String message); // verbose; only when debugging 
   }
 
-  public void setLogger(ILoggingService logger);
+  public void setLogger(@Nonnull ILoggingService logger);
   public ILoggingService getLogger();
 
   public boolean isNoTerminologyServer();

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -314,7 +314,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 
   public String connectToTSServer(TerminologyClient client, String log) {
     try {
-      tlog("Connect to "+client.getAddress());
+      txLog("Connect to "+client.getAddress());
       txClient = client;
       if (log != null && log.endsWith(".txt")) {
         txLog = new TextClientLogger(log);
@@ -359,7 +359,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 		  Bundle bnd = (Bundle) f;
 		  for (BundleEntryComponent e : bnd.getEntry()) {
 		    if (e.getFullUrl() == null) {
-		      logger.logDebugMessage(LogCategory.CONTEXT, "unidentified resource in " + name+" (no fullUrl)");
+		      logDebugMessage(LogCategory.CONTEXT, "unidentified resource in " + name+" (no fullUrl)");
 		    }
 	      if (filter == null || filter.isOkToLoad(e.getResource())) {
 	        String path = loader != null ? loader.getResourcePath(e.getResource()) : null;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -201,6 +201,9 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
     @With
     private final boolean allowLoadingDuplicates;
 
+    @With
+    private final IWorkerContext.ILoggingService loggingService;
+
     public SimpleWorkerContextBuilder() {
       cacheTerminologyClientErrors = false;
       alwaysUseTerminologyServer = false;
@@ -209,6 +212,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
       locale = null;
       userAgent = null;
       allowLoadingDuplicates = false;
+      loggingService = new SystemOutLoggingService();
     }
 
     private SimpleWorkerContext getSimpleWorkerContextInstance() throws IOException {
@@ -227,6 +231,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
     private SimpleWorkerContext build(SimpleWorkerContext context) throws IOException {
       context.initTS(terminologyCachePath);
       context.setUserAgent(userAgent);
+      context.setLogger(loggingService);
       return context;
     }
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -359,7 +359,7 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 		  Bundle bnd = (Bundle) f;
 		  for (BundleEntryComponent e : bnd.getEntry()) {
 		    if (e.getFullUrl() == null) {
-		      logDebugMessage(LogCategory.CONTEXT, "unidentified resource in " + name+" (no fullUrl)");
+		      logger.logDebugMessage(LogCategory.CONTEXT, "unidentified resource in " + name+" (no fullUrl)");
 		    }
 	      if (filter == null || filter.isOkToLoad(e.getResource())) {
 	        String path = loader != null ? loader.getResourcePath(e.getResource()) : null;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SystemOutLoggingService.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SystemOutLoggingService.java
@@ -1,0 +1,14 @@
+package org.hl7.fhir.r5.context;
+
+class SystemOutLoggingService implements IWorkerContext.ILoggingService {
+
+  @Override
+  public void logMessage(String message) {
+    System.out.println(message);
+  }
+
+  @Override
+  public void logDebugMessage(LogCategory category, String message) {
+    System.out.println(" -" + category.name().toLowerCase() + ": " + message);
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SystemOutLoggingService.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SystemOutLoggingService.java
@@ -1,6 +1,15 @@
 package org.hl7.fhir.r5.context;
 
-class SystemOutLoggingService implements IWorkerContext.ILoggingService {
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SystemOutLoggingService implements IWorkerContext.ILoggingService {
+
+  private final boolean debug;
+
+  public SystemOutLoggingService() {
+    this(false);
+  }
 
   @Override
   public void logMessage(String message) {
@@ -9,6 +18,8 @@ class SystemOutLoggingService implements IWorkerContext.ILoggingService {
 
   @Override
   public void logDebugMessage(LogCategory category, String message) {
-    System.out.println(" -" + category.name().toLowerCase() + ": " + message);
-  }
+    if (debug) {
+        System.out.println(" -" + category.name().toLowerCase() + ": " + message);
+      }
+    }
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -2,6 +2,7 @@ package org.hl7.fhir.validation.cli.services;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.context.SystemOutLoggingService;
 import org.hl7.fhir.r5.context.TerminologyCache;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
@@ -329,6 +330,7 @@ public class ValidationService {
       String txver = validator.setTerminologyServer(cliContext.getTxServer(), cliContext.getTxLog(), ver);
       System.out.println(" - Version " + txver + " (" + tt.milestone() + ")");
       validator.setDebug(cliContext.isDoDebug());
+      validator.getContext().setLogger(new SystemOutLoggingService(cliContext.isDoDebug()));
       for (String src : cliContext.getIgs()) {
         igLoader.loadIg(validator.getIgs(), validator.getBinaries(), src, cliContext.isRecursive());
       }


### PR DESCRIPTION
Prior to this fix, the following execution would result in a NullPointerException:

```shell
java -jar validator_cli.jar -compare -dest "/somewhere/on/my/drive" -version 4.0 -ig hl7.fhir.us.carin-bb#1.1.0 -ig hl7.fhir.us.davinci-crd#1.0.0 -left http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Patient -right http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-patient
```

```log
Exception in thread "main" org.hl7.fhir.exceptions.FHIRException: Error reading CapabilityStatement-base.json from package hl7.fhir.r4.examples#4.0.1: null
        at org.hl7.fhir.r5.context.SimpleWorkerContext.loadFromPackageInt(SimpleWorkerContext.java:480)
        at org.hl7.fhir.r5.context.SimpleWorkerContext.loadFromPackage(SimpleWorkerContext.java:419)
        at org.hl7.fhir.validation.IgLoader.loadIg(IgLoader.java:89)
        at org.hl7.fhir.validation.IgLoader.loadIg(IgLoader.java:81)
        at org.hl7.fhir.validation.IgLoader.loadIg(IgLoader.java:81)
        at org.hl7.fhir.validation.cli.services.ValidationService.initializeValidator(ValidationService.java:333)
        at org.hl7.fhir.validation.cli.services.ValidationService.initializeValidator(ValidationService.java:310)
        at org.hl7.fhir.validation.ValidatorCli.doLeftRightComparison(ValidatorCli.java:225)
        at org.hl7.fhir.validation.ValidatorCli.main(ValidatorCli.java:160)
Caused by: java.lang.NullPointerException
        at org.hl7.fhir.r5.context.BaseWorkerContext.cacheResourceFromPackage(BaseWorkerContext.java:391)
        at org.hl7.fhir.r5.context.SimpleWorkerContext.loadFromFileJson(SimpleWorkerContext.java:407)
        at org.hl7.fhir.r5.context.SimpleWorkerContext.loadDefinitionItem(SimpleWorkerContext.java:308)
        at org.hl7.fhir.r5.context.SimpleWorkerContext.loadFromPackageInt(SimpleWorkerContext.java:477)
        ... 8 more
```

This directs these messages to System.out when logger is null.