### PR TITLE
When we load StructureMaps from mapping files, make the mapping langu…

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -81,6 +81,7 @@ import org.hl7.fhir.r4.model.ExpressionNode;
 import org.hl7.fhir.r4.model.ExpressionNode.CollectionStatus;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Narrative.NarrativeStatus;
 import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.Reference;
@@ -742,6 +743,12 @@ public class StructureMapUtilities {
 		while (!lexer.done()) {
 			parseGroup(result, lexer);    
 		}
+
+		Narrative textNode = result.getText();
+		textNode.setStatus(Narrative.NarrativeStatus.ADDITIONAL);
+		XhtmlNode node = new XhtmlNode(NodeType.Element, "div");
+		textNode.setDiv(node);
+		node.pre().tx(text);
 
 		return result;
 	}


### PR DESCRIPTION
…age the narrative.

Right now the narrative is empty, which is useless.  Retaining the map file information is the most human readable mechanism we have for StructureMaps