### PR TITLE
Better errors when connecting to server that doesn't support Terminology Capabilities

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/FHIRToolingClient.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/client/FHIRToolingClient.java
@@ -171,10 +171,13 @@ public class FHIRToolingClient {
   public TerminologyCapabilities getTerminologyCapabilities() {
     TerminologyCapabilities capabilities = null;
 
-      capabilities =  getCapabilities(resourceAddress.resolveMetadataTxCaps(),
+    try {
+      capabilities = getCapabilities(resourceAddress.resolveMetadataTxCaps(),
         "TerminologyCapabilities",
         "Error fetching the server's terminology capabilities");
-
+    } catch (ClassCastException e) {
+      throw new FHIRException("Unexpected response format for Terminology Capability metadata", e);
+    }
     return capabilities;
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
@@ -170,12 +170,11 @@ class FHIRToolingClientTest {
 
     ArgumentCaptor<Headers> headersArgumentCaptor = ArgumentCaptor.forClass(Headers.class);
     toolingClient.setClientHeaders(getHeaders());
-    toolingClient.getTerminologyCapabilities();
-    Mockito.verify(mockClient).issueGetResourceRequest(ArgumentMatchers.any(URI.class), ArgumentMatchers.anyString(),
-      headersArgumentCaptor.capture(), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong());
+    Exception exception = assertThrows(FHIRException.class, () -> {
 
-    Headers argumentCaptorValue = headersArgumentCaptor.getValue();
-    checkHeaders(argumentCaptorValue);
+      toolingClient.getTerminologyCapabilities();
+
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
@@ -32,8 +32,7 @@ import okhttp3.Headers;
 import okhttp3.Request;
 import okhttp3.internal.http2.Header;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 
 class FHIRToolingClientTest {
@@ -171,10 +170,9 @@ class FHIRToolingClientTest {
     ArgumentCaptor<Headers> headersArgumentCaptor = ArgumentCaptor.forClass(Headers.class);
     toolingClient.setClientHeaders(getHeaders());
     Exception exception = assertThrows(FHIRException.class, () -> {
-
       toolingClient.getTerminologyCapabilities();
-
     });
+    assertEquals(exception.getCause().getClass(), ClassCastException.class);
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/client/FHIRToolingClientTest.java
@@ -163,6 +163,22 @@ class FHIRToolingClientTest {
   }
 
   @Test
+  void getTerminologyCapabilitiesNotSupported() throws IOException {
+    Mockito.when(mockClient.issueGetResourceRequest(Mockito.any(URI.class), Mockito.anyString(),
+        Mockito.any(Headers.class), Mockito.eq("TerminologyCapabilities"), Mockito.anyLong()))
+      .thenReturn(new ResourceRequest<>(new CapabilityStatement(), 200, "location"));
+
+    ArgumentCaptor<Headers> headersArgumentCaptor = ArgumentCaptor.forClass(Headers.class);
+    toolingClient.setClientHeaders(getHeaders());
+    toolingClient.getTerminologyCapabilities();
+    Mockito.verify(mockClient).issueGetResourceRequest(ArgumentMatchers.any(URI.class), ArgumentMatchers.anyString(),
+      headersArgumentCaptor.capture(), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong());
+
+    Headers argumentCaptorValue = headersArgumentCaptor.getValue();
+    checkHeaders(argumentCaptorValue);
+  }
+
+  @Test
   void getTerminologyCapabilitiesFailsForJSON() throws IOException {
     Mockito.when(mockClient.issueGetResourceRequest(Mockito.any(URI.class), Mockito.anyString(),
         Mockito.any(Headers.class), Mockito.eq("TerminologyCapabilities"), Mockito.anyLong()))


### PR DESCRIPTION
Improves errors reported in cases where server doesn't return expected TerminologyCapabilities data.

See #831 