### PR TITLE
Fix codecov reporting for PR pipeline

### DIFF
--- a/org.hl7.fhir.report/pom.xml
+++ b/org.hl7.fhir.report/pom.xml
@@ -90,7 +90,7 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <configuration>
-                        <skip>true</skip>
+                        <skipStaging>true</skipStaging>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/org.hl7.fhir.report/pom.xml
+++ b/org.hl7.fhir.report/pom.xml
@@ -57,7 +57,7 @@
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
-                        <phase>prepare-package</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>package</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>


### PR DESCRIPTION
The PR pipeline is no longer reporting codecov code coverage.

This PR should fix that and reports should become available when it is ready to merge.