### PR TITLE
Allow other designations

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/ValueSetRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/ValueSetRenderer.java
@@ -960,7 +960,8 @@ public class ValueSetRenderer extends TerminologyRenderer {
     case "http://snomed.info/sct#900000000000013009":
       return "Synonym";
     default:
-      return null;
+      // As specified in http://www.hl7.org/fhir/valueset-definitions.html#ValueSet.compose.include.concept.designation.use and in http://www.hl7.org/fhir/codesystem-definitions.html#CodeSystem.concept.designation.use the terminology binding is extensible.
+      return url;
     }
   }
 


### PR DESCRIPTION
With returning the url it is possible to allow other designation.use than only the two specified SNOMED codes.

Otherwise, no other designation having a different designation.use.code and designation.use.system would be displayed in the IG.