### PR TITLE
Attempt to fix regex

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/AsteriskFilter.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/AsteriskFilter.java
@@ -6,15 +6,18 @@ import java.io.IOException;
 
 public class AsteriskFilter implements FilenameFilter {
 
+  public static final String EXPRESSION_REGEX = "(.+(?>\\\\|/))*(.*)";
+  
+  public static final String DIR_REGEX = EXPRESSION_REGEX + "\\*(.*)";
 
   String dir;
   String regex;
 
   public AsteriskFilter(String filter) throws IOException {
-    if (!filter.matches("(.*(\\\\|\\/))*(.*)\\*(.*)"))
+    if (!filter.matches(DIR_REGEX))
       throw new IOException("Filter names must have the following syntax: [directorypath][prefix]?*[suffix]?   I.e. The asterisk must be in the filename, not the directory path");
-    dir = filter.replaceAll("(.*(\\\\|\\/))*(.*)\\*(.*)", "$1");
-    String expression = filter.replaceAll("(.*(\\\\|\\/))*(.*)", "$3");
+    dir = filter.replaceAll(DIR_REGEX, "$1");
+    String expression = filter.replaceAll(AsteriskFilter.EXPRESSION_REGEX, "$2");
     regex = "";
     for (int i = 0; i < expression.length(); i++) {
       if (Character.isAlphabetic(expression.codePointAt(i)) || Character.isDigit(expression.codePointAt(i)))

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/AsteriskFilter.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/AsteriskFilter.java
@@ -5,6 +5,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 
 public class AsteriskFilter implements FilenameFilter {
+
+
   String dir;
   String regex;
 
@@ -22,6 +24,10 @@ public class AsteriskFilter implements FilenameFilter {
       else
         regex = regex + "\\" + expression.charAt(i);
     }
+    isDirValid();
+  }
+
+  protected void isDirValid() throws IOException {
     File f = new File(dir);
     if (!f.exists()) {
       throw new IOException("Directory " + dir + " does not exist");

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/utils/AsteriskFilterTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/utils/AsteriskFilterTests.java
@@ -1,0 +1,76 @@
+package org.hl7.fhir.validation.cli.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AsteriskFilterTests {
+
+  private static Stream<Arguments> provideValidFiltersAndDirsForwardSlash() {
+    return Stream.of(
+      Arguments.of("one/*", "one/", ".*"),
+      Arguments.of("/one/*", "/one/", ".*"),
+      Arguments.of("/one/*.*", "/one/", ".*\\..*"),
+      Arguments.of("/one/two.*", "/one/", "two\\..*"),
+      Arguments.of("/one/*.two", "/one/", ".*\\.two"),
+      Arguments.of("one/*/*", "one/*/", ".*"),
+      Arguments.of("one/*/*.*", "one/*/", ".*\\..*"),
+      Arguments.of("/one/two/*", "/one/two/",".*"),
+      Arguments.of("one/two/*/*.*", "one/two/*/", ".*\\..*"),
+      Arguments.of("one/two/*/three.*", "one/two/*/", "three\\..*"),
+      Arguments.of("one/two/*/*.three", "one/two/*/", ".*\\.three"),
+      Arguments.of("one/two/*/*.*three", "one/two/*/", ".*\\..*three"),
+      Arguments.of("/one-two/*", "/one-two/", ".*"),
+      Arguments.of("/one-two/three/*", "/one-two/three/", ".*")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValidFiltersAndDirsForwardSlash")
+  public void testValidFilterDirAndRegex(String filterString, String expectedDir, String expectedRegex) throws IOException {
+    //Test with forward slash separators
+    testFilterDirExtraction(filterString, expectedDir, expectedRegex);
+    //Test with backward slash separators
+    testFilterDirExtraction(filterString.replace('/','\\'), expectedDir.replace('/','\\'), expectedRegex.replace('/','\\'));
+  }
+
+  private static void testFilterDirExtraction(String filterString, String expectedDir, String expectedRegex) throws IOException {
+    AsteriskFilter asteriskFilter = getAsteriskFilterWithoutDirValidityCheck(filterString);
+   assertEquals(expectedRegex, asteriskFilter.regex);
+    assertEquals(expectedDir, asteriskFilter.dir);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "",
+      "one/",
+      "one\\",
+      "one/two",
+      "one\\two"
+    }
+  )
+  public void testInvalidFilterThrowsException(String filterString) {
+    IOException thrown = Assertions.assertThrows(IOException.class, () -> {
+      AsteriskFilter asteriskFilter = getAsteriskFilterWithoutDirValidityCheck(filterString);
+    }, "NumberFormatException was expected");
+  }
+
+  @Nonnull
+  private static AsteriskFilter getAsteriskFilterWithoutDirValidityCheck(String filterString) throws IOException {
+    return new AsteriskFilter(filterString) {
+      @Override
+      protected void isDirValid() throws IOException {
+        // Dont check for existent directory in this case.
+      }
+    };
+  }
+}


### PR DESCRIPTION
This attempts to fix this issue:

```java
 String regex;

  public AsteriskFilter(String filter) throws IOException {
    if (!filter.matches("(.*(\\\\|\\/))*(.*)\\*(.*)"))
```

This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '/'.
