### PR TITLE
Update CDA validation targets

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -331,12 +331,12 @@ public class ValidatorCli {
         res.add("-version");
         res.add("5.0");
         res.add("-ig");
-        res.add("hl7.cda.uv.core#2.1.0-draft1");
+        res.add("hl7.cda.uv.core#2.0.0-sd-ballot");
       } else if (a.equals("-ccda")) {
         res.add("-version");
         res.add("5.0");
         res.add("-ig");
-        res.add("hl7.cda.uv.core#2.1.0-draft1");
+        res.add("hl7.cda.us.ccda#current");
       } else if (a.equals("-view-definition")) {
         res.add("-version");
         res.add("5.0");


### PR DESCRIPTION
Since CDA is in ballot now, it would be great to update the default CDA version to the ballot (especially since this is the basis for the "Common Validation Options" on validator.fhir.org).

Additionally, update C-CDA to use #current, at least until we have a ballot package ready.

@dotasek 