### PR TITLE
Make url parameter type UriType, not StringType

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -1213,7 +1213,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       if (isTxCaching && cacheId != null && vs.getUrl() != null && cached.contains(vs.getUrl()+"|"+vs.getVersion())) {
         pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()+(vs.hasVersion() ? "|"+vs.getVersion() : "")));        
       } else if (options.getVsAsUrl()){
-        pin.addParameter().setName("url").setValue(new StringType(vs.getUrl()));
+        pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()));
       } else {
         pin.addParameter().setName("valueSet").setResource(vs);
         if (vs.getUrl() != null) {


### PR DESCRIPTION
Fixes bug with incorrect parameter type when POSTing a $validate-code request to a remote terminology server