### PR TITLE
Warn CLI users if file.encoding is not UTF-8

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/FileFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/FileFormat.java
@@ -1,0 +1,21 @@
+package org.hl7.fhir.utilities;
+
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class FileFormat {
+
+  public static boolean fileEncodingIsUtf8() {
+    return Charset.defaultCharset().equals(StandardCharsets.UTF_8);
+  }
+
+  public static void checkCharsetAndWarnIfNotUTF8(PrintStream out) {
+    if (fileEncodingIsUtf8()) return;
+    out.println("");
+    out.println("WARNING: Default file encoding is " + Charset.defaultCharset() + " which may cause unexpected results. ");
+    out.println("         To fix this issue, run this program with the parameter '-Dfile.encoding=UTF-8'");
+    out.println("         Future releases may not be able to run at all with encoding " + Charset.defaultCharset());
+    out.println("");
+  }
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/FileFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/FileFormatTest.java
@@ -1,0 +1,33 @@
+package org.hl7.fhir.utilities;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class FileFormatTest {
+  @Test
+  public void testCurrentFileFormat() throws IOException {
+    ByteArrayOutputStream bo = new ByteArrayOutputStream();
+
+    FileFormat.checkCharsetAndWarnIfNotUTF8(new PrintStream(bo));
+
+    bo.flush();
+    String allWrittenLines = new String(bo.toByteArray());
+
+    if (Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
+      assertEquals(0, allWrittenLines.length());
+    }
+    else
+    {
+      assertThat(allWrittenLines, containsString("WARNING"));
+    }
+  }
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/FileFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/FileFormatTest.java
@@ -22,11 +22,13 @@ public class FileFormatTest {
     bo.flush();
     String allWrittenLines = new String(bo.toByteArray());
 
+    assertAWarningIsGivenWhenNotUTF8(allWrittenLines);
+  }
+
+  private static void assertAWarningIsGivenWhenNotUTF8(String allWrittenLines) {
     if (Charset.defaultCharset().equals(StandardCharsets.UTF_8)) {
       assertEquals(0, allWrittenLines.length());
-    }
-    else
-    {
+    } else {
       assertThat(allWrittenLines, containsString("WARNING"));
     }
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -61,6 +61,7 @@ POSSIBILITY OF SUCH DAMAGE.
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.terminologies.JurisdictionUtilities;
+import org.hl7.fhir.utilities.FileFormat;
 import org.hl7.fhir.utilities.TimeTracker;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
@@ -153,6 +154,8 @@ public class ValidatorCli {
     }
 
     CliContext cliContext = Params.loadCliContext(args);
+
+    FileFormat.checkCharsetAndWarnIfNotUTF8(System.out);
 
     if (shouldDisplayHelpToUser(args)) {
       Display.displayHelpDetails();


### PR DESCRIPTION
Since having a file.encoding other that UTF-8 can occasionally result in hard-to-diagnose errors, the Validator CLI will now check the default encoding, and print a warning if it is anything else.