### PR TITLE
Update windows image to windows-latest in PR pipeline

### DIFF
--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -12,6 +12,7 @@ jobs:
           currentImage: ${{image.name}}
           codecov: $(CODECOV_TOKEN)
           VERSION:
+          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
 
         steps:
           # Runs 'mvn clean install'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -14,5 +14,5 @@ jobs:
           jdkVersions:  [ '1.11', '1.17']
         - name: macos-latest
           jdkVersions: [ '1.11', '1.17']
-        - name: windows-2019
+        - name: windows-latest
           jdkVersions: [ '1.11', '1.17']


### PR DESCRIPTION
Azure is giving warnings with regard to deprecated windows images. Switching to {OS} latest across the board will have us 'fail fast' if Azure stops supporting deprecated tools we depend on. 