### PR TITLE
PR Build Refactor 2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/org.hl7.fhir.report/pom.xml
+++ b/org.hl7.fhir.report/pom.xml
@@ -90,7 +90,7 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <configuration>
-                        <skip>true</skip>
+                        <skipStaging>true</skipStaging>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -19,18 +19,30 @@ jobs:
             inputs:
               key: maven | $(Build.BuildId)
               path: $(MAVEN_CACHE_FOLDER)
-          # Runs 'mvn test'
+          # Runs 'mvn install'
           - task: Maven@3
             inputs:
               mavenPomFile: 'pom.xml'
-              options: '-pl "!org.hl7.fhir.validation.cli" -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+              options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
               mavenOptions: '-Xmx3072m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
-              goals: 'test'
+              goals: 'install'
+
+          - task: Maven@3
+            inputs:
+              mavenPomFile: 'pom.xml'
+              mavenOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: '${{image.jdkVersion}}'
+              jdkArchitectureOption: 'x64'
+              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+              publishJUnitResults: false
+              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              goals: 'exec:exec'
 
           # Upload test results to codecov
           - script: bash <(curl https://codecov.io/bash) -t $(codecov)
@@ -45,28 +57,4 @@ jobs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/jacoco.xml'
               reportDirectory: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/'
-
-          # Builds the CLI jar
-          - task: Maven@3
-            inputs:
-              mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx3072m'
-              javaHomeOption: 'JDKVersion'
-              jdkVersionOption: '${{image.jdkVersion}}'
-              jdkArchitectureOption: 'x64'
-              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              publishJUnitResults: false
-              goals: 'install'
-
-          # Executes the CLI jar
-          - task: Maven@3
-            inputs:
-              mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx3072m'
-              javaHomeOption: 'JDKVersion'
-              jdkVersionOption: '${{image.jdkVersion}}'
-              jdkArchitectureOption: 'x64'
-              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              publishJUnitResults: false
-              goals: 'exec:exec'
 

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -11,7 +11,7 @@ pr:
 # Azure doesn't always have the same Java versions on each system, so they are enumerated for each system independently.
 jobs:
   - job: setup
-    displayName: setup-and-cache-build
+    displayName: cache-maven-dependencies
     pool:
       vmImage: ubuntu-latest
     steps:
@@ -28,13 +28,23 @@ jobs:
       - task: Maven@3
         inputs:
           mavenPomFile: 'pom.xml'
+          options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
           mavenOptions: '-Xmx3072m'
-          options: '-pl "!org.hl7.fhir.validation.cli" -DskipTests -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: false
-          goals: 'install'
+          goals: 'dependency:resolve'
+      - task: Maven@3
+        inputs:
+          mavenPomFile: 'pom.xml'
+          options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+          mavenOptions: '-Xmx3072m'
+          javaHomeOption: 'JDKVersion'
+          jdkVersionOption: '1.11'
+          jdkArchitectureOption: 'x64'
+          publishJUnitResults: false
+          goals: 'dependency:resolve-plugins'
   - template: pull-request-pipeline-parameterized.yml
     parameters:
       images:


### PR DESCRIPTION
This reduces the setup stage to only downloading dependencies.

Subsequent stages will still do complete builds, but will hopefully not have to download dependencies in parallel. This should also restore codecov and jacoco, and fix the multiple jacoco reports issue that flew under the radar until now.