### PR TITLE
Bump JaCoCo Version

### DIFF
--- a/org.hl7.fhir.report/pom.xml
+++ b/org.hl7.fhir.report/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <jacoco_version>0.8.5</jacoco_version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>
         <maven_clean_version>3.1.0</maven_clean_version>
         <okhttp.version>4.9.3</okhttp.version>
-        <jacoco_version>0.8.8</jacoco_version>
+        <jacoco_version>0.8.9</jacoco_version>
         <info_cqframework_version>1.5.1</info_cqframework_version>
         <lombok_version>1.18.22</lombok_version>
         <byte_buddy_version>1.12.14</byte_buddy_version>


### PR DESCRIPTION
Bumps the JaCoCo version (maybe fixing our STDOUT errors in pipelines?) and fixes the reports pom.xml, which improperly set JaCoCo to a version out of sync with the rest of the project.