### PR TITLE
Fix for dstu2016may Resource equals methods

### DIFF
--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/Base.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/Base.java
@@ -200,11 +200,11 @@ private Map<String, Object> userData;
   }
 
 	public boolean equalsDeep(Base other) {
-	  return other == this;
+	  return other != null;
   }  
   
 	public boolean equalsShallow(Base other) {
-	  return other == this;
+	  return other != null;
   }  
   
 	public static boolean compareDeep(List<? extends Base> e1, List<? extends Base> e2, boolean allowNull) {

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/ResourceEqualsTests.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/ResourceEqualsTests.java
@@ -47,18 +47,32 @@ public class ResourceEqualsTests {
     return "/" + resource;
   }
 
-  /* All files pairs contain a single difference, which can be evaluated with a diff. These differences are at various depths in the element tree. */
+  /* All files pairs contain a single difference, which can be evaluated with a diff. These differences are at various depths in the element tree, but not at the shallow level. */
   @ParameterizedTest
   @CsvSource({
     "conformance_example_1.json,conformance_example_2.json",
     "immunization_example_1.json,immunization_example_2.json",
     "patient_example_1.json,patient_example_2.json"
   })
-  public void testEqualsFalse(String resourceAName, String resourceBName) throws IOException {
+  public void testEqualsDeepFalse(String resourceAName, String resourceBName) throws IOException {
     org.hl7.fhir.dstu2016may.model.Resource resourceA = getResource(resourceAName);
 
     org.hl7.fhir.dstu2016may.model.Resource resourceB = getResource(resourceBName);
+    assertTrue(resourceA.equalsShallow(resourceB));
+    assertFalse(resourceA.equalsDeep(resourceB));
+  }
 
+  /* All files pairs contain a single difference, which can be evaluated with a diff. These differences are at the shallow level. */
+  @ParameterizedTest
+  @CsvSource({
+    "conformance_example_1.json,conformance_example_3.json",
+    "immunization_example_1.json,immunization_example_3.json",
+    "patient_example_1.json,patient_example_3.json"
+  })
+  public void testEqualsShallowFalse(String resourceAName, String resourceBName) throws IOException {
+    org.hl7.fhir.dstu2016may.model.Resource resourceA = getResource(resourceAName);
+
+    org.hl7.fhir.dstu2016may.model.Resource resourceB = getResource(resourceBName);
     assertFalse(resourceA.equalsShallow(resourceB));
     assertFalse(resourceA.equalsDeep(resourceB));
   }

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/ResourceEqualsTests.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/ResourceEqualsTests.java
@@ -1,0 +1,65 @@
+package org.hl7.fhir.dstu2016may.test;
+
+
+import org.hl7.fhir.dstu2016may.formats.JsonParser;
+import org.hl7.fhir.dstu2016may.model.Resource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResourceEqualsTests {
+
+  private JsonParser dstu2016_parser = new JsonParser();;
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "conformance_example_1.json",
+    "immunization_example_1.json",
+    "patient_example_1.json"
+  })
+  public void testEquals(String resourcePath) throws IOException {
+
+    org.hl7.fhir.dstu2016may.model.Resource resourceA = getResource(resourcePath);
+
+    org.hl7.fhir.dstu2016may.model.Resource resourceB = getResource(resourcePath);
+
+    assertTrue(resourceA.equalsShallow(resourceB));
+    assertTrue(resourceA.equalsDeep(resourceB));
+
+  }
+
+  private Resource getResource(String resource) throws IOException {
+    Resource resourceA;
+    InputStream inputA = this.getClass().getResourceAsStream(getResourcePath(resource));
+    resourceA = dstu2016_parser.parse(inputA);
+    return resourceA;
+  }
+
+  @Nonnull
+  private static String getResourcePath(String resource) {
+    return "/" + resource;
+  }
+
+  /* All files pairs contain a single difference, which can be evaluated with a diff. These differences are at various depths in the element tree. */
+  @ParameterizedTest
+  @CsvSource({
+    "conformance_example_1.json,conformance_example_2.json",
+    "immunization_example_1.json,immunization_example_2.json",
+    "patient_example_1.json,patient_example_2.json"
+  })
+  public void testEqualsFalse(String resourceAName, String resourceBName) throws IOException {
+    org.hl7.fhir.dstu2016may.model.Resource resourceA = getResource(resourceAName);
+
+    org.hl7.fhir.dstu2016may.model.Resource resourceB = getResource(resourceBName);
+
+    assertFalse(resourceA.equalsShallow(resourceB));
+    assertFalse(resourceA.equalsDeep(resourceB));
+  }
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_1.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_1.json
@@ -1,0 +1,282 @@
+{
+  "resourceType": "Conformance",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <p>The EHR Server supports the following transactions for the resource Person: read, vread, \n        update, history, search(name,gender), create and updates.</p>\n      \n      <p>The EHR System supports the following message: admin-notify::Person.</p>\n      \n      <p>The EHR Application has a \n        <a href=\"http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796\">general document profile</a>.\n      </p>\n    \n    </div>"
+  },
+  "url": "68D043B5-9ECF-4559-A57A-396E0D452311",
+  "_url": {
+    "fhir_comments": [
+      "    the identifier for this conformance statement. \n    The identifier and version establish identifiers that other specifications etc.may use to \n    refer to the conformance statement that this resource represents in a logical manner \n    rather than in a literal (URL) fashion \n\n    The identifier should be globally unique - a UUID, an OID, or a URL/URI\n     "
+    ]
+  },
+  "version": "20130510",
+  "name": "ACME EHR Conformance statement",
+  "status": "draft",
+  "experimental": true,
+  "date": "2012-01-04",
+  "publisher": "ACME Corporation",
+  "contact": [
+    {
+      "name": "System Administrator",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "wile@acme.org"
+        }
+      ]
+    }
+  ],
+  "description": "This is the FHIR conformance statement for the main EHR at ACME for the private interface - it does not describe the public interface",
+  "requirements": "Main EHR conformance statement, published for contracting and operational support",
+  "copyright": "Copyright © Acme Healthcare and GoodCorp EHR Systems",
+  "kind": "instance",
+  "software": {
+    "name": "EHR",
+    "version": "0.00.020.2134",
+    "releaseDate": "2012-01-04"
+  },
+  "implementation": {
+    "description": "main EHR at ACME",
+    "url": "http://10.2.3.4/fhir"
+  },
+  "fhirVersion": "1.0.0",
+  "_fhirVersion": {
+    "fhir_comments": [
+      "   while the FHIR infrastructure is turning over prior to development, a version is \n    required. Note that this may be rescinded later?   "
+    ]
+  },
+  "acceptUnknown": "both",
+  "_acceptUnknown": {
+    "fhir_comments": [
+      "   this system accepts unknown content in the resources   "
+    ]
+  },
+  "format": [
+    "xml",
+    "json"
+  ],
+  "_format": [
+    {
+      "fhir_comments": [
+        "   this system can do either xml or json. (Listing both implies full support for either, with interconversion)   "
+      ]
+    },
+    null
+  ],
+  "rest": [
+    {
+      "fhir_comments": [
+        "   in a real conformance statement, it's unlikely that a single conformance statement \n    would declare conformance for REST, messaging and documents, though it is legal. \n    This example does so in order to show all the parts of a conformance statement   "
+      ],
+      "mode": "server",
+      "_mode": {
+        "fhir_comments": [
+          "   this is a server conformance statement. Note that servers are required to provide \n      one of these. It can easily be edited by hand - copy this, replace the metadata above, \n      delete the messaging and document stuff below, and then replace the details appropriately.   "
+        ]
+      },
+      "documentation": "Main FHIR endpoint for acem health",
+      "security": {
+        "cors": true,
+        "_cors": {
+          "fhir_comments": [
+            "  cors support is highly recommended - mandatory if using SMART on FHIR "
+          ]
+        },
+        "service": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/restful-security-service",
+                "code": "SMART-on-FHIR"
+              }
+            ]
+          }
+        ],
+        "description": "See Smart on FHIR documentation",
+        "certificate": [
+          {
+            "type": "application/jwt",
+            "blob": "IHRoaXMgYmxvYiBpcyBub3QgdmFsaWQ=",
+            "_blob": {
+              "fhir_comments": [
+                "  base JWT. this blob is not valid  "
+              ]
+            }
+          }
+        ]
+      },
+      "resource": [
+        {
+          "fhir_comments": [
+            "   zero or more of these - declaration of support for a resource   "
+          ],
+          "type": "Patient",
+          "profile": {
+            "fhir_comments": [
+              "   let's assume that HL7 has stood up a profile registry at http://fhir.hl7.org/fhir \n        - it's likely to have a registry, though this is not decided, nor is a URL decided. \n        This application simply uses a profile registered directly with HL7. For the simplest \n        case of a FHIR REST Server, just delete this profile reference. Profile references do \n        not need to be a UUID, though a profile registry could insist that they are   "
+            ],
+            "reference": "http://fhir.hl7.org/base/Profile7896271d-57f6-4231-89dc-dcc91eab2416"
+          },
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "vread",
+              "documentation": "Only supported for patient records since 12-Dec 2012"
+            },
+            {
+              "code": "update"
+            },
+            {
+              "code": "history-instance"
+            },
+            {
+              "code": "create"
+            },
+            {
+              "code": "history-type"
+            }
+          ],
+          "versioning": "versioned-update",
+          "readHistory": true,
+          "updateCreate": false,
+          "_updateCreate": {
+            "fhir_comments": [
+              "  this server doesn't let the clients create identities  "
+            ]
+          },
+          "conditionalCreate": true,
+          "_conditionalCreate": {
+            "fhir_comments": [
+              "  it's good to support conditional create on patients; this solves a common middleware problem  "
+            ]
+          },
+          "conditionalUpdate": false,
+          "conditionalDelete": "not-supported",
+          "_conditionalDelete": {
+            "fhir_comments": [
+              "  0..1 If allows/uses conditional update  "
+            ]
+          },
+          "searchInclude": [
+            "Organization"
+          ],
+          "searchRevInclude": [
+            "Person"
+          ],
+          "searchParam": [
+            {
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+              "type": "token",
+              "documentation": "Only supports search by institution MRN",
+              "modifier": [
+                "missing"
+              ]
+            },
+            {
+              "name": "careprovider",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-careprovider",
+              "type": "reference",
+              "target": [
+                "Organization"
+              ],
+              "_target": [
+                {
+                  "fhir_comments": [
+                    "  there's not a lot of value in saying this, since it's the only \n          choice anyway. but in other cases it's pretty important  "
+                  ]
+                }
+              ],
+              "modifier": [
+                "missing"
+              ],
+              "chain": [
+                "name",
+                "identifier"
+              ]
+            }
+          ]
+        }
+      ],
+      "interaction": [
+        {
+          "code": "transaction"
+        },
+        {
+          "code": "history-system"
+        }
+      ],
+      "compartment": [
+        "http://hl7.org/fhir/compartment/Patient"
+      ]
+    }
+  ],
+  "messaging": [
+    {
+      "fhir_comments": [
+        "   a messaging conformance statement. Applications are not required to make a conformance \n    statement with regard to messaging, though there is active argument that they should.    "
+      ],
+      "endpoint": [
+        {
+          "protocol": {
+            "system": "http://hl7.org/fhir/message-transport",
+            "code": "mllp"
+          },
+          "address": "mllp:10.1.1.10:9234",
+          "_address": {
+            "fhir_comments": [
+              "  LLP server at 10.1.1.10 on port 9234  "
+            ]
+          }
+        }
+      ],
+      "reliableCache": 30,
+      "documentation": "ADT A08 equivalent for external system notifications",
+      "event": [
+        {
+          "code": {
+            "system": "http://hl7.org/fhir/message-type",
+            "code": "admin-notify"
+          },
+          "category": "Consequence",
+          "mode": "receiver",
+          "_mode": {
+            "fhir_comments": [
+              "   this a receiver - i.e. answers. Not neccessariy a server (though this is)   "
+            ]
+          },
+          "focus": "Patient",
+          "request": {
+            "fhir_comments": [
+              "   specify a profile for the request person. Very often there's no \n        point profiling the response, it's not interesting   "
+            ],
+            "reference": "StructureDefinition/daf-patient"
+          },
+          "response": {
+            "reference": "StructureDefinition/MessageHeader"
+          },
+          "documentation": "Notification of an update to a patient resource. changing the links is not supported"
+        }
+      ]
+    }
+  ],
+  "document": [
+    {
+      "fhir_comments": [
+        "   a document conformance statement   "
+      ],
+      "mode": "consumer",
+      "documentation": "Basic rules for all documents in the EHR system",
+      "profile": {
+        "fhir_comments": [
+          "   this is the important element: a reference to a published document profile \n       note that this is a version specific reference.  "
+        ],
+        "reference": "http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_2.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_2.json
@@ -1,0 +1,282 @@
+{
+  "resourceType": "Conformance",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <p>The EHR Server supports the following transactions for the resource Person: read, vread, \n        update, history, search(name,gender), create and updates.</p>\n      \n      <p>The EHR System supports the following message: admin-notify::Person.</p>\n      \n      <p>The EHR Application has a \n        <a href=\"http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796\">general document profile</a>.\n      </p>\n    \n    </div>"
+  },
+  "url": "68D043B5-9ECF-4559-A57A-396E0D452311",
+  "_url": {
+    "fhir_comments": [
+      "    the identifier for this conformance statement. \n    The identifier and version establish identifiers that other specifications etc.may use to \n    refer to the conformance statement that this resource represents in a logical manner \n    rather than in a literal (URL) fashion \n\n    The identifier should be globally unique - a UUID, an OID, or a URL/URI\n     "
+    ]
+  },
+  "version": "20130510",
+  "name": "ACME EHR Conformance statement",
+  "status": "draft",
+  "experimental": true,
+  "date": "2012-01-04",
+  "publisher": "ACME Corporation",
+  "contact": [
+    {
+      "name": "System Administrator",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "wilecoyote@acme.org"
+        }
+      ]
+    }
+  ],
+  "description": "This is the FHIR conformance statement for the main EHR at ACME for the private interface - it does not describe the public interface",
+  "requirements": "Main EHR conformance statement, published for contracting and operational support",
+  "copyright": "Copyright © Acme Healthcare and GoodCorp EHR Systems",
+  "kind": "instance",
+  "software": {
+    "name": "EHR",
+    "version": "0.00.020.2134",
+    "releaseDate": "2012-01-04"
+  },
+  "implementation": {
+    "description": "main EHR at ACME",
+    "url": "http://10.2.3.4/fhir"
+  },
+  "fhirVersion": "1.0.0",
+  "_fhirVersion": {
+    "fhir_comments": [
+      "   while the FHIR infrastructure is turning over prior to development, a version is \n    required. Note that this may be rescinded later?   "
+    ]
+  },
+  "acceptUnknown": "both",
+  "_acceptUnknown": {
+    "fhir_comments": [
+      "   this system accepts unknown content in the resources   "
+    ]
+  },
+  "format": [
+    "xml",
+    "json"
+  ],
+  "_format": [
+    {
+      "fhir_comments": [
+        "   this system can do either xml or json. (Listing both implies full support for either, with interconversion)   "
+      ]
+    },
+    null
+  ],
+  "rest": [
+    {
+      "fhir_comments": [
+        "   in a real conformance statement, it's unlikely that a single conformance statement \n    would declare conformance for REST, messaging and documents, though it is legal. \n    This example does so in order to show all the parts of a conformance statement   "
+      ],
+      "mode": "server",
+      "_mode": {
+        "fhir_comments": [
+          "   this is a server conformance statement. Note that servers are required to provide \n      one of these. It can easily be edited by hand - copy this, replace the metadata above, \n      delete the messaging and document stuff below, and then replace the details appropriately.   "
+        ]
+      },
+      "documentation": "Main FHIR endpoint for acem health",
+      "security": {
+        "cors": true,
+        "_cors": {
+          "fhir_comments": [
+            "  cors support is highly recommended - mandatory if using SMART on FHIR "
+          ]
+        },
+        "service": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/restful-security-service",
+                "code": "SMART-on-FHIR"
+              }
+            ]
+          }
+        ],
+        "description": "See Smart on FHIR documentation",
+        "certificate": [
+          {
+            "type": "application/jwt",
+            "blob": "IHRoaXMgYmxvYiBpcyBub3QgdmFsaWQ=",
+            "_blob": {
+              "fhir_comments": [
+                "  base JWT. this blob is not valid  "
+              ]
+            }
+          }
+        ]
+      },
+      "resource": [
+        {
+          "fhir_comments": [
+            "   zero or more of these - declaration of support for a resource   "
+          ],
+          "type": "Patient",
+          "profile": {
+            "fhir_comments": [
+              "   let's assume that HL7 has stood up a profile registry at http://fhir.hl7.org/fhir \n        - it's likely to have a registry, though this is not decided, nor is a URL decided. \n        This application simply uses a profile registered directly with HL7. For the simplest \n        case of a FHIR REST Server, just delete this profile reference. Profile references do \n        not need to be a UUID, though a profile registry could insist that they are   "
+            ],
+            "reference": "http://fhir.hl7.org/base/Profile7896271d-57f6-4231-89dc-dcc91eab2416"
+          },
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "vread",
+              "documentation": "Only supported for patient records since 12-Dec 2012"
+            },
+            {
+              "code": "update"
+            },
+            {
+              "code": "history-instance"
+            },
+            {
+              "code": "create"
+            },
+            {
+              "code": "history-type"
+            }
+          ],
+          "versioning": "versioned-update",
+          "readHistory": true,
+          "updateCreate": false,
+          "_updateCreate": {
+            "fhir_comments": [
+              "  this server doesn't let the clients create identities  "
+            ]
+          },
+          "conditionalCreate": true,
+          "_conditionalCreate": {
+            "fhir_comments": [
+              "  it's good to support conditional create on patients; this solves a common middleware problem  "
+            ]
+          },
+          "conditionalUpdate": false,
+          "conditionalDelete": "not-supported",
+          "_conditionalDelete": {
+            "fhir_comments": [
+              "  0..1 If allows/uses conditional update  "
+            ]
+          },
+          "searchInclude": [
+            "Organization"
+          ],
+          "searchRevInclude": [
+            "Person"
+          ],
+          "searchParam": [
+            {
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+              "type": "token",
+              "documentation": "Only supports search by institution MRN",
+              "modifier": [
+                "missing"
+              ]
+            },
+            {
+              "name": "careprovider",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-careprovider",
+              "type": "reference",
+              "target": [
+                "Organization"
+              ],
+              "_target": [
+                {
+                  "fhir_comments": [
+                    "  there's not a lot of value in saying this, since it's the only \n          choice anyway. but in other cases it's pretty important  "
+                  ]
+                }
+              ],
+              "modifier": [
+                "missing"
+              ],
+              "chain": [
+                "name",
+                "identifier"
+              ]
+            }
+          ]
+        }
+      ],
+      "interaction": [
+        {
+          "code": "transaction"
+        },
+        {
+          "code": "history-system"
+        }
+      ],
+      "compartment": [
+        "http://hl7.org/fhir/compartment/Patient"
+      ]
+    }
+  ],
+  "messaging": [
+    {
+      "fhir_comments": [
+        "   a messaging conformance statement. Applications are not required to make a conformance \n    statement with regard to messaging, though there is active argument that they should.    "
+      ],
+      "endpoint": [
+        {
+          "protocol": {
+            "system": "http://hl7.org/fhir/message-transport",
+            "code": "mllp"
+          },
+          "address": "mllp:10.1.1.10:9234",
+          "_address": {
+            "fhir_comments": [
+              "  LLP server at 10.1.1.10 on port 9234  "
+            ]
+          }
+        }
+      ],
+      "reliableCache": 30,
+      "documentation": "ADT A08 equivalent for external system notifications",
+      "event": [
+        {
+          "code": {
+            "system": "http://hl7.org/fhir/message-type",
+            "code": "admin-notify"
+          },
+          "category": "Consequence",
+          "mode": "receiver",
+          "_mode": {
+            "fhir_comments": [
+              "   this a receiver - i.e. answers. Not neccessariy a server (though this is)   "
+            ]
+          },
+          "focus": "Patient",
+          "request": {
+            "fhir_comments": [
+              "   specify a profile for the request person. Very often there's no \n        point profiling the response, it's not interesting   "
+            ],
+            "reference": "StructureDefinition/daf-patient"
+          },
+          "response": {
+            "reference": "StructureDefinition/MessageHeader"
+          },
+          "documentation": "Notification of an update to a patient resource. changing the links is not supported"
+        }
+      ]
+    }
+  ],
+  "document": [
+    {
+      "fhir_comments": [
+        "   a document conformance statement   "
+      ],
+      "mode": "consumer",
+      "documentation": "Basic rules for all documents in the EHR system",
+      "profile": {
+        "fhir_comments": [
+          "   this is the important element: a reference to a published document profile \n       note that this is a version specific reference.  "
+        ],
+        "reference": "http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_3.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/conformance_example_3.json
@@ -1,0 +1,282 @@
+{
+  "resourceType": "Conformance",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <p>The EHR Server supports the following transactions for the resource Person: read, vread, \n        update, history, search(name,gender), create and updates.</p>\n      \n      <p>The EHR System supports the following message: admin-notify::Person.</p>\n      \n      <p>The EHR Application has a \n        <a href=\"http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796\">general document profile</a>.\n      </p>\n    \n    </div>"
+  },
+  "url": "68D043B5-9ECF-4559-A57A-396E0D452311",
+  "_url": {
+    "fhir_comments": [
+      "    the identifier for this conformance statement. \n    The identifier and version establish identifiers that other specifications etc.may use to \n    refer to the conformance statement that this resource represents in a logical manner \n    rather than in a literal (URL) fashion \n\n    The identifier should be globally unique - a UUID, an OID, or a URL/URI\n     "
+    ]
+  },
+  "version": "20140510",
+  "name": "ACME EHR Conformance statement",
+  "status": "draft",
+  "experimental": true,
+  "date": "2012-01-04",
+  "publisher": "ACME Corporation",
+  "contact": [
+    {
+      "name": "System Administrator",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "wile@acme.org"
+        }
+      ]
+    }
+  ],
+  "description": "This is the FHIR conformance statement for the main EHR at ACME for the private interface - it does not describe the public interface",
+  "requirements": "Main EHR conformance statement, published for contracting and operational support",
+  "copyright": "Copyright © Acme Healthcare and GoodCorp EHR Systems",
+  "kind": "instance",
+  "software": {
+    "name": "EHR",
+    "version": "0.00.020.2134",
+    "releaseDate": "2012-01-04"
+  },
+  "implementation": {
+    "description": "main EHR at ACME",
+    "url": "http://10.2.3.4/fhir"
+  },
+  "fhirVersion": "1.0.0",
+  "_fhirVersion": {
+    "fhir_comments": [
+      "   while the FHIR infrastructure is turning over prior to development, a version is \n    required. Note that this may be rescinded later?   "
+    ]
+  },
+  "acceptUnknown": "both",
+  "_acceptUnknown": {
+    "fhir_comments": [
+      "   this system accepts unknown content in the resources   "
+    ]
+  },
+  "format": [
+    "xml",
+    "json"
+  ],
+  "_format": [
+    {
+      "fhir_comments": [
+        "   this system can do either xml or json. (Listing both implies full support for either, with interconversion)   "
+      ]
+    },
+    null
+  ],
+  "rest": [
+    {
+      "fhir_comments": [
+        "   in a real conformance statement, it's unlikely that a single conformance statement \n    would declare conformance for REST, messaging and documents, though it is legal. \n    This example does so in order to show all the parts of a conformance statement   "
+      ],
+      "mode": "server",
+      "_mode": {
+        "fhir_comments": [
+          "   this is a server conformance statement. Note that servers are required to provide \n      one of these. It can easily be edited by hand - copy this, replace the metadata above, \n      delete the messaging and document stuff below, and then replace the details appropriately.   "
+        ]
+      },
+      "documentation": "Main FHIR endpoint for acem health",
+      "security": {
+        "cors": true,
+        "_cors": {
+          "fhir_comments": [
+            "  cors support is highly recommended - mandatory if using SMART on FHIR "
+          ]
+        },
+        "service": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/restful-security-service",
+                "code": "SMART-on-FHIR"
+              }
+            ]
+          }
+        ],
+        "description": "See Smart on FHIR documentation",
+        "certificate": [
+          {
+            "type": "application/jwt",
+            "blob": "IHRoaXMgYmxvYiBpcyBub3QgdmFsaWQ=",
+            "_blob": {
+              "fhir_comments": [
+                "  base JWT. this blob is not valid  "
+              ]
+            }
+          }
+        ]
+      },
+      "resource": [
+        {
+          "fhir_comments": [
+            "   zero or more of these - declaration of support for a resource   "
+          ],
+          "type": "Patient",
+          "profile": {
+            "fhir_comments": [
+              "   let's assume that HL7 has stood up a profile registry at http://fhir.hl7.org/fhir \n        - it's likely to have a registry, though this is not decided, nor is a URL decided. \n        This application simply uses a profile registered directly with HL7. For the simplest \n        case of a FHIR REST Server, just delete this profile reference. Profile references do \n        not need to be a UUID, though a profile registry could insist that they are   "
+            ],
+            "reference": "http://fhir.hl7.org/base/Profile7896271d-57f6-4231-89dc-dcc91eab2416"
+          },
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "vread",
+              "documentation": "Only supported for patient records since 12-Dec 2012"
+            },
+            {
+              "code": "update"
+            },
+            {
+              "code": "history-instance"
+            },
+            {
+              "code": "create"
+            },
+            {
+              "code": "history-type"
+            }
+          ],
+          "versioning": "versioned-update",
+          "readHistory": true,
+          "updateCreate": false,
+          "_updateCreate": {
+            "fhir_comments": [
+              "  this server doesn't let the clients create identities  "
+            ]
+          },
+          "conditionalCreate": true,
+          "_conditionalCreate": {
+            "fhir_comments": [
+              "  it's good to support conditional create on patients; this solves a common middleware problem  "
+            ]
+          },
+          "conditionalUpdate": false,
+          "conditionalDelete": "not-supported",
+          "_conditionalDelete": {
+            "fhir_comments": [
+              "  0..1 If allows/uses conditional update  "
+            ]
+          },
+          "searchInclude": [
+            "Organization"
+          ],
+          "searchRevInclude": [
+            "Person"
+          ],
+          "searchParam": [
+            {
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+              "type": "token",
+              "documentation": "Only supports search by institution MRN",
+              "modifier": [
+                "missing"
+              ]
+            },
+            {
+              "name": "careprovider",
+              "definition": "http://hl7.org/fhir/SearchParameter/Patient-careprovider",
+              "type": "reference",
+              "target": [
+                "Organization"
+              ],
+              "_target": [
+                {
+                  "fhir_comments": [
+                    "  there's not a lot of value in saying this, since it's the only \n          choice anyway. but in other cases it's pretty important  "
+                  ]
+                }
+              ],
+              "modifier": [
+                "missing"
+              ],
+              "chain": [
+                "name",
+                "identifier"
+              ]
+            }
+          ]
+        }
+      ],
+      "interaction": [
+        {
+          "code": "transaction"
+        },
+        {
+          "code": "history-system"
+        }
+      ],
+      "compartment": [
+        "http://hl7.org/fhir/compartment/Patient"
+      ]
+    }
+  ],
+  "messaging": [
+    {
+      "fhir_comments": [
+        "   a messaging conformance statement. Applications are not required to make a conformance \n    statement with regard to messaging, though there is active argument that they should.    "
+      ],
+      "endpoint": [
+        {
+          "protocol": {
+            "system": "http://hl7.org/fhir/message-transport",
+            "code": "mllp"
+          },
+          "address": "mllp:10.1.1.10:9234",
+          "_address": {
+            "fhir_comments": [
+              "  LLP server at 10.1.1.10 on port 9234  "
+            ]
+          }
+        }
+      ],
+      "reliableCache": 30,
+      "documentation": "ADT A08 equivalent for external system notifications",
+      "event": [
+        {
+          "code": {
+            "system": "http://hl7.org/fhir/message-type",
+            "code": "admin-notify"
+          },
+          "category": "Consequence",
+          "mode": "receiver",
+          "_mode": {
+            "fhir_comments": [
+              "   this a receiver - i.e. answers. Not neccessariy a server (though this is)   "
+            ]
+          },
+          "focus": "Patient",
+          "request": {
+            "fhir_comments": [
+              "   specify a profile for the request person. Very often there's no \n        point profiling the response, it's not interesting   "
+            ],
+            "reference": "StructureDefinition/daf-patient"
+          },
+          "response": {
+            "reference": "StructureDefinition/MessageHeader"
+          },
+          "documentation": "Notification of an update to a patient resource. changing the links is not supported"
+        }
+      ]
+    }
+  ],
+  "document": [
+    {
+      "fhir_comments": [
+        "   a document conformance statement   "
+      ],
+      "mode": "consumer",
+      "documentation": "Basic rules for all documents in the EHR system",
+      "profile": {
+        "fhir_comments": [
+          "   this is the important element: a reference to a published document profile \n       note that this is a version specific reference.  "
+        ],
+        "reference": "http://fhir.hl7.org/base/Profilebc054d23-75e1-4dc6-aca5-838b6b1ac81d/_history/b5fdd9fc-b021-4ea1-911a-721a60663796"
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_1.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_1.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Immunization",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: completed</p><p><b>date</b>: 10/01/2013</p><p><b>vaccineCode</b>: Fluvax (Influenza) <span>(Details : {urn:oid:1.2.36.1.2001.1005.17 code 'FLUVAX' = '??)</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>wasNotGiven</b>: false</p><p><b>reported</b>: false</p><p><b>performer</b>: <a>Practitioner/example</a></p><p><b>requester</b>: <a>Practitioner/example</a></p><p><b>encounter</b>: <a>Encounter/example</a></p><p><b>manufacturer</b>: <a>Organization/hl7</a></p><p><b>location</b>: <a>Location/1</a></p><p><b>lotNumber</b>: AAJN11K</p><p><b>expirationDate</b>: 15/02/2015</p><p><b>site</b>: left arm <span>(Details : {http://hl7.org/fhir/v3/ActSite code 'LA' = 'left arm', given as 'left arm'})</span></p><p><b>route</b>: Injection, intramuscular <span>(Details : {http://hl7.org/fhir/v3/RouteOfAdministration code 'IM' = 'Injection, intramuscular', given as 'Injection, intramuscular'})</span></p><p><b>doseQuantity</b>: 5 mg<span> (Details: http://unitsofmeasure.org code mg = 'mg')</span></p><p><b>note</b>: Notes on adminstration of vaccine</p><h3>Explanations</h3><table><tr><td>-</td><td><b>Reason</b></td></tr><tr><td>*</td><td>Procedure to meet occupational requirement (procedure) <span>(Details : {SNOMED CT code '429060002' = 'Procedure to meet occupational requirement (procedure))</span></td></tr></table><h3>Reactions</h3><table><tr><td>-</td><td><b>Date</b></td><td><b>Detail</b></td><td><b>Reported</b></td></tr><tr><td>*</td><td>10/01/2013</td><td><a>Observation/example</a></td><td>true</td></tr></table><h3>VaccinationProtocols</h3><table><tr><td>-</td><td><b>DoseSequence</b></td><td><b>Description</b></td><td><b>Authority</b></td><td><b>Series</b></td><td><b>SeriesDoses</b></td><td><b>TargetDisease</b></td><td><b>DoseStatus</b></td><td><b>DoseStatusReason</b></td></tr><tr><td>*</td><td>1</td><td>Vaccination Protocol Sequence 1</td><td><a>Organization/hl7</a></td><td>Vaccination Series 1</td><td>2</td><td>Congenital rubella syndrome (disorder) <span>(Details : {SNOMED CT code '1857005' = 'Congenital rubella syndrome (disorder))</span></td><td>Counts <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status code 'count' = 'Counts', given as 'Counts'})</span></td><td>Cold chain break <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status-reason code 'coldchbrk' = 'Cold chain break', given as 'Cold chain break'})</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "completed",
+  "date": "2013-01-10",
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.36.1.2001.1005.17",
+        "code": "FLUVAX"
+      }
+    ],
+    "text": "Fluvax (Influenza)"
+  },
+  "patient": {
+    "reference": "Patient/example"
+  },
+  "wasNotGiven": false,
+  "reported": false,
+  "performer": {
+    "reference": "Practitioner/example"
+  },
+  "requester": {
+    "reference": "Practitioner/example"
+  },
+  "encounter": {
+    "reference": "Encounter/example"
+  },
+  "manufacturer": {
+    "reference": "Organization/hl7"
+  },
+  "location": {
+    "reference": "Location/1"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15",
+  "site": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ]
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ]
+  },
+  "doseQuantity": {
+    "value": 5,
+    "system": "http://unitsofmeasure.org",
+    "code": "mg"
+  },
+  "note": [
+    {
+      "text": "Notes on adminstration of vaccine"
+    }
+  ],
+  "explanation": {
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "429060002"
+          }
+        ]
+      }
+    ]
+  },
+  "reaction": [
+    {
+      "date": "2013-01-10",
+      "detail": {
+        "reference": "Observation/example"
+      },
+      "reported": true
+    }
+  ],
+  "vaccinationProtocol": [
+    {
+      "doseSequence": 1,
+      "description": "Vaccination Protocol Sequence 1",
+      "authority": {
+        "reference": "Organization/hl7"
+      },
+      "series": "Vaccination Series 1",
+      "seriesDoses": 2,
+      "targetDisease": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1857005"
+            }
+          ]
+        }
+      ],
+      "doseStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status",
+            "code": "count",
+            "display": "Counts"
+          }
+        ]
+      },
+      "doseStatusReason": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status-reason",
+            "code": "coldchbrk",
+            "display": "Cold chain break"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_2.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_2.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Immunization",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: completed</p><p><b>date</b>: 10/01/2013</p><p><b>vaccineCode</b>: Fluvax (Influenza) <span>(Details : {urn:oid:1.2.36.1.2001.1005.17 code 'FLUVAX' = '??)</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>wasNotGiven</b>: false</p><p><b>reported</b>: false</p><p><b>performer</b>: <a>Practitioner/example</a></p><p><b>requester</b>: <a>Practitioner/example</a></p><p><b>encounter</b>: <a>Encounter/example</a></p><p><b>manufacturer</b>: <a>Organization/hl7</a></p><p><b>location</b>: <a>Location/1</a></p><p><b>lotNumber</b>: AAJN11K</p><p><b>expirationDate</b>: 15/02/2015</p><p><b>site</b>: left arm <span>(Details : {http://hl7.org/fhir/v3/ActSite code 'LA' = 'left arm', given as 'left arm'})</span></p><p><b>route</b>: Injection, intramuscular <span>(Details : {http://hl7.org/fhir/v3/RouteOfAdministration code 'IM' = 'Injection, intramuscular', given as 'Injection, intramuscular'})</span></p><p><b>doseQuantity</b>: 5 mg<span> (Details: http://unitsofmeasure.org code mg = 'mg')</span></p><p><b>note</b>: Notes on adminstration of vaccine</p><h3>Explanations</h3><table><tr><td>-</td><td><b>Reason</b></td></tr><tr><td>*</td><td>Procedure to meet occupational requirement (procedure) <span>(Details : {SNOMED CT code '429060002' = 'Procedure to meet occupational requirement (procedure))</span></td></tr></table><h3>Reactions</h3><table><tr><td>-</td><td><b>Date</b></td><td><b>Detail</b></td><td><b>Reported</b></td></tr><tr><td>*</td><td>10/01/2013</td><td><a>Observation/example</a></td><td>true</td></tr></table><h3>VaccinationProtocols</h3><table><tr><td>-</td><td><b>DoseSequence</b></td><td><b>Description</b></td><td><b>Authority</b></td><td><b>Series</b></td><td><b>SeriesDoses</b></td><td><b>TargetDisease</b></td><td><b>DoseStatus</b></td><td><b>DoseStatusReason</b></td></tr><tr><td>*</td><td>1</td><td>Vaccination Protocol Sequence 1</td><td><a>Organization/hl7</a></td><td>Vaccination Series 1</td><td>2</td><td>Congenital rubella syndrome (disorder) <span>(Details : {SNOMED CT code '1857005' = 'Congenital rubella syndrome (disorder))</span></td><td>Counts <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status code 'count' = 'Counts', given as 'Counts'})</span></td><td>Cold chain break <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status-reason code 'coldchbrk' = 'Cold chain break', given as 'Cold chain break'})</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "completed",
+  "date": "2013-01-10",
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.36.1.2001.1005.17",
+        "code": "FLUVAX"
+      }
+    ],
+    "text": "Fluvax (Influenza)"
+  },
+  "patient": {
+    "reference": "Patient/example"
+  },
+  "wasNotGiven": false,
+  "reported": false,
+  "performer": {
+    "reference": "Practitioner/example"
+  },
+  "requester": {
+    "reference": "Practitioner/example"
+  },
+  "encounter": {
+    "reference": "Encounter/example"
+  },
+  "manufacturer": {
+    "reference": "Organization/hl7"
+  },
+  "location": {
+    "reference": "Location/1"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15",
+  "site": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ]
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ]
+  },
+  "doseQuantity": {
+    "value": 5,
+    "system": "http://unitsofmeasure.org",
+    "code": "mg"
+  },
+  "note": [
+    {
+      "text": "Notes on adminstration of vaccine"
+    }
+  ],
+  "explanation": {
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "429060002"
+          }
+        ]
+      }
+    ]
+  },
+  "reaction": [
+    {
+      "date": "2013-01-10",
+      "detail": {
+        "reference": "Observation/example"
+      },
+      "reported": true
+    }
+  ],
+  "vaccinationProtocol": [
+    {
+      "doseSequence": 1,
+      "description": "Vaccination Protocol Sequence 1",
+      "authority": {
+        "reference": "Organization/hl7"
+      },
+      "series": "Vaccination Series 1",
+      "seriesDoses": 2,
+      "targetDisease": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1857004"
+            }
+          ]
+        }
+      ],
+      "doseStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status",
+            "code": "count",
+            "display": "Counts"
+          }
+        ]
+      },
+      "doseStatusReason": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status-reason",
+            "code": "coldchbrk",
+            "display": "Cold chain break"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_3.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/immunization_example_3.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Immunization",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: completed</p><p><b>date</b>: 10/01/2013</p><p><b>vaccineCode</b>: Fluvax (Influenza) <span>(Details : {urn:oid:1.2.36.1.2001.1005.17 code 'FLUVAX' = '??)</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>wasNotGiven</b>: false</p><p><b>reported</b>: false</p><p><b>performer</b>: <a>Practitioner/example</a></p><p><b>requester</b>: <a>Practitioner/example</a></p><p><b>encounter</b>: <a>Encounter/example</a></p><p><b>manufacturer</b>: <a>Organization/hl7</a></p><p><b>location</b>: <a>Location/1</a></p><p><b>lotNumber</b>: AAJN11K</p><p><b>expirationDate</b>: 15/02/2015</p><p><b>site</b>: left arm <span>(Details : {http://hl7.org/fhir/v3/ActSite code 'LA' = 'left arm', given as 'left arm'})</span></p><p><b>route</b>: Injection, intramuscular <span>(Details : {http://hl7.org/fhir/v3/RouteOfAdministration code 'IM' = 'Injection, intramuscular', given as 'Injection, intramuscular'})</span></p><p><b>doseQuantity</b>: 5 mg<span> (Details: http://unitsofmeasure.org code mg = 'mg')</span></p><p><b>note</b>: Notes on adminstration of vaccine</p><h3>Explanations</h3><table><tr><td>-</td><td><b>Reason</b></td></tr><tr><td>*</td><td>Procedure to meet occupational requirement (procedure) <span>(Details : {SNOMED CT code '429060002' = 'Procedure to meet occupational requirement (procedure))</span></td></tr></table><h3>Reactions</h3><table><tr><td>-</td><td><b>Date</b></td><td><b>Detail</b></td><td><b>Reported</b></td></tr><tr><td>*</td><td>10/01/2013</td><td><a>Observation/example</a></td><td>true</td></tr></table><h3>VaccinationProtocols</h3><table><tr><td>-</td><td><b>DoseSequence</b></td><td><b>Description</b></td><td><b>Authority</b></td><td><b>Series</b></td><td><b>SeriesDoses</b></td><td><b>TargetDisease</b></td><td><b>DoseStatus</b></td><td><b>DoseStatusReason</b></td></tr><tr><td>*</td><td>1</td><td>Vaccination Protocol Sequence 1</td><td><a>Organization/hl7</a></td><td>Vaccination Series 1</td><td>2</td><td>Congenital rubella syndrome (disorder) <span>(Details : {SNOMED CT code '1857005' = 'Congenital rubella syndrome (disorder))</span></td><td>Counts <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status code 'count' = 'Counts', given as 'Counts'})</span></td><td>Cold chain break <span>(Details : {http://hl7.org/fhir/vaccination-protocol-dose-status-reason code 'coldchbrk' = 'Cold chain break', given as 'Cold chain break'})</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "completed",
+  "date": "2013-01-10",
+  "vaccineCode": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.36.1.2001.1005.17",
+        "code": "FLUVAX"
+      }
+    ],
+    "text": "Fluvax (Influenza)"
+  },
+  "patient": {
+    "reference": "Patient/example"
+  },
+  "wasNotGiven": true,
+  "reported": false,
+  "performer": {
+    "reference": "Practitioner/example"
+  },
+  "requester": {
+    "reference": "Practitioner/example"
+  },
+  "encounter": {
+    "reference": "Encounter/example"
+  },
+  "manufacturer": {
+    "reference": "Organization/hl7"
+  },
+  "location": {
+    "reference": "Location/1"
+  },
+  "lotNumber": "AAJN11K",
+  "expirationDate": "2015-02-15",
+  "site": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActSite",
+        "code": "LA",
+        "display": "left arm"
+      }
+    ]
+  },
+  "route": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/RouteOfAdministration",
+        "code": "IM",
+        "display": "Injection, intramuscular"
+      }
+    ]
+  },
+  "doseQuantity": {
+    "value": 5,
+    "system": "http://unitsofmeasure.org",
+    "code": "mg"
+  },
+  "note": [
+    {
+      "text": "Notes on adminstration of vaccine"
+    }
+  ],
+  "explanation": {
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "429060002"
+          }
+        ]
+      }
+    ]
+  },
+  "reaction": [
+    {
+      "date": "2013-01-10",
+      "detail": {
+        "reference": "Observation/example"
+      },
+      "reported": true
+    }
+  ],
+  "vaccinationProtocol": [
+    {
+      "doseSequence": 1,
+      "description": "Vaccination Protocol Sequence 1",
+      "authority": {
+        "reference": "Organization/hl7"
+      },
+      "series": "Vaccination Series 1",
+      "seriesDoses": 2,
+      "targetDisease": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1857005"
+            }
+          ]
+        }
+      ],
+      "doseStatus": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status",
+            "code": "count",
+            "display": "Counts"
+          }
+        ]
+      },
+      "doseStatusReason": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/vaccination-protocol-dose-status-reason",
+            "code": "coldchbrk",
+            "display": "Cold chain break"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_1.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_1.json
@@ -1,0 +1,154 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <table>\n        \n        <tbody>\n          \n          <tr>\n            \n            <td>Name</td>\n            \n            <td>Peter James \n              <b>Chalmers</b> (&quot;Jim&quot;)\n            </td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Address</td>\n            \n            <td>534 Erewhon, Pleasantville, Vic, 3999</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Contacts</td>\n            \n            <td>Home: unknown. Work: (03) 5555 6473</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Id</td>\n            \n            <td>MRN: 12345 (Acme Healthcare)</td>\n          \n          </tr>\n        \n        </tbody>\n      \n      </table>    \n    \n    </div>"
+  },
+  "identifier": [
+    {
+      "fhir_comments": [
+        "   MRN assigned by ACME healthcare on 6-May 2001   "
+      ],
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "system": "urn:oid:1.2.36.146.595.217.0.1",
+      "value": "12345",
+      "period": {
+        "start": "2001-05-06"
+      },
+      "assigner": {
+        "display": "Acme Healthcare"
+      }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "fhir_comments": [
+        "   Peter James Chalmers, but called \"Jim\"   "
+      ],
+      "use": "official",
+      "family": [
+        "Chalmers"
+      ],
+      "given": [
+        "Peter",
+        "James"
+      ]
+    },
+    {
+      "use": "usual",
+      "given": [
+        "Jim"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "fhir_comments": [
+        "   home communication details aren't known   "
+      ],
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "(03) 5555 6473",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "_gender": {
+    "fhir_comments": [
+      "   use FHIR code system for male / female   "
+    ]
+  },
+  "birthDate": "1974-12-25",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "1974-12-25T14:35:45-05:00"
+      }
+    ]
+  },
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "district": "Rainbow",
+      "state": "Vic",
+      "postalCode": "3999",
+      "period": {
+        "start": "1974-12-25"
+      }
+    }
+  ],
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/patient-contact-relationship",
+              "code": "partner"
+            }
+          ]
+        }
+      ],
+      "name": {
+        "family": [
+          "du",
+          "Marché"
+        ],
+        "_family": [
+          {
+            "extension": [
+              {
+                "fhir_comments": [
+                  "   the \"du\" part is a family name prefix (VV in iso 21090)   "
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                "valueCode": "VV"
+              }
+            ]
+          },
+          null
+        ],
+        "given": [
+          "Bénédicte"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "+33 (237) 998327"
+        }
+      ],
+      "gender": "female",
+      "period": {
+        "start": "2012",
+        "_start": {
+          "fhir_comments": [
+            "   The contact relationship started in 2012   "
+          ]
+        }
+      }
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/1"
+  }
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_2.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_2.json
@@ -1,0 +1,153 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <table>\n        \n        <tbody>\n          \n          <tr>\n            \n            <td>Name</td>\n            \n            <td>Peter James \n              <b>Chalmers</b> (&quot;Jim&quot;)\n            </td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Address</td>\n            \n            <td>534 Erewhon, Pleasantville, Vic, 3999</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Contacts</td>\n            \n            <td>Home: unknown. Work: (03) 5555 6473</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Id</td>\n            \n            <td>MRN: 12345 (Acme Healthcare)</td>\n          \n          </tr>\n        \n        </tbody>\n      \n      </table>    \n    \n    </div>"
+  },
+  "identifier": [
+    {
+      "fhir_comments": [
+        "   MRN assigned by ACME healthcare on 6-May 2001   "
+      ],
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "system": "urn:oid:1.2.36.146.595.217.0.1",
+      "value": "12345",
+      "period": {
+        "start": "2001-05-06"
+      },
+      "assigner": {
+        "display": "Acme Healthcare"
+      }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "fhir_comments": [
+        "   Peter James Chalmers, but called \"Jim\"   "
+      ],
+      "use": "official",
+      "family": [
+        "Chalmers"
+      ],
+      "given": [
+        "Supernintendo"
+      ]
+    },
+    {
+      "use": "usual",
+      "given": [
+        "Jim"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "fhir_comments": [
+        "   home communication details aren't known   "
+      ],
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "(03) 5555 6473",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "_gender": {
+    "fhir_comments": [
+      "   use FHIR code system for male / female   "
+    ]
+  },
+  "birthDate": "1974-12-25",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "1974-12-25T14:35:45-05:00"
+      }
+    ]
+  },
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "district": "Rainbow",
+      "state": "Vic",
+      "postalCode": "3999",
+      "period": {
+        "start": "1974-12-25"
+      }
+    }
+  ],
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/patient-contact-relationship",
+              "code": "partner"
+            }
+          ]
+        }
+      ],
+      "name": {
+        "family": [
+          "du",
+          "Marché"
+        ],
+        "_family": [
+          {
+            "extension": [
+              {
+                "fhir_comments": [
+                  "   the \"du\" part is a family name prefix (VV in iso 21090)   "
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                "valueCode": "VV"
+              }
+            ]
+          },
+          null
+        ],
+        "given": [
+          "Bénédicte"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "+33 (237) 998327"
+        }
+      ],
+      "gender": "female",
+      "period": {
+        "start": "2012",
+        "_start": {
+          "fhir_comments": [
+            "   The contact relationship started in 2012   "
+          ]
+        }
+      }
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/1"
+  }
+}

--- a/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_3.json
+++ b/org.hl7.fhir.dstu2016may/src/test/resources/patient_example_3.json
@@ -1,0 +1,154 @@
+{
+  "resourceType": "Patient",
+  "id": "other-example",
+  "text": {
+    "status": "generated",
+    "div": "<div>\n      \n      <table>\n        \n        <tbody>\n          \n          <tr>\n            \n            <td>Name</td>\n            \n            <td>Peter James \n              <b>Chalmers</b> (&quot;Jim&quot;)\n            </td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Address</td>\n            \n            <td>534 Erewhon, Pleasantville, Vic, 3999</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Contacts</td>\n            \n            <td>Home: unknown. Work: (03) 5555 6473</td>\n          \n          </tr>\n          \n          <tr>\n            \n            <td>Id</td>\n            \n            <td>MRN: 12345 (Acme Healthcare)</td>\n          \n          </tr>\n        \n        </tbody>\n      \n      </table>    \n    \n    </div>"
+  },
+  "identifier": [
+    {
+      "fhir_comments": [
+        "   MRN assigned by ACME healthcare on 6-May 2001   "
+      ],
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "system": "urn:oid:1.2.36.146.595.217.0.1",
+      "value": "12345",
+      "period": {
+        "start": "2001-05-06"
+      },
+      "assigner": {
+        "display": "Acme Healthcare"
+      }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "fhir_comments": [
+        "   Peter James Chalmers, but called \"Jim\"   "
+      ],
+      "use": "official",
+      "family": [
+        "Chalmers"
+      ],
+      "given": [
+        "Peter",
+        "James"
+      ]
+    },
+    {
+      "use": "usual",
+      "given": [
+        "Jim"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "fhir_comments": [
+        "   home communication details aren't known   "
+      ],
+      "use": "home"
+    },
+    {
+      "system": "phone",
+      "value": "(03) 5555 6473",
+      "use": "work"
+    }
+  ],
+  "gender": "male",
+  "_gender": {
+    "fhir_comments": [
+      "   use FHIR code system for male / female   "
+    ]
+  },
+  "birthDate": "1974-12-25",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "1974-12-25T14:35:45-05:00"
+      }
+    ]
+  },
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "district": "Rainbow",
+      "state": "Vic",
+      "postalCode": "3999",
+      "period": {
+        "start": "1974-12-25"
+      }
+    }
+  ],
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/patient-contact-relationship",
+              "code": "partner"
+            }
+          ]
+        }
+      ],
+      "name": {
+        "family": [
+          "du",
+          "Marché"
+        ],
+        "_family": [
+          {
+            "extension": [
+              {
+                "fhir_comments": [
+                  "   the \"du\" part is a family name prefix (VV in iso 21090)   "
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                "valueCode": "VV"
+              }
+            ]
+          },
+          null
+        ],
+        "given": [
+          "Bénédicte"
+        ]
+      },
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "+33 (237) 998327"
+        }
+      ],
+      "gender": "female",
+      "period": {
+        "start": "2012",
+        "_start": {
+          "fhir_comments": [
+            "   The contact relationship started in 2012   "
+          ]
+        }
+      }
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/1"
+  }
+}


### PR DESCRIPTION
The deepEquals and shallowEquals methods fail when two resources are equal but not the same instance.

This adds tests and a fix (which matches the method from dstu2 and dstu3 Base).