### PR TITLE
fix np and index out of bound exception

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/ParserBase.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/ParserBase.java
@@ -227,7 +227,7 @@ public abstract class ParserBase {
     if (!"id".equals(e.getName())) {
       return true;
     }
-    if (path.contains(".")) {
+    if (path!=null && path.contains(".")) {
       return idPolicy.forInner();
     } else {
       return idPolicy.forRoot();

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -1680,7 +1680,7 @@ public class StructureMapUtilities {
         case EVALUATE:
           ExpressionNode expr = (ExpressionNode) tgt.getUserData(MAP_EXPRESSION);
           if (expr == null) {
-            expr = fpe.parse(getParamStringNoNull(vars, tgt.getParameter().get(1), tgt.toString()));
+            expr = fpe.parse(getParamStringNoNull(vars, tgt.getParameter().get(tgt.getParameter().size() - 1), tgt.toString()));
             tgt.setUserData(MAP_EXPRESSION, expr);
           }
           List<Base> v = fpe.evaluate(vars, null, null, tgt.getParameter().size() == 2 ? getParam(vars, tgt.getParameter().get(0)) : new BooleanType(false), expr);


### PR DESCRIPTION
while switching to the lastest org.hl7.fhir.core we noticed in our tests a nullpointer exception and index out of bound exceptions happened:

1.  ParserBase excepts a path, but this is not set when within root
2. The expression is in the first getParameter element if the size is only one (should apply same logic as in analyzeTransform https://github.com/hapifhir/org.hl7.fhir.core/blame/master/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java#L2352)