### PR TITLE
TerminologyCache - only trim whitespace outside of the json keys

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/TerminologyCache.java
@@ -695,10 +695,7 @@ public class TerminologyCache {
   }
 
   protected String hashJson(String s) {
-//    s = StringUtils.remove(s, ' ');
-    s = StringUtils.remove(s, '\n');
-    s = StringUtils.remove(s, '\r');
-    return String.valueOf(s.hashCode());
+    return String.valueOf(s.trim().hashCode());
   }
 
   // management


### PR DESCRIPTION
The terminology cache is stripping whitespace from the entire JSON object when generating hashes, but isn't limited to JSON formatting. This will result in inconsistencies when JSON field values rely on those spaces.

Maybe later, this can be made more JSON aware for efficiency, but for now, reducing the normalization to whitespace trimming outside the JSON allows matches that pass existing tests.