### PR TITLE
Add checkstyle plugin

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <property name="severity" value="error"/>
+    <property name="charset" value="UTF-8"/>
+    <property name="fileExtensions" value="java, properties, xml, js, json"/>
+    <module name="TreeWalker">
+        <!--
+        <module name="TodoComment">-->
+            <!-- The (?i) below means Case Insensitive -->
+        <!--<property name="format" value="(?i)FIXME"/>
+-->
+  <module name="RegexpSinglelineJava">
+      <property name="format" value="org\.jetbrains\.annotations\.NotNull"/>
+  </module>
+  <module name="RegexpSinglelineJava">
+      <property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
+  </module>
+  <module name="RegexpSinglelineJava">
+      <property name="format" value="org\.jetbrains\.annotations\.\*"/>
+  </module>
+</module>
+</module>

--- a/org.hl7.fhir.convertors/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.convertors/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.dstu2/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.dstu2/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.dstu2016may/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.dstu2016may/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.dstu3/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.dstu3/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.r4/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.r4/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.r4b/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.r4b/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.r5/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.r5/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.report/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.report/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  
+</suppressions>

--- a/org.hl7.fhir.utilities/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.utilities/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+
+</suppressions>

--- a/org.hl7.fhir.validation.cli/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.validation.cli/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+
+</suppressions>

--- a/org.hl7.fhir.validation/checkstyle_suppressions.xml
+++ b/org.hl7.fhir.validation/checkstyle_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -183,9 +183,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                        <configuration>
+                            <failsOnError>true</failsOnError>
+                            <suppressionsLocation>${project.basedir}/checkstyle_suppressions.xml</suppressionsLocation>
+                            <enableRulesSummary>true</enableRulesSummary>
+                            <enableSeveritySummary>true</enableSeveritySummary>
+                            <consoleOutput>true</consoleOutput>
+                            <configLocation>${project.basedir}/../checkstyle.xml</configLocation>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -416,6 +429,7 @@
                 </executions>
             </plugin>
         </plugins>
+
     </build>
 
     <profiles>


### PR DESCRIPTION
Recent updates to HAPI-FHIR added a checkstyle bump as well as additional rules, which broke the core build. 

This re-instates checkstyle with some basic rules that are core specific.