### PR TITLE
Fix intermittent failure of SnapshotGenerationTests

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
@@ -546,7 +546,7 @@ public class SnapShotGenerationTests {
     }
     if (!fail) {
       test.output = output;
-      TestingUtilities.getSharedWorkerContext().cacheResource(output);
+
       File dst = new File(TestingUtilities.tempFile("snapshot", test.getId() + "-expected.xml"));
       if (dst.exists())
         dst.delete();


### PR DESCRIPTION
DO NOT MERGE YET

There may be more places where IWorkerContext re-use is being mutated.