### PR TITLE
ValidationEngine::validate(): print SourceFile::getRef() instead of Object::toString()

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -598,7 +598,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
       if (ref.isProcess() || all) {
         TimeTracker.Session tts = context.clock().start("validation");
         context.clock().milestone();
-        System.out.println("  Validate " + ref);
+        System.out.println("  Validate " + ref.getRef());
         
         try {
           OperationOutcome outcome = validate(ref.getRef(), ref.getCnt().getFocus(), ref.getCnt().getCntType(), profiles, record);


### PR DESCRIPTION
`ValidationEngine::validate()`  currently prints things like
```
  Validate org.hl7.fhir.validation.ValidatorUtils$SourceFile@5382184b
```
instead of the name of the source file.

The reason is that `ValidationUtils.SourceFile` does not override Java's default implementation of `toString()`. The proposed fix is to print `getRef()` instead.