### PR TITLE
updates for jdk21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven_clean_version>3.1.0</maven_clean_version>
         <okhttp.version>4.11.0</okhttp.version>
         <jacoco_version>0.8.9</jacoco_version>
-        <lombok_version>1.18.22</lombok_version>
+        <lombok_version>1.18.30</lombok_version>
         <byte_buddy_version>1.12.14</byte_buddy_version>
         <apache_poi_version>5.2.1</apache_poi_version>
         <saxon_he_version>9.8.0-15</saxon_he_version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <okhttp.version>4.11.0</okhttp.version>
         <jacoco_version>0.8.9</jacoco_version>
         <lombok_version>1.18.30</lombok_version>
-        <byte_buddy_version>1.12.14</byte_buddy_version>
+        <byte_buddy_version>1.14.8</byte_buddy_version>
         <apache_poi_version>5.2.1</apache_poi_version>
         <saxon_he_version>9.8.0-15</saxon_he_version>
         <maven.compiler.release>11</maven.compiler.release>


### PR DESCRIPTION
running mvn clean install returns an error:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (java-compile) on project org.hl7.fhir.utilities: Compilation failure
> [ERROR] java.lang.NoSuchFieldError: Class [com.sun.tools.javac.tree.JCTree$JCImport](http://com.sun.tools.javac.tree.jctree%24jcimport/) does not have member field '[com.sun.tools.javac.tree.JCTree](http://com.sun.tools.javac.tree.jctree/) qualid'
> [ERROR] 	at lombok.javac.JavacImportList.getFullyQualifiedNameForSimpleNameNoAliasing([JavacImportList.java:53](http://javacimportlist.java:53/))
> [ERROR] 	at lombok.core.TypeResolver.typeRefToFullyQualifiedName([TypeResolver.java:60](http://typeresolver.java:60/))
> [ERROR] 	at lombok.javac.HandlerLibrary.handleAnnotation([HandlerLibrary.java:247](http://handlerlibrary.java:247/))
> [ERROR] 	at lombok.javac.JavacTransformer$AnnotationVisitor.visitAnnotationOnField([JavacTransformer.java:84](http://javactransformer.java:84/))
> [ERROR] 	at lombok.javac.JavacNode.traverse([JavacNode.java:135](http://javacnode.java:135/))
> 


this is due to a [lombok issue](https://github.com/projectlombok/lombok/issues/3393).
updating to the latest dependency fixes the problem.


a second error appeared during validation of tests:

> Mockito cannot mock this class: class org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager.
> 
> If you're not sure why you're getting this error, please open an issue on GitHub.
> 
> 
> Java               : 21
> JVM vendor name    : Homebrew
> JVM vendor version : 21
> JVM name           : OpenJDK 64-Bit Server VM
> JVM version        : 21
> JVM info           : mixed mode, sharing
> OS name            : Mac OS X
> OS version         : 14.0
> 
> 
> You are seeing this disclaimer because Mockito is configured to create inlined mocks.
> You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.
> 
> Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [class org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager, class org.hl7.fhir.utilities.npm.BasePackageCacheManager, class java.lang.Object, interface org.hl7.fhir.utilities.npm.IPackageCacheManager]

this can be fixed also when updating to the latest version of byte_buddy_version.

the build and all tests run then through:

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for HL7 Core Artifacts 6.1.14:
[INFO] 
[INFO] HL7 Core Artifacts ................................. SUCCESS [  1.028 s]
[INFO] org.hl7.fhir.utilities ............................. SUCCESS [ 19.400 s]
[INFO] org.hl7.fhir.dstu2 ................................. SUCCESS [ 13.824 s]
[INFO] org.hl7.fhir.dstu2016may ........................... SUCCESS [ 20.605 s]
[INFO] org.hl7.fhir.dstu3 ................................. SUCCESS [ 23.945 s]
[INFO] org.hl7.fhir.r4 .................................... SUCCESS [ 36.538 s]
[INFO] org.hl7.fhir.r4b ................................... SUCCESS [01:29 min]
[INFO] org.hl7.fhir.r5 .................................... SUCCESS [01:57 min]
[INFO] org.hl7.fhir.convertors ............................ SUCCESS [ 29.702 s]
[INFO] org.hl7.fhir.validation ............................ SUCCESS [04:50 min]
[INFO] org.hl7.fhir.validation.cli ........................ SUCCESS [ 27.946 s]
[INFO] org.hl7.fhir.report ................................ SUCCESS [  9.973 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11:20 min
[INFO] Finished at: 2023-10-10T20:57:50+02:00
[INFO] -----------------------------------------------------------------------


