### PR TITLE
Fix appending text in ProfileUtilities

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/ProfileUtilities.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/ProfileUtilities.java
@@ -891,7 +891,7 @@ public class ProfileUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -902,7 +902,7 @@ public class ProfileUtilities {
 
       if (derived.hasCommentsElement()) {
         if (derived.getComments().startsWith("..."))
-          base.setComments(base.getComments()+"\r\n"+derived.getComments().substring(3));
+          base.setComments(Utilities.appendDerivedTextToBase(base.getComments(), derived.getComments()));
         else if (!Base.compareDeep(derived.getCommentsElement(), base.getCommentsElement(), false))
           base.setCommentsElement(derived.getCommentsElement().copy());
         else if (trimDifferential)
@@ -913,7 +913,7 @@ public class ProfileUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -924,7 +924,7 @@ public class ProfileUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/ProfileUtilities.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/ProfileUtilities.java
@@ -892,7 +892,7 @@ public class ProfileUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -903,7 +903,7 @@ public class ProfileUtilities {
 
       if (derived.hasCommentsElement()) {
         if (derived.getComments().startsWith("..."))
-          base.setComments(base.getComments()+"\r\n"+derived.getComments().substring(3));
+          base.setComments(Utilities.appendDerivedTextToBase(base.getComments(), derived.getComments()));
         else if (!Base.compareDeep(derived.getCommentsElement(), base.getCommentsElement(), false))
           base.setCommentsElement(derived.getCommentsElement().copy());
         else if (trimDifferential)
@@ -914,7 +914,7 @@ public class ProfileUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -925,7 +925,7 @@ public class ProfileUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/conformance/ProfileUtilities.java
@@ -1214,7 +1214,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -1225,7 +1225,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasCommentElement()) {
         if (derived.getComment().startsWith("..."))
-          base.setComment(base.getComment()+"\r\n"+derived.getComment().substring(3));
+          base.setComment(Utilities.appendDerivedTextToBase(base.getComment(), derived.getComment()));
         else if (derived.hasCommentElement()!= base.hasCommentElement() || !Base.compareDeep(derived.getCommentElement(), base.getCommentElement(), false))
           base.setCommentElement(derived.getCommentElement().copy());
         else if (trimDifferential)
@@ -1236,7 +1236,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!base.hasLabelElement() || !Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -1247,7 +1247,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!base.hasRequirementsElement() || !Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/conformance/ProfileUtilities.java
@@ -1719,7 +1719,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -1730,7 +1730,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasCommentElement()) {
         if (derived.getComment().startsWith("..."))
-          base.setComment(base.getComment()+"\r\n"+derived.getComment().substring(3));
+          base.setComment(Utilities.appendDerivedTextToBase(base.getComment(), derived.getComment()));
         else if (derived.hasCommentElement()!= base.hasCommentElement() || !Base.compareDeep(derived.getCommentElement(), base.getCommentElement(), false))
           base.setCommentElement(derived.getCommentElement().copy());
         else if (trimDifferential)
@@ -1741,7 +1741,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!base.hasLabelElement() || !Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -1752,7 +1752,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!base.hasRequirementsElement() || !Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/conformance/ProfileUtilities.java
@@ -2918,7 +2918,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -2929,7 +2929,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasCommentElement()) {
         if (derived.getComment().startsWith("..."))
-          base.setComment(base.getComment()+"\r\n"+derived.getComment().substring(3));
+          base.setComment(Utilities.appendDerivedTextToBase(base.getComment(), derived.getComment()));
         else if (derived.hasCommentElement()!= base.hasCommentElement() || !Base.compareDeep(derived.getCommentElement(), base.getCommentElement(), false))
           base.setCommentElement(derived.getCommentElement().copy());
         else if (trimDifferential)
@@ -2940,7 +2940,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!base.hasLabelElement() || !Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -2951,7 +2951,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!base.hasRequirementsElement() || !Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -2062,7 +2062,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasDefinitionElement()) {
         if (derived.getDefinition().startsWith("..."))
-          base.setDefinition(base.getDefinition()+"\r\n"+derived.getDefinition().substring(3));
+          base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false))
           base.setDefinitionElement(derived.getDefinitionElement().copy());
         else if (trimDifferential)
@@ -2073,7 +2073,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasCommentElement()) {
         if (derived.getComment().startsWith("..."))
-          base.setComment(base.getComment()+"\r\n"+derived.getComment().substring(3));
+          base.setComment(Utilities.appendDerivedTextToBase(base.getComment(), derived.getComment()));
         else if (derived.hasCommentElement()!= base.hasCommentElement() || !Base.compareDeep(derived.getCommentElement(), base.getCommentElement(), false))
           base.setCommentElement(derived.getCommentElement().copy());
         else if (trimDifferential)
@@ -2084,7 +2084,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasLabelElement()) {
         if (derived.getLabel().startsWith("..."))
-          base.setLabel(base.getLabel()+"\r\n"+derived.getLabel().substring(3));
+          base.setLabel(Utilities.appendDerivedTextToBase(base.getLabel(), derived.getLabel()));
         else if (!base.hasLabelElement() || !Base.compareDeep(derived.getLabelElement(), base.getLabelElement(), false))
           base.setLabelElement(derived.getLabelElement().copy());
         else if (trimDifferential)
@@ -2095,7 +2095,7 @@ public class ProfileUtilities extends TranslatingUtilities {
 
       if (derived.hasRequirementsElement()) {
         if (derived.getRequirements().startsWith("..."))
-          base.setRequirements(base.getRequirements()+"\r\n"+derived.getRequirements().substring(3));
+          base.setRequirements(Utilities.appendDerivedTextToBase(base.getRequirements(), derived.getRequirements()));
         else if (!base.hasRequirementsElement() || !Base.compareDeep(derived.getRequirementsElement(), base.getRequirementsElement(), false))
           base.setRequirementsElement(derived.getRequirementsElement().copy());
         else if (trimDifferential)

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
@@ -65,6 +65,8 @@ import org.apache.commons.io.FileUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.utilities.FileNotifier.FileNotifier2;
 
+import javax.annotation.Nullable;
+
 public class Utilities {
 
   private static final String UUID_REGEX = "[0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12}";
@@ -1799,4 +1801,18 @@ public class Utilities {
     }
   }
 
+  /**
+   * Appends a text from a derived element to its base element.
+   *
+   * @param baseText The text set in the base element, or {@code null}.
+   * @param derivedText The text set in the derived element, starting with "...".
+   * @return The resulting text.
+   */
+  public static String appendDerivedTextToBase(@Nullable final String baseText,
+                                               final String derivedText) {
+    if (baseText == null) {
+      return derivedText.substring(3);
+    }
+    return baseText + "\r\n" + derivedText.substring(3);
+  }
 }


### PR DESCRIPTION
If the base text was null, appending a text in the derived element (using "...") would show a "null" before the text. This commit adds the method Utilities.appendDerivedTextToBase() to implement the correct behavior.

Example with:
```json
{
  "id": "MedicationStatement.implicitRules",
  "path": "MedicationStatement.implicitRules",
  "comment": "...All modifiers SHALL be documented in the profile",
  "max": "0"
}
```
![2022-12-23 18 54 53 build fhir org ef2ff575624c](https://user-images.githubusercontent.com/3299399/209384050-308a640e-6f74-469f-b21f-e8379340c914.png)
