### PR TITLE
Fix NullPointer exception when params are null

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,4 +4,5 @@
 
 ## Other code changes
 
-* no changes
+* Fix null pointer on explicitly null params in DSTU3 terminology requests
+* Fix text creation on wrong xhtml node type

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/client/FHIRToolingClient.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/utils/client/FHIRToolingClient.java
@@ -482,9 +482,13 @@ public class FHIRToolingClient extends FHIRBaseToolingClient {
     recordUse();
     Parameters p = expParams == null ? new Parameters() : expParams.copy();
     p.addParameter().setName("valueSet").setResource(source);
-    for (String n : params.keySet()) {
-      p.addParameter().setName(n).setValue(new StringType(params.get(n)));
+    if (params == null) {
+      params = new HashMap<>();
     }
+      for (String n : params.keySet()) {
+        p.addParameter().setName(n).setValue(new StringType(params.get(n)));
+      }
+
     org.hl7.fhir.dstu3.utils.client.network.ResourceRequest<Resource> result = null;
     try {
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <guava_version>32.0.1-jre</guava_version>
         <hapi_fhir_version>6.4.1</hapi_fhir_version>
-        <validator_test_case_version>1.4.26</validator_test_case_version>
+        <validator_test_case_version>1.4.27-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.16.0</jackson_version>
         <junit_jupiter_version>5.9.2</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>


### PR DESCRIPTION
The params in question can be explicitly set to null in some cases, which results in failures in this method, as well as some downstream method calls.