### PR TITLE
Remove excluded tests

### DIFF
--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.validation.cli.model.FileInfo;
 import org.hl7.fhir.validation.cli.model.ValidationRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -74,6 +75,7 @@ class ValidationServiceTest {
   }
 
   @Test
+  @DisplayName("Test that conversion works when a single source is set and the -output param is set")
   public void convertSingleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
@@ -86,6 +88,7 @@ class ValidationServiceTest {
   }
 
   @Test
+  @DisplayName("Test that conversion throws an Exception when no -output or -outputSuffix params are set")
   public void convertSingleSourceNoOutput() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
@@ -100,7 +103,8 @@ class ValidationServiceTest {
 
 
   @Test
-  public void convertMultipleSourceNoSuffix() throws Exception {
+  @DisplayName("Test that conversion throws an Exception when multiple sources are set and an -output param is set")
+  public void convertMultipleSourceOnlyOutput() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -113,6 +117,7 @@ class ValidationServiceTest {
   }
 
   @Test
+  @DisplayName("Test that conversion works when multiple sources are set and an output suffix parameter is set")
   public void convertMultipleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
@@ -126,6 +131,7 @@ class ValidationServiceTest {
   }
 
   @Test
+  @DisplayName("Test that snapshot generation works when a single source is set and the -output param is set")
   public void generateSnapshotSingleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
@@ -139,9 +145,8 @@ class ValidationServiceTest {
     verify(validationEngine).handleOutput(structureDefinition, DUMMY_OUTPUT, DUMMY_SV);
   }
 
-  //FIXME THIS TEST SHOULD NOT BE DISABLED
   @Test
-  @Disabled
+  @DisplayName("Test that snapshot generation throws an Exception when no -output or -outputSuffix params are set")
   public void generateSnapshotSingleSourceNoOutput() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
@@ -149,12 +154,13 @@ class ValidationServiceTest {
 
     CliContext cliContext = getCliContextSingleSource();
     Exception exception = assertThrows( Exception.class, () -> {
-      validationService.generateSnapshot(cliContext.setOutput(DUMMY_OUTPUT).setSv(DUMMY_SV),validationEngine);
+      validationService.generateSnapshot(cliContext.setSv(DUMMY_SV),validationEngine);
     });
   }
 
   @Test
-  public void generateSnapshotMultipleSourceNoSuffix() throws Exception {
+  @DisplayName("Test that snapshot generation throws an Exception when multiple sources are set and an -output param is set")
+  public void generateSnapshotMultipleSourceOnlyOutput() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -167,6 +173,7 @@ class ValidationServiceTest {
   }
 
   @Test
+  @DisplayName("Test that snapshot generation works when multiple sources are set and an output suffix parameter is set")
   public void generateSnapshotMultipleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -8,7 +8,6 @@ import org.hl7.fhir.validation.cli.model.CliContext;
 import org.hl7.fhir.validation.cli.model.FileInfo;
 import org.hl7.fhir.validation.cli.model.ValidationRequest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -16,10 +15,14 @@ import org.mockito.Mockito;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 import static org.hl7.fhir.validation.tests.utilities.TestUtilities.getTerminologyCacheDirectory;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -8,6 +8,7 @@ import org.hl7.fhir.validation.cli.model.CliContext;
 import org.hl7.fhir.validation.cli.model.FileInfo;
 import org.hl7.fhir.validation.cli.model.ValidationRequest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -138,7 +139,9 @@ class ValidationServiceTest {
     verify(validationEngine).handleOutput(structureDefinition, DUMMY_OUTPUT, DUMMY_SV);
   }
 
+  //FIXME THIS TEST SHOULD NOT BE DISABLED
   @Test
+  @Disabled
   public void generateSnapshotSingleSourceNoOutput() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/utils/DisplayTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/utils/DisplayTests.java
@@ -1,6 +1,5 @@
 package org.hl7.fhir.validation.cli.utils;
 
-import org.hl7.fhir.validation.cli.utils.Display;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -391,41 +391,35 @@
                             for forked tests -->
                             <argLine>${argLine} -Xmx4096m -XX:+UseConcMarkSweepGC</argLine>
                             <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                            <excludes>
-                                <exclude>org/hl7/fhir/validation/cli/**</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>surefire-java-9-plus</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven_surefire_version}</version>
-                        <configuration>
-                            <forkCount>1</forkCount>
-                            <reuseForks>true</reuseForks>
-                            <parallel>classes</parallel>
-                            <trimStackTrace>false</trimStackTrace>
-                            <testFailureIgnore>false</testFailureIgnore>
-                            <!-- We need to include the ${argLine} here so the Jacoco test arguments are included in the
-                             Surefire testing run. This may appear as an error in some IDEs, but it will run regardless.
-                            -->
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    <profile>
+        <id>surefire-java-9-plus</id>
+        <activation>
+            <jdk>[9,)</jdk>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven_surefire_version}</version>
+                    <configuration>
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <parallel>classes</parallel>
+                        <trimStackTrace>false</trimStackTrace>
+                        <testFailureIgnore>false</testFailureIgnore>
+                        <!-- We need to include the ${argLine} here so the Jacoco test arguments are included in the
+                         Surefire testing run. This may appear as an error in some IDEs, but it will run regardless.
+                        -->
                             <argLine>${argLine} -Xmx4096m</argLine>
                             <systemPropertyVariables>
                                 <java.locale.providers>COMPAT</java.locale.providers>
                             </systemPropertyVariables>
                             <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                            <excludes>
-                                <exclude>org/hl7/fhir/validation/cli/**</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
There is an exclusion for tests in /validation/cli, which results in tests that can be executed in an IDE, but that aren't actually run by our builds. This removes that exclusion to allow those tests to run.