### PR TITLE
Restore CodeQL regex queries

### DIFF
--- a/.codeql-config.yml
+++ b/.codeql-config.yml
@@ -1,10 +1,7 @@
 name: "Code scanning CodeQL config"
 
 query-filters:
-  # This should be empty, but contains three queries that currently break the CodeQL action - dotasek
-  - exclude:
-      id: java/polynomial-redos
-  - exclude:
-      id: java/redos
-  - exclude:
-      id: java/overly-large-range
+  # This should be empty; if a query times out or causes a exception, you can exclude it here.
+  # See the example commented out below.
+  # - exclude:
+  #    id: java/polynomial-redos


### PR DESCRIPTION
The CodeQL regex queries causing timeouts have been resolved in CodeQL release 2.14.3:

See discussion here:

https://github.com/github/codeql/discussions/13752#discussioncomment-6491765

See completed run here:

https://github.com/hapifhir/org.hl7.fhir.core/actions/runs/6051157714