### PR TITLE
Enhancements to StructureMap transform to support logical models as source and value set lookup

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServices.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServices.java
@@ -96,7 +96,7 @@ public class FFHIRPathHostServices implements FHIRPathEngine.IEvaluationContext 
 
   @Override
   public ValueSet resolveValueSet(Object appContext, String url) {
-    throw new Error("Not Implemented Yet");
+	return structureMapUtilities.getWorker().fetchResource(ValueSet.class, url);
   }
 
 }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServicesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServicesTest.java
@@ -1,0 +1,31 @@
+package org.hl7.fhir.r5.utils.structuremap;
+
+import java.io.IOException;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class FFHIRPathHostServicesTest {
+	  static private SimpleWorkerContext context;
+
+	  @BeforeAll
+	  static public void setUp() throws Exception {
+	    FilesystemPackageCacheManager pcm = new org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager(false);
+	    context = TestingUtilities.getWorkerContext(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
+	  }
+
+	  @Test
+	  public void testrResolveValueSet() throws IOException, FHIRException {
+	    StructureMapUtilities scu = new StructureMapUtilities(context);
+	    FFHIRPathHostServices fphs = new FFHIRPathHostServices(scu);
+	    ValueSet v = fphs.resolveValueSet(null, "http://hl7.org/fhir/ValueSet/FHIR-version");
+	    Assertions.assertNotNull(v);
+	    Assertions.assertEquals("http://hl7.org/fhir/ValueSet/FHIR-version", v.getUrl());
+	  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServicesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/structuremap/FFHIRPathHostServicesTest.java
@@ -12,20 +12,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class FFHIRPathHostServicesTest {
-	  static private SimpleWorkerContext context;
+  static private SimpleWorkerContext context;
 
-	  @BeforeAll
-	  static public void setUp() throws Exception {
-	    FilesystemPackageCacheManager pcm = new org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager(false);
-	    context = TestingUtilities.getWorkerContext(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
-	  }
+  @BeforeAll
+  static public void setUp() throws Exception {
+    FilesystemPackageCacheManager pcm = new org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager(false);
+    context = TestingUtilities.getWorkerContext(pcm.loadPackage("hl7.fhir.r4.core", "4.0.1"));
+  }
 
-	  @Test
-	  public void testrResolveValueSet() throws IOException, FHIRException {
-	    StructureMapUtilities scu = new StructureMapUtilities(context);
-	    FFHIRPathHostServices fphs = new FFHIRPathHostServices(scu);
-	    ValueSet v = fphs.resolveValueSet(null, "http://hl7.org/fhir/ValueSet/FHIR-version");
-	    Assertions.assertNotNull(v);
-	    Assertions.assertEquals("http://hl7.org/fhir/ValueSet/FHIR-version", v.getUrl());
-	  }
+  @Test
+  public void testrResolveValueSet() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    FFHIRPathHostServices fphs = new FFHIRPathHostServices(scu);
+    ValueSet v = fphs.resolveValueSet(null, "http://hl7.org/fhir/ValueSet/FHIR-version");
+    Assertions.assertNotNull(v);
+    Assertions.assertEquals("http://hl7.org/fhir/ValueSet/FHIR-version", v.getUrl());
+  }
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -630,7 +630,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     StructureDefinition sourceSD = getSourceResourceFromStructureMap(map);
     ParserBase parser = Manager.makeParser(context, cntType);
     if (sourceSD.getKind() == StructureDefinition.StructureDefinitionKind.LOGICAL) {
-    	parser.setLogical(sourceSD);
+      parser.setLogical(sourceSD);
     }
     org.hl7.fhir.r5.elementmodel.Element src = parser.parseSingle(new ByteArrayInputStream(source));    
     scu.transform(null, src, map, resource);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.elementmodel.ObjectConverter;
+import org.hl7.fhir.r5.elementmodel.ParserBase;
 import org.hl7.fhir.r5.elementmodel.SHCParser;
 import org.hl7.fhir.r5.formats.FormatUtilities;
 import org.hl7.fhir.r5.formats.IParser.OutputStyle;
@@ -623,10 +624,15 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
   public org.hl7.fhir.r5.elementmodel.Element transform(byte[] source, FhirFormat cntType, String mapUri) throws FHIRException, IOException {
     List<Base> outputs = new ArrayList<>();
     StructureMapUtilities scu = new StructureMapUtilities(context, new TransformSupportServices(outputs, mapLog, context));
-    org.hl7.fhir.r5.elementmodel.Element src = Manager.parseSingle(context, new ByteArrayInputStream(source), cntType);
     StructureMap map = context.fetchResource(StructureMap.class, mapUri);
     if (map == null) throw new Error("Unable to find map " + mapUri + " (Known Maps = " + context.listMapUrls() + ")");
     org.hl7.fhir.r5.elementmodel.Element resource = getTargetResourceFromStructureMap(map);
+    StructureDefinition sourceSD = getSourceResourceFromStructureMap(map);
+    ParserBase parser = Manager.makeParser(context, cntType);
+    if (sourceSD.getKind() == StructureDefinition.StructureDefinitionKind.LOGICAL) {
+    	parser.setLogical(sourceSD);
+    }
+    org.hl7.fhir.r5.elementmodel.Element src = parser.parseSingle(new ByteArrayInputStream(source));    
     scu.transform(null, src, map, resource);
     resource.populatePaths(null);
     return resource;
@@ -655,6 +661,39 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
 
     return Manager.build(getContext(), structureDefinition);
   }
+  
+  private StructureDefinition getSourceResourceFromStructureMap(StructureMap map) {
+	StructureMap.StructureMapGroupComponent g = map.getGroup().get(0);
+	String type = null;
+	for (StructureMap.StructureMapGroupInputComponent inp : g.getInput()) {
+	  if (inp.getMode() == StructureMap.StructureMapInputMode.SOURCE)
+	    if (type != null)
+	      throw new DefinitionException("This engine does not support multiple source inputs");
+	    else
+	      type = inp.getType();
+	}	  
+	  
+	String sourceTypeUrl = null;
+	for (StructureMap.StructureMapStructureComponent component : map.getStructure()) {
+	  if (component.getMode() == StructureMap.StructureMapModelMode.SOURCE
+	      && component.getAlias().equalsIgnoreCase(type)) {
+	    sourceTypeUrl = component.getUrl();
+	    break;
+	  }
+	}
+	    
+	StructureDefinition structureDefinition = null;
+	for (StructureDefinition sd : this.context.fetchResourcesByType(StructureDefinition.class)) {
+	  if (sd.getUrl().equalsIgnoreCase(sourceTypeUrl)) {
+	    structureDefinition = sd;
+	  	break;
+	  }
+	}
+
+	if (structureDefinition == null) throw new FHIRException("Unable to find StructureDefinition for source type ('" + sourceTypeUrl + "')");
+	return structureDefinition;
+  }
+
 
   public Resource generate(String source, String version) throws FHIRException, IOException, EOperationOutcome {
     Content cnt = igLoader.loadContent(source, "validate", false);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/r5/test/StructureMappingTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/r5/test/StructureMappingTests.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.xml.XMLUtil;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.instance.InstanceValidatorFactory;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -127,26 +128,47 @@ public class StructureMappingTests {
     assertTrue(msg, Utilities.noString(msg));
   }
   @Test
+  void testTransformLogicalSource() throws Exception {
+    String map = "map \"http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/cda2qr\" = \"cda2qr\"\n"
+    		+ "\n"
+    		+ "uses \"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse\" alias QuestionnaireResponse as target\n"
+    		+ "uses \"http://hl7.org/fhir/cdatest/StructureDefinition/ClinicalDocument\" alias ClinicalDocument as source\n"
+    		+ "\n"
+    		+ "group ClinicalDocument(source src : ClinicalDocument, target tgt : QuestionnaireResponse) {\n"
+    		+ "  src -> tgt.status = 'in-progress' \"code\";\n"
+    		+ "}";
+    StructureMap r = null;   
+	try {
+	  r = new StructureMapUtilities(context).parse(map, "cda2qr");
+	  context.cacheResource(r);	      
+	  byte[] byteSource = "{}".getBytes();
+	  org.hl7.fhir.r5.elementmodel.Element element = validationEngine.transform(byteSource, FhirFormat.JSON, r.getUrl());
+	  Assertions.assertNotNull(element);
+	} finally {
+	  context.dropResource(r);
+	}      
+  }  
+  @Test
   void testGetSourceResourceFromStructureMapDefinitionException() {
-      StructureMap r = new StructureMap().setUrl("testGetSourceResourceFromStructureMapDefinitionException");      
-      StructureMap.StructureMapGroupComponent g = r.addGroup();
-      g.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setType("input");
-      g.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setType("input");
-      r.addStructure()
-      	.setMode(StructureMap.StructureMapModelMode.TARGET)
-      	.setUrl("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
-      context.cacheResource(r);
-      StructureDefinition structureDefinition = new StructureDefinition();
-      structureDefinition.setUrl("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
-      structureDefinition.getSnapshot().addElement().setPath("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
-      context.cacheResource(structureDefinition);
-      byte[] byteSource = "testGetSourceResourceFromStructureMapDefinitionException".getBytes();
-	  DefinitionException thrown = assertThrows(
-			 DefinitionException.class,
-             () -> validationEngine.transform(byteSource, FhirFormat.JSON, r.getUrl()),
-             "Expected transform() to throw DefinitionException"
-      );
-
-      assertTrue(thrown.getMessage().contentEquals("This engine does not support multiple source inputs"));
+    StructureMap r = new StructureMap().setUrl("testGetSourceResourceFromStructureMapDefinitionException");      
+    StructureMap.StructureMapGroupComponent g = r.addGroup();
+    g.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setType("input");
+    g.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setType("input");
+    r.addStructure()
+      .setMode(StructureMap.StructureMapModelMode.TARGET)
+      .setUrl("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
+    context.cacheResource(r);
+    StructureDefinition structureDefinition = new StructureDefinition().setUrl("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
+    structureDefinition.getSnapshot().addElement().setPath("testGetSourceResourceFromStructureMapDefinitionExceptionTarget");
+    context.cacheResource(structureDefinition);
+    byte[] byteSource = "testGetSourceResourceFromStructureMapDefinitionException".getBytes();
+    DefinitionException thrown = assertThrows(
+    		DefinitionException.class,
+    		() -> validationEngine.transform(byteSource, FhirFormat.JSON, r.getUrl()),
+    		"Expected transform() to throw DefinitionException"
+    		);
+    context.dropResource(r);
+    context.dropResource(structureDefinition);
+    assertTrue(thrown.getMessage().contentEquals("This engine does not support multiple source inputs"));
   }
 }


### PR DESCRIPTION
1. Implements org.hl7.fhir.r5.utils.structuremap.FFHIRPathHostServices.resolveValueSet (taken from AHDIS Matchbox).
2. Sets logical structure definition in input parser when input source is a logical model.

Current behavior for JSON inputs that are instances of a logical model is to look for resourceType, which will cause an exception if not present.

Enhancement extracts the input source type from the first group in the structure map, finds the Structure Definition by URI and sets ParserBase logical property to that Structure Definition if kind is logical. This bypasses the later check for resourceType during the transform execution.