### PR TITLE
Use a copy of worker context from TestingUtilities instead of an actual instance

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -301,10 +301,11 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       canRunWithoutTerminology = other.canRunWithoutTerminology;
       noTerminologyServer = other.noTerminologyServer;
       if (other.txCache != null)
-        txCache = other.txCache.copy();
+        txCache = other.txCache;
       expandCodesLimit = other.expandCodesLimit;
       logger = other.logger;
       expParameters = other.expParameters;
+      ucumService = other.ucumService;
     }
   }
   

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -165,6 +165,9 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
   
   protected void copy(SimpleWorkerContext other) {
     super.copy(other);
+    loadedPackages.clear();
+    loadedPackages.addAll(other.loadedPackages);
+    userAgent = other.userAgent;
     questionnaire = other.questionnaire;
     binaries.putAll(other.binaries);
     version = other.version;
@@ -173,6 +176,9 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
     validatorFactory = other.validatorFactory;
   }
 
+  public SimpleWorkerContext copy() throws IOException {
+    return new SimpleWorkerContext(this);
+  }
 
   public List<String> getLoadedPackages() {
     return loadedPackages;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
@@ -102,7 +102,14 @@ public class TestingUtilities extends BaseTestingUtilities {
         IWorkerContext fcontext = getWorkerContext(version);
         fcontexts.put(v, fcontext);
     }
-    return fcontexts.get(v);
+    try {
+      SimpleWorkerContext copyOfContext = ((SimpleWorkerContext) fcontexts.get(v)).copy();
+      return copyOfContext;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new Error(e);
+    }
+    //return fcontexts.get(v);
   }
 
   public static IWorkerContext getWorkerContext(String version) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.fhir.ucum.UcumException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.PathEngineException;
+import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.formats.XmlParser;
 import org.hl7.fhir.r5.model.*;
@@ -88,17 +89,19 @@ public class FHIRPathTests {
 
     @Override
     public ValueSet resolveValueSet(Object appContext, String url) {
-      return TestingUtilities.getSharedWorkerContext().fetchResource(ValueSet.class, url);
+      return sharedWorkerContext.fetchResource(ValueSet.class, url);
     }
 
   }
 
+  private static IWorkerContext sharedWorkerContext;
   private static FHIRPathEngine fp;
   private final Map<String, Resource> resources = new HashMap<String, Resource>();
 
   @BeforeAll
   public static void setUp() {
-    fp = new FHIRPathEngine(TestingUtilities.getSharedWorkerContext());
+    sharedWorkerContext = TestingUtilities.getSharedWorkerContext();
+    fp = new FHIRPathEngine(sharedWorkerContext);
   }
 
   public static Stream<Arguments> data() throws ParserConfigurationException, SAXException, IOException {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/SnapShotGenerationTests.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.exceptions.PathEngineException;
 import org.hl7.fhir.r5.conformance.ProfileUtilities;
 import org.hl7.fhir.r5.conformance.ProfileUtilities.ProfileKnowledgeProvider;
+import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.test.utils.TestPackageLoader;
 import org.hl7.fhir.r5.formats.IParser.OutputStyle;
 import org.hl7.fhir.r5.formats.JsonParser;
@@ -211,13 +212,13 @@ public class SnapShotGenerationTests {
 
     @Override
     public boolean isDatatype(String name) {
-      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchTypeDefinition(name);
+      StructureDefinition sd = sharedWorkerContext.fetchTypeDefinition(name);
       return (sd != null) && (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION) && (sd.getKind() == StructureDefinitionKind.PRIMITIVETYPE || sd.getKind() == StructureDefinitionKind.COMPLEXTYPE);
     }
 
     @Override
     public boolean isResource(String typeSimple) {
-      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchTypeDefinition(typeSimple);
+      StructureDefinition sd = sharedWorkerContext.fetchTypeDefinition(typeSimple);
       return (sd != null) && (sd.getDerivation() == TypeDerivationRule.SPECIALIZATION) && (sd.getKind() == StructureDefinitionKind.RESOURCE);
     }
 
@@ -249,7 +250,7 @@ public class SnapShotGenerationTests {
 
     @Override
     public String getLinkForProfile(StructureDefinition profile, String url) {
-      StructureDefinition sd = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, url);
+      StructureDefinition sd = sharedWorkerContext.fetchResource(StructureDefinition.class, url);
       if (sd == null)
         return url + "|" + url;
       else
@@ -275,15 +276,15 @@ public class SnapShotGenerationTests {
     public Resource fetchFixture(String id) {
       TestFetchMode mode = TestFetchMode.INPUT;
       if (id.equals("patient"))
-        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient");
+        return sharedWorkerContext.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Patient");
       if (id.equals("valueset"))
-        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet");
+        return sharedWorkerContext.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/ValueSet");
       if (id.equals("organization"))
-        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Organization");
+        return sharedWorkerContext.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Organization");
       if (id.equals("operationoutcome"))
-        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/OperationOutcome");
+        return sharedWorkerContext.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/OperationOutcome");
       if (id.equals("parameters"))
-        return TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Parameters");
+        return sharedWorkerContext.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/Parameters");
 
       if (id.contains("-")) {
         String[] p = id.split("\\-");
@@ -339,7 +340,7 @@ public class SnapShotGenerationTests {
     @Override
     public TypeDetails checkFunction(Object appContext, String functionName, List<TypeDetails> parameters) throws PathEngineException {
       if ("fixture".equals(functionName))
-        return new TypeDetails(CollectionStatus.SINGLETON, TestingUtilities.getSharedWorkerContext().getResourceNamesAsSet());
+        return new TypeDetails(CollectionStatus.SINGLETON, sharedWorkerContext.getResourceNamesAsSet());
       return null;
     }
 
@@ -366,7 +367,7 @@ public class SnapShotGenerationTests {
 
     @Override
     public boolean conformsToProfile(Object appContext, Base item, String url) throws FHIRException {
-      IResourceValidator val = TestingUtilities.getSharedWorkerContext().newValidator();
+      IResourceValidator val = sharedWorkerContext.newValidator();
       List<ValidationMessage> valerrors = new ArrayList<ValidationMessage>();
       if (item instanceof Resource) {
         val.validate(appContext, valerrors, (Resource) item, url);
@@ -399,12 +400,14 @@ public class SnapShotGenerationTests {
 
   }
 
+  private static IWorkerContext sharedWorkerContext;
   private static FHIRPathEngine fp;
   private List<ValidationMessage> messages;
 
   @BeforeAll
   public static void setUp() {
-    fp = new FHIRPathEngine(TestingUtilities.getSharedWorkerContext());
+    sharedWorkerContext = TestingUtilities.getSharedWorkerContext();
+    fp = new FHIRPathEngine(sharedWorkerContext);
   }
 
   public static Stream<Arguments> data() throws ParserConfigurationException, IOException, FHIRFormatError, SAXException {
@@ -462,7 +465,7 @@ public class SnapShotGenerationTests {
   private void testSort(TestDetails test, SnapShotGenerationTestsContext context) throws DefinitionException, FHIRException, IOException {
     StructureDefinition base = getSD(test.getSource().getBaseDefinition(), context);
     test.setOutput(test.getSource().copy());
-    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), null, null);
+    ProfileUtilities pu = new ProfileUtilities(sharedWorkerContext, null, null);
     pu.setIds(test.getSource(), false);
     List<String> errors = new ArrayList<String>();
     pu.sortDifferential(base, test.getOutput(), test.getOutput().getUrl(), errors, false);
@@ -476,17 +479,17 @@ public class SnapShotGenerationTests {
   private void testGen(boolean fail, TestDetails test, SnapShotGenerationTestsContext context) throws Exception {
     if (!Utilities.noString(test.register)) {
       List<ValidationMessage> messages = new ArrayList<ValidationMessage>();
-      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, null);
+      ProfileUtilities pu = new ProfileUtilities(sharedWorkerContext, messages, null);
       pu.setNewSlicingProcessing(true);
       for (StructureDefinition sd : test.included) {
         pu.setIds(sd, false);
       }
       for (StructureDefinition sd : test.included) {
-        if (!TestingUtilities.getSharedWorkerContext().hasResource(StructureDefinition.class, sd.getUrl())) {
-          TestingUtilities.getSharedWorkerContext().cacheResource(sd);
+        if (!sharedWorkerContext.hasResource(StructureDefinition.class, sd.getUrl())) {
+          sharedWorkerContext.cacheResource(sd);
         }
       }
-      StructureDefinition base = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, test.included.get(0).getBaseDefinition());
+      StructureDefinition base = sharedWorkerContext.fetchResource(StructureDefinition.class, test.included.get(0).getBaseDefinition());
       if (base != null) {
         pu.generateSnapshot(base, test.included.get(0), test.included.get(0).getUrl(), "http://test.org/profile", test.included.get(0).getName());
       }
@@ -505,16 +508,16 @@ public class SnapShotGenerationTests {
       throw new Exception("URL mismatch on base: " + base.getUrl() + " wanting " + test.getSource().getBaseDefinition());
 
     StructureDefinition output = test.getSource().copy();
-    ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, new TestPKP());
+    ProfileUtilities pu = new ProfileUtilities(sharedWorkerContext, messages, new TestPKP());
     pu.setNewSlicingProcessing(test.isNewSliceProcessing());
     pu.setThrowException(false);
     pu.setDebug(test.isDebug());
     pu.setIds(test.getSource(), false);
-    if (!TestingUtilities.getSharedWorkerContext().hasPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER)) {
+    if (!sharedWorkerContext.hasPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER)) {
       NpmPackage npm = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION).loadPackage(CommonPackages.ID_XVER, CommonPackages.VER_XVER);
-      TestingUtilities.getSharedWorkerContext().loadFromPackage(npm, new TestPackageLoader(new String[]{"StructureDefinition"}), new String[]{"StructureDefinition"});
+      sharedWorkerContext.loadFromPackage(npm, new TestPackageLoader(new String[]{"StructureDefinition"}), new String[]{"StructureDefinition"});
     }
-    pu.setXver(new XVerExtensionManager(TestingUtilities.getSharedWorkerContext()));
+    pu.setXver(new XVerExtensionManager(sharedWorkerContext));
     if (test.isSort()) {
       List<String> errors = new ArrayList<String>();
       int lastCount = output.getDifferential().getElement().size();
@@ -539,14 +542,14 @@ public class SnapShotGenerationTests {
       throw e;
     }
     if (output.getDifferential().hasElement()) {
-      RenderingContext rc = new RenderingContext(TestingUtilities.getSharedWorkerContext(), null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
+      RenderingContext rc = new RenderingContext(sharedWorkerContext, null, null, "http://hl7.org/fhir", "", null, ResourceRendererMode.END_USER);
       rc.setDestDir(Utilities.path("[tmp]", "snapshot"));
-      rc.setProfileUtilities(new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), null, new TestPKP()));
+      rc.setProfileUtilities(new ProfileUtilities(sharedWorkerContext, null, new TestPKP()));
       RendererFactory.factory(output, rc).render(output);
     }
     if (!fail) {
       test.output = output;
-      TestingUtilities.getSharedWorkerContext().cacheResource(output);
+      sharedWorkerContext.cacheResource(output);
       File dst = new File(TestingUtilities.tempFile("snapshot", test.getId() + "-expected.xml"));
       if (dst.exists())
         dst.delete();
@@ -563,14 +566,14 @@ public class SnapShotGenerationTests {
   private StructureDefinition getSD(String url, SnapShotGenerationTestsContext context) throws DefinitionException, FHIRException, IOException {
     StructureDefinition sd = context.getByUrl(url);
     if (sd == null) {
-      sd = TestingUtilities.getSharedWorkerContext().fetchResource(StructureDefinition.class, url);
+      sd = sharedWorkerContext.fetchResource(StructureDefinition.class, url);
     } 
     if (sd == null) {
       throw new DefinitionException("Unable to find profile "+url);
     }
     if (!sd.hasSnapshot()) {
       StructureDefinition base = getSD(sd.getBaseDefinition(), context);
-      ProfileUtilities pu = new ProfileUtilities(TestingUtilities.getSharedWorkerContext(), messages, new TestPKP());
+      ProfileUtilities pu = new ProfileUtilities(sharedWorkerContext, messages, new TestPKP());
       pu.setNewSlicingProcessing(true);
       List<String> errors = new ArrayList<String>();
       pu.sortDifferential(base, sd, url, errors, false);


### PR DESCRIPTION
Currently when TestingUtilities provides a IWorkerContext, it provides a reference to an instance. This can cause problems down the line if a test loads a package that interferes with the results of another test, as tests are run in random order.

This change makes TestingUtilities provide a copy of a standard worker context instead, which means that individual tests will load packages to a copy of a context, instead of a single shared instance, preventing the issues above.