### PR TITLE
Bundle.getLink(String) comparing string to enum

### DIFF
--- a/org.hl7.fhir.core.generator/configuration/Bundle.java
+++ b/org.hl7.fhir.core.generator/configuration/Bundle.java
@@ -13,7 +13,7 @@
   public BundleLinkComponent getLink(String theRelation) { 
     org.apache.commons.lang3.Validate.notBlank(theRelation, "theRelation may not be null or empty"); 
     for (BundleLinkComponent next : getLink()) { 
-      if (theRelation.equals(next.getRelation())) { 
+      if (theRelation.equals(next.getRelation().toCode())) {
         return next; 
       } 
     } 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Bundle.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Bundle.java
@@ -5307,7 +5307,7 @@ public class Bundle extends Resource implements IBaseBundle {
   public BundleLinkComponent getLink(String theRelation) { 
     org.apache.commons.lang3.Validate.notBlank(theRelation, "theRelation may not be null or empty"); 
     for (BundleLinkComponent next : getLink()) { 
-      if (theRelation.equals(next.getRelation())) { 
+      if (theRelation.equals(next.getRelation().toCode())) {
         return next; 
       } 
     } 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BundleTypeTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BundleTypeTest.java
@@ -1,0 +1,31 @@
+package org.hl7.fhir.r5.model;
+
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class BundleTypeTest {
+
+  @Test
+  @DisplayName("Test getLink by string when present")
+  public void getLinkShouldFindWhenPresent() {
+    Bundle bundle = new Bundle();
+    Bundle.BundleLinkComponent link = new Bundle.BundleLinkComponent();
+    link.setRelation(Bundle.LinkRelationTypes.NEXT);
+    bundle.getLink().add(link);
+    Bundle.BundleLinkComponent returnedLink = bundle.getLink(IBaseBundle.LINK_NEXT);
+    Assertions.assertNotNull(returnedLink);
+  }
+
+  @Test
+  @DisplayName("Test getLink by string when not present")
+  public void getLinkStringShouldReturnNullWhenNoLinksMatch() {
+    Bundle bundle = new Bundle();
+    Bundle.BundleLinkComponent previousLink = new Bundle.BundleLinkComponent();
+    previousLink.setRelation(Bundle.LinkRelationTypes.PREV);
+    bundle.getLink().add(previousLink);
+    Bundle.BundleLinkComponent returnedLink = bundle.getLink(IBaseBundle.LINK_NEXT);
+    Assertions.assertNull(returnedLink);
+  }
+}


### PR DESCRIPTION
Compare the string value of a LinkRelationTypes enum in Bundle.getLink(String)

Fixes #1266