### PR TITLE
For maven 3.9.0 plus, use wagon resolution (has retries)

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -89,7 +89,7 @@ steps:
       javaHomeOption: 'JDKVersion'
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
-      options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype'
+      options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype -Dmaven.resolver.transport=wagon'
       mavenOptions: '-Xmx768m'
       publishJUnitResults: false
 

--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -89,8 +89,8 @@ steps:
       javaHomeOption: 'JDKVersion'
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
-      options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype -Dmaven.resolver.transport=wagon'
-      mavenOptions: '-Xmx768m'
+      options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -DdeployToSonatype'
+      mavenOptions: '-Xmx768m -Dmaven.resolver.transport=wagon'
       publishJUnitResults: false
 
   # Deploy the SNAPSHOT artifact to GitHub packages.
@@ -104,5 +104,5 @@ steps:
       jdkVersionOption: '1.11'
       jdkArchitectureOption: 'x64'
       options: '--settings $(System.DefaultWorkingDirectory)/settings.xml -pl "!org.hl7.fhir.report, !org.hl7.fhir.validation.cli" -Dmaven.test.skip -DdeployToGitHub'
-      mavenOptions: '-Xmx768m'
+      mavenOptions: '-Xmx768m  -Dmaven.resolver.transport=wagon'
       publishJUnitResults: false

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -39,7 +39,7 @@ jobs:
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
-              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon'
               publishJUnitResults: false
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               goals: 'exec:exec'

--- a/pull-request-pipeline-parameterized.yml
+++ b/pull-request-pipeline-parameterized.yml
@@ -24,7 +24,7 @@ jobs:
             inputs:
               mavenPomFile: 'pom.xml'
               options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-              mavenOptions: '-Xmx768m'
+              mavenOptions: '-Xmx768m -Dmaven.resolver.transport=wagon'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
@@ -35,11 +35,11 @@ jobs:
           - task: Maven@3
             inputs:
               mavenPomFile: 'pom.xml'
-              mavenOptions: '-Xmx768m'
+              mavenOptions: '-Xmx768m -Dmaven.resolver.transport=wagon'
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '${{image.jdkVersion}}'
               jdkArchitectureOption: 'x64'
-              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon'
+              options: '-pl org.hl7.fhir.validation.cli -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
               publishJUnitResults: false
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               goals: 'exec:exec'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
         inputs:
           mavenPomFile: 'pom.xml'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-          mavenOptions: '-Xmx768m'
+          mavenOptions: '-Xmx768m  -Dmaven.resolver.transport=wagon'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'
@@ -39,7 +39,7 @@ jobs:
         inputs:
           mavenPomFile: 'pom.xml'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-          mavenOptions: '-Xmx4096m'
+          mavenOptions: '-Xmx4096m -Dmaven.resolver.transport=wagon'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           jdkArchitectureOption: 'x64'

--- a/release-branch-pipeline.yml
+++ b/release-branch-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
         - task: Maven@3
           inputs:
             mavenPomFile: 'pom.xml'
-            mavenOptions: '-Xmx768m'
+            mavenOptions: '-Xmx768m -Dmaven.resolver.transport=wagon'
             javaHomeOption: 'JDKVersion'
             jdkVersionOption: '1.11'
             jdkArchitectureOption: 'x64'


### PR DESCRIPTION
Some builds continue to fail with this: 

```
[ERROR] Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.0 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-resources-plugin:jar:3.3.0: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.0 from/to central (https://repo.maven.apache.org/maven2): Connection reset -> [Help 1]
```

It looks like some Azure machines run with Maven 3.9.0... this uses a default dependency resolved that potentially has NO RETRIES. See: https://questdb.io/blog/maven-troubleshooting-open-source/

This change should switch to the wagon resolver, which has retries (default of 3, which should be sufficient).