### PR TITLE
Balance heap space between Maven and Surefire

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -90,7 +90,7 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype'
-      mavenOptions: '-Xmx4096m'
+      mavenOptions: '-Xmx768m'
       publishJUnitResults: false
 
   # Deploy the SNAPSHOT artifact to GitHub packages.
@@ -104,5 +104,5 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -Dmaven.test.skip -DdeployToGitHub'
-      mavenOptions: '-Xmx4096m'
+      mavenOptions: '-Xmx768m'
       publishJUnitResults: false

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
                         <!-- We need to include the ${argLine} here so the Jacoco test arguments are included in the
                          Surefire testing run. This may appear as an error in some IDEs, but it will run regardless.
                         -->
-                            <argLine>${argLine} -Xmx4096m</argLine>
+                            <argLine>${argLine} -Xmx5632m</argLine>
                             <systemPropertyVariables>
                                 <java.locale.providers>COMPAT</java.locale.providers>
                             </systemPropertyVariables>

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -24,7 +24,7 @@ jobs:
             inputs:
               mavenPomFile: 'pom.xml'
               options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              mavenOptions: '-Xmx4096m'
+              mavenOptions: '-Xmx768m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
@@ -35,7 +35,7 @@ jobs:
           - task: Maven@3
             inputs:
               mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx4096m'
+              mavenOptions: '-Xmx768m'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
         inputs:
           mavenPomFile: 'pom.xml'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-          mavenOptions: '-Xmx3072m'
+          mavenOptions: '-Xmx768m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'

--- a/release-branch-pipeline.yml
+++ b/release-branch-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
         - task: Maven@3
           inputs:
             mavenPomFile: 'pom.xml'
-            mavenOptions: '-Xmx4096m'
+            mavenOptions: '-Xmx768m'
             javaHomeOption: 'JDKVersion'
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'


### PR DESCRIPTION
Maven and Surefire may be competing for heap space allocation the way we're set up now. From profiling, I can see Maven itself maxes out at 464MB, while it's being allocated 4G explicitly. This change explicitly limits the max heap for Maven it so it doesn't steal from the Surefire runner, and bumps the Surefire heap allocation by 1.5G.
