### PR TITLE
Fix incorrect medication test

### DIFF
--- a/org.hl7.fhir.convertors/src/test/resources/0_medication_10.json
+++ b/org.hl7.fhir.convertors/src/test/resources/0_medication_10.json
@@ -11,6 +11,7 @@
     ],
     "text": "CIPROFLOXACIN 500 MG TABLET"
   },
+  "product": {
   "form": {
     "coding": [
       {
@@ -20,5 +21,6 @@
       }
     ],
     "text": "Tablet"
+  }
   }
 }

--- a/org.hl7.fhir.convertors/src/test/resources/0_medication_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/0_medication_40.json
@@ -11,7 +11,6 @@
     ],
     "text": "CIPROFLOXACIN 500 MG TABLET"
   },
-  "product": {
     "form": {
       "coding": [
         {
@@ -22,5 +21,4 @@
       ],
       "text": "Tablet"
     }
-  }
 }


### PR DESCRIPTION
The Medication test had swapped versions in the test resources. Version 10 was missing the product field, which meant that the form element was being ignored, and Version 40 enclosed the form element in a product field, meaning it was ignored there as well.

The test reported the conversion as correct only because both elements were dropped.

This restores the correct structure, and now the test is testing against included and populated elements.