### PR TITLE
Fix typo in ValidatorUtils::readInteger(), fix accident-prone file list loop & exempt missing files from processing

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -584,7 +584,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     // available for other resources to depend on. if it fails to load, there'll be an error if there's
     // something that should've been loaded
     for (SourceFile ref : refs) {
-      if (ref.isProcess() || all) {
+      if (ref.isProcess() || all && !ref.isKnownToBeMissing()) {
         ref.setCnt(igLoader.loadContent(ref.getRef(), "validate", false, first));
         if (loader != null && ref.getCnt() != null) {
           try {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorUtils.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorUtils.java
@@ -69,6 +69,9 @@ public class ValidatorUtils {
     public void setCnt(Content cnt) {
       this.cnt = cnt;
     }
+    public boolean isKnownToBeMissing () { 
+      return date == 0;  // File::lastModified() returns 0 if the file is missing
+    }
   }
   
   protected static void grabNatives(Map<String, byte[]> source, Map<String, byte[]> binaries, String prefix) {
@@ -181,11 +184,10 @@ public class ValidatorUtils {
       if (file.isFile()) {
         addSourceFile(refs, file);
       } else {
-        for (int i = 0; i < file.listFiles().length; i++) {
-          File[] fileList = file.listFiles();
-          if (fileList[i].isFile()) {
-            if (!Utilities.isIgnorableFile(fileList[i])) {
-              addSourceFile(refs, fileList[i]);
+        for (File fileInDirectory : file.listFiles()) {
+          if (fileInDirectory.isFile()) {
+            if (!Utilities.isIgnorableFile(fileInDirectory)) {
+              addSourceFile(refs, fileInDirectory);
             }
           }
         }
@@ -196,9 +198,9 @@ public class ValidatorUtils {
 
   private static SourceFile addSourceFile(List<SourceFile> refs, File file) {
     SourceFile src = addSourceFile(refs, file.getPath());
-    Long l = file.lastModified();
+    long l = file.lastModified();  // returns 0 if the file is missing
     if (src.date != l) {
-      src.setProcess(true);
+      src.setProcess(l != 0);  // process only if not missing
     }
     src.date = l;
     return src;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
@@ -427,11 +427,11 @@ public class Params {
     return cliContext;
   }
 
-  private static int readInteger(String n, String v) {
-    if (!Utilities.isInteger(v)) {
-      throw new Error("Unable to read "+v+" provided for '"+n+"' - must be an integer");
+  private static int readInteger(String name, String value) {
+    if (!Utilities.isInteger(value)) {
+      throw new Error("Unable to read "+value+" provided for '"+name+"' - must be an integer");
     }
-    return Integer.parseInt(n);
+    return Integer.parseInt(value);
   }
 
   private static ValidatorWatchMode readWatchMode(String s) {


### PR DESCRIPTION
This patch fixes a typo in `ValidatorUtils::readInteger()` that currently prevents any use of the `watch-mode-delay` and `watch-settle-time` parameters. This solves issue #1328.

It fixes a file list processing loop that misbehaves if the contents of the directory it is processing can change concurrently. This was discussed in the fhir.org chat [watch mode topic](https://chat.fhir.org/#narrow/stream/179239-tooling/topic/Validator.20CLI.20watch.20mode/near/369582987).

The patch also contains two small, surgical changes that keep disappeared files from being processed if their disappearance is already known. This significantly improves stability in the face of disappearing/deleted files.