### PR TITLE
Repair output of GraphQL response to include only idPart

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLEngine.java
@@ -557,7 +557,7 @@ public class GraphQLEngine implements IGraphQLEngine {
             if (!isPrimitive(prop.getTypeCode()) && sel.getField().getName().startsWith("_"))
               throw new EGraphQLException("Unknown property "+sel.getField().getName()+" on "+source.fhirType());
 
-          if ("id".equals(prop.getName())) {
+          if ("id".equals(prop.getName()) && context != null) {
             prop.getValues().set(0, new IdType(context.getIdPart()));
           }
 


### PR DESCRIPTION
A description of the issue is in this comment: https://github.com/hapifhir/org.hl7.fhir.core/issues/795#issuecomment-1113733549

> While reviewing other parts of the code and testing some things out in HAPI-FHIR, I noticed that our GraphQL output still appears to be wrong. We are finding the right resource, but the GraphQL output is including the history string in the ID, which is contrary to what a resource's output would look like:

```json
{
  "id":"example/_history/1",
  "ConditionList":[{
    "id":"example"
  }]
}
```

> The "id" should conform to the expectations and be "id": "example"

This requires the following fhir-test-cases PR to be merged to pass: https://github.com/FHIR/fhir-test-cases/pull/109