### PR TITLE
Get IPackageProvider from test resource properties file

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/PackageProvider.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/PackageProvider.java
@@ -1,0 +1,20 @@
+package org.hl7.fhir.r5.test.utils;
+
+import org.hl7.fhir.utilities.npm.BasePackageCacheManager;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+
+import java.io.IOException;
+
+public class PackageProvider implements FilesystemPackageCacheManager.IPackageProvider {
+
+  @Override
+  public boolean handlesPackage(String id, String version) {
+    return id.equals("hl7.fhir.r5.core");
+  }
+
+  @Override
+  public BasePackageCacheManager.InputStreamWithSrc provide(String id, String version) throws IOException {
+    return new BasePackageCacheManager.InputStreamWithSrc(TestingUtilities.loadR5CorePackageSource(), "Test Case Repository", "5.0.0");
+  }
+
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/TestingUtilities.java
@@ -25,20 +25,6 @@ import org.hl7.fhir.utilities.tests.TestConfig;
 
 public class TestingUtilities extends BaseTestingUtilities {
 
-  public static class PackageProvider implements IPackageProvider {
-
-    @Override
-    public boolean handlesPackage(String id, String version) {
-      return id.equals("hl7.fhir.r5.core");
-    }
-
-    @Override
-    public InputStreamWithSrc provide(String id, String version) throws IOException {
-      return new InputStreamWithSrc(TestingUtilities.loadR5CorePackageSource(), "Test Case Repository", "5.0.0");
-    }
-
-  }
-
   static public Map<String, IWorkerContext> fcontexts;
 
   final static public String DEFAULT_CONTEXT_VERSION = "5.0.0";
@@ -109,7 +95,7 @@ public class TestingUtilities extends BaseTestingUtilities {
     return NpmPackage.fromPackage(loadR5CorePackageSource());
   }
 
-  private static InputStream loadR5CorePackageSource() throws IOException {
+  protected static InputStream loadR5CorePackageSource() throws IOException {
     return TestingUtilities.loadTestResourceStream("r5", "packages", "hl7.fhir.r5.core.tgz");
   }
 
@@ -170,10 +156,5 @@ public class TestingUtilities extends BaseTestingUtilities {
       return s;
     throw new Error("FHIR US directory not configured");
   }
-
-  public static void injectCorePackageLoader() {
-    FilesystemPackageCacheManager.setPackageProvider(new TestingUtilities.PackageProvider());    
-  }
-
 
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/UtilitiesProperties.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/UtilitiesProperties.java
@@ -1,0 +1,33 @@
+package org.hl7.fhir.utilities;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public abstract class UtilitiesProperties {
+
+  Properties properties = null;
+
+  public static final String PROPERTY_FILE_NAME = "hl7.core.utilities.properties";
+
+  private Properties getProperties() {
+    if (properties == null)
+      properties = new Properties();
+    InputStream stream = getClass().getClassLoader().getSystemResourceAsStream(PROPERTY_FILE_NAME);
+    if (stream != null) {
+      try {
+        properties.load(stream);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return properties;
+  }
+
+  private static final String I_PACKAGE_PROVIDER_CLASSNAME = "hl7.core.utilities.iPackageProvider.classname";
+
+
+  public String getIPackageProviderClassName() {
+    return getProperties().getProperty(I_PACKAGE_PROVIDER_CLASSNAME);
+  }
+}

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/UtilitiesPropertiesImpl.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/UtilitiesPropertiesImpl.java
@@ -1,0 +1,10 @@
+package org.hl7.fhir.utilities;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class UtilitiesPropertiesImpl extends UtilitiesProperties {
+
+
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesPackageProvider.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesPackageProvider.java
@@ -1,0 +1,21 @@
+package org.hl7.fhir.utilities;
+
+import org.hl7.fhir.utilities.npm.BasePackageCacheManager;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+
+import java.io.IOException;
+
+public class UtilitiesPackageProvider  implements FilesystemPackageCacheManager.IPackageProvider {
+
+    @Override
+    public boolean handlesPackage(String id, String version) {
+      return false;
+    }
+
+    @Override
+    public BasePackageCacheManager.InputStreamWithSrc provide(String id, String version) throws IOException {
+     throw new IOException("This should never be called.");
+    }
+
+
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesPropertiesTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/UtilitiesPropertiesTest.java
@@ -1,0 +1,17 @@
+package org.hl7.fhir.utilities;
+
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UtilitiesPropertiesTest {
+
+  @Test
+    public void test() throws ClassNotFoundException {
+  String className = new UtilitiesPropertiesImpl().getIPackageProviderClassName();
+
+    assertEquals("org.hl7.fhir.utilities.UtilitiesPackageProvider", className);
+  }
+
+}

--- a/org.hl7.fhir.utilities/src/test/resources/hl7.core.utilities.properties
+++ b/org.hl7.fhir.utilities/src/test/resources/hl7.core.utilities.properties
@@ -1,0 +1,1 @@
+hl7.core.utilities.iPackageProvider.classname=org.hl7.fhir.utilities.UtilitiesPackageProvider

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/comparison/tests/ComparisonTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/comparison/tests/ComparisonTests.java
@@ -101,7 +101,7 @@ public class ComparisonTests {
   @ParameterizedTest(name = "{index}: id {0}")
   @MethodSource("data")
   public void test(String name, JsonObject content) throws Exception {
-    TestingUtilities.injectCorePackageLoader();
+
     this.content = content;
 
     if (content.has("use-test") && !content.get("use-test").getAsBoolean())

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/ResourceValidationTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/ResourceValidationTests.java
@@ -43,7 +43,7 @@ public class ResourceValidationTests {
 
 
   private void runTest(String filename) throws IOException, FileNotFoundException, Exception {
-    TestingUtilities.injectCorePackageLoader();
+
     if (val == null) {
       ctxt = TestingUtilities.getSharedWorkerContext();
       engine = TestUtilities.getValidationEngine("hl7.fhir.r5.core#5.0.0", ValidationEngineTests.DEF_TX, null, FhirPublication.R5, true, "5.0.0");

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -41,7 +41,7 @@ class ValidationServiceTest {
 
   @Test
   void validateSources() throws Exception {
-    TestingUtilities.injectCorePackageLoader();
+
     SessionCache sessionCache = Mockito.spy(new SessionCache());
     ValidationService myService = new ValidationService(sessionCache);
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/TransformationTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/TransformationTests.java
@@ -13,7 +13,6 @@ public class TransformationTests {
 
   @Test
   public void testCCDA() throws Exception {
-    TestingUtilities.injectCorePackageLoader();
 
     String mappings = Utilities.path(TestingUtilities.home(), "tests", "transform-examples", "ccda");
     String input = Utilities.path(TestingUtilities.home(), "tests", "transform-examples", "ccda.xml");

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
@@ -164,7 +164,6 @@ public class ValidationTests implements IEvaluationContext, IValidatorResourceFe
   @SuppressWarnings("deprecation")
   @Test
   public void test() throws Exception {
-    TestingUtilities.injectCorePackageLoader();
 
     CacheVerificationLogger logger = new CacheVerificationLogger();
     long setup = System.nanoTime();

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/utilities/TestUtilities.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/utilities/TestUtilities.java
@@ -14,7 +14,6 @@ public class TestUtilities {
   public static boolean silent = false;
 
   public static ValidationEngine getValidationEngine(java.lang.String src, java.lang.String txServer, String txLog, FhirPublication version, boolean canRunWithoutTerminologyServer, java.lang.String vString) throws Exception {
-    TestingUtilities.injectCorePackageLoader();
 
    final ValidationEngine validationEngine = new ValidationEngine.ValidationEngineBuilder()
       .withCanRunWithoutTerminologyServer(canRunWithoutTerminologyServer)
@@ -33,7 +32,6 @@ public class TestUtilities {
   }
 
   public static ValidationEngine getValidationEngine(java.lang.String src, java.lang.String txServer, FhirPublication version, java.lang.String vString) throws Exception {
-    TestingUtilities.injectCorePackageLoader();
     final ValidationEngine validationEngine = new ValidationEngine.ValidationEngineBuilder()
       .withVersion(vString)
       .withUserAgent(TestConstants.USER_AGENT)

--- a/org.hl7.fhir.validation/src/test/resources/hl7.core.utilities.properties
+++ b/org.hl7.fhir.validation/src/test/resources/hl7.core.utilities.properties
@@ -1,0 +1,1 @@
+hl7.core.utilities.iPackageProvider.classname=org.hl7.fhir.r5.test.utils.PackageProvider


### PR DESCRIPTION
This gets a properties file from the resource folder of the test src and uses it to instantiate the IPackageProvider used in FilesystemPackageCacheManager.

Practically speaking, this means that if the hl7.core.utilities.properties file is present in the src/test/resources/ folder, all tests will run with the FilesystemPackageCacheManager using whatever IPackageProvider is indicated in that file.

This replaces https://github.com/hapifhir/org.hl7.fhir.core/pull/1193, which had become too difficult to merge automatically.