### PR TITLE
fixes #1040 (NullPointerException while comparing profiles)

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/ProfileUtilities.java
@@ -4147,7 +4147,7 @@ public class ProfileUtilities extends TranslatingUtilities {
             if (!useTableForFixedValues || !allowSubRows || definition.getFixed().isPrimitive()) {
               String s = buildJson(definition.getFixed());
               String link = null;
-              if (Utilities.isAbsoluteUrl(s))
+              if (Utilities.isAbsoluteUrl(s) && pkp != null)
                 link = pkp.getLinkForUrl(corePath, s);
               c.getPieces().add(checkForNoChange(definition.getFixed(), gen.new Piece(link, s, null).addStyle("color: darkgreen")));
             } else {


### PR DESCRIPTION
fixes the issue #1040 (exception while comparing profiles, which constraint meta.profile to some fixed values)