### PR TITLE
Update to cqframework 2.11 and remove unused common-beanutils declaration

### DIFF
--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -19,3 +19,5 @@
 (Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.12.14 - https://bytebuddy.net/byte-buddy)
 # Appears to be Apache 2.0: https://github.com/NCIP/lexevs/blob/master/lgSharedLibraries/apache/commons/jakarta-regexp-1.4.license.txt
 (Unknown license) jakarta-regexp (jakarta-regexp:jakarta-regexp:1.4 - no url defined)
+# License string includes nested brackets, causing parser breakage, but is a valid BSD license.
+(BSD 3-Clause "New" or "Revised" License (BSD-3-Clause)) abego TreeLayout Core (org.abego.treelayout:org.abego.treelayout.core:1.0.3 - http://treelayout.sourceforge.net)

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -14,7 +14,7 @@
 
     <properties>
         <checkstyle_config_location>${project.parent.basedir}</checkstyle_config_location>
-        <info_cqframework_version>1.5.12</info_cqframework_version>
+        <info_cqframework_version>2.11.0</info_cqframework_version>
     </properties>
 
     <dependencies>
@@ -129,13 +129,6 @@
             <groupId>info.cqframework</groupId>
             <artifactId>model</artifactId>
             <version>${info_cqframework_version}</version>
-            <exclusions>
-                <!-- exclude this in favor of 1.9.4 for security reasons -->
-                <exclusion>
-                    <groupId>commons-beanutils</groupId>
-                    <artifactId>commons-beanutils</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
@@ -156,11 +149,6 @@
             <groupId>info.cqframework</groupId>
             <artifactId>qdm</artifactId>
             <version>${info_cqframework_version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
         </dependency>
         <!-- OkHttpDependency -->
         <dependency>


### PR DESCRIPTION
hapi fhir validation introduce the usage of commons-beanutils with 05134dc because a transitive outdated was received from cqframework 1.5. Commons-beanutils was never needed at runtime by cqframework and only during buildtime. cqframework 1.5 wrongly declare jaxb2-basics as compile dependency, while only jaxb2-basics-runtime is needed. This was fixed with cqfamework 2.x.
Since 2.x seems to work properly what i could see, an update seems to run without any issue in test execution and the commons-beanutils was removed.