### PR TITLE
Fix asStringValue on IdType

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/IdType.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/IdType.java
@@ -410,6 +410,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
   }
 
   @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
+  @Override
   public String getVersionIdPart() {
     return myUnqualifiedVersionId;
   }

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/IdType.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/IdType.java
@@ -388,6 +388,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
   }
 
   @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
+  @Override
   public String getVersionIdPart() {
     return myUnqualifiedVersionId;
   }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/IdType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/IdType.java
@@ -385,6 +385,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
   }
 
   @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
+  @Override
   public String getVersionIdPart() {
     return myUnqualifiedVersionId;
   }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/IdType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/IdType.java
@@ -495,6 +495,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
     return getValue();
   }
 
+  @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
   /**
    * Set the value
    * <p>

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/IdType.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/IdType.java
@@ -493,6 +493,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
     return getValue();
   }
 
+  @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
   /**
    * Set the value
    * <p>

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/IdType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/IdType.java
@@ -493,6 +493,11 @@ public final class IdType extends UriType implements IPrimitiveType<String>, IId
     return getValue();
   }
 
+  @Override
+  public String asStringValue() {
+    return getValue();
+  }
+
   /**
    * Set the value
    * <p>

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IdTypeTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IdTypeTest.java
@@ -1,0 +1,25 @@
+package org.hl7.fhir.r5.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IdTypeTest {
+
+  @Test
+  public void testAsString() {
+    IdType t = new IdType("Patient/123");
+    assertEquals("Patient/123", t.asStringValue());
+    assertEquals("Patient/123", t.getValueAsString());
+    assertEquals("Patient/123", t.getValue());
+  }
+
+  @Test
+  public void testAsStringFromComponentParts() {
+    IdType t = new IdType("http://foo", "Patient", "123", "1");
+    assertEquals("http://foo/Patient/123/_history/1", t.asStringValue());
+    assertEquals("http://foo/Patient/123/_history/1", t.getValueAsString());
+    assertEquals("http://foo/Patient/123/_history/1", t.getValue());
+  }
+
+}


### PR DESCRIPTION
Fix #1262

The `IdType#asStringValue()` method returns `null` if the IdType is populated with the component parts. This is never useful behaviour, so this PR fixes that.