### PR TITLE
WIP Add new param to BaseAdvisor_40_50

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/advisors/impl/BaseAdvisor_40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/advisors/impl/BaseAdvisor_40_50.java
@@ -11,7 +11,7 @@ import org.hl7.fhir.exceptions.FHIRException;
 public class BaseAdvisor_40_50 extends BaseAdvisor50<org.hl7.fhir.r4.model.Extension> {
 
   private static final List<String> TestScriptIgnoredUrls = Arrays.asList("http://hl7.org/fhir/5.0/StructureDefinition/extension-TestScript.scope");
-  private boolean convertImplementationGuideDefinitionParameterComponent = true;
+  private boolean produceIllegalParameters = false;
 
   public BaseAdvisor_40_50() {
 
@@ -21,9 +21,9 @@ public class BaseAdvisor_40_50 extends BaseAdvisor50<org.hl7.fhir.r4.model.Exten
     this.failFast = failFast;
   }
 
-  public BaseAdvisor_40_50(Boolean failFast, Boolean convertImplementationGuideDefinitionParameterComponent) {
+  public BaseAdvisor_40_50(Boolean failFast, Boolean produceIllegalParameters) {
     this.failFast = failFast;
-    this.convertImplementationGuideDefinitionParameterComponent = convertImplementationGuideDefinitionParameterComponent;
+    this.produceIllegalParameters = produceIllegalParameters;
   }
 
 
@@ -37,7 +37,7 @@ public class BaseAdvisor_40_50 extends BaseAdvisor50<org.hl7.fhir.r4.model.Exten
       return false;
   }
 
-  public boolean convertImplementationGuideDefinitionParameterComponent() {
-    return convertImplementationGuideDefinitionParameterComponent;
+  public boolean produceIllegalParameters() {
+    return produceIllegalParameters;
   }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/advisors/impl/BaseAdvisor_40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/advisors/impl/BaseAdvisor_40_50.java
@@ -11,14 +11,21 @@ import org.hl7.fhir.exceptions.FHIRException;
 public class BaseAdvisor_40_50 extends BaseAdvisor50<org.hl7.fhir.r4.model.Extension> {
 
   private static final List<String> TestScriptIgnoredUrls = Arrays.asList("http://hl7.org/fhir/5.0/StructureDefinition/extension-TestScript.scope");
+  private boolean convertImplementationGuideDefinitionParameterComponent = true;
 
   public BaseAdvisor_40_50() {
+
   }
 
   public BaseAdvisor_40_50(Boolean failFast) {
     this.failFast = failFast;
   }
-  
+
+  public BaseAdvisor_40_50(Boolean failFast, Boolean convertImplementationGuideDefinitionParameterComponent) {
+    this.failFast = failFast;
+    this.convertImplementationGuideDefinitionParameterComponent = convertImplementationGuideDefinitionParameterComponent;
+  }
+
 
   @Override
   public boolean ignoreExtension(@Nonnull String path,
@@ -30,4 +37,7 @@ public class BaseAdvisor_40_50 extends BaseAdvisor50<org.hl7.fhir.r4.model.Exten
       return false;
   }
 
+  public boolean convertImplementationGuideDefinitionParameterComponent() {
+    return convertImplementationGuideDefinitionParameterComponent;
+  }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.convertors.conv40_50.datatypes40_50.primitive40_50.Url40_50;
 import org.hl7.fhir.convertors.conv40_50.datatypes40_50.special40_50.Reference40_50;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.hl7.fhir.utilities.Utilities;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -2340,8 +2341,8 @@ public class ImplementationGuide40_50 {
     if (src.hasPage())
       tgt.setPage(convertImplementationGuideDefinitionPageComponent(src.getPage()));
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionParameterComponent t : src.getParameter()) {
-//      if (Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"))
-        if (produceIllegalParameters) {
+//      if (                            Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"))
+        if (produceIllegalParameters || Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template")) {
           tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
         } else {
           org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
@@ -2341,7 +2341,6 @@ public class ImplementationGuide40_50 {
     if (src.hasPage())
       tgt.setPage(convertImplementationGuideDefinitionPageComponent(src.getPage()));
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionParameterComponent t : src.getParameter()) {
-//      if (                            Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"))
         if (produceIllegalParameters || Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template")) {
           tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
         } else {

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
@@ -101,7 +101,7 @@ public class ImplementationGuide40_50 {
     return tgt;
   }
 
-  public static org.hl7.fhir.r4.model.ImplementationGuide convertImplementationGuide(ImplementationGuide src, boolean convertImplementationGuideDefinitionParameterComponent) throws FHIRException {
+  public static org.hl7.fhir.r4.model.ImplementationGuide convertImplementationGuide(ImplementationGuide src, boolean produceIllegalParameters) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.ImplementationGuide tgt = new org.hl7.fhir.r4.model.ImplementationGuide();
@@ -144,7 +144,7 @@ public class ImplementationGuide40_50 {
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideGlobalComponent t : src.getGlobal())
       tgt.addGlobal(convertImplementationGuideGlobalComponent(t));
     if (src.hasDefinition())
-      tgt.setDefinition(convertImplementationGuideDefinitionComponent(src.getDefinition(), convertImplementationGuideDefinitionParameterComponent));
+      tgt.setDefinition(convertImplementationGuideDefinitionComponent(src.getDefinition(), produceIllegalParameters));
     if (src.hasManifest())
       tgt.setManifest(convertImplementationGuideManifestComponent(src.getManifest()));
     return tgt;
@@ -2328,7 +2328,7 @@ public class ImplementationGuide40_50 {
     return tgt;
   }
 
-  public static org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent convertImplementationGuideDefinitionComponent(ImplementationGuide.ImplementationGuideDefinitionComponent src, boolean convertImplementationGuideDefinitionParameterComponent) throws FHIRException {
+  public static org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent convertImplementationGuideDefinitionComponent(ImplementationGuide.ImplementationGuideDefinitionComponent src, boolean produceIllegalParameters) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent tgt = new org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent();
@@ -2341,16 +2341,16 @@ public class ImplementationGuide40_50 {
       tgt.setPage(convertImplementationGuideDefinitionPageComponent(src.getPage()));
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionParameterComponent t : src.getParameter()) {
 //      if (Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"))
-        if (convertImplementationGuideDefinitionParameterComponent)
+        if (produceIllegalParameters) {
           tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
-//      else {
-//        org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);
-//        org.hl7.fhir.r4.model.Extension eCode = new org.hl7.fhir.r4.model.Extension("code", new org.hl7.fhir.r4.model.StringType(t.getCode().getCode()));
-//        org.hl7.fhir.r4.model.Extension eValue = new org.hl7.fhir.r4.model.Extension("value", new org.hl7.fhir.r4.model.StringType(t.getValue()));
-//        e.addExtension(eCode);
-//        e.addExtension(eValue);
-//        tgt.addExtension(e);
-//      }
+        } else {
+        org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);
+        org.hl7.fhir.r4.model.Extension eCode = new org.hl7.fhir.r4.model.Extension("code", new org.hl7.fhir.r4.model.StringType(t.getCode().getCode()));
+        org.hl7.fhir.r4.model.Extension eValue = new org.hl7.fhir.r4.model.Extension("value", new org.hl7.fhir.r4.model.StringType(t.getValue()));
+        e.addExtension(eCode);
+        e.addExtension(eValue);
+          tgt.addExtension(e);
+      }
     }
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionTemplateComponent t : src.getTemplate())
       tgt.addTemplate(convertImplementationGuideDefinitionTemplateComponent(t));

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
@@ -17,7 +17,7 @@ import org.hl7.fhir.convertors.conv40_50.datatypes40_50.primitive40_50.Uri40_50;
 import org.hl7.fhir.convertors.conv40_50.datatypes40_50.primitive40_50.Url40_50;
 import org.hl7.fhir.convertors.conv40_50.datatypes40_50.special40_50.Reference40_50;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.utilities.Utilities;
+import org.hl7.fhir.r5.model.ImplementationGuide;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -101,7 +101,7 @@ public class ImplementationGuide40_50 {
     return tgt;
   }
 
-  public static org.hl7.fhir.r4.model.ImplementationGuide convertImplementationGuide(org.hl7.fhir.r5.model.ImplementationGuide src) throws FHIRException {
+  public static org.hl7.fhir.r4.model.ImplementationGuide convertImplementationGuide(ImplementationGuide src, boolean convertImplementationGuideDefinitionParameterComponent) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.ImplementationGuide tgt = new org.hl7.fhir.r4.model.ImplementationGuide();
@@ -144,7 +144,7 @@ public class ImplementationGuide40_50 {
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideGlobalComponent t : src.getGlobal())
       tgt.addGlobal(convertImplementationGuideGlobalComponent(t));
     if (src.hasDefinition())
-      tgt.setDefinition(convertImplementationGuideDefinitionComponent(src.getDefinition()));
+      tgt.setDefinition(convertImplementationGuideDefinitionComponent(src.getDefinition(), convertImplementationGuideDefinitionParameterComponent));
     if (src.hasManifest())
       tgt.setManifest(convertImplementationGuideManifestComponent(src.getManifest()));
     return tgt;
@@ -2328,7 +2328,7 @@ public class ImplementationGuide40_50 {
     return tgt;
   }
 
-  public static org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent convertImplementationGuideDefinitionComponent(org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionComponent src) throws FHIRException {
+  public static org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent convertImplementationGuideDefinitionComponent(ImplementationGuide.ImplementationGuideDefinitionComponent src, boolean convertImplementationGuideDefinitionParameterComponent) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent tgt = new org.hl7.fhir.r4.model.ImplementationGuide.ImplementationGuideDefinitionComponent();
@@ -2341,7 +2341,8 @@ public class ImplementationGuide40_50 {
       tgt.setPage(convertImplementationGuideDefinitionPageComponent(src.getPage()));
     for (org.hl7.fhir.r5.model.ImplementationGuide.ImplementationGuideDefinitionParameterComponent t : src.getParameter()) {
 //      if (Utilities.existsInList(t.getCode().getCode(), "apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"))
-        tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
+        if (convertImplementationGuideDefinitionParameterComponent)
+          tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
 //      else {
 //        org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);
 //        org.hl7.fhir.r4.model.Extension eCode = new org.hl7.fhir.r4.model.Extension("code", new org.hl7.fhir.r4.model.StringType(t.getCode().getCode()));

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/ImplementationGuide40_50.java
@@ -2344,11 +2344,11 @@ public class ImplementationGuide40_50 {
         if (produceIllegalParameters) {
           tgt.addParameter(convertImplementationGuideDefinitionParameterComponent(t));
         } else {
-        org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);
-        org.hl7.fhir.r4.model.Extension eCode = new org.hl7.fhir.r4.model.Extension("code", new org.hl7.fhir.r4.model.StringType(t.getCode().getCode()));
-        org.hl7.fhir.r4.model.Extension eValue = new org.hl7.fhir.r4.model.Extension("value", new org.hl7.fhir.r4.model.StringType(t.getValue()));
-        e.addExtension(eCode);
-        e.addExtension(eValue);
+          org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(EXT_IG_DEFINITION_PARAMETER);
+          org.hl7.fhir.r4.model.Extension eCode = new org.hl7.fhir.r4.model.Extension("code", new org.hl7.fhir.r4.model.StringType(t.getCode().getCode()));
+          org.hl7.fhir.r4.model.Extension eValue = new org.hl7.fhir.r4.model.Extension("value", new org.hl7.fhir.r4.model.StringType(t.getValue()));
+          e.addExtension(eCode);
+          e.addExtension(eValue);
           tgt.addExtension(e);
       }
     }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/Resource40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/Resource40_50.java
@@ -385,7 +385,7 @@ public class Resource40_50 {
     if (src instanceof org.hl7.fhir.r5.model.ImmunizationRecommendation)
       return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r5.model.ImmunizationRecommendation) src);
     if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src, advisor.convertImplementationGuideDefinitionParameterComponent());
+      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src, advisor.produceIllegalParameters());
     if (src instanceof org.hl7.fhir.r5.model.InsurancePlan)
       return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r5.model.InsurancePlan) src);
     if (src instanceof org.hl7.fhir.r5.model.Invoice)

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/Resource40_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv40_50/resources40_50/Resource40_50.java
@@ -385,7 +385,7 @@ public class Resource40_50 {
     if (src instanceof org.hl7.fhir.r5.model.ImmunizationRecommendation)
       return ImmunizationRecommendation40_50.convertImmunizationRecommendation((org.hl7.fhir.r5.model.ImmunizationRecommendation) src);
     if (src instanceof org.hl7.fhir.r5.model.ImplementationGuide)
-      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src);
+      return ImplementationGuide40_50.convertImplementationGuide((org.hl7.fhir.r5.model.ImplementationGuide) src, advisor.convertImplementationGuideDefinitionParameterComponent());
     if (src instanceof org.hl7.fhir.r5.model.InsurancePlan)
       return InsurancePlan40_50.convertInsurancePlan((org.hl7.fhir.r5.model.InsurancePlan) src);
     if (src instanceof org.hl7.fhir.r5.model.Invoice)

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/ImplementationGuide40_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/ImplementationGuide40_50Test.java
@@ -1,0 +1,46 @@
+package org.hl7.fhir.convertors.conv40_50;
+
+import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
+import org.hl7.fhir.convertors.conv40_50.resources40_50.ImplementationGuide40_50;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
+import org.hl7.fhir.r5.model.ImplementationGuide;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ImplementationGuide40_50Test {
+
+  public void testProduceIllegalParameters() throws IOException {
+    ImplementationGuide r5_actual = getR5ImplementationGuide();
+
+    org.hl7.fhir.r4.model.ImplementationGuide converted = (org.hl7.fhir.r4.model.ImplementationGuide) VersionConvertorFactory_40_50.convertResource(
+      r5_actual,
+      new BaseAdvisor_40_50(true, true));
+
+    assertEquals(2, converted.getDefinition().getParameter().size());
+    assertEquals("copyrightyear", converted.getDefinition().getParameter().get(1).getCode());
+    assertEquals("2020+", converted.getDefinition().getParameter().get(1).getValue());
+  }
+
+  @Test
+  public void testDefaultParameters() throws IOException {
+    ImplementationGuide r5_actual = getR5ImplementationGuide();
+
+    org.hl7.fhir.r4.model.ImplementationGuide converted = (org.hl7.fhir.r4.model.ImplementationGuide) VersionConvertorFactory_40_50.convertResource(r5_actual);
+
+    assertEquals(1, converted.getDefinition().getParameter().size());
+    assertEquals("copyrightyear", converted.getDefinition().getExtension().get(0).getExtension().get(0).getValue().primitiveValue());
+    assertEquals("2020+", converted.getDefinition().getExtension().get(0).getExtension().get(1).getValue().primitiveValue());
+
+  }
+
+  private ImplementationGuide getR5ImplementationGuide() throws IOException {
+    ImplementationGuide r5_actual;
+    InputStream r5_stream = this.getClass().getResourceAsStream("/implementation_guide_50.json");
+    r5_actual = (ImplementationGuide) new org.hl7.fhir.r5.formats.JsonParser().parse(r5_stream);
+    return r5_actual;
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/implementation_guide_50.json
+++ b/org.hl7.fhir.convertors/src/test/resources/implementation_guide_50.json
@@ -1,0 +1,142 @@
+{
+  "resourceType": "ImplementationGuide",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ImplementationGuide</b><a name=\"example\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ImplementationGuide &quot;example&quot; </p></div><p><b>url</b>: <code>http://hl7.org/fhir/us/daf</code></p><p><b>version</b>: 0</p><p><b>name</b>: Data Access Framework (DAF)</p><p><b>status</b>: draft</p><p><b>experimental</b>: false</p><p><b>date</b>: 2015-01-01</p><p><b>publisher</b>: ONC / HL7 Joint project</p><p><b>contact</b>: ONC: <a href=\"http://www.healthit.gov\">http://www.healthit.gov</a>, HL7: <a href=\"http://hl7.org/fhir\">http://hl7.org/fhir</a></p><p><b>description</b>: The Data Access Framework (DAF) Initiative leverages the HL7 FHIR standards to standardize access to Meaningful Use Stage 2 structured information both within the organization and from external organizations</p><p><b>jurisdiction</b>: United States of America <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#US)</span></p><p><b>copyright</b>: Published by ONC under the standard FHIR license (CC0)</p><p><b>packageId</b>: hl7.fhir.us.daf</p><p><b>license</b>: CC0-1.0</p><p><b>fhirVersion</b>: 5.0.0</p><h3>DependsOns</h3><table class=\"grid\"><tr><td>-</td><td><b>Uri</b></td></tr><tr><td>*</td><td><a href=\"http://hl7.org/fhir/ImplementationGuide/uscore\">http://hl7.org/fhir/ImplementationGuide/uscore</a></td></tr></table><h3>Globals</h3><table class=\"grid\"><tr><td>-</td><td><b>Type</b></td><td><b>Profile</b></td></tr><tr><td>*</td><td>Patient</td><td><a href=\"http://hl7.org/fhir/us/core/StructureDefinition/patient\">http://hl7.org/fhir/us/core/StructureDefinition/patient</a></td></tr></table><blockquote><p><b>definition</b></p><h3>Groupings</h3><table class=\"grid\"><tr><td>-</td><td><b>Name</b></td><td><b>Description</b></td></tr><tr><td>*</td><td>test</td><td>Base package (not broken up into multiple packages)</td></tr></table><h3>Resources</h3><table class=\"grid\"><tr><td>-</td><td><b>Reference</b></td><td><b>Name</b></td><td><b>Description</b></td><td><b>Profile</b></td></tr><tr><td>*</td><td><a href=\"broken-link.html\">Patient/test</a></td><td>Test Example</td><td>A test example to show how an implementation guide works</td><td><a href=\"http://hl7.org/fhir/us/core/StructureDefinition/patient\">http://hl7.org/fhir/us/core/StructureDefinition/patient</a></td></tr></table><blockquote><p><b>page</b></p><p><b>name</b>: <code>patient-example.html</code></p><p><b>title</b>: Example Patient Page</p><p><b>generation</b>: html</p><h3>Pages</h3><table class=\"grid\"><tr><td>-</td><td><b>Name</b></td><td><b>Title</b></td><td><b>Generation</b></td></tr><tr><td>*</td><td><code>list.html</code></td><td>Value Set Page</td><td>html</td></tr></table></blockquote><h3>Parameters</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Value</b></td></tr><tr><td>*</td><td>Apply Metadata Value (Details: http://hl7.org/fhir/guide-parameter-code code apply = 'Apply Metadata Value', stated as 'null')</td><td>version</td></tr></table></blockquote><blockquote><p><b>manifest</b></p><p><b>rendering</b>: <a href=\"http://hl7.org/fhir/us/daf\">http://hl7.org/fhir/us/daf</a></p><h3>Resources</h3><table class=\"grid\"><tr><td>-</td><td><b>Reference</b></td><td><b>Profile</b></td><td><b>RelativePath</b></td></tr><tr><td>*</td><td><a href=\"broken-link.html\">Patient/test</a></td><td><a href=\"http://hl7.org/fhir/us/core/StructureDefinition/patient\">http://hl7.org/fhir/us/core/StructureDefinition/patient</a></td><td><code>patient-test.html#patient-test</code></td></tr></table><h3>Pages</h3><table class=\"grid\"><tr><td>-</td><td><b>Name</b></td><td><b>Title</b></td><td><b>Anchor</b></td></tr><tr><td>*</td><td>patient-test.html</td><td>Test Patient Example</td><td>patient-test, tx, uml</td></tr></table><p><b>image</b>: fhir.png</p><p><b>other</b>: fhir.css</p></blockquote></div>"
+  },
+  "url": "http://hl7.org/fhir/us/daf",
+  "version": "0",
+  "name": "Data Access Framework (DAF)",
+  "status": "draft",
+  "experimental": false,
+  "date": "2015-01-01",
+  "publisher": "ONC / HL7 Joint project",
+  "contact": [
+    {
+      "name": "ONC",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.healthit.gov"
+        }
+      ]
+    },
+    {
+      "name": "HL7",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/fhir"
+        }
+      ]
+    }
+  ],
+  "description": "The Data Access Framework (DAF) Initiative leverages the HL7 FHIR standards to standardize access to Meaningful Use Stage 2 structured information both within the organization and from external organizations",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "copyright": "Published by ONC under the standard FHIR license (CC0)",
+  "packageId": "hl7.fhir.us.daf",
+  "license": "CC0-1.0",
+  "fhirVersion": [
+    "5.0.0"
+  ],
+  "dependsOn": [
+    {
+      "uri": "http://hl7.org/fhir/ImplementationGuide/uscore"
+    }
+  ],
+  "global": [
+    {
+      "type": "Patient",
+      "profile": "http://hl7.org/fhir/us/core/StructureDefinition/patient"
+    }
+  ],
+  "definition": {
+    "grouping": [
+      {
+        "name": "test",
+        "description": "Base package (not broken up into multiple packages)"
+      }
+    ],
+    "resource": [
+      {
+        "reference": {
+          "reference": "Patient/test"
+        },
+        "name": "Test Example",
+        "description": "A test example to show how an implementation guide works",
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/patient"
+        ]
+      }
+    ],
+    "page": {
+      "name": "patient-example.html",
+      "title": "Example Patient Page",
+      "generation": "html",
+      "page": [
+        {
+          "name": "list.html",
+          "title": "Value Set Page",
+          "generation": "html"
+        }
+      ]
+    },
+    "parameter": [
+      {
+        "code": {
+          "system": "http://hl7.org/fhir/guide-parameter-code",
+          "code": "apply"
+        },
+        "value": "version"
+      },
+      {
+        "code" : {
+          "system": "http://hl7.org/fhir/guide-parameter-code",
+          "code": "copyrightyear"
+        },
+        "value": "2020+"
+      }
+    ]
+  },
+  "manifest": {
+    "rendering": "http://hl7.org/fhir/us/daf",
+    "resource": [
+      {
+        "reference": {
+          "reference": "Patient/test"
+        },
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/patient"
+        ],
+        "relativePath": "patient-test.html#patient-test"
+      }
+    ],
+    "page": [
+      {
+        "name": "patient-test.html",
+        "title": "Test Patient Example",
+        "anchor": [
+          "patient-test",
+          "tx",
+          "uml"
+        ]
+      }
+    ],
+    "image": [
+      "fhir.png"
+    ],
+    "other": [
+      "fhir.css"
+    ]
+  }
+}


### PR DESCRIPTION
This adds a new field to BaseAdvisor_40_50, `produceIllegalParameters`, which manages the conversion of 'illegal' parameters 'Illegal' parameters are those whose code is not in the following list: 

```java
"apply", "path-resource", "path-pages", "path-tx-cache", "expansion-parameter", "rule-broken-links", "generate-xml", "generate-json", "generate-turtle", "html-template"
```

By default, any parameters not in that list will be added as an extension. However, if the flag `produceIllegalParameters` is set to true, the parameter will be added as is.