### PR TITLE
Update to Java 11 Minimum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,16 +18,16 @@
     <packaging>pom</packaging>
 
     <properties>
-        <hapi_fhir_version>5.4.0</hapi_fhir_version>
+        <hapi_fhir_version>6.2.1</hapi_fhir_version>
         <validator_test_case_version>1.1.127-SNAPSHOT</validator_test_case_version>
         <junit_jupiter_version>5.7.1</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>
         <maven_clean_version>3.1.0</maven_clean_version>
-        <jacoco_version>0.8.7</jacoco_version>
+        <jacoco_version>0.8.8</jacoco_version>
         <info_cqframework_version>1.5.1</info_cqframework_version>
         <lombok_version>1.18.22</lombok_version>
-        <byte_buddy_version>1.10.21</byte_buddy_version>
+        <byte_buddy_version>1.12.14</byte_buddy_version>
         <apache_poi_version>4.1.1</apache_poi_version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
         <lombok_version>1.18.22</lombok_version>
         <byte_buddy_version>1.12.14</byte_buddy_version>
         <apache_poi_version>4.1.1</apache_poi_version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <name>HL7 Core Artifacts</name>
@@ -162,10 +165,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.10.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                     <forceJavacCompilerUse>false</forceJavacCompilerUse>
                     <encoding>UTF-8</encoding>
                     <!-- Allows running the compiler in a separate process. If false it uses the built in compiler,
@@ -368,34 +370,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>surefire-java-8</id>
-            <activation>
-                <jdk>(,1.8]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven_surefire_version}</version>
-                        <configuration>
-                            <forkCount>1</forkCount>
-                            <reuseForks>true</reuseForks>
-                            <parallel>classes</parallel>
-                            <trimStackTrace>false</trimStackTrace>
-                            <testFailureIgnore>false</testFailureIgnore>
-                            <!-- We need to include the ${argLine} here so the Jacoco test arguments are included in the
-                             Surefire testing run. This may appear as an error in some IDEs, but it will run regardless.
-                            -->
-                            <!-- UseConcMarkSweepGC is required for Java 8 builds, or else garbage collection will fail
-                            for forked tests -->
-                            <argLine>${argLine} -Xmx4096m -XX:+UseConcMarkSweepGC</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
     <profile>
         <id>surefire-java-9-plus</id>
         <activation>


### PR DESCRIPTION
This change drops Java 8 support, and requires a Java 11 build.