### PR TITLE
Rework precision checking in datetime

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/BaseDateTimeType.java
@@ -110,33 +110,33 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @throws IllegalArgumentException
 	 *             If the specified precision is not allowed for this type
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision) {
 		setValue(theDate, thePrecision);
-		if (isPrecisionAllowed(thePrecision) == false) {
-			throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + thePrecision + " precision): " + theDate);
-		}
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @throws IllegalArgumentException
 	 *             If the specified precision is not allowed for this type
 	 */
 	public BaseDateTimeType(String theString) {
 		setValueAsString(theString);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
 	 * Constructor
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision, TimeZone theTimeZone) {
-		this(theDate, thePrecision);
-		setTimeZone(theTimeZone);
+    this(theDate, thePrecision);
+    setTimeZone(theTimeZone);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	private void clearTimeZone() {
@@ -144,7 +144,13 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		myTimeZoneZulu = false;
 	}
 
-	@Override
+  private void validatePrecisionAndThrowIllegalArgumentException() {
+    if (!isPrecisionAllowed(getPrecision())) {
+      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + getValueAsString());
+    }
+  }
+
+  @Override
 	protected String encode(Date theValue) {
 		if (theValue == null) {
 			return null;
@@ -204,7 +210,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	/**
 	 * Gets the precision for this datatype (using the default for the given type if not set)
-	 * 
+	 *
 	 * @see #setPrecision(TemporalPrecisionEnum)
 	 */
 	public TemporalPrecisionEnum getPrecision() {
@@ -251,7 +257,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	/**
 	 * Returns <code>true</code> if this object represents a date that is today's date
-	 * 
+	 *
 	 * @throws NullPointerException
 	 *             if {@link #getValue()} returns <code>null</code>
 	 */
@@ -264,46 +270,26 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	protected Date parse(String theValue) throws IllegalArgumentException {
 		try {
 			if (theValue.length() == 4 && ourYearPattern.matcher(theValue).matches()) {
-				if (!isPrecisionAllowed(YEAR)) {
-					// ourLog.debug("Invalid date/time string (datatype " + getClass().getSimpleName() +
-					// " does not support YEAR precision): " + theValue);
-				}
 				setPrecision(YEAR);
 				clearTimeZone();
 				return ((ourYearFormat).parse(theValue));
 			} else if (theValue.length() == 6 && ourYearMonthPattern.matcher(theValue).matches()) {
 				// Eg. 198401 (allow this just to be lenient)
-				if (!isPrecisionAllowed(MONTH)) {
-					// ourLog.debug("Invalid date/time string (datatype " + getClass().getSimpleName() +
-					// " does not support DAY precision): " + theValue);
-				}
 				setPrecision(MONTH);
 				clearTimeZone();
 				return ((ourYearMonthNoDashesFormat).parse(theValue));
 			} else if (theValue.length() == 7 && ourYearDashMonthPattern.matcher(theValue).matches()) {
 				// E.g. 1984-01 (this is valid according to the spec)
-				if (!isPrecisionAllowed(MONTH)) {
-					// ourLog.debug("Invalid date/time string (datatype " + getClass().getSimpleName() +
-					// " does not support MONTH precision): " + theValue);
-				}
 				setPrecision(MONTH);
 				clearTimeZone();
 				return ((ourYearMonthFormat).parse(theValue));
 			} else if (theValue.length() == 8 && ourYearMonthDayPattern.matcher(theValue).matches()) {
 				// Eg. 19840101 (allow this just to be lenient)
-				if (!isPrecisionAllowed(DAY)) {
-					// ourLog.debug("Invalid date/time string (datatype " + getClass().getSimpleName() +
-					// " does not support DAY precision): " + theValue);
-				}
 				setPrecision(DAY);
 				clearTimeZone();
 				return ((ourYearMonthDayNoDashesFormat).parse(theValue));
 			} else if (theValue.length() == 10 && ourYearDashMonthDashDayPattern.matcher(theValue).matches()) {
 				// E.g. 1984-01-01 (this is valid according to the spec)
-				if (!isPrecisionAllowed(DAY)) {
-					// ourLog.debug("Invalid date/time string (datatype " + getClass().getSimpleName() +
-					// " does not support DAY precision): " + theValue);
-				}
 				setPrecision(DAY);
 				clearTimeZone();
 				return ((ourYearMonthDayFormat).parse(theValue));
@@ -312,19 +298,11 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 				if (firstColonIndex == -1) {
 					throw new IllegalArgumentException("Invalid date/time string: " + theValue);
 				}
-				
-				boolean hasSeconds = theValue.length() > firstColonIndex+3 ? theValue.charAt(firstColonIndex+3) == ':' : false; 
-				
+
+				boolean hasSeconds = theValue.length() > firstColonIndex+3 ? theValue.charAt(firstColonIndex+3) == ':' : false;
+
 				int dotIndex = theValue.length() >= 18 ? theValue.indexOf('.', 18): -1;
 				boolean hasMillis = dotIndex > -1;
-
-//				if (!hasMillis && !isPrecisionAllowed(SECOND)) {
-					// ourLog.debug("Invalid date/time string (data type does not support SECONDS precision): " +
-					// theValue);
-//				} else if (hasMillis && !isPrecisionAllowed(MILLI)) {
-					// ourLog.debug("Invalid date/time string (data type " + getClass().getSimpleName() +
-					// " does not support MILLIS precision):" + theValue);
-//				}
 
 				Date retVal;
 				if (hasMillis) {
@@ -390,7 +368,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 * <li>{@link Calendar#MONTH}
 	 * <li>{@link Calendar#YEAR}
 	 * </ul>
-	 * 
+	 *
 	 * @throws IllegalArgumentException
 	 */
 	public void setPrecision(TemporalPrecisionEnum thePrecision) throws IllegalArgumentException {
@@ -429,7 +407,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 * Sets the value of this date/time using the default level of precision
 	 * for this datatype
 	 * using the system local time zone
-	 * 
+	 *
 	 * @param theValue
 	 *            The date value
 	 */
@@ -446,7 +424,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	/**
 	 * Sets the value of this date/time using the specified level of precision
 	 * using the system local time zone
-	 * 
+	 *
 	 * @param theValue
 	 *            The date value
 	 * @param thePrecision
@@ -465,9 +443,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public void setValueAsString(String theString) throws IllegalArgumentException {
 		clearTimeZone();
 		super.setValueAsString(theString);
-    if (isPrecisionAllowed(getPrecision()) == false) {
-      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + theString);
-    }
 	}
 
 	/**
@@ -545,7 +520,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	/**
 	 * Adds the given amount to the field specified by theField
-	 * 
+	 *
 	 * @param theField
 	 *            The field, uses constants from {@link Calendar} such as {@link Calendar#YEAR}
 	 * @param theValue
@@ -591,7 +566,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 					timeZone = (theV3String.substring(i));
 					break;
 				}
-				
+
 				// assertEquals("2013-02-02T20:13:03-05:00", DateAndTime.parseV3("20130202201303-0500").toString());
 				if (i == 4 || i == 6) {
 					b.append('-');
@@ -600,7 +575,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 				} else if (i == 10 || i == 12) {
 					b.append(':');
 				}
-				
+
 				b.append(nextChar);
 			}
 
@@ -615,7 +590,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 					b.append(timeZone);
 				}
 			}
-			
+
 			setValueAsString(b.toString());
 		}
 	}

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/model/BaseDateTimeTypeTests.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/model/BaseDateTimeTypeTests.java
@@ -26,11 +26,9 @@ public class BaseDateTimeTypeTests {
 
   @ParameterizedTest
   @MethodSource("getInvalidStringParams")
-  public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+  public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
     assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
-     K srcInstance = clazz.getDeclaredConstructor().newInstance();
-     Assertions.assertThrows(IllegalArgumentException.class, () -> srcInstance.setValueAsString(param));
   }
 
   private static Stream<Arguments> getValidStringParams() {

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeTypeTests.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeTypeTests.java
@@ -27,11 +27,9 @@ public class BaseDateTimeTypeTests {
 
   @ParameterizedTest
   @MethodSource("getInvalidStringParams")
-  public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+  public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
-    assertEquals(DataFormatException.class, exceptionWrapper.getTargetException().getClass());
-     K srcInstance = clazz.getDeclaredConstructor().newInstance();
-     Assertions.assertThrows(DataFormatException.class, () -> srcInstance.setValueAsString(param));
+    assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
   }
 
   private static Stream<Arguments> getValidStringParams() {

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
@@ -79,7 +79,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
    */
   public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision) {
     setValue(theDate, thePrecision);
-    validatePrecisionAndThrowDataFormatException(getValueAsString(), getPrecision());
+    validatePrecisionAndThrowIllegalArgumentException();
   }
 
   /**
@@ -88,7 +88,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
   public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision, TimeZone theTimeZone) {
     this(theDate, thePrecision);
     setTimeZone(theTimeZone);
-    validatePrecisionAndThrowDataFormatException(getValueAsString(), getPrecision());
+    validatePrecisionAndThrowIllegalArgumentException();
   }
 
   /**
@@ -99,7 +99,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
    */
   public BaseDateTimeType(String theString) {
     setValueAsString(theString);
-
+    validatePrecisionAndThrowIllegalArgumentException();
   }
 
   /**
@@ -504,7 +504,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     }
 
     if (precision == TemporalPrecisionEnum.MINUTE) {
-      validatePrecisionAndThrowDataFormatException(value, precision);
+      validatePrecisionAndThrowIllegalArgumentException();
     }
 
     myPrecision = precision;
@@ -713,7 +713,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
   public void setValueAsString(String theString) throws DataFormatException {
     clearTimeZone();
     super.setValueAsString(theString);
-    validatePrecisionAndThrowDataFormatException(theString, getPrecision());
   }
 
   protected void setValueAsV3String(String theV3String) {
@@ -833,9 +832,9 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     }
   }
 
-  private void validatePrecisionAndThrowDataFormatException(String theValue, TemporalPrecisionEnum thePrecision) {
-    if (isPrecisionAllowed(thePrecision) == false) {
-      throw new DataFormatException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + thePrecision + " precision): " + theValue);
+  private void validatePrecisionAndThrowIllegalArgumentException() {
+    if (!isPrecisionAllowed(getPrecision())) {
+      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + getValueAsString());
     }
   }
 

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BaseDateTimeTypeTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BaseDateTimeTypeTests.java
@@ -29,9 +29,7 @@ public class BaseDateTimeTypeTests {
   @MethodSource("getInvalidStringParams")
   public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
-    assertEquals(DataFormatException.class, exceptionWrapper.getTargetException().getClass());
-     K srcInstance = clazz.getDeclaredConstructor().newInstance();
-     Assertions.assertThrows(DataFormatException.class, () -> srcInstance.setValueAsString(param));
+    assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
   }
 
   private static Stream<Arguments> getValidStringParams() {

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
@@ -43,7 +43,6 @@ import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
-import org.apache.commons.lang3.time.FastDateFormat;
 
 import ca.uhn.fhir.parser.DataFormatException;
 import org.hl7.fhir.utilities.DateTimeUtil;
@@ -54,9 +53,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	static final long NANOS_PER_SECOND = 1000000000L;
   private static final Map<String, TimeZone> timezoneCache = new ConcurrentHashMap<>();
-	private static final FastDateFormat ourHumanDateFormat = FastDateFormat.getDateInstance(FastDateFormat.MEDIUM);
-
-	private static final FastDateFormat ourHumanDateTimeFormat = FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM);
 	private static final long serialVersionUID = 1L;
 
 	private String myFractionalSeconds;
@@ -79,9 +75,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision) {
 		setValue(theDate, thePrecision);
-		if (isPrecisionAllowed(thePrecision) == false) {
-			throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + thePrecision + " precision): " + theDate);
-		}
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
@@ -90,6 +84,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision, TimeZone theTimeZone) {
 		this(theDate, thePrecision);
 		setTimeZone(theTimeZone);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
@@ -100,9 +95,16 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(String theString) {
 		setValueAsString(theString);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
-	/**
+  private void validatePrecisionAndThrowIllegalArgumentException() {
+    if (!isPrecisionAllowed(getPrecision())) {
+      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + getValueAsString());
+    }
+  }
+
+  /**
 	 * Adds the given amount to the field specified by theField
 	 *
 	 * @param theField
@@ -709,9 +711,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public void setValueAsString(String theString) throws DataFormatException {
 		clearTimeZone();
 		super.setValueAsString(theString);
-    if (isPrecisionAllowed(getPrecision()) == false) {
-      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + theString);
-    }
 	}
 
 	protected void setValueAsV3String(String theV3String) {

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BaseDateTimeTypeTest.java
@@ -1,6 +1,5 @@
 package org.hl7.fhir.r4.model;
 
-import ca.uhn.fhir.parser.DataFormatException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -96,8 +95,6 @@ public class BaseDateTimeTypeTest {
   public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
     assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
-    K srcInstance = clazz.getDeclaredConstructor().newInstance();
-    Assertions.assertThrows(IllegalArgumentException.class, () -> srcInstance.setValueAsString(param));
   }
 
   private static Stream<Arguments> getValidStringParams() {

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
@@ -35,7 +35,6 @@ import ca.uhn.fhir.parser.DataFormatException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
-import org.apache.commons.lang3.time.FastDateFormat;
 import org.hl7.fhir.utilities.DateTimeUtil;
 import org.hl7.fhir.utilities.Utilities;
 
@@ -54,9 +53,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	static final long NANOS_PER_SECOND = 1000000000L;
   private static final Map<String, TimeZone> timezoneCache = new ConcurrentHashMap<>();
-	private static final FastDateFormat ourHumanDateFormat = FastDateFormat.getDateInstance(FastDateFormat.MEDIUM);
-
-	private static final FastDateFormat ourHumanDateTimeFormat = FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM);
 	private static final long serialVersionUID = 1L;
 
 	private String myFractionalSeconds;
@@ -79,9 +75,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision) {
 		setValue(theDate, thePrecision);
-		if (isPrecisionAllowed(thePrecision) == false) {
-			throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + thePrecision + " precision): " + theDate);
-		}
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
@@ -90,6 +84,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision, TimeZone theTimeZone) {
 		this(theDate, thePrecision);
 		setTimeZone(theTimeZone);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
@@ -100,7 +95,14 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(String theString) {
 		setValueAsString(theString);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
+
+  private void validatePrecisionAndThrowIllegalArgumentException() {
+    if (!isPrecisionAllowed(getPrecision())) {
+      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + getValueAsString());
+    }
+  }
 
 	/**
 	 * Adds the given amount to the field specified by theField
@@ -716,9 +718,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public void setValueAsString(String theString) throws DataFormatException {
 		clearTimeZone();
 		super.setValueAsString(theString);
-    if (isPrecisionAllowed(getPrecision()) == false) {
-      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + theString);
-    }
 	}
 
 	protected void setValueAsV3String(String theV3String) {

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BaseDateTimeTypeTest.java
@@ -1,14 +1,14 @@
 package org.hl7.fhir.r4b.model;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.TimeZone;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -128,8 +128,6 @@ public class BaseDateTimeTypeTest {
   public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
     assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
-    K srcInstance = clazz.getDeclaredConstructor().newInstance();
-    Assertions.assertThrows(IllegalArgumentException.class, () -> srcInstance.setValueAsString(param));
   }
 
   private static Stream<Arguments> getValidStringParams() {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
@@ -35,7 +35,6 @@ import ca.uhn.fhir.parser.DataFormatException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
-import org.apache.commons.lang3.time.FastDateFormat;
 import org.hl7.fhir.utilities.DateTimeUtil;
 import org.hl7.fhir.utilities.Utilities;
 
@@ -54,9 +53,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	static final long NANOS_PER_SECOND = 1000000000L;
   private static final Map<String, TimeZone> timezoneCache = new ConcurrentHashMap<>();
-	private static final FastDateFormat ourHumanDateFormat = FastDateFormat.getDateInstance(FastDateFormat.MEDIUM);
-
-	private static final FastDateFormat ourHumanDateTimeFormat = FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM);
 	private static final long serialVersionUID = 1L;
 
 	private String myFractionalSeconds;
@@ -79,17 +75,16 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision) {
 		setValue(theDate, thePrecision);
-		if (isPrecisionAllowed(thePrecision) == false) {
-			throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + thePrecision + " precision): " + theDate);
-		}
-	}
+    validatePrecisionAndThrowIllegalArgumentException();
+  }
 
-	/**
+  /**
 	 * Constructor
 	 */
 	public BaseDateTimeType(Date theDate, TemporalPrecisionEnum thePrecision, TimeZone theTimeZone) {
 		this(theDate, thePrecision);
 		setTimeZone(theTimeZone);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
 
 	/**
@@ -100,7 +95,14 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	 */
 	public BaseDateTimeType(String theString) {
 		setValueAsString(theString);
+    validatePrecisionAndThrowIllegalArgumentException();
 	}
+
+  private void validatePrecisionAndThrowIllegalArgumentException() {
+    if (!isPrecisionAllowed(getPrecision())) {
+      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + getValueAsString());
+    }
+  }
 
 	/**
 	 * Adds the given amount to the field specified by theField
@@ -716,9 +718,6 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 	public void setValueAsString(String theString) throws DataFormatException {
 		clearTimeZone();
 		super.setValueAsString(theString);
-    if (isPrecisionAllowed(getPrecision()) == false) {
-      throw new IllegalArgumentException("Invalid date/time string (datatype " + getClass().getSimpleName() + " does not support " + getPrecision() + " precision): " + theString);
-    }
 	}
 
 	protected void setValueAsV3String(String theV3String) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BaseDateTimeTypeTest.java
@@ -1,14 +1,14 @@
 package org.hl7.fhir.r5.model;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.TimeZone;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -128,8 +128,6 @@ public class BaseDateTimeTypeTest {
   public <K extends BaseDateTimeType> void testInvalidString(Class<K> clazz, String param) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     InvocationTargetException exceptionWrapper =  Assertions.assertThrows(InvocationTargetException.class, () ->  clazz.getConstructor(String.class).newInstance(param));
     assertEquals(IllegalArgumentException.class, exceptionWrapper.getTargetException().getClass());
-    K srcInstance = clazz.getDeclaredConstructor().newInstance();
-    Assertions.assertThrows(IllegalArgumentException.class, () -> srcInstance.setValueAsString(param));
   }
 
   private static Stream<Arguments> getValidStringParams() {


### PR DESCRIPTION
Avoid throwing an exception when parsing resources, in order to prevent people from being unable to parse known invalid resources.