### PR TITLE
Fix problem with SVG rendering

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
@@ -483,7 +483,6 @@ public class XhtmlParser {
     for (String an : node.getAttributes().keySet()) {
       if (an.equals("xmlns")) {
         result.def(node.getAttribute(an));
-        nsattrs.add(an);
       }
       if (an.startsWith("xmlns:")) {
         result.ns(an.substring(6), node.getAttribute(an));


### PR DESCRIPTION
The SVG namespace was getting stripped from included SVG files - and hyperlinks were not working when using img instead of include.