### PR TITLE
Output literal datatypes for anyURI types in RDF examples

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -505,6 +505,8 @@ public class TurtleParser extends ParserBase {
       xst = "^^xsd:decimal";
     else if (type.equals("base64Binary"))
       xst = "^^xsd:base64Binary";
+    else if (type.equals("canonical") || type.equals("oid") || type.equals("uri") || type.equals("url") || type.equals("uuid"))
+  	  xst = "^^xsd:anyURI";
     else if (type.equals("instant"))
       xst = "^^xsd:dateTime";
     else if (type.equals("time"))


### PR DESCRIPTION
This is a small correction to the previous PR #1110 related to Jira ticket https://jira.hl7.org/browse/FHIR-39075.