### PR TITLE
Surefire Test Ignore Setup

### DIFF
--- a/org.hl7.fhir.utilities/src/test/java/MyIgnorableTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/MyIgnorableTest.java
@@ -1,0 +1,14 @@
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+
+public class MyIgnorableTest {
+
+  @Test
+
+  public void testMe() {
+    System.out.println("You have tested me.");
+  }
+}
+

--- a/org.hl7.fhir.utilities/src/test/java/MyIgnorableTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/MyIgnorableTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 public class MyIgnorableTest {
 
   @Test
-
+  @Tag("excludedInSurefire")
   public void testMe() {
     System.out.println("You have tested me.");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,7 @@
                             <java.locale.providers>COMPAT</java.locale.providers>
                         </systemPropertyVariables>
                         <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                        <excludedGroups>excludedInSurefire</excludedGroups>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
This PR illustrates how to have tests runnable within IDEs (tested in IntelliJ + Eclipse), that are ignored by the surefire test executor. 