### PR TITLE
Optimize I/O operations in the TextFile utility class

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/TextFile.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/TextFile.java
@@ -3,50 +3,41 @@ package org.hl7.fhir.utilities;
 /*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without modification, 
+
+  Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
-    
-   * Redistributions of source code must retain the above copyright notice, this 
+
+   * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   * Neither the name of HL7 nor the names of its contributors may be used to 
-     endorse or promote products derived from this software without specific 
+   * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
      prior written permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
-  
+
  */
 
 
-
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.util.List;
 
 /**
@@ -57,232 +48,151 @@ import java.util.List;
  */
 public class TextFile {
 
-	public static List<String> readAllLines(String path) throws IOException
-	{
-		List<String> result = new ArrayList<String>();
-		
-		File file = new CSFile(path);
-		FileInputStream fs = new FileInputStream(file);
-		try {
-		  BufferedReader reader = new BufferedReader(new InputStreamReader(fs,"UTF-8"));
-
-		  while( reader.ready() )
-		    result.add(reader.readLine());
-
-		  reader.close();
-		  return result;
-		} finally {
-		  fs.close();
-		}
-	}
-	
-	public static void writeAllLines(String path, List<String> lines) throws IOException
-	{
-		File file = new CSFile(path);
-		FileOutputStream s = new FileOutputStream(file);
-		OutputStreamWriter sw = new OutputStreamWriter(s, "UTF-8");
-		for( String line : lines )
-			sw.write(line + "\r\n");
-		
-		sw.flush();
-		s.close();
-	}
-	
-	
-  public static void stringToFile(String content, File file) throws IOException {
-    FileOutputStream fs = new FileOutputStream(file);
-    try {
-      OutputStreamWriter sw = new OutputStreamWriter(fs, "UTF-8");
-      sw.write('\ufeff');  // Unicode BOM, translates to UTF-8 with the configured outputstreamwriter
-      sw.write(content);
-      sw.flush();
-      sw.close();
-    } finally {
-      fs.close();
-    }
+  public static List<String> readAllLines(final String path) throws IOException	{
+    final File file = new CSFile(path);
+    return Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
   }
-  
-  public static void stringToStream(String content, OutputStream stream, boolean bom) throws IOException {
-    OutputStreamWriter sw = new OutputStreamWriter(stream, "UTF-8");
+
+  public static void writeAllLines(final String path, final List<String> lines) throws IOException {
+    final File file = new CSFile(path);
+    Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+  }
+
+
+  public static void stringToFile(final String content, final File file) throws IOException {
+    stringToFile(content, file, true);
+  }
+
+  public static void stringToStream(final String content, final OutputStream stream, final boolean bom) throws IOException {
     if (bom) {
-      sw.write('\ufeff');  // Unicode BOM, translates to UTF-8 with the configured outputstreamwriter
+      stream.write('\ufeff');
     }
-    sw.write(content);
-    sw.flush();
-    sw.close();
+    stream.write(content.getBytes(StandardCharsets.UTF_8));
   }
-  
-  public static byte[] stringToBytes(String content, boolean bom) throws IOException {
-    ByteArrayOutputStream bs = new ByteArrayOutputStream();
-    OutputStreamWriter sw = new OutputStreamWriter(bs, "UTF-8");
+
+  public static byte[] stringToBytes(String content, final boolean bom) {
     if (bom)
-      sw.write('\ufeff');  // Unicode BOM, translates to UTF-8 with the configured outputstreamwriter
-    sw.write(content);
-    sw.flush();
-    sw.close();
-    return bs.toByteArray(); 
+      content = '\ufeff' + content;
+    return content.getBytes(StandardCharsets.UTF_8);
   }
-  
-  public static void stringToFile(String content, String path) throws IOException  {
-    File file = new CSFile(path);
+
+  public static void stringToFile(final String content, final String path) throws IOException  {
+    final File file = new CSFile(path);
     stringToFile(content, file);
   }
 
-  public static void stringToFile(String content, File file, boolean bom) throws IOException  {
-    FileOutputStream fs = new FileOutputStream(file);
-    OutputStreamWriter sw = new OutputStreamWriter(fs, "UTF-8");
-    if (bom)
-      sw.write('\ufeff');  // Unicode BOM, translates to UTF-8 with the configured outputstreamwriter
-    sw.write(content);
-    sw.flush();
-    sw.close();
+  public static void stringToFile(final String content, final File file, final boolean bom) throws IOException {
+    try (final OutputStream output = Files.newOutputStream(file.toPath())) {
+      if (bom)
+        output.write(new byte[]{(byte)239, (byte)187, (byte)191});
+      output.write(content.getBytes(StandardCharsets.UTF_8));
+    }
   }
-  
-  public static void stringToFile(String content, String path, boolean bom) throws IOException  {
-    File file = new CSFile(path);
+
+  public static void stringToFile(final String content, final String path, final boolean bom) throws IOException {
+    final File file = new CSFile(path);
     stringToFile(content, file, bom);
   }
 
-  public static void stringToFileNoPrefix(String content, String path) throws IOException  {
-    File file = new CSFile(path);
-    OutputStreamWriter sw = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
-    sw.write(content);
-    sw.flush();
-    sw.close();
-  }
-
-  public static String fileToString(File f) throws FileNotFoundException, IOException {
-    FileInputStream fs = new FileInputStream(f);
-    try {
-      return streamToString(fs);
-    } finally {
-      fs.close();
+  public static void stringToFileNoPrefix(final String content, final String path) throws IOException {
+    try (final FileOutputStream fs = new FileOutputStream(new CSFile(path))) {
+      fs.write(content.getBytes(StandardCharsets.UTF_8));
     }
   }
-  
-  public static String fileToString(String src) throws FileNotFoundException, IOException  {
-    CSFile f = new CSFile(src);
+
+  public static String fileToString(final File f) throws IOException {
+    // Files.readString(Path) will fail on invalid UTF-8 byte sequences, so we use Files.readAllBytes() instead.
+    // This would happen when reading an XSLX file, for example.
+    return new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+  }
+
+  public static String fileToString(final String src) throws IOException  {
+    final CSFile f = new CSFile(src);
     if (!f.exists()) {
       throw new IOException("File "+src+" not found");
     }
-    FileInputStream fs = new FileInputStream(f);
-    try {
-      return streamToString(fs);
-    } finally {
-      fs.close();
-    }
+    return fileToString(f);
   }
 
-  public static String streamToString(InputStream input) throws IOException  {
-    InputStreamReader sr = new InputStreamReader(input, "UTF-8");    
-    StringBuilder b = new StringBuilder();
-    //while (sr.ready()) { Commented out by Claude Nanjo (1/14/2014) - sr.ready() always returns false - please remove if change does not impact other areas of codebase
-    int i = -1;
-    while((i = sr.read()) > -1) {
-      String s = Character.toString(i);
-      b.append(s);
-    }
-    sr.close();
-    
-    return b.toString().replace("\uFEFF", ""); 
+  public static String streamToString(final InputStream input) throws IOException  {
+    return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\uFEFF", "");
   }
 
-  public static byte[] streamToBytes(InputStream input) throws IOException  {
-    if (input== null) {
+  public static byte[] streamToBytes(final InputStream input) throws IOException  {
+    if (input == null) {
       return null;
     }
-    ByteArrayOutputStream r = new ByteArrayOutputStream(2048);
-    byte[] read = new byte[512]; 
-    for (int i; -1 != (i = input.read(read)); r.write(read, 0, i));
+    final byte[] read = input.readAllBytes();
     input.close();
-    return r.toByteArray();
+    return read;
   }
 
-  public static byte[] streamToBytesNoClose(InputStream input) throws IOException  {
-    if (input== null) {
+  public static byte[] streamToBytesNoClose(final InputStream input) throws IOException {
+    if (input == null) {
       return null;
     }
-    ByteArrayOutputStream r = new ByteArrayOutputStream(2048);
-    byte[] read = new byte[512]; 
-    for (int i; -1 != (i = input.read(read)); r.write(read, 0, i));
-    return r.toByteArray();
+    return input.readAllBytes();
   }
 
-  public static void bytesToFile(byte[] bytes, String path) throws IOException {
-    File file = new CSFile(path);
-    OutputStream sw = new FileOutputStream(file);
-    sw.write(bytes);
-    sw.flush();
-    sw.close(); 
-  }
-  
-  public static void bytesToFile(byte[] bytes, File f) throws IOException {
-    OutputStream sw = new FileOutputStream(f);
-    sw.write(bytes);
-    sw.flush();
-    sw.close(); 
-  }
-  
-  public static void appendBytesToFile(byte[] bytes, String path) throws IOException {
-    byte[] linebreak = new byte[] {13, 10};
-    Files.write(Paths.get(path), linebreak, StandardOpenOption.APPEND);
-    Files.write(Paths.get(path), bytes, StandardOpenOption.APPEND);
-  }
-
-  public static byte[] fileToBytes(String srcFile) throws FileNotFoundException, IOException {
-    FileInputStream fs = new FileInputStream(new CSFile(srcFile));
-    try {
-      return streamToBytes(fs);
-    } finally {
-      fs.close();
+  public static void bytesToFile(final byte[] bytes, final String path) throws IOException {
+    try (final OutputStream sw = new FileOutputStream(new CSFile(path))) {
+      sw.write(bytes);
     }
+  }
+
+  public static void bytesToFile(final byte[] bytes, final File f) throws IOException {
+    try (final OutputStream sw = new FileOutputStream(f)) {
+      sw.write(bytes);
+    }
+  }
+
+  public static void appendBytesToFile(final byte[] bytes, final String path) throws IOException {
+    final byte[] bytesToWrite = new byte[bytes.length + 1];
+    bytesToWrite[0] = 10; // That is a new line
+    System.arraycopy(bytes, 0, bytesToWrite, 1, bytes.length);
+    Files.write(Paths.get(path), bytesToWrite, StandardOpenOption.APPEND);
+  }
+
+  public static byte[] fileToBytes(final String srcFile) throws IOException {
+    final File f = new CSFile(srcFile);
+    return Files.readAllBytes(f.toPath());
   }
 
   /**
-   * 
-   * fileToBytes insists in case correctness to ensure that stuff works across linux and windows, but it's not always appropriate to ceheck case (e.g. validator parameters)
-   * 
+   *
+   * fileToBytes insists in case correctness to ensure that stuff works across linux and windows, but it's not always appropriate to check case (e.g. validator parameters)
+   *
    * @param srcFile
    * @return
    * @throws FileNotFoundException
    * @throws IOException
    */
-  public static byte[] fileToBytesNCS(String srcFile) throws FileNotFoundException, IOException {
-    FileInputStream fs = new FileInputStream(new File(srcFile));
-    try {
-      return streamToBytes(fs);
-    } finally {
-      fs.close();
-    }
+  public static byte[] fileToBytesNCS(final String srcFile) throws IOException {
+    return Files.readAllBytes(Path.of(srcFile));
   }
 
-  public static byte[] fileToBytes(File file) throws FileNotFoundException, IOException {
-    FileInputStream fs = new FileInputStream(file);
-    try {
-      return streamToBytes(fs);
-    } finally {
-      fs.close();
-    }
+  public static byte[] fileToBytes(final File file) throws IOException {
+    return Files.readAllBytes(file.toPath());
   }
 
-  public static String bytesToString(byte[] bs) throws IOException {
-    return streamToString(new ByteArrayInputStream(bs));
+  public static String bytesToString(final byte[] bs) {
+    return new String(bs, StandardCharsets.UTF_8);
   }
 
-  public static String bytesToString(byte[] bs, boolean removeBOM) throws IOException {
+  public static String bytesToString(final byte[] bs, final boolean removeBOM) {
+    final String read = new String(bs, StandardCharsets.UTF_8);
     if (removeBOM)
-      return streamToString(new ByteArrayInputStream(bs)).replace("\uFEFF", "");
+      return read.replace("\uFEFF", "");
     else
-      return streamToString(new ByteArrayInputStream(bs));
+      return read;
   }
 
-  public static void streamToFile(InputStream stream, String filename) throws IOException {
-    byte[] cnt = streamToBytes(stream);
-    bytesToFile(cnt, filename);
+  public static void streamToFile(final InputStream stream, final String filename) throws IOException {
+    Files.copy(stream, Path.of(filename), StandardCopyOption.REPLACE_EXISTING);
+    stream.close();
   }
 
-  public static void streamToFileNoClose(InputStream stream, String filename) throws IOException {
-    byte[] cnt = streamToBytesNoClose(stream);
-    bytesToFile(cnt, filename);
+  public static void streamToFileNoClose(final InputStream stream, final String filename) throws IOException {
+    Files.copy(stream, Path.of(filename), StandardCopyOption.REPLACE_EXISTING);
   }
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/TextFileTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/TextFileTest.java
@@ -1,0 +1,129 @@
+package org.hl7.fhir.utilities;
+
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test bench for {@link TextFile}.
+ *
+ * @author Quentin Ligier
+ **/
+class TextFileTest {
+
+  private static final String SAMPLE_CONTENT = "Line 1\nLine 2\nLine 3";
+  private static final List<String> SAMPLE_CONTENT_LINES = List.of("Line 1", "Line 2", "Line 3");
+  private static final String BOM = "\uFEFF";
+
+  private static File readFile;
+  private final static List<File> createdFiles = new ArrayList<>(4);
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    readFile = createTempFile();
+    readFile.deleteOnExit();
+    Files.writeString(readFile.toPath(), SAMPLE_CONTENT);
+  }
+
+  @AfterAll
+  static void tearDown() throws IOException {
+    for (final var file : createdFiles) {
+      Files.deleteIfExists(file.toPath());
+    }
+  }
+
+  @Test
+  void testReadAllLines() throws IOException {
+    final var readLines = TextFile.readAllLines(readFile.getAbsolutePath());
+    assertEquals(3, readLines.size());
+    assertEquals(SAMPLE_CONTENT_LINES, readLines);
+  }
+
+  @Test
+  void testBytesToString1() {
+    final var converted = TextFile.bytesToString(SAMPLE_CONTENT.getBytes(StandardCharsets.UTF_8));
+    assertEquals(SAMPLE_CONTENT, converted);
+  }
+
+  @Test
+  void testBytesToString2() {
+    final var bytesWithoutBom = SAMPLE_CONTENT.getBytes(StandardCharsets.UTF_8);
+    final var bomBytes = BOM.getBytes(StandardCharsets.UTF_8);
+    final var bytesWithBom = Arrays.copyOf(bomBytes, bomBytes.length + bytesWithoutBom.length);
+    System.arraycopy(bytesWithoutBom, 0, bytesWithBom, bomBytes.length, bytesWithoutBom.length);
+
+    var converted = TextFile.bytesToString(bytesWithoutBom, true);
+    assertEquals(SAMPLE_CONTENT, converted);
+
+    converted = TextFile.bytesToString(bytesWithoutBom, false);
+    assertEquals(SAMPLE_CONTENT, converted);
+
+    converted = TextFile.bytesToString(bytesWithBom, true);
+    assertEquals(SAMPLE_CONTENT, converted);
+
+    converted = TextFile.bytesToString(bytesWithBom, false);
+    assertEquals(BOM + SAMPLE_CONTENT, converted);
+  }
+
+  @Test
+  void testFileToString1() throws IOException {
+    final var read = TextFile.fileToString(readFile);
+    assertEquals(SAMPLE_CONTENT, read);
+  }
+
+  @Test
+  void testFileToString2() throws IOException {
+    final var read = TextFile.fileToString(readFile.getAbsolutePath());
+    assertEquals(SAMPLE_CONTENT, read);
+  }
+
+  @Test
+  void testFileToBytes1() throws IOException {
+    final var read = TextFile.fileToBytes(readFile);
+    assertArrayEquals(SAMPLE_CONTENT.getBytes(StandardCharsets.UTF_8), read);
+  }
+
+  @Test
+  void testFileToBytesNCS() throws IOException {
+    final var read = TextFile.fileToBytesNCS(readFile.getAbsolutePath());
+    assertArrayEquals(SAMPLE_CONTENT.getBytes(StandardCharsets.UTF_8), read);
+  }
+
+  @Test
+  void testFileToBytes2() throws IOException {
+    final var read = TextFile.fileToBytes(readFile.getAbsolutePath());
+    assertArrayEquals(SAMPLE_CONTENT.getBytes(StandardCharsets.UTF_8), read);
+  }
+
+  @Test
+  void testStringToFile() throws IOException {
+    final var writeFile = createTempFile();
+    TextFile.stringToFile(SAMPLE_CONTENT, writeFile, true);
+    assertEquals(BOM + SAMPLE_CONTENT, Files.readString(writeFile.toPath()));
+
+    TextFile.stringToFile(SAMPLE_CONTENT, writeFile, false);
+    assertEquals(SAMPLE_CONTENT, Files.readString(writeFile.toPath()));
+  }
+
+  @Test
+  void testWriteAllLines() throws IOException {
+    final var writeFile = createTempFile();
+    TextFile.writeAllLines(writeFile.getAbsolutePath(), SAMPLE_CONTENT_LINES);
+    assertEquals(SAMPLE_CONTENT_LINES, Files.readAllLines(writeFile.toPath()));
+  }
+
+  private static File createTempFile() throws IOException {
+    final var file = Files.createTempFile("test_fhir_utilities_", ".txt").toFile();
+    file.deleteOnExit();
+    createdFiles.add(file);
+    return file;
+  }
+}


### PR DESCRIPTION
This PR adds unit tests for `org.hl7.fhir.utilities.TextFile` and optimize I/O operations in it.

While analyzing the IG Publisher performance, I saw that methods in `TextFile` took a lot of time for simple I/O operations, so I optimized it.

For the performance changes, I measured building [CH Core](https://github.com/hl7ch/ch-core) before and after the patch:
|                             | Before         |                   | After          |                   |
|-----------------------------|----------------|-------------------|----------------|-------------------|
|                             | Execution time | Memory allocation | Execution time | Memory allocation |
| streamToString(InputStream) | 19.107 s       | 22.66 GB          | 0.140 s        | 300 MB            |
| fileToString(String)        | 5.355 s        | 6.01 GB           | 0.301 s        | 544 MB            |
| bytesToString(byte[])       | 3.527 s        | 4.19 GB           | 0.076 s        | 307 MB            |

The total build time went from 4min31 to 4min06 on those runs.

I also tested the IG Publisher on some other IGs, with success.

The BOM support for writing files is a bit surprising. I am unsure it is desired to write `.fhir/packages/packages.ini` without BOM, but the different _.index.json_ with BOM (maybe a method confusion?).
Renaming the methods could be helpful.

I wrote a small blog post that contains a bit more details: https://blog.qligier.ch/posts/2024-improving-perf-ig-publisher-io/