### PR TITLE
New getValueAsString(TemporalPrecisionEnum) method for DateTimeType

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/model/BaseDateTimeType.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.hl7.fhir.utilities.DateTimeUtil;
 
+import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -150,60 +151,73 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     }
   }
 
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
   @Override
 	protected String encode(Date theValue) {
-		if (theValue == null) {
-			return null;
+    return encode(theValue, myPrecision);
+  }
+
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
+    if (theValue == null) {
+      return null;
 		} else {
-			switch (myPrecision) {
+      switch (thePrecision) {
 			case DAY:
-				return ourYearMonthDayFormat.format(theValue);
+        return ourYearMonthDayFormat.format(theValue);
 			case MONTH:
-				return ourYearMonthFormat.format(theValue);
+        return ourYearMonthFormat.format(theValue);
 			case YEAR:
-				return ourYearFormat.format(theValue);
+        return ourYearFormat.format(theValue);
 			case MINUTE:
 				if (myTimeZoneZulu) {
 					GregorianCalendar cal = new GregorianCalendar(getTimeZone("GMT"));
 					cal.setTime(theValue);
-					return ourYearMonthDayTimeMinsFormat.format(cal) + "Z";
+          return ourYearMonthDayTimeMinsFormat.format(cal) + "Z";
 				} else if (myTimeZone != null) {
 					GregorianCalendar cal = new GregorianCalendar(myTimeZone);
 					cal.setTime(theValue);
-					return (ourYearMonthDayTimeMinsZoneFormat.format(cal));
+          return (ourYearMonthDayTimeMinsZoneFormat.format(cal));
 				} else {
-					return ourYearMonthDayTimeMinsFormat.format(theValue);
+          return ourYearMonthDayTimeMinsFormat.format(theValue);
 				}
 			case SECOND:
 				if (myTimeZoneZulu) {
 					GregorianCalendar cal = new GregorianCalendar(getTimeZone("GMT"));
 					cal.setTime(theValue);
-					return ourYearMonthDayTimeFormat.format(cal) + "Z";
+          return ourYearMonthDayTimeFormat.format(cal) + "Z";
 				} else if (myTimeZone != null) {
 					GregorianCalendar cal = new GregorianCalendar(myTimeZone);
 					cal.setTime(theValue);
-					return (ourYearMonthDayTimeZoneFormat.format(cal));
+          return (ourYearMonthDayTimeZoneFormat.format(cal));
 				} else {
-					return ourYearMonthDayTimeFormat.format(theValue);
+          return ourYearMonthDayTimeFormat.format(theValue);
 				}
 			case MILLI:
 				if (myTimeZoneZulu) {
 					GregorianCalendar cal = new GregorianCalendar(getTimeZone("GMT"));
 					cal.setTime(theValue);
-					return ourYearMonthDayTimeMilliFormat.format(cal) + "Z";
+          return ourYearMonthDayTimeMilliFormat.format(cal) + "Z";
 				} else if (myTimeZone != null) {
 					GregorianCalendar cal = new GregorianCalendar(myTimeZone);
 					cal.setTime(theValue);
-					return (ourYearMonthDayTimeMilliZoneFormat.format(cal));
+          return (ourYearMonthDayTimeMilliZoneFormat.format(cal));
 				} else {
-					return ourYearMonthDayTimeMilliFormat.format(theValue);
+          return ourYearMonthDayTimeMilliFormat.format(theValue);
 				}
 			}
-			throw new IllegalStateException("Invalid precision (this is a bug, shouldn't happen https://xkcd.com/2200/): " + myPrecision);
+			throw new IllegalStateException("Invalid precision (this is a bug, shouldn't happen https://xkcd.com/2200/): " + thePrecision);
 		}
-	}
+  }
 
-	/**
+  /**
 	 * Returns the default precision for the given datatype
 	 */
 	protected abstract TemporalPrecisionEnum getDefaultPrecisionForDatatype();

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/model/BaseDateTimeTypeTests.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/model/BaseDateTimeTypeTests.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.dstu2.model;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -57,5 +58,24 @@ public class BaseDateTimeTypeTests {
     K srcInstance = clazz.getDeclaredConstructor().newInstance();
     srcInstance.setValueAsString(param);
     assertEquals(param, srcInstance.getValueAsString());
+  }
+
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
   }
 }

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/model/BaseDateTimeType.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.utilities.DateTimeUtil;
 
+import javax.annotation.Nullable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -105,8 +106,21 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     myTimeZoneZulu = false;
   }
 
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
   @Override
   protected String encode(Date theValue) {
+    return encode(theValue, myPrecision);
+  }
+
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
     if (theValue == null) {
       return null;
     } else {
@@ -122,21 +136,22 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
       StringBuilder b = new StringBuilder();
       leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
-      if (myPrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
+
+      if (thePrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
         b.append('-');
         leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
-        if (myPrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
+        if (thePrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
           b.append('-');
           leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
-          if (myPrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+          if (thePrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
             b.append('T');
             leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
             b.append(':');
             leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
-            if (myPrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
+            if (thePrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
               b.append(':');
               leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
-              if (myPrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
+              if (thePrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
                 b.append('.');
                 b.append(myFractionalSeconds);
                 for (int i = myFractionalSeconds.length(); i < 3; i++) {

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/test/BaseDateTimeTypeTest.java
@@ -2,15 +2,22 @@ package org.hl7.fhir.dstu2016may.test;
 
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.hl7.fhir.dstu2016may.model.DateTimeType;
 import org.hl7.fhir.dstu2016may.model.DateType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaseDateTimeTypeTest {
 	private SimpleDateFormat myDateInstantParser;
@@ -51,4 +58,23 @@ public class BaseDateTimeTypeTest {
 		date.setValue(time);
     Assertions.assertEquals("2012-01-02", date.getValueAsString());
 	}
+
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
+  }
 }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/model/BaseDateTimeType.java
@@ -48,6 +48,8 @@ import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.parser.DataFormatException;
 import org.hl7.fhir.utilities.DateTimeUtil;
 
+import javax.annotation.Nullable;
+
 public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
   static final long NANOS_PER_MILLIS = 1000000L;
@@ -167,8 +169,21 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
     myTimeZoneZulu = false;
   }
 
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
   @Override
   protected String encode(Date theValue) {
+    return encode(theValue, myPrecision);
+  }
+
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
     if (theValue == null) {
       return null;
     } else {
@@ -184,21 +199,22 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
       StringBuilder b = new StringBuilder();
       leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
-      if (myPrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
+
+      if (thePrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
         b.append('-');
         leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
-        if (myPrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
+        if (thePrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
           b.append('-');
           leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
-          if (myPrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+          if (thePrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
             b.append('T');
             leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
             b.append(':');
             leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
-            if (myPrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
+            if (thePrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
               b.append(':');
               leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
-              if (myPrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
+              if (thePrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
                 b.append('.');
                 b.append(myFractionalSeconds);
                 for (int i = myFractionalSeconds.length(); i < 3; i++) {

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BaseDateTimeTypeTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BaseDateTimeTypeTests.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.dstu3.model;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.parser.DataFormatException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,5 +59,24 @@ public class BaseDateTimeTypeTests {
     K srcInstance = clazz.getDeclaredConstructor().newInstance();
     srcInstance.setValueAsString(param);
     assertEquals(param, srcInstance.getValueAsString());
+  }
+
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
   }
 }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/model/BaseDateTimeType.java
@@ -49,6 +49,8 @@ import ca.uhn.fhir.parser.DataFormatException;
 import org.hl7.fhir.utilities.DateTimeUtil;
 import org.hl7.fhir.utilities.Utilities;
 
+import javax.annotation.Nullable;
+
 public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 	static final long NANOS_PER_MILLIS = 1000000L;
@@ -171,72 +173,86 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		myTimeZoneZulu = false;
 	}
 
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
 	@Override
 	protected String encode(Date theValue) {
-		if (theValue == null) {
-			return null;
-		} else {
-			GregorianCalendar cal;
-			if (myTimeZoneZulu) {
-				cal = new GregorianCalendar(getTimeZone("GMT"));
-			} else if (myTimeZone != null) {
-				cal = new GregorianCalendar(myTimeZone);
-			} else {
-				cal = new GregorianCalendar();
-			}
-			cal.setTime(theValue);
+    return encode(theValue, myPrecision);
+  }
 
-			StringBuilder b = new StringBuilder();
-			leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
-			if (myPrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
-				b.append('-');
-				leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
-				if (myPrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
-					b.append('-');
-					leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
-					if (myPrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
-						b.append('T');
-						leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
-						b.append(':');
-						leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
-						if (myPrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
-							b.append(':');
-							leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
-							if (myPrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
-								b.append('.');
-								b.append(myFractionalSeconds);
-								for (int i = myFractionalSeconds.length(); i < 3; i++) {
-									b.append('0');
-								}
-							}
-						}
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
+    if (theValue == null) {
+      return null;
+    } else {
+      GregorianCalendar cal;
+      if (myTimeZoneZulu) {
+        cal = new GregorianCalendar(getTimeZone("GMT"));
+      } else if (myTimeZone != null) {
+        cal = new GregorianCalendar(myTimeZone);
+      } else {
+        cal = new GregorianCalendar();
+      }
+      cal.setTime(theValue);
 
-						if (myTimeZoneZulu) {
-							b.append('Z');
-						} else if (myTimeZone != null) {
-							int offset = myTimeZone.getOffset(theValue.getTime());
-							if (offset >= 0) {
-								b.append('+');
-							} else {
-								b.append('-');
-								offset = Math.abs(offset);
-							}
+      StringBuilder b = new StringBuilder();
+      leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
 
-							int hoursOffset = (int) (offset / DateUtils.MILLIS_PER_HOUR);
-							leftPadWithZeros(hoursOffset, 2, b);
-							b.append(':');
-							int minutesOffset = (int) (offset % DateUtils.MILLIS_PER_HOUR);
-							minutesOffset = (int) (minutesOffset / DateUtils.MILLIS_PER_MINUTE);
-							leftPadWithZeros(minutesOffset, 2, b);
-						}
-					}
-				}
-			}
-			return b.toString();
-		}
-	}
+if (thePrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
+        b.append('-');
+        leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
+        if (thePrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
+          b.append('-');
+          leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
+          if (thePrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+            b.append('T');
+            leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
+            b.append(':');
+            leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
+            if (thePrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
+              b.append(':');
+              leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
+              if (thePrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
+                b.append('.');
+                b.append(myFractionalSeconds);
+                for (int i = myFractionalSeconds.length(); i < 3; i++) {
+                  b.append('0');
+                }
+              }
+            }
 
-	/**
+            if (myTimeZoneZulu) {
+              b.append('Z');
+            } else if (myTimeZone != null) {
+              int offset = myTimeZone.getOffset(theValue.getTime());
+              if (offset >= 0) {
+                b.append('+');
+              } else {
+                b.append('-');
+                offset = Math.abs(offset);
+              }
+
+              int hoursOffset = (int) (offset / DateUtils.MILLIS_PER_HOUR);
+              leftPadWithZeros(hoursOffset, 2, b);
+              b.append(':');
+              int minutesOffset = (int) (offset % DateUtils.MILLIS_PER_HOUR);
+              minutesOffset = (int) (minutesOffset / DateUtils.MILLIS_PER_MINUTE);
+              leftPadWithZeros(minutesOffset, 2, b);
+            }
+          }
+        }
+      }
+      return b.toString();
+    }
+  }
+
+  /**
 	 * Returns the month with 1-index, e.g. 1=the first day of the month
 	 */
 	public Integer getDay() {

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BaseDateTimeTypeTest.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.r4.model;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -125,4 +126,22 @@ public class BaseDateTimeTypeTest {
     assertEquals(param, srcInstance.getValueAsString());
   }
 
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
+  }
 }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/model/BaseDateTimeType.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.utilities.DateTimeUtil;
 import org.hl7.fhir.utilities.Utilities;
 
+import javax.annotation.Nullable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -169,10 +170,23 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		myTimeZoneZulu = false;
 	}
 
-	@Override
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
+  @Override
 	protected String encode(Date theValue) {
-		if (theValue == null) {
-			return null;
+    return encode(theValue, myPrecision);
+  }
+
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
+    if (theValue == null) {
+      return null;
 		} else {
 			GregorianCalendar cal;
 			if (myTimeZoneZulu) {
@@ -186,21 +200,22 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 			StringBuilder b = new StringBuilder();
 			leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
-			if (myPrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
+
+      if (thePrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
 				b.append('-');
 				leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
-				if (myPrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
+				if (thePrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
 					b.append('-');
 					leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
-					if (myPrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+					if (thePrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
 						b.append('T');
 						leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
 						b.append(':');
 						leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
-						if (myPrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
+						if (thePrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
 							b.append(':');
 							leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
-							if (myPrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
+							if (thePrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
 								b.append('.');
 								b.append(myFractionalSeconds);
 								for (int i = myFractionalSeconds.length(); i < 3; i++) {
@@ -230,11 +245,11 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 					}
 				}
 			}
-			return b.toString();
+      return b.toString();
 		}
-	}
+  }
 
-	/**
+  /**
 	 * Returns the month with 1-index, e.g. 1=the first day of the month
 	 */
 	public Integer getDay() {

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BaseDateTimeTypeTest.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.r4b.model;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -158,4 +159,22 @@ public class BaseDateTimeTypeTest {
     assertEquals(param, srcInstance.getValueAsString());
   }
 
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
+  }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
@@ -170,6 +170,10 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		myTimeZoneZulu = false;
 	}
 
+  /**
+   * @param thePrecision
+   * @return the String value of this instance with the specified precision.
+   */
   public String getValueAsString(TemporalPrecisionEnum thePrecision) {
     return encode(getValue(), thePrecision);
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BaseDateTimeType.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.utilities.DateTimeUtil;
 import org.hl7.fhir.utilities.Utilities;
 
+import javax.annotation.Nullable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -169,10 +170,19 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 		myTimeZoneZulu = false;
 	}
 
+  public String getValueAsString(TemporalPrecisionEnum thePrecision) {
+    return encode(getValue(), thePrecision);
+  }
+
 	@Override
 	protected String encode(Date theValue) {
-		if (theValue == null) {
-			return null;
+    return encode(theValue, myPrecision);
+  }
+
+  @Nullable
+  private String encode(Date theValue, TemporalPrecisionEnum thePrecision) {
+    if (theValue == null) {
+      return null;
 		} else {
 			GregorianCalendar cal;
 			if (myTimeZoneZulu) {
@@ -186,21 +196,22 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 
 			StringBuilder b = new StringBuilder();
 			leftPadWithZeros(cal.get(Calendar.YEAR), 4, b);
-			if (myPrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
+
+      if (thePrecision.ordinal() > TemporalPrecisionEnum.YEAR.ordinal()) {
 				b.append('-');
 				leftPadWithZeros(cal.get(Calendar.MONTH) + 1, 2, b);
-				if (myPrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
+				if (thePrecision.ordinal() > TemporalPrecisionEnum.MONTH.ordinal()) {
 					b.append('-');
 					leftPadWithZeros(cal.get(Calendar.DATE), 2, b);
-					if (myPrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+					if (thePrecision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
 						b.append('T');
 						leftPadWithZeros(cal.get(Calendar.HOUR_OF_DAY), 2, b);
 						b.append(':');
 						leftPadWithZeros(cal.get(Calendar.MINUTE), 2, b);
-						if (myPrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
+						if (thePrecision.ordinal() > TemporalPrecisionEnum.MINUTE.ordinal()) {
 							b.append(':');
 							leftPadWithZeros(cal.get(Calendar.SECOND), 2, b);
-							if (myPrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
+							if (thePrecision.ordinal() > TemporalPrecisionEnum.SECOND.ordinal()) {
 								b.append('.');
 								b.append(myFractionalSeconds);
 								for (int i = myFractionalSeconds.length(); i < 3; i++) {
@@ -230,11 +241,11 @@ public abstract class BaseDateTimeType extends PrimitiveType<Date> {
 					}
 				}
 			}
-			return b.toString();
+      return b.toString();
 		}
-	}
+  }
 
-	/**
+  /**
 	 * Returns the month with 1-index, e.g. 1=the first day of the month
 	 */
 	public Integer getDay() {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BaseDateTimeTypeTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BaseDateTimeTypeTest.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.r5.model;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -158,4 +159,22 @@ public class BaseDateTimeTypeTest {
     assertEquals(param, srcInstance.getValueAsString());
   }
 
+  private static Stream<Arguments> getGetValueAsStringParams() {
+
+    return Stream.of(
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MILLI, "1933-01-02T12:34:56.789"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.SECOND, "1933-01-02T12:34:56"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MINUTE, "1933-01-02T12:34"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.DAY, "1933-01-02"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.MONTH, "1933-01"),
+      Arguments.of(new DateTimeType("1933-01-02T12:34:56.789"), TemporalPrecisionEnum.YEAR, "1933")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getGetValueAsStringParams")
+  public void testGetValueAsString(DateTimeType theType, TemporalPrecisionEnum thePrecision, String expectedStringValue) {
+    assertEquals(expectedStringValue, theType.getValueAsString(thePrecision));
+  }
 }


### PR DESCRIPTION
Adds a convenience method to get a DateTimeType value as a string with a specific precision that isn't the instances set precision.

Implements https://github.com/hapifhir/org.hl7.fhir.core/issues/1282