### PR TITLE
FML lexer source element delimiter support (update)

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -69,18 +69,11 @@ import org.hl7.fhir.r5.utils.FHIRLexer.FHIRLexerException;
 import org.hl7.fhir.r5.utils.FHIRPathEngine;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
 import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
-import org.hl7.fhir.utilities.SourceLocation;
 import org.hl7.fhir.utilities.Utilities;
-import org.hl7.fhir.utilities.VersionUtilities;
-import org.hl7.fhir.utilities.validation.ValidationMessage;
-import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
-import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
-import org.hl7.fhir.utilities.validation.ValidationMessage.Source;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.*;
 
@@ -1047,7 +1040,7 @@ public class StructureMapUtilities {
       lexer.token(")");
     } else if (lexer.hasToken(".")) {
       lexer.token(".");
-      source.setElement(lexer.take());
+      source.setElement(readAsStringOrProcessedConstant(lexer.take(), lexer));
     }
     if (lexer.hasToken(":")) {
       // type and cardinality
@@ -1090,6 +1083,12 @@ public class StructureMapUtilities {
     }
   }
 
+  private String readAsStringOrProcessedConstant(String s, FHIRLexer lexer) throws FHIRLexerException {
+    if (s.startsWith("\"") || s.startsWith("`"))
+      return lexer.processConstant(s);
+    else
+      return s;
+  }
  
   private void parseTarget(StructureMapGroupRuleComponent rule, FHIRLexer lexer) throws FHIRException {
     StructureMapGroupRuleTargetComponent target = rule.addTarget();

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -89,6 +89,25 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     assertSerializeDeserialize(map);
   }
 
+  @Test
+  public void testSourceElementDelimiter() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(context, this);
+    String fileMap = "map \"http://github.com/FHIR/testSourceElementDelimiter\" = \"testSourceElementDelimiter\"\r\n"
+      + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias Patient as source\r\n"
+      + "uses \"http://hl7.org/fhir/StructureDefinition/Basic\" alias Basic as target\r\n"
+      + "group Patient(source src : Patient, target tgt : Basic) {\r\n"
+      + "  src.identifier -> tgt.identifier;\r\n"
+      + "  src.\"-quote\" -> tgt.quote;\r\n"
+      + "  src.`-backtick` -> tgt.backtick;\r\n"
+      + "}";
+    System.out.println(fileMap);
+
+    StructureMap structureMap = scu.parse(fileMap, "testSourceElementDelimiter");
+    Assertions.assertEquals("identifier", structureMap.getGroup().get(0).getRule().get(0).getSourceFirstRep().getElement());
+    Assertions.assertEquals("-quote", structureMap.getGroup().get(0).getRule().get(1).getSourceFirstRep().getElement());
+    Assertions.assertEquals("-backtick", structureMap.getGroup().get(0).getRule().get(2).getSourceFirstRep().getElement());
+  }
+
   @Override
   public void log(String message) {
   }


### PR DESCRIPTION
Duplicates https://github.com/hapifhir/org.hl7.fhir.core/pull/1108, but with current code base and gentle renaming.

From original PR:

> FML mapping.g4 grammar indicates source element can be alphanumeric IDENTIFIER or DELIMITEDIDENTIFIER surrounded by doublequote or backtick.

> Current behavior: src."-quote" in FML map file becomes "element": "\"-quote\"" in Structure Map, which causes input source key mismatch due to expected doublequotes.

> Implemented fix: src."-quote" in map becomes "element": "-quote" (without escaping) in Structure Map, which allows input source JSON data {"-quote": "value"}.