### PR TITLE
Add r5 + r4b conversion support in CLI

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -906,7 +906,11 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
           return VersionConvertor.convertVersionNativeR3(targetVer, cnt, format);
         } else if (VersionUtilities.isR4Ver(version)) {
           return VersionConvertor.convertVersionNativeR4(targetVer, cnt, format);
-        } else {
+        } else if (VersionUtilities.isR4BVer(version)) {
+          return VersionConvertor.convertVersionNativeR4b(targetVer, cnt, format);
+        } else if (VersionUtilities.isR5Ver(version)) {
+            return VersionConvertor.convertVersionNativeR5(targetVer, cnt, format);
+        }else {
           throw new FHIRException("Source version not supported yet: " + version);
         }
       } catch (Exception e) {
@@ -944,6 +948,13 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     } else if (VersionUtilities.isR4Ver(version)) {
       if (VersionUtilities.isR3Ver(targetVer)) {
         return "http://hl7.org/fhir/StructureMap/" + type + "4to3";
+      }
+      else if (VersionUtilities.isR5Ver(targetVer)) {
+        return "http://hl7.org/fhir/StructureMap/" + type + "4to5";
+      }
+    } else if (VersionUtilities.isR5Ver(version)) {
+      if (VersionUtilities.isR4Ver(targetVer)) {
+        return "http://hl7.org/fhir/StructureMap/" + type + "5to4";
       }
     }
     throw new FHIRException("Source/Target version not supported: " + version + " -> " + targetVer);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/VersionConvertor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/VersionConvertor.java
@@ -3,11 +3,7 @@ package org.hl7.fhir.validation;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_30;
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_40;
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_14_30;
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_14_40;
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.hl7.fhir.convertors.factory.*;
 import org.hl7.fhir.dstu2016may.model.Resource;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.elementmodel.Manager;
@@ -37,6 +33,8 @@ public class VersionConvertor {
       return getBytesDstu3(cnt, format, VersionConvertorFactory_10_30.convertResource(r2));
     } else if (VersionUtilities.isR4Ver(targetVer)) {
       return getBytesR4(cnt, format, VersionConvertorFactory_10_40.convertResource(r2));
+    } else if (VersionUtilities.isR5Ver(targetVer)) {
+      return getBytesR5(cnt, format, VersionConvertorFactory_10_50.convertResource(r2));
     } else {
       throw new FHIRException("Target Version not supported yet: " + targetVer);
     }
@@ -64,6 +62,8 @@ public class VersionConvertor {
       return getBytesDstu3(cnt, format, VersionConvertorFactory_14_30.convertResource(r2b));
     } else if (VersionUtilities.isR4Ver(targetVer)) {
       return getBytesR4(cnt, format, VersionConvertorFactory_14_40.convertResource(r2b));
+    } else if (VersionUtilities.isR5Ver(targetVer)) {
+      return getBytesR5(cnt, format, VersionConvertorFactory_14_50.convertResource(r2b));
     } else {
       throw new FHIRException("Target Version not supported yet: " + targetVer);
     }
@@ -89,6 +89,8 @@ public class VersionConvertor {
       return getBytesDstu3(cnt, format, r3);
     } else if (VersionUtilities.isR4Ver(targetVer)) {
       return getBytesR4(cnt, format, VersionConvertorFactory_30_40.convertResource(r3));
+    } else if (VersionUtilities.isR5Ver(targetVer)) {
+        return getBytesR5(cnt, format, VersionConvertorFactory_30_50.convertResource(r3));
     } else {
       throw new FHIRException("Target Version not supported yet: " + targetVer);
     }
@@ -114,11 +116,68 @@ public class VersionConvertor {
       return getBytesDstu3(cnt, format, VersionConvertorFactory_30_40.convertResource(r4));
     } else if (VersionUtilities.isR4Ver(targetVer)) {
       return getBytesR4(cnt, format, r4);
-    } else {
+    } else if (VersionUtilities.isR5Ver(targetVer)) {
+      return getBytesR5(cnt, format, VersionConvertorFactory_40_50.convertResource(r4));
+    }
+    else {
       throw new FHIRException("Target Version not supported yet: " + targetVer);
     }
   }
 
+  public static byte[] convertVersionNativeR4b(String targetVer, Content cnt, Manager.FhirFormat format) throws IOException, Exception {
+    org.hl7.fhir.r4b.model.Resource r4b;
+    switch (cnt.getCntType()) {
+      case JSON:
+        r4b = new org.hl7.fhir.r4b.formats.JsonParser().parse(cnt.getFocus());
+        break;
+      case XML:
+        r4b = new org.hl7.fhir.r4b.formats.XmlParser().parse(cnt.getFocus());
+        break;
+      default:
+        throw new FHIRException("Unsupported input format: " + cnt.getCntType().toString());
+    }
+    if (VersionUtilities.isR4BVer(targetVer)) {
+      return getBytesR4B(cnt, format, r4b);
+    } else if (VersionUtilities.isR5Ver(targetVer)) {
+      return getBytesR5(cnt, format, VersionConvertorFactory_43_50.convertResource(r4b));
+    }
+    else {
+      throw new FHIRException("Target Version not supported yet: " + targetVer);
+    }
+  }
+
+  public static byte[] convertVersionNativeR5(String targetVer, Content cnt, Manager.FhirFormat format) throws IOException, Exception {
+    org.hl7.fhir.r5.model.Resource r5;
+    switch (cnt.getCntType()) {
+      case JSON:
+        r5 = new org.hl7.fhir.r5.formats.JsonParser().parse(cnt.getFocus());
+        break;
+      case XML:
+        r5 = new org.hl7.fhir.r5.formats.XmlParser().parse(cnt.getFocus());
+        break;
+      default:
+        throw new FHIRException("Unsupported input format: " + cnt.getCntType().toString());
+    }
+    if (VersionUtilities.isR2Ver(targetVer)) {
+      return getBytesDstu2(cnt, format, VersionConvertorFactory_10_50.convertResource(r5));
+    } else if (VersionUtilities.isR2BVer(targetVer)) {
+      return getBytesDstu2016(cnt, format, VersionConvertorFactory_14_50.convertResource(r5));
+    } else if (VersionUtilities.isR3Ver(targetVer)) {
+      return getBytesDstu3(cnt, format, VersionConvertorFactory_30_50.convertResource(r5));
+    }
+    else if (VersionUtilities.isR4BVer(targetVer)) {
+      return getBytesR4B(cnt, format, VersionConvertorFactory_43_50.convertResource(r5));
+    }
+    else if (VersionUtilities.isR4Ver(targetVer)) {
+      return getBytesR4(cnt, format, VersionConvertorFactory_40_50.convertResource(r5));
+    }
+    else if (VersionUtilities.isR5Ver(targetVer)) {
+      return getBytesR5(cnt, format, r5);
+    }
+    else {
+      throw new FHIRException("Target Version not supported yet: " + targetVer);
+    }
+  }
   private static byte[] getBytesDstu2(Content cnt, Manager.FhirFormat format, org.hl7.fhir.dstu2.model.Resource r2) throws IOException {
     ByteArrayOutputStream bs = new ByteArrayOutputStream();
     switch (format) {
@@ -169,6 +228,34 @@ public class VersionConvertor {
         return bs.toByteArray();
       case XML:
         new org.hl7.fhir.r4.formats.XmlParser().compose(bs, r4);
+        return bs.toByteArray();
+      default:
+        throw new FHIRException("Unsupported output format: " + cnt.getCntType().toString());
+    }
+  }
+
+  private static byte[] getBytesR4B(Content cnt, Manager.FhirFormat format, org.hl7.fhir.r4b.model.Resource r4b) throws IOException {
+    ByteArrayOutputStream bs = new ByteArrayOutputStream();
+    switch (format) {
+      case JSON:
+        new org.hl7.fhir.r4b.formats.JsonParser().compose(bs, r4b);
+        return bs.toByteArray();
+      case XML:
+        new org.hl7.fhir.r4b.formats.XmlParser().compose(bs, r4b);
+        return bs.toByteArray();
+      default:
+        throw new FHIRException("Unsupported output format: " + cnt.getCntType().toString());
+    }
+  }
+
+  private static byte[] getBytesR5(Content cnt, Manager.FhirFormat format, org.hl7.fhir.r5.model.Resource r5) throws IOException {
+    ByteArrayOutputStream bs = new ByteArrayOutputStream();
+    switch (format) {
+      case JSON:
+        new org.hl7.fhir.r5.formats.JsonParser().compose(bs, r5);
+        return bs.toByteArray();
+      case XML:
+        new org.hl7.fhir.r5.formats.XmlParser().compose(bs, r5);
         return bs.toByteArray();
       default:
         throw new FHIRException("Unsupported output format: " + cnt.getCntType().toString());


### PR DESCRIPTION
The Validator CLI doesn't currently support conversion from/to r4b or r5.

If I execute the following:

```sh
java -jar validator_cli.jar /Users/david.otasek/IN/2023-05-01-domain-conversion-refactor/capability_statement_30.json -version 3.0 -to-version 5.0 -output /Users/david.otasek/IN/2023-05-01-domain-conversion-refactor/not-going-to-work.json
```

It fails with the following exception:

```log
 ...Failure: Source/Target version not supported: 3.0 -> 5.0
org.hl7.fhir.exceptions.FHIRException: Source/Target version not supported: 3.0 -> 5.0
        at org.hl7.fhir.validation.ValidationEngine.getMapId(ValidationEngine.java:949)
        at org.hl7.fhir.validation.ValidationEngine.transformVersion(ValidationEngine.java:920)
        at org.hl7.fhir.validation.cli.services.ValidationService.transformVersion(ValidationService.java:389)
        at org.hl7.fhir.validation.ValidatorCli.doValidation(ValidatorCli.java:351)
        at org.hl7.fhir.validation.ValidatorCli.main(ValidatorCli.java:153)
```

No command line conversions are possible with either r5 or r4b

This adds that support.

# NOTE: This is not ready for merge until the following is resolved:

Using the `-do-native` command, this works for CapabilityStatement. However, using 4to5 mappings (default behaviour without the `-do-native` param), the conversion fails:

```log
 ...Failure: Exception executing transform tgt.id = create() as vvv on Rule "Resource5to4|Resource|id": Cannot invoke "org.hl7.fhir.r5.model.StructureDefinition.getSnapshot()" because "sd" is null
Done. Times: Loading: 00:37.566. Max Memory = 4Gb
org.hl7.fhir.exceptions.FHIRException: Exception executing transform tgt.id = create() as vvv on Rule "Resource5to4|Resource|id": Cannot invoke "org.hl7.fhir.r5.model.StructureDefinition.getSnapshot()" because "sd" is null
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.runTransform(StructureMapUtilities.java:1893)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.processTarget(StructureMapUtilities.java:1720)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.executeRule(StructureMapUtilities.java:1313)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.executeGroup(StructureMapUtilities.java:1300)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.executeGroup(StructureMapUtilities.java:1296)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.executeGroup(StructureMapUtilities.java:1296)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.transform(StructureMapUtilities.java:1262)
	at org.hl7.fhir.validation.ValidationEngine.transformVersion(ValidationEngine.java:931)
	at org.hl7.fhir.validation.cli.services.ValidationService.transformVersion(ValidationService.java:389)
	at org.hl7.fhir.validation.ValidatorCli.doValidation(ValidatorCli.java:351)
	at org.hl7.fhir.validation.ValidatorCli.main(ValidatorCli.java:153)
Caused by: java.lang.NullPointerException: Cannot invoke "org.hl7.fhir.r5.model.StructureDefinition.getSnapshot()" because "sd" is null
	at org.hl7.fhir.r5.elementmodel.Manager.build(Manager.java:129)
	at org.hl7.fhir.validation.TransformSupportServices.createType(TransformSupportServices.java:39)
	at org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities.runTransform(StructureMapUtilities.java:1767)
	... 10 more

Process finished with exit code 0```

