### PR TITLE
Correct GraphQL Schema Validation Errors

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -298,12 +298,12 @@ public class GraphQLSchemaGenerator {
       List<StringBuilder> list = new ArrayList<>();
       StringBuilder b = new StringBuilder();
       list.add(b);
-      b.append("type ");
-      b.append(sd.getName());
-      StructureDefinition sdp = context.fetchResource(StructureDefinition.class, sd.getBaseDefinition());
-      if (sdp != null) {
+      b.append("interface ");
+      b.append(sd.getName() + "Base");
+      StructureDefinition baseSd = context.fetchResource(StructureDefinition.class, sd.getBaseDefinition());
+      if (baseSd != null) {
         b.append(" implements ");
-        b.append(sdp.getType());
+        b.append(baseSd.getType() + "Base");
       }
       b.append(" {\r\n");
       ElementDefinition ed = sd.getSnapshot().getElementFirstRep();
@@ -311,6 +311,17 @@ public class GraphQLSchemaGenerator {
       b.append("}");
       b.append("\r\n");
       b.append("\r\n");
+
+      b.append("type ");
+      b.append(sd.getName());
+      b.append(" implements ");
+      b.append(sd.getName() + "Base");
+      b.append(" {\r\n");
+      generateProperties(existingTypeNames, list, b, sd.getName(), sd, ed, "type", "");
+      b.append("}");
+      b.append("\r\n");
+      b.append("\r\n");
+
       for (StringBuilder bs : list) {
         writer.write(bs.toString());
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -277,8 +277,14 @@ public class GraphQLSchemaGenerator {
 
   private void generateElementBase(Writer writer, EnumSet<FHIROperationType> operations) throws IOException {
     if (operations.contains(FHIROperationType.READ) || operations.contains(FHIROperationType.SEARCH)) {
+      writer.write("interface IElement {\r\n");
+      writer.write("  id: String\r\n");
+      writer.write("  extension: [Extension]\r\n");
+      writer.write("}\r\n");
+      writer.write("\r\n");
+
       writer.write("type ElementBase {\r\n");
-      writer.write("  id: ID\r\n");
+      writer.write("  id: String\r\n");
       writer.write("  extension: [Extension]\r\n");
       writer.write("}\r\n");
       writer.write("\r\n");
@@ -299,12 +305,8 @@ public class GraphQLSchemaGenerator {
       StringBuilder b = new StringBuilder();
       list.add(b);
       b.append("interface ");
-      b.append(sd.getName() + "Base");
-      StructureDefinition baseSd = context.fetchResource(StructureDefinition.class, sd.getBaseDefinition());
-      if (baseSd != null) {
-        b.append(" implements ");
-        b.append(baseSd.getType() + "Base");
-      }
+      b.append("I" + sd.getName());
+      generateTypeSuperinterfaceDeclaration(sd, b);
       b.append(" {\r\n");
       ElementDefinition ed = sd.getSnapshot().getElementFirstRep();
       generateProperties(existingTypeNames, list, b, sd.getName(), sd, ed, "type", "");
@@ -314,8 +316,7 @@ public class GraphQLSchemaGenerator {
 
       b.append("type ");
       b.append(sd.getName());
-      b.append(" implements ");
-      b.append(sd.getName() + "Base");
+      generateTypeSuperinterfaceDeclaration(sd, b);
       b.append(" {\r\n");
       generateProperties(existingTypeNames, list, b, sd.getName(), sd, ed, "type", "");
       b.append("}");
@@ -345,6 +346,23 @@ public class GraphQLSchemaGenerator {
       }
     }
 
+  }
+
+  private void generateTypeSuperinterfaceDeclaration(StructureDefinition theParentSd, StringBuilder theBuilder) {
+    StructureDefinition baseSd = theParentSd;
+    boolean first = true;
+    while (baseSd != null && baseSd.getBaseDefinition() != null) {
+      baseSd = context.fetchResource(StructureDefinition.class, baseSd.getBaseDefinition());
+      if (baseSd != null) {
+        if (first) {
+          theBuilder.append(" implements ");
+          first = false;
+        } else {
+          theBuilder.append(" & ");
+        }
+        theBuilder.append("I" + baseSd.getType());
+      }
+    }
   }
 
   private void generateProperties(Map<String, String> existingTypeNames, List<StringBuilder> list, StringBuilder b, String typeName, StructureDefinition sd, ElementDefinition ed, String mode, String suffix) throws IOException {


### PR DESCRIPTION
The current GraphQL schema generator generates schemas that fail validation. The issue is that inheritance in GraphQL has to be done with interfaces (ie you can't extend a type, only an interface) so fragments like the following don't work:

(Ignore the line numbers, they are a fragment of HAPI's logging)

```
52: type Age implements Quantity {
53:   id: String
54:   extension: [Extension]
55:   value: decimal  _value: ElementBase
56:   comparator: code  _comparator: ElementBase
57:   unit: String  _unit: ElementBase
58:   system: uri  _system: ElementBase
59:   code: code  _code: ElementBase
60: }
```

```
743: type Quantity implements Element {
744:   id: String
745:   extension: [Extension]
746:   value: decimal  _value: ElementBase
747:   comparator: code  _comparator: ElementBase
748:   unit: String  _unit: ElementBase
749:   system: uri  _system: ElementBase
750:   code: code  _code: ElementBase
751: }
```

As it turns out, inheritance in GraphQL is pretty bizarre:
* Only interfaces can really do any kind of true inheritance
* Interface inheritance is transitive but is required to be explicit (e.g. if `Dog` implements `Animal` and `Animal` implements `LivingThing`, then it's an error for `Dog` to not also explcitly implement `LivingThing`)
* Elements defined in an interface have to be repeated in the type definition that implenents that interface (ie you don't get them for free through the inheritance)

This PR resolves these issues so that the schema fully validates.


