### PR TITLE
Fix test dependency on resource path more consistently

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/test/utils/TestingUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/test/utils/TestingUtilities.java
@@ -55,6 +55,7 @@ import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.ToolsVersion;
+import org.hl7.fhir.utilities.tests.BaseTestingUtilities;
 import org.hl7.fhir.utilities.tests.ResourceLoaderTests;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -444,8 +445,7 @@ public class TestingUtilities {
   }
   
   public static String resourceNameToFile(String name) throws IOException {
-    //return Utilities.path(System.getProperty("user.dir"), "src", "test", "resources", name);
-   return resourceNameToFile(null, name);
+    return resourceNameToFile(null, name);
   }
 
   private static boolean fileForPathExists(String path) {
@@ -454,7 +454,7 @@ public class TestingUtilities {
 
   public static String generateResourcePath(String subFolder, String name) throws IOException {
     String path = Utilities.path(System.getProperty("user.dir"), "src", "test", "resources", subFolder, name);
-    createParentDirectoryPathIfNotExists(Paths.get(path));
+    BaseTestingUtilities.createParentDirIfNotExists(Paths.get(path));
     return path;
   }
   public static String resourceNameToFile(String subFolder, String name) throws IOException {
@@ -472,15 +472,10 @@ public class TestingUtilities {
   }
 
   private static void copyResourceToNewFile(String resourcePath, Path newFilePath) throws IOException {
-    createParentDirectoryPathIfNotExists(newFilePath);
+    BaseTestingUtilities.createParentDirIfNotExists(newFilePath);
     ResourceLoaderTests.copyResourceToFile(TestingUtilities.class, newFilePath, resourcePath);
   }
 
-  private static void createParentDirectoryPathIfNotExists(Path newFilePath) {
-    Path parent = newFilePath.getParent();
-    if (!parent.toFile().exists()) {
-      parent.toFile().mkdirs();
-    }
-  }
+
 
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/BaseTestingUtilities.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.utilities.ToolGlobalSettings;
 import org.hl7.fhir.utilities.Utilities;
 
 import java.io.*;
+import java.nio.file.Path;
 
 public class BaseTestingUtilities {
 
@@ -114,4 +115,11 @@ public class BaseTestingUtilities {
 
     public static void setFhirTestCasesDirectory(String s) {
     }
+
+  public static void createParentDirIfNotExists(Path target) {
+    Path parent = target.getParent();
+    if (!parent.toFile().exists()) {
+      parent.toFile().mkdirs();
+    }
+  }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/ResourceLoaderTests.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/tests/ResourceLoaderTests.java
@@ -1,6 +1,5 @@
 package org.hl7.fhir.utilities.tests;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -23,7 +22,7 @@ public interface ResourceLoaderTests {
 
   public static void copyResourceToFile(Class<?> clazz, Path target, String ... resourcePath) throws IOException {
     InputStream initialStream = getResourceAsInputStream(clazz, resourcePath);
-
+    BaseTestingUtilities.createParentDirIfNotExists(target);
     java.nio.file.Files.copy(
       initialStream,
       target,
@@ -31,4 +30,5 @@ public interface ResourceLoaderTests {
 
     initialStream.close();
   }
+
 }


### PR DESCRIPTION
Some tests need to generate files to work correctly, and must also generate the parent directories for those files. This re-uses code to add this to several tests that would fail on the first run because the path did not exist.