### PR TITLE
Initial support (R4B) to handle multiple source rules in a group

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -1320,6 +1320,13 @@ public class StructureMapUtilities {
   }
 
   public class Variables {
+    public Variables() {
+    }
+    public Variables(Variables parent) {
+      _parent = parent;
+    }
+  
+    private Variables _parent;
     private List<Variable> list = new ArrayList<Variable>();
 
     public void add(VariableMode mode, String name, Base object) {
@@ -1335,6 +1342,7 @@ public class StructureMapUtilities {
     public Variables copy() {
       Variables result = new Variables();
       result.list.addAll(list);
+      result._parent = _parent;
       return result;
     }
 
@@ -1342,6 +1350,8 @@ public class StructureMapUtilities {
       for (Variable v : list)
         if ((v.mode == mode) && v.getName().equals(name))
           return v.getObject();
+      if (_parent != null)
+        return _parent.get(mode, name);
       return null;
     }
 
@@ -1349,7 +1359,7 @@ public class StructureMapUtilities {
       CommaSeparatedStringBuilder s = new CommaSeparatedStringBuilder();
       CommaSeparatedStringBuilder t = new CommaSeparatedStringBuilder();
       CommaSeparatedStringBuilder sh = new CommaSeparatedStringBuilder();
-      for (Variable v : list)
+      for (Variable v : list) {
         switch (v.mode) {
         case INPUT:
           s.append(v.summary());
@@ -1361,8 +1371,12 @@ public class StructureMapUtilities {
           sh.append(v.summary());
           break;
         }
-      return "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables ["
+      }
+      var localVarSummary = "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables ["
           + sh.toString() + "]";
+      if (_parent != null)
+        return localVarSummary + "\n" + _parent.summary();
+      return localVarSummary;
     }
 
   }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -1467,7 +1467,9 @@ public class StructureMapUtilities {
       StructureMapGroupComponent group, StructureMapGroupRuleComponent rule, boolean atRoot) throws FHIRException {
     log(indent + "rule : " + rule.getName() + "; vars = " + vars.summary());
     Variables srcVars = vars.copy();
-    if (rule.getSource().size() != 1)
+    if (rule.getSource().size() != 0)
+      throw new FHIRException("Rule \"" + rule.getName() + "\": has no sources");
+    if (rule.getSource().size() > 1)
       throw new FHIRException("Rule \"" + rule.getName() + "\": not handled yet");
     List<Variables> source = processSource(rule.getName(), context, srcVars, rule.getSource().get(0), map.getUrl(),
         indent);
@@ -2488,7 +2490,9 @@ public class StructureMapUtilities {
     XhtmlNode xt = tr.addTag("td");
 
     VariablesForProfiling srcVars = vars.copy();
-    if (rule.getSource().size() != 1)
+    if (rule.getSource().size() != 0)
+      throw new FHIRException("Rule \"" + rule.getName() + "\": has no sources");
+    if (rule.getSource().size() > 1)
       throw new FHIRException("Rule \"" + rule.getName() + "\": not handled yet");
     VariablesForProfiling source = analyseSource(rule.getName(), context, srcVars, rule.getSourceFirstRep(), xs);
 

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/misc/StructureMapTestsBrian.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/misc/StructureMapTestsBrian.java
@@ -1,0 +1,86 @@
+package org.hl7.fhir.r4.test.misc;
+
+import java.io.FileNotFoundException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hl7.fhir.r4.utils.StructureMapUtilities;
+import org.hl7.fhir.r4.context.IWorkerContext;
+import org.hl7.fhir.r4.formats.ParserType;
+import org.hl7.fhir.r4.formats.IParser.OutputStyle;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.StructureMap;
+import org.hl7.fhir.r4.test.utils.TestingUtilities;
+
+public class StructureMapTestsBrian {
+
+  static private IWorkerContext context;
+
+  @BeforeAll
+  static public void setUp() throws Exception {
+    context = TestingUtilities.context();
+  }
+
+  @Test
+  public void testMultipleSourceVariables() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    var parser = context.getParser(ParserType.JSON);
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getAbatementStringType().asStringValue());
+  }
+
+  @Test
+  public void testMultipleSourceVariablesCopyId() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    var parser = context.getParser(ParserType.JSON);
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source-id.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getId());
+  }
+}

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/StructureMapUtilities.java
@@ -2243,7 +2243,9 @@ public class StructureMapUtilities {
     XhtmlNode xt = tr.addTag("td");
 
     VariablesForProfiling srcVars = vars.copy();
-    if (rule.getSource().size() != 1)
+    if (rule.getSource().size() != 0)
+      throw new FHIRException("Rule \"" + rule.getName() + "\": has no sources");
+    if (rule.getSource().size() > 1)
       throw new FHIRException("Rule \"" + rule.getName() + "\": not handled yet");
     VariablesForProfiling source = analyseSource(rule.getName(), context, srcVars, rule.getSourceFirstRep(), xs);
 

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/Variables.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/Variables.java
@@ -30,6 +30,7 @@ public class Variables {
   public Variables copy() {
     Variables result = new Variables();
     result.list.addAll(list);
+    result._parent = _parent;
     return result;
   }
 
@@ -46,7 +47,7 @@ public class Variables {
     CommaSeparatedStringBuilder s = new CommaSeparatedStringBuilder();
     CommaSeparatedStringBuilder t = new CommaSeparatedStringBuilder();
     CommaSeparatedStringBuilder sh = new CommaSeparatedStringBuilder();
-    for (Variable v : list)
+    for (Variable v : list) {
       switch (v.getMode()) {
       case INPUT:
         s.append(v.summary());
@@ -58,8 +59,11 @@ public class Variables {
         sh.append(v.summary());
         break;
       }
-    return "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables ["
+    }
+    var localVarSummary = "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables ["
         + sh.toString() + "]";
+    if (_parent != null)
+      return localVarSummary + "\n" + _parent.summary();
+    return localVarSummary;
   }
-
 }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/Variables.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/Variables.java
@@ -7,6 +7,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Variables {
+  public Variables() {
+  }
+  public Variables(Variables parent) {
+    _parent = parent;
+  }
+
+  private Variables _parent;
+
   private List<Variable> list = new ArrayList<Variable>();
 
   public void add(VariableMode mode, String name, Base object) {
@@ -29,6 +37,8 @@ public class Variables {
     for (Variable v : list)
       if ((v.getMode() == mode) && v.getName().equals(name))
         return v.getObject();
+    if (_parent != null)
+      return _parent.get(mode, name);
     return null;
   }
 

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/misc/StructureMapTestsBrian.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/misc/StructureMapTestsBrian.java
@@ -1,0 +1,127 @@
+package org.hl7.fhir.r4b.test.misc;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hl7.fhir.r4b.utils.structuremap.ITransformerServices;
+import org.hl7.fhir.r4b.utils.structuremap.StructureMapUtilities;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4b.context.IWorkerContext;
+import org.hl7.fhir.r4b.formats.ParserType;
+import org.hl7.fhir.r4b.formats.IParser.OutputStyle;
+import org.hl7.fhir.r4b.model.Base;
+import org.hl7.fhir.r4b.model.Bundle;
+import org.hl7.fhir.r4b.model.Coding;
+import org.hl7.fhir.r4b.model.Condition;
+import org.hl7.fhir.r4b.model.QuestionnaireResponse;
+import org.hl7.fhir.r4b.model.StructureMap;
+import org.hl7.fhir.r4b.test.utils.TestingUtilities;
+
+public class StructureMapTestsBrian implements ITransformerServices {
+
+  static private IWorkerContext context;
+
+  @BeforeAll
+  static public void setUp() throws Exception {
+    context = TestingUtilities.context();
+  }
+
+  @Test
+  public void testMultipleSourceVariables() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    var parser = context.getParser(ParserType.JSON);
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getAbatementStringType().asStringValue());
+  }
+
+  @Test
+  public void testMultipleSourceVariablesCopyId() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    var parser = context.getParser(ParserType.JSON);
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source-id.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getId());
+  }
+
+  @Override
+  public void log(String message) {
+    // TODO Auto-generated method stub
+    System.out.println(message);
+  }
+
+  @Override
+  public Base createType(Object appInfo, String name) throws FHIRException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'createType'");
+  }
+
+  @Override
+  public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'createResource'");
+  }
+
+  @Override
+  public Coding translate(Object appInfo, Coding source, String conceptMapUrl) throws FHIRException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'translate'");
+  }
+
+  @Override
+  public Base resolveReference(Object appContext, String url) throws FHIRException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'resolveReference'");
+  }
+
+  @Override
+  public List<Base> performSearch(Object appContext, String url) throws FHIRException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'performSearch'");
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -1304,7 +1304,9 @@ public class StructureMapUtilities {
   private void executeRule(String indent, TransformContext context, StructureMap map, Variables vars, StructureMapGroupComponent group, StructureMapGroupRuleComponent rule, boolean atRoot) throws FHIRException {
     log(indent + "rule : " + rule.getName() + "; vars = " + vars.summary());
     Variables srcVars = vars.copy();
-    if (rule.getSource().size() != 1)
+    if (rule.getSource().size() != 0)
+      throw new FHIRException("Rule \"" + rule.getName() + "\": has no sources");
+    if (rule.getSource().size() > 1)
       throw new FHIRException("Rule \"" + rule.getName() + "\": not handled yet");
     List<Variables> source = processSource(rule.getName(), context, srcVars, rule.getSource().get(0), map.getUrl(), indent);
     if (source != null) {
@@ -2171,7 +2173,9 @@ public class StructureMapUtilities {
     XhtmlNode xt = tr.addTag("td");
 
     VariablesForProfiling srcVars = vars.copy();
-    if (rule.getSource().size() != 1)
+    if (rule.getSource().size() != 0)
+      throw new FHIRException("Rule \"" + rule.getName() + "\": has no sources");
+    if (rule.getSource().size() > 1)
       throw new FHIRException("Rule \"" + rule.getName() + "\": not handled yet");
     VariablesForProfiling source = analyseSource(rule.getName(), context, srcVars, rule.getSourceFirstRep(), xs);
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/Variables.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/Variables.java
@@ -7,6 +7,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Variables {
+  public Variables() {
+  }
+  public Variables(Variables parent) {
+    _parent = parent;
+  }
+
+  private Variables _parent;
+
   private List<Variable> list = new ArrayList<Variable>();
 
   public void add(VariableMode mode, String name, Base object) {
@@ -22,6 +30,7 @@ public class Variables {
   public Variables copy() {
     Variables result = new Variables();
     result.list.addAll(list);
+    result._parent = _parent;
     return result;
   }
 
@@ -29,6 +38,8 @@ public class Variables {
     for (Variable v : list)
       if ((v.getMode() == mode) && v.getName().equals(name))
         return v.getObject();
+    if (_parent != null)
+      return _parent.get(mode, name);
     return null;
   }
 
@@ -36,19 +47,23 @@ public class Variables {
     CommaSeparatedStringBuilder s = new CommaSeparatedStringBuilder();
     CommaSeparatedStringBuilder t = new CommaSeparatedStringBuilder();
     CommaSeparatedStringBuilder sh = new CommaSeparatedStringBuilder();
-    for (Variable v : list)
+    for (Variable v : list) {
       switch (v.getMode()) {
-        case INPUT:
-          s.append(v.summary());
-          break;
-        case OUTPUT:
-          t.append(v.summary());
-          break;
-        case SHARED:
-          sh.append(v.summary());
-          break;
+      case INPUT:
+        s.append(v.summary());
+        break;
+      case OUTPUT:
+        t.append(v.summary());
+        break;
+      case SHARED:
+        sh.append(v.summary());
+        break;
       }
-    return "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables [" + sh.toString() + "]";
+    }
+    var localVarSummary = "source variables [" + s.toString() + "], target variables [" + t.toString() + "], shared variables ["
+        + sh.toString() + "]";
+    if (_parent != null)
+      return localVarSummary + "\n" + _parent.summary();
+    return localVarSummary;
   }
-
 }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/misc/StructureMapTestsBrian.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/misc/StructureMapTestsBrian.java
@@ -1,0 +1,87 @@
+package org.hl7.fhir.r5.test.misc;
+
+import java.io.FileNotFoundException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.formats.IParser;
+import org.hl7.fhir.r5.formats.JsonParser;
+import org.hl7.fhir.r5.formats.IParser.OutputStyle;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.Condition;
+import org.hl7.fhir.r5.model.QuestionnaireResponse;
+import org.hl7.fhir.r5.model.StructureMap;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+
+public class StructureMapTestsBrian {
+
+  static private IWorkerContext context;
+
+  @BeforeAll
+  static public void setUp() throws Exception {
+    context = TestingUtilities.getSharedWorkerContext();
+  }
+
+  @Test
+  public void testMultipleSourceVariables() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    IParser parser = new JsonParser();
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getAbatementStringType().asStringValue());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getAbatementStringType().asStringValue());
+  }
+
+  @Test
+  public void testMultipleSourceVariablesCopyId() throws FileNotFoundException, Exception {
+    // read in the test data
+    String mapQR = TestingUtilities.loadTestResource("r4b", "structure-mapping", "qr-multiple-source.json");
+    var parser = new JsonParser();
+    QuestionnaireResponse qr = (QuestionnaireResponse) parser.parse(mapQR);
+    String mapString = TestingUtilities.loadTestResource("r4b", "structure-mapping", "multiple-source-id.map");
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(mapString, null);
+
+    // Now that we have a map and a QR, we can run the transform
+    Bundle target = new Bundle(); // new bundle to hold the transformed QR
+    scu.transform(null, qr, map, target);
+
+    // Now validate that this resource is exactly what we expected to get
+    parser.setOutputStyle(OutputStyle.PRETTY);
+    var jsonResult = parser.composeString(target);
+    System.out.println(jsonResult);
+    
+    // Finally some actual assertions
+    Assertions.assertEquals(3, target.getEntry().size());
+    var entries = target.getEntry();
+    var cond1 = (Condition)entries.get(0).getResource();
+    var cond2 = (Condition)entries.get(1).getResource();
+    var cond3 = (Condition)entries.get(2).getResource();
+    Assertions.assertEquals("condition_71802-3_LA31994-9", cond1.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-6", cond2.getId());
+    Assertions.assertEquals("condition_71802-3_LA31995-3", cond3.getId());
+  }
+}


### PR DESCRIPTION
Add support for rules that have multiple source variables
(as noted in the spec here: https://www.hl7.org/fhir/mapping-language.html#7.8.0.8.1 )
e.g.
```
item.linkId as itemId, itemAnswer.value as coding
     -> condition.id = ('condition_' + %itemId.substring(1) + '_'+ %coding.code
```
The unit test requires some test files that are in the fhir-test-cases repo here:
https://github.com/FHIR/fhir-test-cases/compare/master...brianpos:fhir-test-cases:master

This is only draft as I've only ported the change to the R4B branch, once conceptually approved, I will copy this change (and test) into R4 and R5.
