### PR TITLE
Fix problem rendering canonical URLs with | in them

### DIFF
--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/DataRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/DataRenderer.java
@@ -544,7 +544,11 @@ public class DataRenderer extends Renderer {
     if (uri.getValue().startsWith("mailto:")) {
       x.ah(uri.getValue()).addText(uri.getValue().substring(7));
     } else if (Utilities.isAbsoluteUrlLinkable(uri.getValue()) && !(uri instanceof IdType)) {
-      x.ah(uri.getValue()).addText(uri.getValue());
+      if (uri.getValue().contains("|")) {
+        x.ah(uri.getValue().substring(0, uri.getValue().indexOf("|"))).addText(uri.getValue());
+      } else {
+        x.ah(uri.getValue()).addText(uri.getValue());
+      }
     } else {
       x.addText(uri.getValue());
     }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/DataRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/DataRenderer.java
@@ -721,7 +721,11 @@ public class DataRenderer extends Renderer {
     if (uri.getValue().startsWith("mailto:")) {
       x.ah(uri.getValue()).addText(uri.getValue().substring(7));
     } else if (Utilities.isAbsoluteUrlLinkable(uri.getValue()) && !(uri instanceof IdType)) {
-      x.ah(uri.getValue()).addText(uri.getValue());
+      if (uri.getValue().contains("|")) {
+        x.ah(uri.getValue().substring(0, uri.getValue().indexOf("|"))).addText(uri.getValue());
+      } else {
+        x.ah(uri.getValue()).addText(uri.getValue());
+      }
     } else {
       x.addText(uri.getValue());
     }


### PR DESCRIPTION
In the Data Requirements section of the narrative for a Library that references versioned ValueSets,
IS:
```
        <tr>
            <td>code</td>
            <td>In ValueSet <a
                    href=\"http://example/fhir/ValueSet/medications|2.19.1\">http://example/fhir/ValueSet/medications|2.19.1</a>
            </td>
        </tr>
```
Note the href contains a "|" (pipe) character, which is an "unwise" url character that causes an error in the publisher (Java).

Should be:
no "|" character