### PR TITLE
Fix StructureDefinition40_50Test on Windows pipeline

### DIFF
--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/StructureDefinition40_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/StructureDefinition40_50Test.java
@@ -9,10 +9,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.text.StringEscapeUtils;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,8 +24,10 @@ public class StructureDefinition40_50Test {
   @Test
   @DisplayName("Test r5 -> r4 AuditEvent conversion.")
   public void testR5_R4() throws IOException {
-    byte[] r4_input = TextFile.streamToBytes(this.getClass().getResourceAsStream("/sd-xpath-constraint-r4.xml"));
-    byte[] r5_input = TextFile.streamToBytes(this.getClass().getResourceAsStream("/sd-xpath-constraint-r5.xml"));
+    //FIXME Do not keep this line separator output
+    System.out.println("SYSTEM LINE SEPARATOR: " + StringEscapeUtils.escapeJava(System.lineSeparator()));
+    byte[] r4_input = getLineSeparatorNormalizedBytes("/sd-xpath-constraint-r4.xml");
+    byte[] r5_input = getLineSeparatorNormalizedBytes("/sd-xpath-constraint-r5.xml");
 
     org.hl7.fhir.r5.model.StructureDefinition r5_actual = (org.hl7.fhir.r5.model.StructureDefinition) new org.hl7.fhir.r5.formats.XmlParser().parse(r5_input);
     org.hl7.fhir.r4.model.StructureDefinition r4_conv = (org.hl7.fhir.r4.model.StructureDefinition) VersionConvertorFactory_40_50.convertResource(r5_actual);
@@ -36,12 +40,17 @@ public class StructureDefinition40_50Test {
     assertArrayEquals(r4_input, r4_output);
   }
 
+  @Nullable
+  private byte[] getLineSeparatorNormalizedBytes(String fileName) throws IOException {
+    return new String(TextFile.streamToBytes(this.getClass().getResourceAsStream(fileName))).replace(System.lineSeparator(), "\n").getBytes();
+  }
+
 
   @Test
   @DisplayName("Test r4 -> r5 AuditEvent conversion.")
   public void testR4_R5() throws IOException {
-    byte[] r4_input = TextFile.streamToBytes(this.getClass().getResourceAsStream("/sd-xpath-constraint-r4.xml"));
-    byte[] r5_input = TextFile.streamToBytes(this.getClass().getResourceAsStream("/sd-xpath-constraint-r5.xml"));
+    byte[] r4_input = getLineSeparatorNormalizedBytes("/sd-xpath-constraint-r4.xml");
+    byte[] r5_input = getLineSeparatorNormalizedBytes("/sd-xpath-constraint-r5.xml");
 
     org.hl7.fhir.r4.model.StructureDefinition r4_actual = (org.hl7.fhir.r4.model.StructureDefinition) new org.hl7.fhir.r4.formats.XmlParser().parse(r4_input);
     org.hl7.fhir.r5.model.StructureDefinition r5_conv = (org.hl7.fhir.r5.model.StructureDefinition) VersionConvertorFactory_40_50.convertResource(r4_actual);


### PR DESCRIPTION
On the pipelines, and possibly on some developer machines, git may be configured to introduce CR characters into downloaded files. This results in errors when a byte-by-byte compare is made in tests.

In one of these breaking tests, the default system lineSeparator is replaced by the single java newline `/n` character to prevent this from impacting the test.