### PR TITLE
Handle toString for XhtmlNode when nodeType == null

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlNode.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlNode.java
@@ -626,6 +626,9 @@ public class XhtmlNode extends XhtmlFluent implements IBaseXhtml {
 
   @Override
   public String toString() {
+    if (nodeType == null) {
+      return super.toString();
+    }
     switch (nodeType) {
     case Document: 
     case Element:

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/XhtmlTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/XhtmlTests.java
@@ -1,0 +1,16 @@
+package org.hl7.fhir.utilities.xhtml;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class XhtmlTests {
+
+  @Test
+  public void testToStringOnNullType()
+  {
+      XhtmlNode node = new XhtmlNode(null, "Blah");
+      String actual = node.toString();
+      assertTrue(actual.startsWith("org.hl7.fhir.utilities.xhtml.XhtmlNode@"), "toString() should return java the toString default method for objects, which starts with the full class name");
+  }
+}


### PR DESCRIPTION
If nodeType == null, a call to toString() will result in a NullPointer exception. This should never happen.