### PR TITLE
Fix r5 url for package fetch

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -621,9 +621,10 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
         InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), false);
         return new InputStreamWithSrc(stream, Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), "current$"+branch);
       }
-    } else if (id.startsWith("hl7.fhir.r5")) {
-      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL("http://build.fhir.org", id + ".tgz"), false);
-      return new InputStreamWithSrc(stream, Utilities.pathURL("http://build.fhir.org", id + ".tgz"), "current");
+    } else if (id.startsWith("hl7.fhir.r5") || id.startsWith("hl7.fhir.r6")) {
+      final String baseUrl = id.endsWith("r6") ? "http://build.fhir.org" : "https://hl7.org/fhir";
+      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(baseUrl, id + ".tgz"), false);
+      return new InputStreamWithSrc(stream, Utilities.pathURL(baseUrl, id + ".tgz"), "current");
     } else {
       throw new FHIRException("The package '" + id + "' has no entry on the current build server ("+ciList.toString()+")");
     }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -621,10 +621,9 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
         InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), false);
         return new InputStreamWithSrc(stream, Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), "current$"+branch);
       }
-    } else if (id.startsWith("hl7.fhir.r5") || id.startsWith("hl7.fhir.r6")) {
-      final String baseUrl = id.endsWith("r6") ? "http://build.fhir.org" : "https://hl7.org/fhir";
-      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(baseUrl, id + ".tgz"), false);
-      return new InputStreamWithSrc(stream, Utilities.pathURL(baseUrl, id + ".tgz"), "current");
+    } else if (id.startsWith("hl7.fhir.r5")) {
+      InputStream stream = fetchFromUrlSpecific(Utilities.pathURL("http://build.fhir.org", id + ".tgz"), false);
+      return new InputStreamWithSrc(stream, Utilities.pathURL("http://build.fhir.org", id + ".tgz"), "current");
     } else {
       throw new FHIRException("The package '" + id + "' has no entry on the current build server ("+ciList.toString()+")");
     }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -621,7 +621,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
         InputStream stream = fetchFromUrlSpecific(Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), false);
         return new InputStreamWithSrc(stream, Utilities.pathURL(ciList.get(id), "branches", branch, "package.tgz"), "current$"+branch);
       }
-    } else if (id.startsWith("hl7.fhir.r5")) {
+    } else if (id.startsWith("hl7.fhir.r6")) {
       InputStream stream = fetchFromUrlSpecific(Utilities.pathURL("http://build.fhir.org", id + ".tgz"), false);
       return new InputStreamWithSrc(stream, Utilities.pathURL("http://build.fhir.org", id + ".tgz"), "current");
     } else {


### PR DESCRIPTION
With changes to HL7/fhir, http://build.fhir.org/hl7.fhir.r6.core.tgz replaces http://build.fhir.org/hl7.fhir.r5.core.tgz 

This means that package fetching for the r5 tgz no longer works.

This PR reworks the logic to get the appropriate url for r5 packages.