### PR TITLE
configurable sessions expiration

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/PassiveExpiringSessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/PassiveExpiringSessionCache.java
@@ -1,0 +1,124 @@
+package org.hl7.fhir.validation.cli.services;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.hl7.fhir.validation.ValidationEngine;
+
+/**
+ * SessionCache for storing and retrieving ValidationEngine instances, so callers do not have to re-instantiate a new
+ * instance for each validation request.
+ */
+public class PassiveExpiringSessionCache implements SessionCache {
+
+  protected static final long TIME_TO_LIVE = 60;
+  protected static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
+  protected boolean resetExpirationAfterAccess = false;
+
+  private final PassiveExpiringMap<String, ValidationEngine> cachedSessions;
+
+  public PassiveExpiringSessionCache() {
+    cachedSessions = new PassiveExpiringMap<>(TIME_TO_LIVE, TIME_UNIT);
+  }
+
+  /**
+   * @param sessionLength the constant amount of time an entry is available before it expires. A negative value results
+   *                      in entries that NEVER expire. A zero value results in entries that ALWAYS expire.
+   * @param sessionLengthUnit the unit of time for the timeToLive parameter, must not be null
+   */
+  public PassiveExpiringSessionCache(long sessionLength, TimeUnit sessionLengthUnit) {
+    cachedSessions = new PassiveExpiringMap<>(sessionLength, sessionLengthUnit);
+  }
+
+  /**
+   * Stores the initialized {@link ValidationEngine} in the cache. Returns the session id that will be associated with
+   * this instance.
+   * @param validationEngine {@link ValidationEngine}
+   * @return The {@link String} id associated with the stored instance.
+   */
+  public String cacheSession(ValidationEngine validationEngine) {
+    String generatedId = generateID();
+    cachedSessions.put(generatedId, validationEngine);
+    return generatedId;
+  }
+
+  /**
+   * Stores the initialized {@link ValidationEngine} in the cache with the passed in id as the key. If a null key is
+   * passed in, a new key is generated and returned.
+   * @param sessionId The {@link String} key to associate with this stored {@link ValidationEngine}
+   * @param validationEngine The {@link ValidationEngine} instance to cache.
+   * @return The {@link String} id that will be associated with the stored {@link ValidationEngine}
+   */
+  public String cacheSession(String sessionId, ValidationEngine validationEngine) {
+    if(sessionId == null) {
+      sessionId = cacheSession(validationEngine);
+    } else {
+      cachedSessions.put(sessionId, validationEngine);
+    }
+    return sessionId;
+  }
+
+   /**
+   * Allows for configuration of whether or not cachedSession entry expiration times reset
+   * after they are accessed.
+   * @param reset The boolean determining session expiration policy
+   * @return The {@link SessionCache} with the explicit expiration policy
+   */
+  public SessionCache setExpirationAfterAccess(boolean reset) {
+    this.resetExpirationAfterAccess = reset;
+    return this;
+  }
+
+  /**
+   * When called, this actively checks the cache for expired entries and removes
+   * them.
+   */
+  public void removeExpiredSessions() {
+    /*
+    The PassiveExpiringMap will remove entries when accessing the mapped value
+    for a key, OR when invoking methods that involve accessing the entire map
+    contents. So, we call keySet below to force removal of all expired entries.
+    * */
+    cachedSessions.keySet();
+  }
+
+  /**
+   * Checks if the passed in {@link String} id exists in the set of stored session id.
+   * @param sessionId The {@link String} id to search for.
+   * @return {@link Boolean#TRUE} if such id exists.
+   */
+  public boolean sessionExists(String sessionId) {
+    return cachedSessions.containsKey(sessionId);
+  }
+
+  /**
+   * Returns the stored {@link ValidationEngine} associated with the passed in session id, if one such instance exists.
+   * @param sessionId The {@link String} session id.
+   * @return The {@link ValidationEngine} associated with the passed in id, or null if none exists.
+   */
+  public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
+    ValidationEngine engine = cachedSessions.get(sessionId);
+    if (this.resetExpirationAfterAccess) {
+      cachedSessions.put(sessionId, engine);
+    }   
+    return engine;
+  }
+
+  /**
+   * Returns the set of stored session ids.
+   * @return {@link Set} of session ids.
+   */
+  public Set<String> getSessionIds() {
+    return cachedSessions.keySet();
+  }
+
+  /**
+   * Session ids generated internally are UUID {@link String}.
+   * @return A new {@link String} session id.
+   */
+  private String generateID() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -23,19 +23,8 @@ public interface SessionCache {
    */
   String cacheSession(String sessionId, ValidationEngine validationEngine);
 
-  /**
-   * Allows for configuration of whether or not cachedSession entry expiration times reset
-   * after they are accessed.
-   * @param reset The boolean determining session expiration policy
-   * @return The {@link SessionCache} with the explicit expiration policy
-   */
-  SessionCache setExpirationAfterAccess(boolean reset);
 
-  /**
-   * When called, this actively checks the cache for expired entries and removes
-   * them.
-   */
-  void removeExpiredSessions();
+
 
   /**
    * Checks if the passed in {@link String} id exists in the set of stored session id.

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/SessionCache.java
@@ -1,35 +1,10 @@
 package org.hl7.fhir.validation.cli.services;
 
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.hl7.fhir.validation.ValidationEngine;
 
-/**
- * SessionCache for storing and retrieving ValidationEngine instances, so callers do not have to re-instantiate a new
- * instance for each validation request.
- */
-public class SessionCache {
-
-  protected static final long TIME_TO_LIVE = 60;
-  protected static final TimeUnit TIME_UNIT = TimeUnit.MINUTES;
-
-  private final PassiveExpiringMap<String, ValidationEngine> cachedSessions;
-
-  public SessionCache() {
-    cachedSessions = new PassiveExpiringMap<>(TIME_TO_LIVE, TIME_UNIT);
-  }
-
-  /**
-   * @param sessionLength the constant amount of time an entry is available before it expires. A negative value results
-   *                      in entries that NEVER expire. A zero value results in entries that ALWAYS expire.
-   * @param sessionLengthUnit the unit of time for the timeToLive parameter, must not be null
-   */
-  public SessionCache(long sessionLength, TimeUnit sessionLengthUnit) {
-    cachedSessions = new PassiveExpiringMap<>(sessionLength, sessionLengthUnit);
-  }
+public interface SessionCache {
 
   /**
    * Stores the initialized {@link ValidationEngine} in the cache. Returns the session id that will be associated with
@@ -37,11 +12,7 @@ public class SessionCache {
    * @param validationEngine {@link ValidationEngine}
    * @return The {@link String} id associated with the stored instance.
    */
-  public String cacheSession(ValidationEngine validationEngine) {
-    String generatedId = generateID();
-    cachedSessions.put(generatedId, validationEngine);
-    return generatedId;
-  }
+  String cacheSession(ValidationEngine validationEngine);
 
   /**
    * Stores the initialized {@link ValidationEngine} in the cache with the passed in id as the key. If a null key is
@@ -50,59 +21,40 @@ public class SessionCache {
    * @param validationEngine The {@link ValidationEngine} instance to cache.
    * @return The {@link String} id that will be associated with the stored {@link ValidationEngine}
    */
-  public String cacheSession(String sessionId, ValidationEngine validationEngine) {
-    if(sessionId == null) {
-      sessionId = cacheSession(validationEngine);
-    } else {
-      cachedSessions.put(sessionId, validationEngine);
-    }
-    return sessionId;
-  }
+  String cacheSession(String sessionId, ValidationEngine validationEngine);
+
+  /**
+   * Allows for configuration of whether or not cachedSession entry expiration times reset
+   * after they are accessed.
+   * @param reset The boolean determining session expiration policy
+   * @return The {@link SessionCache} with the explicit expiration policy
+   */
+  SessionCache setExpirationAfterAccess(boolean reset);
 
   /**
    * When called, this actively checks the cache for expired entries and removes
    * them.
    */
-  public void removeExpiredSessions() {
-    /*
-    The PassiveExpiringMap will remove entries when accessing the mapped value
-    for a key, OR when invoking methods that involve accessing the entire map
-    contents. So, we call keySet below to force removal of all expired entries.
-    * */
-    cachedSessions.keySet();
-  }
+  void removeExpiredSessions();
 
   /**
    * Checks if the passed in {@link String} id exists in the set of stored session id.
    * @param sessionId The {@link String} id to search for.
    * @return {@link Boolean#TRUE} if such id exists.
    */
-  public boolean sessionExists(String sessionId) {
-    return cachedSessions.containsKey(sessionId);
-  }
+  boolean sessionExists(String sessionId);
 
   /**
    * Returns the stored {@link ValidationEngine} associated with the passed in session id, if one such instance exists.
    * @param sessionId The {@link String} session id.
    * @return The {@link ValidationEngine} associated with the passed in id, or null if none exists.
    */
-  public ValidationEngine fetchSessionValidatorEngine(String sessionId) {
-    return cachedSessions.get(sessionId);
-  }
+  ValidationEngine fetchSessionValidatorEngine(String sessionId);
 
   /**
    * Returns the set of stored session ids.
    * @return {@link Set} of session ids.
    */
-  public Set<String> getSessionIds() {
-    return cachedSessions.keySet();
-  }
-
-  /**
-   * Session ids generated internally are UUID {@link String}.
-   * @return A new {@link String} session id.
-   */
-  private String generateID() {
-    return UUID.randomUUID().toString();
-  }
+  Set<String> getSessionIds();
+    
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -439,7 +439,7 @@ public class ValidationService {
 
   public String initializeValidator(CliContext cliContext, String definitions, TimeTracker tt, String sessionId) throws Exception {
     tt.milestone();
-    sessionCache.removeExpiredSessions();
+
     if (!sessionCache.sessionExists(sessionId)) {
       if (sessionId != null) {
         System.out.println("No such cached session exists for session id " + sessionId + ", re-instantiating validator.");

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -76,11 +76,11 @@ public class ValidationService {
   private String runDate;
 
   public ValidationService() {
-    sessionCache = new SessionCache();
+    sessionCache = new PassiveExpiringSessionCache();
     runDate = new SimpleDateFormat("hh:mm:ss", new Locale("en", "US")).format(new Date());
   }
 
-  protected ValidationService(SessionCache cache) {
+  public ValidationService(SessionCache cache) {
     this.sessionCache = cache;
   }
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/PassiveExpiringSessionCacheTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/PassiveExpiringSessionCacheTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class SessionCacheTest {
+class PassiveExpiringSessionCacheTest {
 
   @Test
   @DisplayName("test session expiration works")
@@ -50,10 +50,10 @@ class SessionCacheTest {
   }
 
   @Test
-  @DisplayName("test that explicit removeExiredSessions works")
+  @DisplayName("test that explicit removeExpiredSessions works")
   void testRemoveExpiredSessions() throws InterruptedException, IOException {
     final long EXPIRE_TIME = 5L;
-    SessionCache cache = new PassiveExpiringSessionCache(EXPIRE_TIME, TimeUnit.SECONDS);
+    PassiveExpiringSessionCache cache = new PassiveExpiringSessionCache(EXPIRE_TIME, TimeUnit.SECONDS);
     ValidationEngine testEngine = new ValidationEngine.ValidationEngineBuilder().fromNothing();
     String sessionId = cache.cacheSession(testEngine);
     Assertions.assertTrue(cache.sessionExists(sessionId));
@@ -65,13 +65,14 @@ class SessionCacheTest {
   @Test
   @DisplayName("test that explicitly configured expiration reset works")
   void testConfigureDuration() throws InterruptedException, IOException {
-    final long EXPIRE_TIME = 5L;
-    SessionCache cache = new PassiveExpiringSessionCache(EXPIRE_TIME, TimeUnit.SECONDS).setExpirationAfterAccess(true);
+    final long EXPIRE_TIME = 15L;
+    PassiveExpiringSessionCache cache = new PassiveExpiringSessionCache(EXPIRE_TIME, TimeUnit.SECONDS).setResetExpirationAfterFetch(true);
     ValidationEngine testEngine = new ValidationEngine.ValidationEngineBuilder().fromNothing();
     String sessionId = cache.cacheSession(testEngine);
-    TimeUnit.SECONDS.sleep(4L);
+    TimeUnit.SECONDS.sleep(10L);
     Assertions.assertTrue(cache.sessionExists(sessionId));
-    TimeUnit.SECONDS.sleep(3L);
+    cache.fetchSessionValidatorEngine(sessionId);
+    TimeUnit.SECONDS.sleep(10L);
     Assertions.assertTrue(cache.sessionExists(sessionId));
   }
 }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/cli/services/ValidationServiceTest.java
@@ -55,7 +55,7 @@ class ValidationServiceTest  {
   @Test
   void validateSources() throws Exception {
     TestingUtilities.injectCorePackageLoader();
-    SessionCache sessionCache = Mockito.spy(new SessionCache());
+    SessionCache sessionCache = Mockito.spy(new PassiveExpiringSessionCache());
     ValidationService myService = new ValidationService(sessionCache);
 
     String resource = IOUtils.toString(getFileFromResourceAsStream("detected_issues.json"), StandardCharsets.UTF_8);


### PR DESCRIPTION
### Summary

Original thread [here](https://chat.fhir.org/#narrow/stream/291844-FHIR-Validator/topic/Session.20Refresh/near/403249530). I didn't refactor SessionCache into an interface, but I'm happy to do so while we're looking at it.

This is meant to be a simple addition to allow the [wrapper](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/pull/158) to create a `ValidationService` with a configurable `SessionCache`. That is, when `resetExpirationAfterAccess` is `true`, an active session's expiration time resets when it is accessed.