### PR TITLE
Bump Maven memory heap

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -90,7 +90,7 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype'
-      mavenOptions: '-Xmx4072m'
+      mavenOptions: '-Xmx4096m'
       publishJUnitResults: false
 
   # Deploy the SNAPSHOT artifact to GitHub packages.
@@ -104,5 +104,5 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -Dmaven.test.skip -DdeployToGitHub'
-      mavenOptions: '-Xmx4072m'
+      mavenOptions: '-Xmx4096m'
       publishJUnitResults: false

--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -90,6 +90,7 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype'
+      mavenOptions: '-Xmx4072m'
       publishJUnitResults: false
 
   # Deploy the SNAPSHOT artifact to GitHub packages.
@@ -103,4 +104,5 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -Dmaven.test.skip -DdeployToGitHub'
+      mavenOptions: '-Xmx4072m'
       publishJUnitResults: false

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -24,7 +24,7 @@ jobs:
             inputs:
               mavenPomFile: 'pom.xml'
               options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              mavenOptions: '-Xmx3072m'
+              mavenOptions: '-Xmx4072m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
@@ -35,7 +35,7 @@ jobs:
           - task: Maven@3
             inputs:
               mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx3072m'
+              mavenOptions: '-Xmx4072m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -24,7 +24,7 @@ jobs:
             inputs:
               mavenPomFile: 'pom.xml'
               options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              mavenOptions: '-Xmx4072m'
+              mavenOptions: '-Xmx4096m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
@@ -35,7 +35,7 @@ jobs:
           - task: Maven@3
             inputs:
               mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx4072m'
+              mavenOptions: '-Xmx4096m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -39,7 +39,7 @@ jobs:
         inputs:
           mavenPomFile: 'pom.xml'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-          mavenOptions: '-Xmx4072m'
+          mavenOptions: '-Xmx4096m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -39,7 +39,7 @@ jobs:
         inputs:
           mavenPomFile: 'pom.xml'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-          mavenOptions: '-Xmx3072m'
+          mavenOptions: '-Xmx4072m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'

--- a/release-branch-pipeline.yml
+++ b/release-branch-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
         - task: Maven@3
           inputs:
             mavenPomFile: 'pom.xml'
-            mavenOptions: '-Xmx4072m'
+            mavenOptions: '-Xmx4096m'
             javaHomeOption: 'JDKVersion'
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'

--- a/release-branch-pipeline.yml
+++ b/release-branch-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
         - task: Maven@3
           inputs:
             mavenPomFile: 'pom.xml'
-            mavenOptions: '-Xmx3072m'
+            mavenOptions: '-Xmx4072m'
             javaHomeOption: 'JDKVersion'
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'


### PR DESCRIPTION
The Maven portion of the pipeline builds intermittently runs out of heap space. 

At a minimum, Azure machines have 7G available. This bumps our Maven heap space to 4G out of that.