### PR TITLE
Do not delete previously undefined xmlns attributes when processing Xhtml nodes

### DIFF
--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/XhtmlNodeTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/XhtmlNodeTest.java
@@ -13,6 +13,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 
+import static org.junit.Assert.assertEquals;
+
 public class XhtmlNodeTest {
 
   private static final Logger ourLog = LoggerFactory.getLogger(XhtmlNodeTest.class);
@@ -110,8 +112,31 @@ public class XhtmlNodeTest {
   @Test
   public void testParseEntities() throws FHIRFormatError, IOException {
     XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "entities.html"), "div");
-  }
-    
 
+  }
+
+  @Test
+  public void testParseSvg() throws FHIRFormatError, IOException {
+    XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "svg.html"), "svg");
+
+    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(1).getAttributes().get("xmlns"));
+    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+  }
+
+  @Test
+  public void testParseSvgNotRoot() throws FHIRFormatError, IOException {
+    XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "non-root-svg.html"), "div");
+
+    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
+    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+  }
+
+  @Test
+  public void testParseNamespacedSvgNotRoot() throws FHIRFormatError, IOException {
+    XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "namespaced-non-root-svg.html"), "div");
+
+    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
+    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+  }
 
 }


### PR DESCRIPTION
By default, xmlns attributes are stripped from an XHTML node.

Previously, only the xmlns attribute was added back when:

1. It was a root node.
2. It was a non-root node and its namespace was different than the default.

In the case of SVG nodes, this resulted in necessary namespaces like xlink being stripped.

This change adds back any namespaces that haven't been defined in the parent node.
