### PR TITLE
Add lenient-display-validation param

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -1296,6 +1296,11 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       throw new Error(formatMessage(I18nConstants.NO_EXPANSIONPROFILE_PROVIDED));
     }
     pin.addParameter().setName("profile").setResource(expParameters);
+
+    if (options.isDisplayWarningMode()) {
+      pin.addParameter("mode","lenient-display-validation");
+    }
+
     if (txLog != null) {
       txLog.clearLastId();
     }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -1260,7 +1260,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
 
   protected ValidationResult validateOnServer(ValueSet vs, Parameters pin, ValidationOptions options) throws FHIRException {
-    boolean cache = false;
+
     if (vs != null) {
       for (ConceptSetComponent inc : vs.getCompose().getInclude()) {
         codeSystemsUsed.add(inc.getSystem());
@@ -1269,37 +1269,8 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
         codeSystemsUsed.add(inc.getSystem());
       }
     }
-    
-    if (vs != null) {
-      if (tcc.isTxCaching() && tcc.getCacheId() != null && vs.getUrl() != null && tcc.getCached().contains(vs.getUrl()+"|"+vs.getVersion())) {
-        pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()+(vs.hasVersion() ? "|"+vs.getVersion() : "")));        
-      } else if (options.getVsAsUrl()){
-        pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()));
-      } else {
-        pin.addParameter().setName("valueSet").setResource(vs);
-        if (vs.getUrl() != null) {
-          tcc.getCached().add(vs.getUrl()+"|"+vs.getVersion());
-        }
-      }
-      cache = true;
-      addDependentResources(pin, vs);
-    }
-    if (cache) {
-      pin.addParameter().setName("cache-id").setValue(new IdType(tcc.getCacheId()));              
-    }
-    for (ParametersParameterComponent pp : pin.getParameter()) {
-      if (pp.getName().equals("profile")) {
-        throw new Error(formatMessage(I18nConstants.CAN_ONLY_SPECIFY_PROFILE_IN_THE_CONTEXT));
-      }
-    }
-    if (expParameters == null) {
-      throw new Error(formatMessage(I18nConstants.NO_EXPANSIONPROFILE_PROVIDED));
-    }
-    pin.addParameter().setName("profile").setResource(expParameters);
 
-    if (options.isDisplayWarningMode()) {
-      pin.addParameter("mode","lenient-display-validation");
-    }
+    addServerValidationParameters(vs, pin, options);
 
     if (txLog != null) {
       txLog.clearLastId();
@@ -1314,6 +1285,40 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       pOut = tcc.getClient().validateVS(pin);
     }
     return processValidationResult(pOut);
+  }
+
+  protected void addServerValidationParameters(ValueSet vs, Parameters pin, ValidationOptions options) {
+    boolean cache = false;
+    if (vs != null) {
+      if (tcc.isTxCaching() && tcc.getCacheId() != null && vs.getUrl() != null && tcc.getCached().contains(vs.getUrl()+"|"+ vs.getVersion())) {
+        pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()+(vs.hasVersion() ? "|"+ vs.getVersion() : "")));
+      } else if (options.getVsAsUrl()){
+        pin.addParameter().setName("url").setValue(new UriType(vs.getUrl()));
+      } else {
+        pin.addParameter().setName("valueSet").setResource(vs);
+        if (vs.getUrl() != null) {
+          tcc.getCached().add(vs.getUrl()+"|"+ vs.getVersion());
+        }
+      }
+      cache = true;
+      addDependentResources(pin, vs);
+    }
+    if (cache) {
+      pin.addParameter().setName("cache-id").setValue(new IdType(tcc.getCacheId()));
+    }
+    for (ParametersParameterComponent pp : pin.getParameter()) {
+      if (pp.getName().equals("profile")) {
+        throw new Error(formatMessage(I18nConstants.CAN_ONLY_SPECIFY_PROFILE_IN_THE_CONTEXT));
+      }
+    }
+    if (expParameters == null) {
+      throw new Error(formatMessage(I18nConstants.NO_EXPANSIONPROFILE_PROVIDED));
+    }
+    pin.addParameter().setName("profile").setResource(expParameters);
+
+    if (options.isDisplayWarningMode()) {
+      pin.addParameter("mode","lenient-display-validation");
+    }
   }
 
   private boolean addDependentResources(Parameters pin, ValueSet vs) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/BaseWorkerContextTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/BaseWorkerContextTests.java
@@ -1,0 +1,99 @@
+package org.hl7.fhir.r5.context;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.PackageInformation;
+import org.hl7.fhir.r5.model.Parameters;
+import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.r5.utils.validation.IResourceValidator;
+import org.hl7.fhir.utilities.npm.BasePackageCacheManager;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class BaseWorkerContextTests {
+
+  private BaseWorkerContext getBaseWorkerContext() throws IOException {
+    BaseWorkerContext baseWorkerContext = new BaseWorkerContext() {
+      @Override
+      public String getVersion() {
+        return null;
+      }
+
+      @Override
+      public IResourceValidator newValidator() throws FHIRException {
+        return null;
+      }
+
+      @Override
+      public void cachePackage(PackageInformation packageInfo) {
+
+      }
+
+      @Override
+      public List<String> getResourceNames() {
+        return null;
+      }
+
+      @Override
+      public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader) throws FileNotFoundException, IOException, FHIRException {
+        return 0;
+      }
+
+      @Override
+      public int loadFromPackage(NpmPackage pi, IContextResourceLoader loader, List<String> types) throws FileNotFoundException, IOException, FHIRException {
+        return 0;
+      }
+
+      @Override
+      public int loadFromPackageAndDependencies(NpmPackage pi, IContextResourceLoader loader, BasePackageCacheManager pcm) throws FileNotFoundException, IOException, FHIRException {
+        return 0;
+      }
+
+      @Override
+      public boolean hasPackage(String id, String ver) {
+        return false;
+      }
+
+      @Override
+      public boolean hasPackage(PackageInformation pack) {
+        return false;
+      }
+
+      @Override
+      public PackageInformation getPackage(String id, String ver) {
+        return null;
+      }
+
+      @Override
+      public String getSpecUrl() {
+        return null;
+      }
+    };
+    baseWorkerContext.expParameters = new Parameters();
+    return baseWorkerContext;
+  }
+
+  @Test
+  public void testAddServerValidationParametersDisplayWarning() throws IOException {
+    BaseWorkerContext baseWorkerContext = getBaseWorkerContext();
+    Parameters pin = new Parameters();
+    baseWorkerContext.addServerValidationParameters(new ValueSet(), pin, new ValidationOptions().setDisplayWarningMode(true));
+    assertEquals("lenient-display-validation", pin.getParameter("mode").getValue().primitiveValue());
+  }
+
+  @Test
+  public void testAddServerValidationParametersDisplayError() throws IOException {
+    BaseWorkerContext baseWorkerContext = getBaseWorkerContext();
+
+    Parameters pin = new Parameters();
+    baseWorkerContext.addServerValidationParameters(new ValueSet(), pin, new ValidationOptions());
+    assertNull(pin.getParameter("mode"));
+  }
+}


### PR DESCRIPTION
Validation from the remote server doesn't create a `lenient-display-validation` param, meaning that when the Validator CLI is run with  `-display-issues-are-warnings`, this isn't passed on to the server, and all display errors remain errors.

This adds that param.
