### PR TITLE
Updates for jdk21

### DIFF
--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -16,7 +16,7 @@
 # Actually a BSD license https://mvnrepository.com/artifact/org.antlr/ST4/4.1
 (Unknown license) StringTemplate 4 (org.antlr:ST4:4.1 - http://nexus.sonatype.org/oss-repository-hosting.html/ST4)
 # without dependencies is incorrectly intepreted as a license name
-(Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.12.14 - https://bytebuddy.net/byte-buddy)
+(Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.14.8 - https://bytebuddy.net/byte-buddy)
 # Appears to be Apache 2.0: https://github.com/NCIP/lexevs/blob/master/lgSharedLibraries/apache/commons/jakarta-regexp-1.4.license.txt
 (Unknown license) jakarta-regexp (jakarta-regexp:jakarta-regexp:1.4 - no url defined)
 # License string includes nested brackets, causing parser breakage, but is a valid BSD license.

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <maven_clean_version>3.1.0</maven_clean_version>
         <okhttp.version>4.11.0</okhttp.version>
         <jacoco_version>0.8.9</jacoco_version>
-        <lombok_version>1.18.22</lombok_version>
-        <byte_buddy_version>1.12.14</byte_buddy_version>
+        <lombok_version>1.18.30</lombok_version>
+        <byte_buddy_version>1.14.8</byte_buddy_version>
         <apache_poi_version>5.2.1</apache_poi_version>
         <saxon_he_version>9.8.0-15</saxon_he_version>
         <maven.compiler.release>11</maven.compiler.release>


### PR DESCRIPTION


Copy of https://github.com/hapifhir/org.hl7.fhir.core/pull/1457 which compiles against current master pom and includes a license check. 