### PR TITLE
Remove hard coded output stream paths from SubscriptionTopic40_50Test class

### DIFF
--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/SubscriptionTopic40_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/SubscriptionTopic40_50Test.java
@@ -2,19 +2,16 @@ package org.hl7.fhir.convertors.conv40_50;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.FileOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
-import org.hl7.fhir.r5.formats.IParser.OutputStyle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SubscriptionTopic40_50Test {
-
 
   @Test
   @DisplayName("Test r5 -> r4 SubscriptionTopic conversion.")
@@ -31,10 +28,6 @@ public class SubscriptionTopic40_50Test {
 
     org.hl7.fhir.r4.model.Resource r4_streamed = (org.hl7.fhir.r4.model.Basic) new org.hl7.fhir.r4.formats.XmlParser().parse(new ByteArrayInputStream(stream.toByteArray()));
     org.hl7.fhir.r5.model.Resource r5_conv = VersionConvertorFactory_40_50.convertResource(r4_streamed);
-
-    org.hl7.fhir.r5.formats.JsonParser r5_parser = new org.hl7.fhir.r5.formats.JsonParser();
-    r5_parser.setOutputStyle(OutputStyle.PRETTY).compose(new FileOutputStream("/tmp/source.json"), r5_actual);
-    r5_parser.setOutputStyle(OutputStyle.PRETTY).compose(new FileOutputStream("/tmp/output.json"), r5_conv);
 
     assertTrue(r5_actual.equalsDeep(r5_conv), "should be the same");
   }


### PR DESCRIPTION
Hard coded output stream paths in the SubscriptionTopic40_50Test class are preventing successful builds of the **org.hl7.fhir.convertors** project in a local Windows environment.

Addresses hapifhir issue #1301