### PR TITLE
Add -extension parameter to validator cli help

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -343,7 +343,7 @@ public class ValidationService {
       validator.setDoNative(cliContext.isDoNative());
       validator.setHintAboutNonMustSupport(cliContext.isHintAboutNonMustSupport());
       for (String s : cliContext.getExtensions()) {
-        if ("*".equals(s)) {
+        if ("any".equals(s)) {
           validator.setAnyExtensionsAllowed(true);
         } else {          
           validator.getExtensionDomains().add(s);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
@@ -1,7 +1,6 @@
 package org.hl7.fhir.validation.cli.utils;
 
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r5.terminologies.JurisdictionUtilities;
 import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
 import org.hl7.fhir.utilities.VersionUtilities;
@@ -29,7 +28,7 @@ public class Params {
   public static final String RECURSE = "-recurse";
   public static final String SHOW_MESSAGES_FROM_REFERENCES = "-showReferenceMessages";
   public static final String LOCALE = "-locale";
-  public static final String EXTENSIONS = "-extensions";
+  public static final String EXTENSION = "-extension";
   public static final String HINT_ABOUT_NON_MUST_SUPPORT = "-hintAboutNonMustSupport";
   public static final String TO_VERSION = "-to-version";
   public static final String DO_NATIVE = "-do-native";
@@ -173,7 +172,7 @@ public class Params {
         } else {
           cliContext.setLocale(new Locale(args[++i]));
         }
-      } else if (args[i].equals(EXTENSIONS)) {
+      } else if (args[i].equals(EXTENSION)) {
         cliContext.getExtensions().add(args[++i]);
       } else if (args[i].equals(NO_INTERNAL_CACHING)) {
         cliContext.setNoInternalCaching(true);

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -91,9 +91,10 @@ The following parameters are supported:
     value as for xml:lang
        Not used if the resource specifies language
     Default: no specified language
--strictExtensions: If present, treat extensions not defined within the specified
-    FHIR version and any referenced implementation guides or profiles as errors.
-    (Default is to only raise information messages.)
+-extension: Controls how extensions are validated by the validator. The value
+    for this parameter is a URL for a domain from which extensions will be
+    allowed. By default, unknown extensions are prohibited, but can be allowed
+    by using the * wildcard. This parameter can repeat any number of times.
 -hintAboutNonMustSupport: If present, raise hints if the instance contains data
     elements that are not marked as mustSupport=true.  Useful to identify
     elements included that may be ignored by recipients

--- a/org.hl7.fhir.validation/src/main/resources/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help.txt
@@ -94,7 +94,8 @@ The following parameters are supported:
 -extension: Controls how extensions are validated by the validator. The value
     for this parameter is a URL for a domain from which extensions will be
     allowed. By default, unknown extensions are prohibited, but can be allowed
-    by using the * wildcard. This parameter can repeat any number of times.
+    by using the value 'any' (e.g. -extension any). This parameter can repeat
+    any number of times.
 -hintAboutNonMustSupport: If present, raise hints if the instance contains data
     elements that are not marked as mustSupport=true.  Useful to identify
     elements included that may be ignored by recipients


### PR DESCRIPTION
Fixes #814 by adding -extension parameter documentation in Validator CLI help.

Fixes additional commentary in #824 regarding `-extension` and `-extensions` confusion in the documentation. 

When no longer in draft, will also address asterisk as valid value (#824).