### PR TITLE
Remove basic auth (unneeded) for AU connectathon test

### DIFF
--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class IpsBuilderTest {
 
   @Test
-  @Disabled
+  @Disabled("Work in progress.")
   @DisplayName("Test IPS Generation")
   void testIpsGeneration() throws URISyntaxException, FileNotFoundException, IOException {
     FHIRToolingClient server = new FHIRToolingClient("https://hl7auconnectathon.salessbx.smiledigitalhealth.com/fhir-request", "FHIR-Validator");

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
@@ -11,12 +11,14 @@ import org.hl7.fhir.r4.model.Base64BinaryType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.utils.client.FHIRToolingClient;
 import org.hl7.fhir.utilities.Utilities;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class IpsBuilderTest {
 
   @Test
+  @Disabled
   @DisplayName("Test IPS Generation")
   void testIpsGeneration() throws URISyntaxException, FileNotFoundException, IOException {
     FHIRToolingClient server = new FHIRToolingClient("https://hl7auconnectathon.salessbx.smiledigitalhealth.com/fhir-request", "FHIR-Validator");

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
@@ -20,8 +20,6 @@ public class IpsBuilderTest {
   @DisplayName("Test IPS Generation")
   void testIpsGeneration() throws URISyntaxException, FileNotFoundException, IOException {
     FHIRToolingClient server = new FHIRToolingClient("https://hl7auconnectathon.salessbx.smiledigitalhealth.com/fhir-request", "FHIR-Validator");
-    server.setUsername("HL7AU");
-    server.setPassword("Connectathon123");
     Bundle bnd = IPSBuilder.generateIPS(server, "wang-li");
     new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(new FileOutputStream(Utilities.path("[tmp]", "ips-gen.json")), bnd);
     

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/ips/IpsBuilderTest.java
@@ -13,12 +13,13 @@ import org.hl7.fhir.r4.utils.client.FHIRToolingClient;
 import org.hl7.fhir.utilities.Utilities;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class IpsBuilderTest {
 
   @Test
-  @Disabled("Work in progress.")
+  @Tag("excludedInSurefire")
   @DisplayName("Test IPS Generation")
   void testIpsGeneration() throws URISyntaxException, FileNotFoundException, IOException {
     FHIRToolingClient server = new FHIRToolingClient("https://hl7auconnectathon.salessbx.smiledigitalhealth.com/fhir-request", "FHIR-Validator");


### PR DESCRIPTION
IPSBuilderTest is failing because basic auth is no longer needed (the test will work correctly without auth)