### PR TITLE
Fix DateTimeType inconsistencies when using field setting

### DIFF
--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeType.java
@@ -675,7 +675,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     validateValueInRange(theValue, theMinimum, theMaximum);
     Calendar cal;
     if (getValue() == null) {
-      cal = new GregorianCalendar(0, 0, 0);
+      cal = new GregorianCalendar();
     } else {
       cal = getValueAsCalendar();
     }

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/DateTimeTypeFieldTests.java
@@ -1,0 +1,29 @@
+package org.hl7.fhir.dstu2016may.model;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeTypeFieldTests {
+  @Test
+  public void testFieldSet() {
+    final int YEAR = 1979;
+    final int MONTH = 0; // January
+    final int DAY = 23;
+    final DateTimeType dateTimeYearFirst = new DateTimeType();
+    dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeYearFirst.setYear(YEAR);
+    dateTimeYearFirst.setDay(DAY);
+    dateTimeYearFirst.setMonth(MONTH);
+
+    final DateTimeType dateTimeDayFirst = new DateTimeType();
+    dateTimeDayFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeDayFirst.setDay(DAY);
+    dateTimeDayFirst.setYear(YEAR);
+    dateTimeDayFirst.setMonth(MONTH);
+
+    assertEquals("1979-01-23",dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeYearFirst.asStringValue());
+  }
+}

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
@@ -539,7 +539,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     validateValueInRange(theValue, theMinimum, theMaximum);
     Calendar cal;
     if (getValue() == null) {
-      cal = new GregorianCalendar(0, 0, 0);
+      cal = new GregorianCalendar();
     } else {
       cal = getValueAsCalendar();
     }

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTimeTypeFieldTests.java
@@ -1,0 +1,29 @@
+package org.hl7.fhir.dstu3.model;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeTypeFieldTests {
+  @Test
+  public void testFieldSet() {
+    final int YEAR = 1979;
+    final int MONTH = 0; // January
+    final int DAY = 23;
+    final DateTimeType dateTimeYearFirst = new DateTimeType();
+    dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeYearFirst.setYear(YEAR);
+    dateTimeYearFirst.setDay(DAY);
+    dateTimeYearFirst.setMonth(MONTH);
+
+    final DateTimeType dateTimeDayFirst = new DateTimeType();
+    dateTimeDayFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeDayFirst.setDay(DAY);
+    dateTimeDayFirst.setYear(YEAR);
+    dateTimeDayFirst.setMonth(MONTH);
+
+    assertEquals("1979-01-23",dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeYearFirst.asStringValue());
+  }
+}

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
@@ -537,7 +537,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		validateValueInRange(theValue, theMinimum, theMaximum);
 		Calendar cal;
 		if (getValue() == null) {
-			cal = new GregorianCalendar();
+			cal = new GregorianCalendar(0,0,0);
 		} else {
 			cal = getValueAsCalendar();
 		}

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
@@ -537,7 +537,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		validateValueInRange(theValue, theMinimum, theMaximum);
 		Calendar cal;
 		if (getValue() == null) {
-			cal = new GregorianCalendar(0,0,0);
+			cal = new GregorianCalendar();
 		} else {
 			cal = getValueAsCalendar();
 		}

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
@@ -537,7 +537,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		validateValueInRange(theValue, theMinimum, theMaximum);
 		Calendar cal;
 		if (getValue() == null) {
-			cal = new GregorianCalendar(0, 0, 0);
+			cal = new GregorianCalendar();
 		} else {
 			cal = getValueAsCalendar();
 		}

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeFieldTests.java
@@ -1,0 +1,28 @@
+package org.hl7.fhir.r4.model;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeTypeFieldTests {
+  @Test
+  public void testFieldSet() {
+    final int YEAR = 1979;
+    final int MONTH = 1;
+    final int DAY = 23;
+    final DateTimeType dateTimeYearFirst = new DateTimeType();
+    dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeYearFirst.setYear(YEAR);
+    dateTimeYearFirst.setDay(DAY);
+    dateTimeYearFirst.setMonth(MONTH);
+
+    final DateTimeType dateTimeDayFirst = new DateTimeType();
+    dateTimeDayFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeDayFirst.setDay(DAY);
+    dateTimeDayFirst.setYear(YEAR);
+    dateTimeDayFirst.setMonth(MONTH);
+
+    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+  }
+}

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeFieldTests.java
@@ -9,7 +9,7 @@ public class DateTimeTypeFieldTests {
   @Test
   public void testFieldSet() {
     final int YEAR = 1979;
-    final int MONTH = 1;
+    final int MONTH = 0; // January
     final int DAY = 23;
     final DateTimeType dateTimeYearFirst = new DateTimeType();
     dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
@@ -23,6 +23,7 @@ public class DateTimeTypeFieldTests {
     dateTimeDayFirst.setYear(YEAR);
     dateTimeDayFirst.setMonth(MONTH);
 
-    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeYearFirst.asStringValue());
   }
 }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
@@ -544,7 +544,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		validateValueInRange(theValue, theMinimum, theMaximum);
 		Calendar cal;
 		if (getValue() == null) {
-			cal = new GregorianCalendar(0, 0, 0);
+			cal = new GregorianCalendar();
 		} else {
 			cal = getValueAsCalendar();
 		}

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeFieldTests.java
@@ -1,0 +1,28 @@
+package org.hl7.fhir.r4b.model;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeTypeFieldTests {
+  @Test
+  public void testFieldSet() {
+    final int YEAR = 1979;
+    final int MONTH = 1;
+    final int DAY = 23;
+    final DateTimeType dateTimeYearFirst = new DateTimeType();
+    dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeYearFirst.setYear(YEAR);
+    dateTimeYearFirst.setDay(DAY);
+    dateTimeYearFirst.setMonth(MONTH);
+
+    final DateTimeType dateTimeDayFirst = new DateTimeType();
+    dateTimeDayFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeDayFirst.setDay(DAY);
+    dateTimeDayFirst.setYear(YEAR);
+    dateTimeDayFirst.setMonth(MONTH);
+
+    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+  }
+}

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeFieldTests.java
@@ -9,7 +9,7 @@ public class DateTimeTypeFieldTests {
   @Test
   public void testFieldSet() {
     final int YEAR = 1979;
-    final int MONTH = 1;
+    final int MONTH = 0; // January
     final int DAY = 23;
     final DateTimeType dateTimeYearFirst = new DateTimeType();
     dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
@@ -23,6 +23,7 @@ public class DateTimeTypeFieldTests {
     dateTimeDayFirst.setYear(YEAR);
     dateTimeDayFirst.setMonth(MONTH);
 
-    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeYearFirst.asStringValue());
   }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
@@ -544,7 +544,7 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		validateValueInRange(theValue, theMinimum, theMaximum);
 		Calendar cal;
 		if (getValue() == null) {
-			cal = new GregorianCalendar(0, 0, 0);
+			cal = new GregorianCalendar();
 		} else {
 			cal = getValueAsCalendar();
 		}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeFieldTests.java
@@ -1,0 +1,28 @@
+package org.hl7.fhir.r5.model;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTimeTypeFieldTests {
+  @Test
+  public void testFieldSet() {
+    final int YEAR = 1979;
+    final int MONTH = 1;
+    final int DAY = 23;
+    final DateTimeType dateTimeYearFirst = new DateTimeType();
+    dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeYearFirst.setYear(YEAR);
+    dateTimeYearFirst.setDay(DAY);
+    dateTimeYearFirst.setMonth(MONTH);
+
+    final DateTimeType dateTimeDayFirst = new DateTimeType();
+    dateTimeDayFirst.setPrecision(TemporalPrecisionEnum.DAY);
+    dateTimeDayFirst.setDay(DAY);
+    dateTimeDayFirst.setYear(YEAR);
+    dateTimeDayFirst.setMonth(MONTH);
+
+    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeFieldTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeFieldTests.java
@@ -9,7 +9,7 @@ public class DateTimeTypeFieldTests {
   @Test
   public void testFieldSet() {
     final int YEAR = 1979;
-    final int MONTH = 1;
+    final int MONTH = 0; // January
     final int DAY = 23;
     final DateTimeType dateTimeYearFirst = new DateTimeType();
     dateTimeYearFirst.setPrecision(TemporalPrecisionEnum.DAY);
@@ -23,6 +23,7 @@ public class DateTimeTypeFieldTests {
     dateTimeDayFirst.setYear(YEAR);
     dateTimeDayFirst.setMonth(MONTH);
 
-    assertEquals(dateTimeYearFirst.asStringValue(), dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeDayFirst.asStringValue());
+    assertEquals("1979-01-23",dateTimeYearFirst.asStringValue());
   }
 }


### PR DESCRIPTION
Fix for #901 

When setting the fields of a no-arg constructed DateTimeType, it was using setFieldValue(), which in turn used new GregorianCalendar(0, 0, 0);

Switching to GregorianCalendar() fixes this issue. 