### PR TITLE
Swap out xpp3 dependency

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -3,6 +3,12 @@
 name: License Check
 
 on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
   workflow_dispatch:
    
 
@@ -27,4 +33,4 @@ jobs:
       run: chmod u+x .github/workflows/license-check/license-check.sh
     - name: Run script
       run: .github/workflows/license-check/license-check.sh
-      continue-on-error: true
+      #continue-on-error: true

--- a/.github/workflows/license-check/README.md
+++ b/.github/workflows/license-check/README.md
@@ -1,0 +1,65 @@
+# License Check
+
+The license check script is a basic bash script that consumes the output from maven license checks, and throws errors if any are found that are not in specified whitelists.
+
+## Pre-requisite Maven commands
+
+The following two maven commands, executed in the root of the project, will generate license files in the target locations: `target/generated-sources/license/THIRD-PARTY.txt` 
+
+This command will generate all the license files for each module:
+
+```shell
+mvn license:add-third-party
+```
+
+This command will generate all the license files for the whole project (must be run after the first command, or it will have no licenses to aggregate):
+
+```shell
+mvn license:aggregate-add-third-party
+```
+
+## Bash script
+
+From the root of the project, execute the following:
+
+```shell
+./.github/workflows/license-check/license-check.sh 
+```
+
+Note that this requires a recent version of bash.
+
+## Whitelists
+
+Whitelists are license names permitted for use within this project. This project uses an Apache 2.0 license. and follows the rule that a selection of dependencies with copyleft licenses can be included in the project as binaries, but shouldn't appear in the source release. https://www.apache.org/legal/resolved.html#weak-copyleft-licenses
+
+This list includes:
+
+* Common Development and Distribution Licenses: CDDL 1.0 and CDDL 1.1
+* Common Public License: CPL 1.0
+* Eclipse Public License: EPL 1.0
+* IBM Public License: IPL 1.0
+* Mozilla Public Licenses: MPL 1.0, MPL 1.1, and MPL 2.0
+* Sun Public License: SPL 1.0
+* Open Software License 3.0
+* Erlang Public License
+* UnRAR License (only for unarchiving)
+* SIL Open Font License
+* Ubuntu Font License Version 1.0
+* IPA Font License Agreement v1.0
+* Ruby License (including the older version when GPLv2 was a listed alternative Ruby 1.9.2 license)
+* Eclipse Public License 2.0: EPL 2.0
+
+There are two Whitelist files, necessitated by the sometimes inconsistent formatting of `THIRD-PARTY.txt`.
+
+`license-whitelist.txt` contains individual licenses that are permitted in the project. Note that these are repeated in multiple formats, as these are a strict string match, and licenses names do not have a single canonical text representation (example: 'Apache Software License 2.0',
+'The Apache License, Version 2.0',
+'The Apache Software License, Version 2.0')
+
+'license-special-cases.txt' contains entire lines from the `THIRD-PARTY.txt` to account for cases where the license name itself may be problematic to whitelist, such as `(Unknown License)`:
+
+```text
+# Is not included in the dependency but is GNU Lesser GPL. See: https://code.google.com/archive/p/javaparser/
+(Unknown license) javaparser (com.google.code.javaparser:javaparser:1.0.11 - http://code.google.com/p/javaparser/)
+```
+
+Note that for each of these there should be an explicit reason for the special case in a comment, to prevent unnecessarily re-evaluating of special cases.

--- a/.github/workflows/license-check/license-check.sh
+++ b/.github/workflows/license-check/license-check.sh
@@ -46,4 +46,13 @@ do
     fi
 done
 
+echo "Check complete."
+
+if (( exitStatus == 0 ))
+then
+  echo "All licenses OK"
+else
+  echo "Possible license incompatibilities found. Check above logs."
+fi
+
 exit $exitStatus

--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -1,3 +1,19 @@
+# Is not included in the dependency but is GNU Lesser GPL. See: https://code.google.com/archive/p/javaparser/
 (Unknown license) javaparser (com.google.code.javaparser:javaparser:1.0.11 - http://code.google.com/p/javaparser/)
-# IGNORE ME
+# Because of parsing issues, FHIR R4 shows up as a license. I really need to redo this script in Python for cleaner parsing. -dotasek
 (Apache Software License 2.0) HAPI FHIR - Validation Resources (FHIR R4) (ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:6.4.1 - https://hapifhir.io/hapi-deployable-pom/hapi-fhir-validation-resources-r4)
+# The following can be licensed with either license, of which the Apache is compatible
+(Apache Software License, version 1.1) (Indiana University Extreme! Lab Software License, vesion 1.1.1) (Public Domain) MXP1: Xml Pull Parser 3rd Edition (XPP3) (xpp3:xpp3:1.1.4c - http://www.extreme.indiana.edu/xgws/xsoap/xpp/mxp1/)
+(Indiana University Extreme! Lab Software License, vesion 1.1.1) MXP1: Xml Pull Parser 3rd Edition (XPP3) (xpp3:xpp3_xpath:1.1.4c - http://www.extreme.indiana.edu/xgws/xsoap/xpp/mxp1/)
+# Aggregator is incorrectly parsed as a license.
+(Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.9.1 - https://junit.org/junit5/)
+# https://www.jcp.org/en/jsr/detail?id=374 specifies this as an OR relationship between possible licenses, of which CDDL is compatible
+(Dual license consisting of the CDDL v1.1 and GPL v2) JSR 353 (JSON Processing) Default Provider (org.glassfish:javax.json:1.0.4 - http://jsonp.java.net)
+# javax.xml.bind is incorrectly interpreted as a license name.
+(The Apache Software License, Version 2.0) Jackson module: Old JAXB Annotations (javax.xml.bind) (com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.15.2 - https://github.com/FasterXML/jackson-modules-base)
+# full is incorrectly interpreted as a license name
+(Apache License, Version 2.0) Apache POI - OOXML schemas (full) (org.apache.poi:poi-ooxml-full:5.2.1 - https://poi.apache.org/)
+# Actually a BSD license https://mvnrepository.com/artifact/org.antlr/ST4/4.1
+(Unknown license) StringTemplate 4 (org.antlr:ST4:4.1 - http://nexus.sonatype.org/oss-repository-hosting.html/ST4)
+# without dependencies is incorrectly intepreted as a license name
+(Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.12.14 - https://bytebuddy.net/byte-buddy)

--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -17,3 +17,5 @@
 (Unknown license) StringTemplate 4 (org.antlr:ST4:4.1 - http://nexus.sonatype.org/oss-repository-hosting.html/ST4)
 # without dependencies is incorrectly intepreted as a license name
 (Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.12.14 - https://bytebuddy.net/byte-buddy)
+# Appears to be Apache 2.0: https://github.com/NCIP/lexevs/blob/master/lgSharedLibraries/apache/commons/jakarta-regexp-1.4.license.txt
+(Unknown license) jakarta-regexp (jakarta-regexp:jakarta-regexp:1.4 - no url defined)

--- a/.github/workflows/license-check/license-whitelist.txt
+++ b/.github/workflows/license-check/license-whitelist.txt
@@ -6,6 +6,7 @@ The Apache Software License, Version 2.0
 MIT License
 The MIT License
 Apache Software License, version 1.1
+Apache-2.0
 Apache 2
 Apache 2.0
 Apache License 2.0
@@ -17,9 +18,15 @@ BSD License 3
 New BSD License
 BSD 3 Clause
 The JSON License
+Eclipse Public License 1.0
 Eclipse Public License - v 1.0
 Eclipse Public License v. 2.0
 Eclipse Distribution License v. 1.0
 Eclipse Distribution License - v 1.0
+EDL 1.0
 Unicode/ICU License
 BSD 2-Clause License
+LGPL 2.1
+GNU Lesser General Public License
+MPL 1.1
+Mozilla Public License Version 2.0

--- a/org.hl7.fhir.convertors/pom.xml
+++ b/org.hl7.fhir.convertors/pom.xml
@@ -82,13 +82,8 @@
         </dependency>
 
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
             <optional>true</optional>
         </dependency>
         <!-- HTTP Client -->

--- a/org.hl7.fhir.dstu2/pom.xml
+++ b/org.hl7.fhir.dstu2/pom.xml
@@ -37,13 +37,8 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/org.hl7.fhir.dstu2016may/pom.xml
+++ b/org.hl7.fhir.dstu2016may/pom.xml
@@ -37,14 +37,8 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- JSON Parsers -->

--- a/org.hl7.fhir.dstu3/pom.xml
+++ b/org.hl7.fhir.dstu3/pom.xml
@@ -37,15 +37,11 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <optional>true</optional>
-        </dependency>
+
 
         <!-- JSON Parsers -->
         <dependency>

--- a/org.hl7.fhir.r4/pom.xml
+++ b/org.hl7.fhir.r4/pom.xml
@@ -44,13 +44,8 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>xpp3</groupId>
+			<groupId>org.ogce</groupId>
 			<artifactId>xpp3</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>xpp3</groupId>
-			<artifactId>xpp3_xpath</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/org.hl7.fhir.r4b/pom.xml
+++ b/org.hl7.fhir.r4b/pom.xml
@@ -43,13 +43,8 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>xpp3</groupId>
+			<groupId>org.ogce</groupId>
 			<artifactId>xpp3</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>xpp3</groupId>
-			<artifactId>xpp3_xpath</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -44,15 +44,11 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>xpp3</groupId>
+			<groupId>org.ogce</groupId>
 			<artifactId>xpp3</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>xpp3</groupId>
-			<artifactId>xpp3_xpath</artifactId>
-			<optional>true</optional>
-		</dependency>
+
 
 		<!-- JSON Parsers -->
 		<dependency>

--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -84,15 +84,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <optional>true</optional>
-        </dependency>
+
 
         <dependency>
             <groupId>com.ibm.icu</groupId>

--- a/org.hl7.fhir.validation.cli/pom.xml
+++ b/org.hl7.fhir.validation.cli/pom.xml
@@ -288,13 +288,10 @@
             <artifactId>ucum</artifactId>
         </dependency>
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -82,12 +82,8 @@
             <artifactId>Saxon-HE</artifactId>
         </dependency>
         <dependency>
-            <groupId>xpp3</groupId>
+            <groupId>org.ogce</groupId>
             <artifactId>xpp3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
         </dependency>
 
         <!-- JSON Utilities -->

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,11 @@
                 <artifactId>thymeleaf</artifactId>
                 <version>3.1.2.RELEASE</version>
             </dependency>
+            <dependency>
+                <groupId>org.ogce</groupId>
+                <artifactId>xpp3</artifactId>
+                <version>1.1.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Swaps out the xpp3 implementation to a newer version offered by org.ogce under the Apache 2.0 license. 

See https://mvnrepository.com/artifact/xpp3/xpp3:

> Note: This artifact was moved to:

> [org.ogce](https://mvnrepository.com/artifact/org.ogce) » [xpp3](https://mvnrepository.com/artifact/org.ogce/xpp3)