### PR TITLE
FML lexer source element delimiter support

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -1280,8 +1280,10 @@ public class StructureMapUtilities {
       source.setElement(node.toString());
       lexer.token(")");
     } else if (lexer.hasToken(".")) {
-      lexer.token(".");
-      source.setElement(lexer.take());
+      lexer.token(".");      
+      String el = (lexer.getCurrent().startsWith("\"") || lexer.getCurrent().startsWith("`")) 
+    		  ? lexer.processConstant(lexer.take()) : lexer.take();
+      source.setElement(el);
     }
     if (lexer.hasToken(":")) {
       // type and cardinality

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -1281,9 +1281,7 @@ public class StructureMapUtilities {
       lexer.token(")");
     } else if (lexer.hasToken(".")) {
       lexer.token(".");      
-      String el = (lexer.getCurrent().startsWith("\"") || lexer.getCurrent().startsWith("`")) 
-    		  ? lexer.processConstant(lexer.take()) : lexer.take();
-      source.setElement(el);
+      source.setElement(readIdentifierEM(lexer.take(), lexer));
     }
     if (lexer.hasToken(":")) {
       // type and cardinality
@@ -1589,6 +1587,13 @@ public class StructureMapUtilities {
       return s;
     else
       return lexer.processConstant(s);
+  }
+  
+  private String readIdentifierEM(String s, FHIRLexer lexer) throws FHIRLexerException {
+    if (s.startsWith("\"") || s.startsWith("`")) 
+      return lexer.processConstant(s);
+	else
+	  return s;
   }
 
   public StructureDefinition getTargetType(StructureMap map) throws FHIRException {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -106,6 +106,25 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
 //    System.out.println(map);
 //    assertSerializeDeserialize(map);
   }
+  
+  @Test
+  public void testSourceElementDelimiter() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(context, this);
+    String fileMap = "map \"http://github.com/FHIR/testSourceElementDelimiter\" = \"testSourceElementDelimiter\"\r\n"
+    		+ "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias Patient as source\r\n"
+    		+ "uses \"http://hl7.org/fhir/StructureDefinition/Basic\" alias Basic as target\r\n"
+    		+ "group Patient(source src : Patient, target tgt : Basic) {\r\n"
+    		+ "  src.identifier -> tgt.identifier;\r\n"    		
+    		+ "  src.\"-quote\" -> tgt.quote;\r\n"
+    		+ "  src.`-backtick` -> tgt.backtick;\r\n"
+    		+ "}";
+    System.out.println(fileMap);
+
+    StructureMap structureMap = scu.parse(fileMap, "testSourceElementDelimiter");
+    Assertions.assertEquals("identifier", structureMap.getGroup().get(0).getRule().get(0).getSourceFirstRep().getElement());
+    Assertions.assertEquals("-quote", structureMap.getGroup().get(0).getRule().get(1).getSourceFirstRep().getElement());
+    Assertions.assertEquals("-backtick", structureMap.getGroup().get(0).getRule().get(2).getSourceFirstRep().getElement());
+  }
 
 
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
@@ -819,7 +819,7 @@ public class IgLoader {
       else
         throw new FHIRException("Unsupported format for " + fn);
       r = VersionConvertorFactory_10_50.convertResource(res, new org.hl7.fhir.convertors.misc.IGR2ConvertorAdvisor5());
-    } else if (fhirVersion.startsWith("5.0")) {
+    } else if (fhirVersion.startsWith("5.0") || fhirVersion.equals("current")) {
       if (fn.endsWith(".xml") && !fn.endsWith("template.xml"))
         r = new XmlParser().parse(new ByteArrayInputStream(content));
       else if (fn.endsWith(".json") && !fn.endsWith("template.json"))


### PR DESCRIPTION
FML mapping.g4 grammar indicates source element can be alphanumeric IDENTIFIER or DELIMITEDIDENTIFIER surrounded by doublequote or backtick.

Current behavior: src."-quote" in FML map file becomes "element": "\\"-quote\\"" in Structure Map, which causes input source key mismatch due to expected doublequotes.

Implemented fix: src."-quote" in map becomes "element": "-quote" (without escaping) in Structure Map, which allows input source JSON data {"-quote": "value"}.