### PR TITLE
Backport ProfileUtilities changes from r5 to r4b

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <hapi_fhir_version>5.4.0</hapi_fhir_version>
-        <validator_test_case_version>1.1.99</validator_test_case_version>
+        <validator_test_case_version>1.1.100</validator_test_case_version>
         <junit_jupiter_version>5.7.1</junit_jupiter_version>
         <junit_platform_launcher_version>1.7.1</junit_platform_launcher_version>
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>


### PR DESCRIPTION
When updating fhir-test-cases version to 1.1.100, SnapshotGenerationTests for r4b would fail on test id `choice_min_1`.

The same test would pass correctly in r5. Backporting recent changes to ProfileUtilities from r5 to r4b fixes the failing test.