### PR TITLE
Add check for DO_NOT_RELEASE comment

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,19 +9,18 @@
     <property name="charset" value="UTF-8"/>
     <property name="fileExtensions" value="java, properties, xml, js, json"/>
     <module name="TreeWalker">
-        <!--
-        <module name="TodoComment">-->
+        <module name="TodoComment">
             <!-- The (?i) below means Case Insensitive -->
-        <!--<property name="format" value="(?i)FIXME"/>
--->
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.NotNull"/>
-  </module>
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
-  </module>
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.\*"/>
-  </module>
-</module>
+            <property name="format" value="(?i)DO_NOT_RELEASE"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.NotNull"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.\*"/>
+        </module>
+    </module>
 </module>


### PR DESCRIPTION
This adds a checkstyle config that checks for any comments containing DO_NOT_RELEASE.

This should catch the following patterns with various whitespace variations and result in a failed build:

//DO_NOT_RELEASE
//TODO: DO_NOT_RELEASE
//FIXME: DO_NOT_RELEASE
