### PR TITLE
Bump to test cases 1.3.16-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <guava_version>32.0.1-jre</guava_version>
         <hapi_fhir_version>6.4.1</hapi_fhir_version>
-        <validator_test_case_version>1.3.15</validator_test_case_version>
+        <validator_test_case_version>1.3.16-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.15.2</jackson_version>
         <junit_jupiter_version>5.9.2</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>


### PR DESCRIPTION
This coincides with the following commit, which changes the parent structure of fhir-test-cases: https://github.com/FHIR/fhir-test-cases/commit/f43c0a6eb6ca59ad53dc9c5309ad7f365ea0ee79