### PR TITLE
Fix https for terminology server

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactory.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactory.java
@@ -60,7 +60,7 @@ public class TerminologyClientFactory {
   private static String checkEndsWith(String term, String url) {
     if (url.endsWith(term))
       return url;
-    if (url.startsWith("http://tx.fhir.org"))
+    if (url.startsWith("http://tx.fhir.org") || url.startsWith("https://tx.fhir.org"))
       return Utilities.pathURL(url, term);
     if (url.equals("http://local.fhir.org:8080"))
       return Utilities.pathURL(url, term);

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
@@ -13,6 +13,6 @@ public class TerminologyClientFactoryTest {
   public void testMakeClient() throws URISyntaxException {
     TerminologyClient terminologyClient = TerminologyClientFactory.makeClient("https://tx.fhir.org", "dummyUserAgent", FhirPublication.R4);
     String expectedAddress = "https://tx.fhir.org/r4";
-    assertEquals(expectedAddress, terminologyClient.getAddress();
+    assertEquals(expectedAddress, terminologyClient.getAddress());
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
@@ -3,16 +3,72 @@ package org.hl7.fhir.convertors.txClient;
 import org.hl7.fhir.r5.terminologies.TerminologyClient;
 import org.hl7.fhir.utilities.FhirPublication;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TerminologyClientFactoryTest {
-  @Test
-  public void testMakeClient() throws URISyntaxException {
-    TerminologyClient terminologyClient = TerminologyClientFactory.makeClient("https://tx.fhir.org", "dummyUserAgent", FhirPublication.R4);
-    String expectedAddress = "https://tx.fhir.org/r4";
+
+  public static Stream<Arguments> data() throws ParserConfigurationException, SAXException, IOException {
+    List<Arguments> objects = new ArrayList<>();
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r4", "tx.fhir.org", FhirPublication.R4));
+    objects.addAll(getHttpAndHttpsArgs("tx.fhir.org", null, "tx.fhir.org/r4"));
+    objects.addAll(getHttpAndHttpsArgs("tx.fhir.org/r4", null, "tx.fhir.org/r4"));
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r2", "tx.fhir.org", FhirPublication.DSTU2));
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r3", "tx.fhir.org", FhirPublication.DSTU2016May));
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r4", "tx.fhir.org", FhirPublication.R4B));
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r4", "tx.fhir.org", FhirPublication.R5));
+    objects.addAll(getDefaultServerArgs("tx.fhir.org/r3", "tx.fhir.org", FhirPublication.STU3));
+    objects.addAll(getHttpAndHttpsArgs("someserver.org", FhirPublication.R4, "someserver.org"));
+    objects.addAll(getHttpAndHttpsArgs("someserver.org", null, "someserver.org"));
+    return objects.stream();
+  }
+
+  private static List<Arguments> getDefaultServerArgs(String explicitUrl, String baseUrl, FhirPublication fhirPublication) {
+    List<Arguments> objects = new ArrayList<>();
+    objects.addAll(getHttpAndHttpsArgs(baseUrl, fhirPublication, explicitUrl));
+    objects.addAll(getHttpAndHttpsArgs(explicitUrl, fhirPublication, explicitUrl));
+    return objects;
+  }
+
+  private static List<Arguments> getHttpAndHttpsArgs(String baseUrl, FhirPublication fhirPublication, String baseExpectedAddress) {
+    return List.of(
+      Arguments.of("https://" + baseUrl, fhirPublication, "https://" + baseExpectedAddress),
+      Arguments.of("http://" + baseUrl, fhirPublication, "http://" + baseExpectedAddress)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMakeClient(String url, FhirPublication fhirPublication, String expectedAddress) throws URISyntaxException {
+    TerminologyClient terminologyClient = TerminologyClientFactory.makeClient(url, "dummyUserAgent", fhirPublication);
     assertEquals(expectedAddress, terminologyClient.getAddress());
+  }
+
+  @Test
+  public void testMakeClientDstu1Fails() throws URISyntaxException {
+    assertThrows(Error.class, () -> {
+        TerminologyClient terminologyClient = TerminologyClientFactory.makeClient("urldoesnotmatter", "dummyUserAgent", FhirPublication.DSTU1);
+      }
+    );
+  }
+
+  @Test
+  public void testMakeClientNullFails() throws URISyntaxException {
+    assertThrows(Error.class, () -> {
+        TerminologyClient terminologyClient = TerminologyClientFactory.makeClient("urldoesnotmatter", "dummyUserAgent", FhirPublication.NULL);
+      }
+    );
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
@@ -1,0 +1,18 @@
+package org.hl7.fhir.convertors.txClient;
+
+import org.hl7.fhir.r5.terminologies.TerminologyClient;
+import org.hl7.fhir.utilities.FhirPublication;
+import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TerminologyClientFactoryTest {
+  @Test
+  public void testMakeClient() throws URISyntaxException {
+    TerminologyClient terminologyClient = TerminologyClientFactory.makeClient("https://tx.fhir.org", "dummyUserAgent", FhirPublication.R4);
+    String expectedAddress = "https://tx.fhir.org/r4";
+    assertEquals(expectedAddress, terminologyClient.getAddress();
+  }
+}

--- a/org.hl7.fhir.validation.cli/pom.xml
+++ b/org.hl7.fhir.validation.cli/pom.xml
@@ -310,7 +310,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <maven.compiler.testRelease>11</maven.compiler.testRelease>
         <maven.compiler.testSource>11</maven.compiler.testSource>
         <maven.compiler.testTarget>11</maven.compiler.testTarget>
+        <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
     </properties>
 
     <name>HL7 Core Artifacts</name>
@@ -228,7 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${maven-jar-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Connecting to the terminology server via https was failing due to the processing in TerminologyClient.checkEndsWith

This adds tests for expected terminology servers hosted on tx.fhir.org and fixes the https issue.