### PR TITLE
Fix NP for PatientRenderer #896

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/PatientRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/PatientRenderer.java
@@ -101,6 +101,9 @@ public class PatientRenderer extends ResourceRenderer {
     if (newUse == null) {
       return true;
     }
+    if (oldUse == null) {
+      return existsInList(newUse, NameUse.OFFICIAL, NameUse.USUAL);
+    }
     switch (oldUse) {
       case ANONYMOUS: return existsInList(newUse, NameUse.OFFICIAL, NameUse.USUAL);
       case MAIDEN: return existsInList(newUse, NameUse.OFFICIAL, NameUse.USUAL);


### PR DESCRIPTION
PR with avoiding the NP that the switch statement is not called and
returns true if newUse has NameUse.OFFICIAL, NameUse.USUAL (same
expression as value for NULL in switch statement).