### PR TITLE
Temporarily disable CodeQL ReDoS and overly-large-range

### DIFF
--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -2,4 +2,4 @@ name: "Code scanning CodeQL config"
 
 query-filters:
   - exclude:
-      id: java/redos
+      id: java/polynomial-redos

--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -1,6 +1,7 @@
 name: "Code scanning CodeQL config"
 
 query-filters:
+  # This should be empty, but contains three queries that currently break the CodeQL action - dotasek
   - exclude:
       id: java/polynomial-redos
   - exclude:

--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -5,3 +5,5 @@ query-filters:
       id: java/polynomial-redos
   - exclude:
       id: java/redos
+  - exclude:
+      id: java/overly-large-range

--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -3,3 +3,5 @@ name: "Code scanning CodeQL config"
 query-filters:
   - exclude:
       id: java/polynomial-redos
+  - exclude:
+      id: java/redos

--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -1,0 +1,5 @@
+name: "Code scanning CodeQL config"
+
+query-filters:
+  - exclude:
+      id: codeql/java-queries/Security/CWE/CWE-730/ReDoS

--- a/.github/workflows/.codeql-config.yml
+++ b/.github/workflows/.codeql-config.yml
@@ -2,4 +2,4 @@ name: "Code scanning CodeQL config"
 
 query-filters:
   - exclude:
-      id: codeql/java-queries/Security/CWE/CWE-730/ReDoS
+      id: codeql/java-queries/Security/CWE/CWE-730/ReDoS.ql

--- a/.github/workflows/.codeql-config.yml
+++ b/.github/workflows/.codeql-config.yml
@@ -2,4 +2,4 @@ name: "Code scanning CodeQL config"
 
 query-filters:
   - exclude:
-      id: codeql/java-queries/Security/CWE/CWE-730/ReDoS.ql
+      id: java/redos

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,4 +70,5 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
+        config-file: .codeql-config.yml
         category: "/language:${{matrix.language}}:${{ matrix.module }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        config-file: ./.github/workflows/.codeql-config.yml
         languages: ${{ matrix.language }}
+        config-file: ./.github/workflows/.codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,5 +70,5 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        config-file: .codeql-config.yml
+        config-file: ./.github/workflows/.codeql-config.yml
         category: "/language:${{matrix.language}}:${{ matrix.module }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        config-file: ./.github/workflows/.codeql-config.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -70,5 +71,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        config-file: ./.github/workflows/.codeql-config.yml
         category: "/language:${{matrix.language}}:${{ matrix.module }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        config-file: ./.github/workflows/.codeql-config.yml
+        config-file: ./.codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Validator Changes
 
-* no changes
+* no changes 
 
 ## Other code changes
 


### PR DESCRIPTION
The following CodeQL queries produce out-of-memory errors when run on r5:

- java/polynomial-redos
- java/redos
- java/overly-large-range

Until the code that causes this can be located, these tests are disabled so that CodeQL can at least run the 69 other queries in the database.