### PR TITLE
Make XhtmlNode validation case insensitive

### DIFF
--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/XhtmlNodeTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/tests/XhtmlNodeTest.java
@@ -3,6 +3,7 @@ package org.hl7.fhir.utilities.tests;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.FHIRFormatError;
@@ -12,8 +13,12 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.hl7.fhir.utilities.xhtml.XhtmlParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class XhtmlNodeTest {
 
@@ -28,12 +33,12 @@ public class XhtmlNodeTest {
     // Entity that appears in XHTML not not in XML
     XhtmlNode node = new XhtmlNode();
     node.setValueAsString("<div>&reg;</div>");
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">®</div>", node.getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">®</div>", node.getValueAsString());
 
     // Entity that appears in both
     node = new XhtmlNode();
     node.setValueAsString("<div>&lt;</div>");
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;</div>", node.getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">&lt;</div>", node.getValueAsString());
   }
 
   /**
@@ -43,24 +48,24 @@ public class XhtmlNodeTest {
   public void testLangAttributePreserved() {
     XhtmlNode dt = new XhtmlNode();
     dt.setValueAsString("<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en-US\">help i'm a bug</div>");
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en-US\">help i'm a bug</div>", dt.getValueAsString());
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en-US\">help i'm a bug</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en-US\">help i'm a bug</div>", dt.getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en-US\">help i'm a bug</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
   }
 
   @Test
   public void testParseRsquo() {
     XhtmlNode dt = new XhtmlNode();
     dt.setValueAsString("It&rsquo;s January again");
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">It’s January again</div>", dt.getValueAsString());
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">It’s January again</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">It’s January again</div>", dt.getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">It’s January again</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
   }
 
   @Test
   public void testProcessingInstructionNotPreserved() {
     XhtmlNode dt = new XhtmlNode();
     dt.setValueAsString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><div xmlns=\"http://www.w3.org/1999/xhtml\">help i'm a bug</div>");
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">help i'm a bug</div>", dt.getValueAsString());
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">help i'm a bug</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">help i'm a bug</div>", dt.getValueAsString());
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">help i'm a bug</div>", new XhtmlNode().setValue(dt.getValue()).getValueAsString());
   }
 
   @Test
@@ -75,7 +80,7 @@ public class XhtmlNodeTest {
     String output = node.getValueAsString();
 //    ourLog.info(output);
 
-    Assertions.assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\"><img src=\"http://pbs.twimg.com/profile_images/544507893991485440/r_vo3uj2_bigger.png\" alt=\"Twitter Avatar\"/>@fhirabend</div>", output);
+    assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\"><img src=\"http://pbs.twimg.com/profile_images/544507893991485440/r_vo3uj2_bigger.png\" alt=\"Twitter Avatar\"/>@fhirabend</div>", output);
   }
 
   @Test
@@ -119,24 +124,24 @@ public class XhtmlNodeTest {
   public void testParseSvg() throws FHIRFormatError, IOException {
     XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "svg.html"), "svg");
 
-    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(1).getAttributes().get("xmlns"));
-    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+    assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(1).getAttributes().get("xmlns"));
+    assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
   }
 
   @Test
   public void testParseSvgNotRoot() throws FHIRFormatError, IOException {
     XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "non-root-svg.html"), "div");
 
-    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
-    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+    assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
+    assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
   }
 
   @Test
   public void testParseNamespacedSvgNotRoot() throws FHIRFormatError, IOException {
     XhtmlNode x = new XhtmlParser().parse(BaseTestingUtilities.loadTestResource("xhtml", "namespaced-non-root-svg.html"), "div");
 
-    Assertions.assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
-    Assertions.assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
+    assertEquals("http://www.w3.org/2000/svg", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns"));
+    assertEquals("http://www.w3.org/1999/xlink", x.getChildNodes().get(0).getChildNodes().get(1).getAttributes().get("xmlns:xlink"));
   }
 
 
@@ -147,8 +152,23 @@ public class XhtmlNodeTest {
    
     
     String xml = new XhtmlComposer(false, false).compose(x);
-    Assertions.assertEquals(src.trim(), xml.trim());
+    assertEquals(src.trim(), xml.trim());
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "<div><SPAN ID=\"foo\">hello</SPAN></div> , true",
+    "<div><span id=\"foo\">hello</span></div> , true",
+    "<div><SPAN ONCLICK=\"hello()\">hello</SPAN></div> , false",
+    "<div><span onclick=\"hello()\">hello</span></div> , false"
+  })
+  public void testValidateIsCaseInsensitive(String theHtml, boolean theExpectedValid) {
+    XhtmlNode node = new XhtmlNode();
+    node.setValueAsString(theHtml);
+    ArrayList<String> errors = new ArrayList<>();
+    node.validate(errors, "", true, false, false);
+
+    assertEquals(theExpectedValid, errors.isEmpty());
+  }
   
 }


### PR DESCRIPTION
Currently the XhtmlNode#validate() method expects tag names to be lowercase, and all attributes to be lowercase except `ID` which has to be upper case. This PR makes this all case insensitive.

It also uses sets instead of lists for better performance.