### PR TITLE
Include time tracking for ValidationResponse

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -12,10 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.naming.Context;
-
-import org.antlr.v4.codegen.model.decl.ContextTokenGetterDecl;
-
 /*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
@@ -70,7 +66,6 @@ import org.hl7.fhir.r5.terminologies.ValueSetUtilities;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
 import org.hl7.fhir.r5.utils.XVerExtensionManager;
 import org.hl7.fhir.r5.utils.XVerExtensionManager.XVerExtensionStatus;
-import org.hl7.fhir.r5.utils.validation.IResourceValidator;
 import org.hl7.fhir.r5.utils.validation.ValidationContextCarrier.IValidationContextResourceLoader;
 import org.hl7.fhir.r5.utils.validation.constants.BestPracticeWarningLevel;
 import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
@@ -164,7 +159,7 @@ public class BaseValidator implements IValidationContextResourceLoader {
   protected BaseValidator parent;
   protected Source source;
   protected IWorkerContext context;
-  protected TimeTracker timeTracker = new TimeTracker();
+  protected ValidationTimeTracker timeTracker = new ValidationTimeTracker();
   protected XVerExtensionManager xverManager;
   protected List<TrackedLocationRelatedMessage> trackedMessages = new ArrayList<>();
   protected List<ValidationMessage> messagesToRemove = new ArrayList<>();

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -90,6 +90,8 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
 import org.hl7.fhir.validation.ValidatorUtils.SourceFile;
 import org.hl7.fhir.validation.cli.model.HtmlInMarkdownCheck;
+import org.hl7.fhir.validation.cli.model.ValidatedFragments;
+import org.hl7.fhir.validation.cli.model.ValidationTime;
 import org.hl7.fhir.validation.cli.services.IPackageInstaller;
 import org.hl7.fhir.validation.cli.utils.ProfileLoader;
 import org.hl7.fhir.validation.cli.utils.QuestionnaireMode;
@@ -632,10 +634,11 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
   }
 
 
-  public List<ValidatedFragment> validateAsFragments(byte[] source, FhirFormat cntType, List<String> profiles, List<ValidationMessage> messages) throws FHIRException, IOException, EOperationOutcome {
+  public ValidatedFragments validateAsFragments(byte[] source, FhirFormat cntType, List<String> profiles, List<ValidationMessage> messages) throws FHIRException, IOException, EOperationOutcome {
     InstanceValidator validator = getValidator(cntType);
     validator.validate(null, messages, new ByteArrayInputStream(source), cntType, asSdList(profiles));
-    return validator.validatedContent;
+    return new ValidatedFragments(validator.validatedContent,
+      ValidationTime.fromTimeTracker(validator.timeTracker));
   }
 
   public OperationOutcome validate(byte[] source, FhirFormat cntType, List<String> profiles, List<ValidationMessage> messages) throws FHIRException, IOException, EOperationOutcome {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationTimeTracker.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationTimeTracker.java
@@ -1,6 +1,6 @@
 package org.hl7.fhir.validation;
 
-public class TimeTracker {
+public class ValidationTimeTracker {
   private long overall = 0;
   private long txTime = 0;
   private long sdTime = 0;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidatedFragments.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidatedFragments.java
@@ -1,0 +1,26 @@
+package org.hl7.fhir.validation.cli.model;
+
+import org.hl7.fhir.r5.elementmodel.ValidatedFragment;
+
+import java.util.List;
+
+public class ValidatedFragments {
+
+  public List<ValidatedFragment> getValidatedFragments() {
+    return validatedFragments;
+  }
+
+  public ValidationTime getValidationTime() {
+    return validationTime;
+  }
+
+  private List<ValidatedFragment> validatedFragments;
+
+  private ValidationTime validationTime;
+
+  public ValidatedFragments(List<ValidatedFragment> validatedFragments, ValidationTime validationTime) {
+    this.validatedFragments = validatedFragments;
+    this.validationTime = validationTime;
+  }
+
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
@@ -13,6 +13,9 @@ public class ValidationResponse {
   @JsonProperty("sessionId")
   public String sessionId;
 
+  @JsonProperty("validationTime")
+  public ValidationTime validationTime;
+
   public ValidationResponse() {}
 
   public ValidationResponse(List<ValidationOutcome> outcomes) {
@@ -51,6 +54,17 @@ public class ValidationResponse {
       outcomes = new ArrayList<>();
     }
     outcomes.add(outcome);
+    return this;
+  }
+
+  @JsonProperty("validationTime")
+  public ValidationTime getValidationTime() {
+    return validationTime;
+  }
+
+  @JsonProperty("validationTime")
+  public ValidationResponse setValidationTime(ValidationTime validationTime) {
+    this.validationTime = validationTime;
     return this;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationResponse.java
@@ -1,7 +1,9 @@
 package org.hl7.fhir.validation.cli.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -13,19 +15,21 @@ public class ValidationResponse {
   @JsonProperty("sessionId")
   public String sessionId;
 
-  @JsonProperty("validationTime")
-  public ValidationTime validationTime;
+  @JsonProperty("validationTimes")
+  public Map<String, ValidationTime> validationTimes;
 
   public ValidationResponse() {}
 
   public ValidationResponse(List<ValidationOutcome> outcomes) {
-    this(outcomes, null);
+    this(outcomes, null, new HashMap<>());
   }
 
-  public ValidationResponse(List<ValidationOutcome> outcomes, String sessionId) {
+  public ValidationResponse(List<ValidationOutcome> outcomes, String sessionId, Map<String, ValidationTime> validationTimes) {
     this.outcomes = outcomes;
     this.sessionId = sessionId;
+    this.validationTimes = validationTimes;
   }
+
 
   @JsonProperty("outcomes")
   public List<ValidationOutcome> getOutcomes() {
@@ -57,14 +61,14 @@ public class ValidationResponse {
     return this;
   }
 
-  @JsonProperty("validationTime")
-  public ValidationTime getValidationTime() {
-    return validationTime;
+  @JsonProperty("validationTimes")
+  public Map<String, ValidationTime> getValidationTimes() {
+    return validationTimes;
   }
 
-  @JsonProperty("validationTime")
-  public ValidationResponse setValidationTime(ValidationTime validationTime) {
-    this.validationTime = validationTime;
+  @JsonProperty("validationTimes")
+  public ValidationResponse setValidationTimes(Map<String, ValidationTime> validationTimes) {
+    this.validationTimes = validationTimes;
     return this;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationTime.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationTime.java
@@ -1,0 +1,102 @@
+package org.hl7.fhir.validation.cli.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hl7.fhir.validation.TimeTracker;
+
+public class ValidationTime {
+
+
+  @JsonProperty("overall")
+  private long overall = 0;
+
+  @JsonProperty("terminology")
+  private long txTime = 0;
+
+  @JsonProperty("structureDefinition")
+  private long sdTime = 0;
+
+  @JsonProperty("resourceParse")
+  private long loadTime = 0;
+
+  @JsonProperty("fhirPath")
+  private long fpeTime = 0;
+
+  @JsonProperty("checkingSpecials")
+  private long specTime = 0;
+
+  @JsonProperty("terminology")
+  public long getTxTime() {
+    return txTime;
+  }
+
+  @JsonProperty("terminology")
+  public ValidationTime setTxTime(long txTime) {
+    this.txTime = txTime;
+    return this;
+  }
+
+  @JsonProperty("structureDefinition")
+  public long getSdTime() {
+    return sdTime;
+  }
+
+  @JsonProperty("structureDefinition")
+  public ValidationTime setSdTime(long sdTime) {
+    this.sdTime = sdTime;
+    return this;
+  }
+
+  @JsonProperty("resourceParse")
+  public long getLoadTime() {
+    return loadTime;
+  }
+
+  @JsonProperty("resourceParse")
+  public ValidationTime setLoadTime(long loadTime) {
+    this.loadTime = loadTime;
+    return this;
+  }
+
+  @JsonProperty("fhirPath")
+  public long getFpeTime() {
+    return fpeTime;
+  }
+
+  @JsonProperty("fhirPath")
+  public ValidationTime setFpeTime(long fpeTime) {
+    this.fpeTime = fpeTime;
+    return this;
+  }
+
+  @JsonProperty("checkingSpecials")
+  public long getSpecTime() {
+    return specTime;
+  }
+
+  @JsonProperty("checkingSpecials")
+  public ValidationTime setSpecTime(long specTime) {
+    this.specTime = specTime;
+    return this;
+  }
+
+  @JsonProperty("overall")
+  public long getOverall() {
+    return overall;
+  }
+
+  @JsonProperty("overall")
+  public ValidationTime setOverall(long overall) {
+    this.overall = overall;
+    return this;
+  }
+
+  public static ValidationTime fromTimeTracker(TimeTracker timeTracker) {
+    return new ValidationTime()
+      .setSdTime(timeTracker.getSdTime())
+      .setTxTime(timeTracker.getTxTime())
+      .setSpecTime(timeTracker.getSpecTime())
+      .setFpeTime(timeTracker.getFpeTime())
+      .setOverall(timeTracker.getOverall())
+      .setLoadTime(timeTracker.getLoadTime());
+  }
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationTime.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/ValidationTime.java
@@ -1,81 +1,81 @@
 package org.hl7.fhir.validation.cli.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hl7.fhir.validation.TimeTracker;
+import org.hl7.fhir.validation.ValidationTimeTracker;
 
 public class ValidationTime {
 
-
+  public ValidationTime() {}
   @JsonProperty("overall")
   private long overall = 0;
 
   @JsonProperty("terminology")
-  private long txTime = 0;
+  private long terminology = 0;
 
   @JsonProperty("structureDefinition")
-  private long sdTime = 0;
+  private long structureDefinition = 0;
 
   @JsonProperty("resourceParse")
-  private long loadTime = 0;
+  private long resourceParse = 0;
 
   @JsonProperty("fhirPath")
-  private long fpeTime = 0;
+  private long fhirPath = 0;
 
   @JsonProperty("checkingSpecials")
-  private long specTime = 0;
+  private long checkingSpecials = 0;
 
   @JsonProperty("terminology")
-  public long getTxTime() {
-    return txTime;
+  public long getTerminology() {
+    return terminology;
   }
 
   @JsonProperty("terminology")
-  public ValidationTime setTxTime(long txTime) {
-    this.txTime = txTime;
+  public ValidationTime setTerminology(long terminology) {
+    this.terminology = terminology;
     return this;
   }
 
   @JsonProperty("structureDefinition")
-  public long getSdTime() {
-    return sdTime;
+  public long getStructureDefinition() {
+    return structureDefinition;
   }
 
   @JsonProperty("structureDefinition")
-  public ValidationTime setSdTime(long sdTime) {
-    this.sdTime = sdTime;
+  public ValidationTime setStructureDefinition(long structureDefinition) {
+    this.structureDefinition = structureDefinition;
     return this;
   }
 
   @JsonProperty("resourceParse")
-  public long getLoadTime() {
-    return loadTime;
+  public long getResourceParse() {
+    return resourceParse;
   }
 
   @JsonProperty("resourceParse")
-  public ValidationTime setLoadTime(long loadTime) {
-    this.loadTime = loadTime;
+  public ValidationTime setResourceParse(long resourceParse) {
+    this.resourceParse = resourceParse;
     return this;
   }
 
   @JsonProperty("fhirPath")
-  public long getFpeTime() {
-    return fpeTime;
+  public long getFhirPath() {
+    return fhirPath;
   }
 
   @JsonProperty("fhirPath")
-  public ValidationTime setFpeTime(long fpeTime) {
-    this.fpeTime = fpeTime;
+  public ValidationTime setFhirPath(long fpeTime) {
+    this.fhirPath = fpeTime;
     return this;
   }
 
   @JsonProperty("checkingSpecials")
-  public long getSpecTime() {
-    return specTime;
+  public long getCheckingSpecials() {
+    return checkingSpecials;
   }
 
   @JsonProperty("checkingSpecials")
-  public ValidationTime setSpecTime(long specTime) {
-    this.specTime = specTime;
+  public ValidationTime setCheckingSpecials(long checkingSpecials) {
+    this.checkingSpecials = checkingSpecials;
     return this;
   }
 
@@ -90,13 +90,13 @@ public class ValidationTime {
     return this;
   }
 
-  public static ValidationTime fromTimeTracker(TimeTracker timeTracker) {
+  public static ValidationTime fromTimeTracker(ValidationTimeTracker timeTracker) {
     return new ValidationTime()
-      .setSdTime(timeTracker.getSdTime())
-      .setTxTime(timeTracker.getTxTime())
-      .setSpecTime(timeTracker.getSpecTime())
-      .setFpeTime(timeTracker.getFpeTime())
+      .setStructureDefinition(timeTracker.getSdTime())
+      .setTerminology(timeTracker.getTxTime())
+      .setCheckingSpecials(timeTracker.getSpecTime())
+      .setFhirPath(timeTracker.getFpeTime())
       .setOverall(timeTracker.getOverall())
-      .setLoadTime(timeTracker.getLoadTime());
+      .setResourceParse(timeTracker.getLoadTime());
   }
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -10,12 +10,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 import javax.annotation.Nonnull;
 
@@ -107,7 +102,7 @@ public class ValidationService {
       System.out.println("  .. validate " + request.listSourceFiles());
     }
 
-    ValidationResponse response = new ValidationResponse().setSessionId(sessionId);
+    ValidationResponse response = new ValidationResponse().setSessionId(sessionId).setValidationTimes(new HashMap<>());
 
     for (FileInfo fileToValidate : request.getFilesToValidate()) {
       if (fileToValidate.getFileType() == null) {
@@ -127,7 +122,7 @@ public class ValidationService {
       if (validatedFragments.getValidatedFragments().size() == 1 && !validatedFragments.getValidatedFragments().get(0).isDerivedContent()) {
         ValidatedFragment validatedFragment = validatedFragments.getValidatedFragments().get(0);
         ValidationOutcome outcome = new ValidationOutcome();
-          FileInfo fileInfo = new FileInfo(
+        FileInfo fileInfo = new FileInfo(
           fileToValidate.getFileName(),
           new String(validatedFragment.getContent()),
           validatedFragment.getExtension());
@@ -147,11 +142,10 @@ public class ValidationService {
         }
       }
 
-      if (request.getCliContext().isShowTimes())
-        response.setValidationTime(validatedFragments.getValidationTime()
-      );
+      if (request.getCliContext().isShowTimes()) {
+        response.getValidationTimes().put(fileToValidate.getFileName(), validatedFragments.getValidationTime());
+      }
     }
-
 
     System.out.println("  Max Memory: "+Runtime.getRuntime().maxMemory());
     return response;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/CodeSystemValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/CodeSystemValidator.java
@@ -3,22 +3,15 @@ package org.hl7.fhir.validation.instance.type;
 import java.util.List;
 
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
-import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.ValueSet;
-import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
-import org.hl7.fhir.r5.utils.XVerExtensionManager;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
-import org.hl7.fhir.utilities.validation.ValidationMessage.Source;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.validation.BaseValidator;
-import org.hl7.fhir.validation.TimeTracker;
-import org.hl7.fhir.validation.instance.InstanceValidator;
 import org.hl7.fhir.validation.instance.utils.NodeStack;
 
 public class CodeSystemValidator  extends BaseValidator {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/ConceptMapValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/ConceptMapValidator.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.CodeSystem.ConceptDefinitionComponent;
@@ -16,17 +15,12 @@ import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r5.terminologies.utilities.CodingValidationRequest;
 import org.hl7.fhir.r5.terminologies.utilities.TerminologyServiceErrorClass;
 import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
-import org.hl7.fhir.r5.utils.XVerExtensionManager;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
-import org.hl7.fhir.utilities.validation.ValidationMessage.Source;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.validation.BaseValidator;
-import org.hl7.fhir.validation.TimeTracker;
-import org.hl7.fhir.validation.instance.InstanceValidator;
-import org.hl7.fhir.validation.instance.type.ValueSetValidator.VSCodingValidationRequest;
 import org.hl7.fhir.validation.instance.utils.NodeStack;
 
 


### PR DESCRIPTION
Adds time tracking to ValidationResponse.

This is required for the validator website to be able to report time tracking.

As some validations might break their validation into multiple validation fragments, time tracking is included as a map, with the original file name as the key to each entry.