### PR TITLE
Fixed Out Of Memory issue during resource validation with local reference check enabled

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
@@ -1080,7 +1080,7 @@ public class FHIRPathEngine {
     }
   }
 
-  private static class ExecutionContext {
+  private class ExecutionContext {
     private Object appInfo;
     private Base focusResource;
     private Base rootResource;
@@ -5909,7 +5909,7 @@ public class FHIRPathEngine {
     return result;
   }
 
-  public class ElementDefinitionMatch {
+  public static class ElementDefinitionMatch {
     private ElementDefinition definition;
     private ElementDefinition sourceDefinition; // if there was a content reference
     private String fixedType;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/FHIRPathEngine.java
@@ -116,7 +116,7 @@ public class FHIRPathEngine {
 
   private enum Equality { Null, True, False }
 
-  private class FHIRConstant extends Base {
+  private static class FHIRConstant extends Base {
 
     private static final long serialVersionUID = -8933773658248269439L;
     private String value;
@@ -158,7 +158,7 @@ public class FHIRPathEngine {
     }
   }
 
-  private class ClassTypeInfo extends Base {
+  private static class ClassTypeInfo extends Base {
     private static final long serialVersionUID = 4909223114071029317L;
     private Base instance;
 
@@ -1080,7 +1080,7 @@ public class FHIRPathEngine {
     }
   }
 
-  private class ExecutionContext {
+  private static class ExecutionContext {
     private Object appInfo;
     private Base focusResource;
     private Base rootResource;
@@ -1139,7 +1139,7 @@ public class FHIRPathEngine {
     }
   }
 
-  private class ExecutionTypeContext {
+  private static class ExecutionTypeContext {
     private Object appInfo; 
     private String resource;
     private TypeDetails context;


### PR DESCRIPTION
During the validation of the resource with local reference check enabled slow memory leak is happening.
This causes an Out Of Memory error.

This is an Inner Classes That Reference Outer Classes memory issue which can be fixed by making inner classes static.
As inner class object implicitly holds a reference to the outer class object, thereby making it an invalid candidate for garbage collection.

closes issue #1412