### PR TITLE
Restore saxon dependency dropped by HAPI FHIR

### DIFF
--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -68,7 +68,6 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
             <optional>true</optional>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>xpp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
             <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Use saxon for xml processing -->
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>${saxon_he_version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -158,7 +165,7 @@
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
                 <version>${saxon_he_version}</version>
-                <scope>test</scope>
+
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This restores a Saxon dependency previously set in HAPI FHIR.

This impacts XSLT transforms which expect slightly different behaviours from instances produced by TransformerFactory.