### PR TITLE
Break into build and test steps

### DIFF
--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -22,9 +22,19 @@ jobs:
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
+              options: '-DskipTests'
+              goals: 'install'
+
+          - task: Maven@3
+            inputs:
+              mavenPomFile: 'pom.xml'
+              mavenOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: '${{image.jdkVersion}}'
+              jdkArchitectureOption: 'x64'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              goals: 'install'
+              goals: 'test'
 
           - task: Maven@3
             inputs:

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -32,7 +32,7 @@ jobs:
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
-              options: '-pl -org.hl7.fhir.validation.cli'
+              options: '-pl "!org.hl7.fhir.validation.cli"'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               goals: 'test'

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -32,6 +32,7 @@ jobs:
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
+              options: '-pl -org.hl7.fhir.validation.cli'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               goals: 'test'


### PR DESCRIPTION
We are frequently experiencing closed connections during our builds, which means many fail inconsistently.

This may be caused by the http connections being kept open over a long build process.

This PR splits the build and tests; if all pipelines cleanly pass, this is likely an appropriate fix.