### PR TITLE
copy Element children to prevent value modification when validating

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
@@ -1368,7 +1368,9 @@ public class Element extends Base {
     dest.value = value;
     if (children != null) {
       dest.children = new ArrayList<>();
-      dest.children.addAll(children);
+      for (Element child : children) {
+        dest.children.add((Element) child.copy());
+      }
     } else {
       dest.children = null;
     }


### PR DESCRIPTION
# Problem (short)
Running the IG Publisher with validation (implemented in org.hl7.fhir.core) results in unintended modifications of resource instance values in the resulting implementation guide.

# Problem (long)
During validation, when validating invariants for the Range datatype, the values of range.low and range.high fields are changed by the [Utilities.lowBoundaryForDecimal()](https://github.com/hapifhir/org.hl7.fhir.core/blob/233d0ecf86f7a93cc2be2d8b8c7f4056ba0c9ce3/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java#L1550) / [Utilities.highBoundaryForDecimal()](https://github.com/hapifhir/org.hl7.fhir.core/blob/233d0ecf86f7a93cc2be2d8b8c7f4056ba0c9ce3/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java#L1672) functions. To prevent changes of the original resource, the elements are [copy()'d before](https://github.com/hapifhir/org.hl7.fhir.core/blob/233d0ecf86f7a93cc2be2d8b8c7f4056ba0c9ce3/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java#L4018), but this function [does not create copies of the Element.children ArrayList entries](https://github.com/hapifhir/org.hl7.fhir.core/blob/233d0ecf86f7a93cc2be2d8b8c7f4056ba0c9ce3/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java#L1371), which include the range.low.value field. Therefore, the value changes by Utilities.lowBoundaryForDecimal() are carried over in the resource instances in the actual implementation guide.

# Reproduce
Create a sushi project, change `fhirVersion` to 5.0.0 in `sushi-config.yaml` and create an `input/fsh/example.fsh` file with the following content:
```
Instance: ProcedureExample
InstanceOf: Procedure
Description: "Example procedure"
* status = #unknown
* subject.display = "subject"
* occurrenceRange
  * low = 40 's'
  * high = 41 's'
```

## Expected output in the IG after running the ig publisher
```json
...
  "occurrenceRange" : {
    "low" : {
      "value" : 40,
      "system" : "http://unitsofmeasure.org",
      "code" : "s"
    },
...
```
Note: This is the output after running sushi (i.e. in `fsh-generated/resources`) , but NOT after running the ig publisher (in `output/`), see below.

## Actual output in the IG
```json
...
  "occurrenceRange" : {
    "low" : {
      "value" : 39.50000000,
      "system" : "http://unitsofmeasure.org",
      "code" : "s"
    },
...
```

## Solution
Copy the actual elements in element.children.
