### PR TITLE
Check for null in VersionComparisonAnnotation

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/comparison/VersionComparisonAnnotation.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/comparison/VersionComparisonAnnotation.java
@@ -91,7 +91,7 @@ public class VersionComparisonAnnotation {
   }
   
   public static XhtmlNode render(Base b, XhtmlNode x) {
-    if (b.hasUserData(USER_DATA_NAME)) {
+    if (b != null && b.hasUserData(USER_DATA_NAME)) {
       VersionComparisonAnnotation self = (VersionComparisonAnnotation) b.getUserData(USER_DATA_NAME);
       return self.render(x);
     } else {


### PR DESCRIPTION
Fixes a NullPointerException resulting from this call, which explicitly sets it as null. This was causing failures in IG Publisher in publishing ACME-FSH-IG-Example

https://github.com/hapifhir/org.hl7.fhir.core/blob/4766cb3e4e9c435a48b821ce2484d084566636e4/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/StructureDefinitionRenderer.java#L4348

See this stack trace.

```log
render:94, VersionComparisonAnnotation (org.hl7.fhir.r5.comparison)
compareString:3372, StructureDefinitionRenderer (org.hl7.fhir.r5.renderers)
getMapping:4348, StructureDefinitionRenderer (org.hl7.fhir.r5.renderers)
generateElementInner:3564, StructureDefinitionRenderer (org.hl7.fhir.r5.renderers)
renderDict:3119, StructureDefinitionRenderer (org.hl7.fhir.r5.renderers)
dict:1049, StructureDefinitionRenderer (org.hl7.fhir.igtools.renderers)
generateOutputsStructureDefinition:11030, Publisher (org.hl7.fhir.igtools.publisher)
generateResourceHtml:9982, Publisher (org.hl7.fhir.igtools.publisher)
generateHtmlOutputs:9834, Publisher (org.hl7.fhir.igtools.publisher)
generate:7066, Publisher (org.hl7.fhir.igtools.publisher)
createIg:1052, Publisher (org.hl7.fhir.igtools.publisher)
execute:882, Publisher (org.hl7.fhir.igtools.publisher)
main:11921, Publisher (org.hl7.fhir.igtools.publisher)
```