### PR TITLE
Add missing space to FHIRException message (matches r5 ResourceType now)

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/ResourceType.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/ResourceType.java
@@ -517,7 +517,7 @@ public enum ResourceType {
     if ("VisionPrescription".equals(code))
       return VisionPrescription;
 
-    throw new FHIRException("Unknown resource type"+code);
+    throw new FHIRException("Unknown resource type "+code);
   }
 
 }

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/ResourceType.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/ResourceType.java
@@ -612,7 +612,7 @@ public enum ResourceType {
     if ("VisionPrescription".equals(code))
       return VisionPrescription;
 
-    throw new FHIRException("Unknown resource type"+code);
+    throw new FHIRException("Unknown resource type "+code);
   }
 
 }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/ResourceType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/ResourceType.java
@@ -632,7 +632,7 @@ public enum ResourceType {
     if ("VisionPrescription".equals(code))
       return VisionPrescription;
 
-    throw new FHIRException("Unknown resource type"+code);
+    throw new FHIRException("Unknown resource type "+code);
   }
 
 }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ResourceType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/ResourceType.java
@@ -746,7 +746,7 @@ public enum ResourceType {
     if ("VisionPrescription".equals(code))
       return VisionPrescription;
 
-    throw new FHIRException("Unknown resource type"+code);
+    throw new FHIRException("Unknown resource type "+code);
   }
 
 }


### PR DESCRIPTION
There is a missing space in the FHIRException message in ResourceType for all versions of FHIR prior to r5.