### PR TITLE
CDA Logical model validation: if choice is only value don't add type

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/utils/NodeStack.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/utils/NodeStack.java
@@ -111,11 +111,15 @@ public class NodeStack {
     else if (element.getProperty().isChoice()) {
       String n = res.literalPath.substring(res.literalPath.lastIndexOf(".") + 1);
       String en = element.getProperty().getName();
-      en = en.substring(0, en.length() - 3);
-      String t = n.substring(en.length());
-      if (isPrimitiveType(Utilities.uncapitalize(t)))
-        t = Utilities.uncapitalize(t);
-      res.literalPath = res.literalPath.substring(0, res.literalPath.lastIndexOf(".")) + "." + en + ".ofType(" + t + ")";
+      if (en.endsWith("[x]")) {
+        en = en.substring(0, en.length() - 3);
+        String t = n.substring(en.length());
+        if (isPrimitiveType(Utilities.uncapitalize(t)))
+          t = Utilities.uncapitalize(t);
+        res.literalPath = res.literalPath.substring(0, res.literalPath.lastIndexOf(".")) + "." + en + ".ofType(" + t + ")";
+      } else {
+        res.literalPath = res.literalPath.substring(0, res.literalPath.lastIndexOf(".")) + "." + en;;
+      }
     }
     res.logicalPaths = new ArrayList<String>();
     if (type != null) {


### PR DESCRIPTION
When validating CDA documents the validator gives a validation error that here is a path mismatch:

> ClinicalDocument.component.structuredBody.component[0].section.component[0].section.entry[0].act.entryRelationship[1].observation.referenceRange[0].observationRange.value  -  
> 
> localStack.getLiteralPath: 
> 
> ClinicalDocument.component.structuredBody.component[0].section.component[0].section.entry[0].act.entryRelationship[1].observation.referenceRange[0].observationRange.va.ofType(lue)
> 
> at org.hl7.fhir.validation.instance.InstanceValidator.checkChildByDefinition([InstanceValidator.java:5478]
> 


observationRange.value is defined as a choice, but not ending with [x], thats why the value element gets modififed to **va.ofType(lue)**. This PR does not substract the three chars from value and does not add the Type.

See related discussion on [CDA-core model](https://github.com/HL7/CDA-core-2.0/pull/39).
 
