### PR TITLE
Add missing elements to SubscriptionStatus conversion

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv43_50/resources43_50/SubscriptionStatus43_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv43_50/resources43_50/SubscriptionStatus43_50.java
@@ -3,7 +3,9 @@ package org.hl7.fhir.convertors.conv43_50.resources43_50;
 import org.hl7.fhir.convertors.context.ConversionContext43_50;
 import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Canonical43_50;
 
+import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Instant43_50;
 import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Integer64_43_50;
+import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Time43_50;
 import org.hl7.fhir.convertors.conv43_50.datatypes43_50.special43_50.Reference43_50;
 
 public class SubscriptionStatus43_50 {
@@ -44,6 +46,9 @@ public class SubscriptionStatus43_50 {
     org.hl7.fhir.r4b.model.SubscriptionStatus.SubscriptionStatusNotificationEventComponent tgt = new org.hl7.fhir.r4b.model.SubscriptionStatus.SubscriptionStatusNotificationEventComponent();
     if (src.hasEventNumber()) {
       tgt.setEventNumberElement(Integer64_43_50.convertInteger64ToString(src.getEventNumberElement()));
+    }
+    if (src.hasTimestamp()) {
+      tgt.setTimestampElement(Instant43_50.convertInstant(src.getTimestampElement()));
     }
     if (src.hasFocus()) {
       tgt.setFocus(Reference43_50.convertReference(src.getFocus()));
@@ -115,6 +120,9 @@ public class SubscriptionStatus43_50 {
     org.hl7.fhir.r5.model.SubscriptionStatus.SubscriptionStatusNotificationEventComponent tgt = new org.hl7.fhir.r5.model.SubscriptionStatus.SubscriptionStatusNotificationEventComponent();
     if (src.hasEventNumber()) {
       tgt.setEventNumberElement(Integer64_43_50.convertStringToInteger64(src.getEventNumberElement()));
+    }
+    if (src.hasTimestamp()) {
+      tgt.setTimestampElement(Instant43_50.convertInstant(src.getTimestampElement()));
     }
     if (src.hasFocus()) {
       tgt.setFocus(Reference43_50.convertReference(src.getFocus()));

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv43_50/resources43_50/SubscriptionStatus43_50.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv43_50/resources43_50/SubscriptionStatus43_50.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.convertors.conv43_50.resources43_50;
 
 import org.hl7.fhir.convertors.context.ConversionContext43_50;
+import org.hl7.fhir.convertors.conv43_50.datatypes43_50.general43_50.CodeableConcept43_50;
 import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Canonical43_50;
 
 import org.hl7.fhir.convertors.conv43_50.datatypes43_50.primitive43_50.Instant43_50;
@@ -39,6 +40,11 @@ public class SubscriptionStatus43_50 {
     if (src.hasTopic()) {
       tgt.setTopicElement(Canonical43_50.convertCanonical(src.getTopicElement()));
     }
+    if (src.hasError()) {
+      for (org.hl7.fhir.r5.model.CodeableConcept srcError : src.getError()) {
+        tgt.addError(CodeableConcept43_50.convertCodeableConcept(srcError));
+      }
+    }
     return tgt;
   }
 
@@ -52,6 +58,11 @@ public class SubscriptionStatus43_50 {
     }
     if (src.hasFocus()) {
       tgt.setFocus(Reference43_50.convertReference(src.getFocus()));
+    }
+    if (src.hasAdditionalContext()) {
+      for (org.hl7.fhir.r5.model.Reference ref : src.getAdditionalContext()) {
+        tgt.addAdditionalContext(Reference43_50.convertReference(ref));
+      }
     }
     return tgt;
   }
@@ -113,6 +124,11 @@ public class SubscriptionStatus43_50 {
     if (src.hasTopic()) {
       tgt.setTopicElement(Canonical43_50.convertCanonical(src.getTopicElement()));
     }
+    if (src.hasError()) {
+      for (org.hl7.fhir.r4b.model.CodeableConcept srcError : src.getError()) {
+        tgt.addError(CodeableConcept43_50.convertCodeableConcept(srcError));
+      }
+    }
     return tgt;
   }
 
@@ -126,6 +142,11 @@ public class SubscriptionStatus43_50 {
     }
     if (src.hasFocus()) {
       tgt.setFocus(Reference43_50.convertReference(src.getFocus()));
+    }
+    if (src.hasAdditionalContext()) {
+      for (org.hl7.fhir.r4b.model.Reference ref : src.getAdditionalContext()) {
+        tgt.addAdditionalContext(Reference43_50.convertReference(ref));
+      }
     }
     return tgt;
   }

--- a/org.hl7.fhir.convertors/src/test/resources/subscription_status_50.json
+++ b/org.hl7.fhir.convertors/src/test/resources/subscription_status_50.json
@@ -9,7 +9,8 @@
   "type" : "event-notification",
   "eventsSinceSubscriptionStart" : "1000",
   "notificationEvent" : [{
-    "eventNumber" : "1000"
+    "eventNumber" : "1000",
+    "timestamp" : "2022-02-10T15:12:28-05:00"
   }],
   "subscription" : {
     "reference" : "http://example.org/FHIR/R5/Subscription/123"

--- a/org.hl7.fhir.convertors/src/test/resources/subscription_status_50.json
+++ b/org.hl7.fhir.convertors/src/test/resources/subscription_status_50.json
@@ -10,10 +10,27 @@
   "eventsSinceSubscriptionStart" : "1000",
   "notificationEvent" : [{
     "eventNumber" : "1000",
-    "timestamp" : "2022-02-10T15:12:28-05:00"
+    "timestamp" : "2022-02-10T15:12:28-05:00",
+    "additionalContext": [
+      {
+        "reference": "http://example.org/FHIR/R5/Patient/ABC"
+      }
+    ]
   }],
   "subscription" : {
     "reference" : "http://example.org/FHIR/R5/Subscription/123"
   },
-  "topic" : "http://example.org/FHIR/R5/SubscriptionTopic/admission"
+  "topic" : "http://example.org/FHIR/R5/SubscriptionTopic/admission",
+  "error": [
+    {
+      "code": {
+        "coding": [
+          {
+            "code": "no-response ",
+            "system": "http://terminology.hl7.org/CodeSystem/subscription-error"
+          }
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The following elements were missing from SubscriptionStatus43_50 conversion, and are added in this PR:

SubscriptionStatus.error
SubscriptionStatus.notificationEvent.timestamp
SubscriptionStatus.notificationEvent.additionalContext

