### PR TITLE
Restore and fix failing SimpleWorkerContextTests

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/SimpleWorkerContextTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/SimpleWorkerContextTests.java
@@ -325,7 +325,7 @@ public class SimpleWorkerContextTests {
 
     ValueSetExpansionOutcome actualExpansionResult = context.expandVS(inc, true, false);
 
-    // assertEquals(expectedValueSet, actualExpansionResult.getValueset());
+     assertEquals(expectedValueSet, actualExpansionResult.getValueset());
 
     Mockito.verify(terminologyCache).getExpansion(cacheToken);
     Mockito.verify(terminologyCache).cacheExpansion(cacheToken, actualExpansionResult,true);
@@ -412,7 +412,7 @@ public class SimpleWorkerContextTests {
 
     ValueSetExpansionOutcome actualExpansionResult = context.expandVS(vs, true,  true, true, pIn, false);
 
-  //  assertEquals(expectedValueSet, actualExpansionResult.getValueset());
+    assertEquals(expectedValueSet, actualExpansionResult.getValueset());
 
     Mockito.verify(terminologyCache).getExpansion(cacheToken);
     Mockito.verify(terminologyCache).cacheExpansion(cacheToken, actualExpansionResult, true);
@@ -421,40 +421,37 @@ public class SimpleWorkerContextTests {
 
   @Test
   public void testInitializationWithCache() {
-//    String address = "/...";
-//    
-//    Mockito.doReturn(true).when(terminologyCache).hasTerminologyCapabilities(address);
-////    Mockito.doReturn(true).when(terminologyCache).hasCapabilityStatement();
-//
-//    Mockito.doReturn(terminologyCapabilities).when(terminologyCache).getTerminologyCapabilities(address);
-////    Mockito.doReturn(capabilitiesStatement).when(terminologyCache).getCapabilityStatement();
-//
-//    context.connectToTSServer(new TerminologyClientR5Factory(), terminologyClient);
-//
-//    Mockito.verify(terminologyCache).getTerminologyCapabilities(address);
-//    Mockito.verify(terminologyClient).getCapabilitiesStatementQuick();
-//    
-//    Mockito.verify(terminologyCache, times(0)).getCapabilityStatement(address);
-//    Mockito.verify(terminologyClient, times(0)).getTerminologyCapabilities();
+   String address = "dummyUrl";
+
+   Mockito.doReturn(true).when(terminologyCache).hasTerminologyCapabilities(address);
+
+    Mockito.doReturn(terminologyCapabilities).when(terminologyCache).getTerminologyCapabilities(address);
+
+    context.connectToTSServer(new TerminologyClientR5Factory(), terminologyClient);
+
+    Mockito.verify(terminologyCache).getTerminologyCapabilities(address);
+    Mockito.verify(terminologyClient).getCapabilitiesStatementQuick();
+
+    Mockito.verify(terminologyCache, times(0)).getCapabilityStatement(address);
+    Mockito.verify(terminologyClient, times(0)).getTerminologyCapabilities();
   }
 
   @Test
   public void testInitializationWithClient() {
-//    String address = "/...";
-//
-//    Mockito.doReturn(false).when(terminologyCache).hasTerminologyCapabilities(address);
-////    Mockito.doReturn(false).when(terminologyCache).hasCapabilityStatement();
-//
-//    Mockito.doReturn(terminologyCapabilities).when(terminologyClient).getTerminologyCapabilities();
-//    Mockito.doReturn(capabilitiesStatement).when(terminologyClient).getCapabilitiesStatementQuick();
-//
-//    context.connectToTSServer(new TerminologyClientR5Factory(), terminologyClient);
-//
-//    Mockito.verify(terminologyCache, times(0)).getTerminologyCapabilities(address);
-//    Mockito.verify(terminologyCache, times(0)).getCapabilityStatement(address);
-//
-//    Mockito.verify(terminologyClient).getTerminologyCapabilities();
-//    Mockito.verify(terminologyClient).getCapabilitiesStatementQuick();
+    String address = "dummyUrl";
+
+    Mockito.doReturn(false).when(terminologyCache).hasTerminologyCapabilities(address);
+
+    Mockito.doReturn(terminologyCapabilities).when(terminologyClient).getTerminologyCapabilities();
+    Mockito.doReturn(capabilitiesStatement).when(terminologyClient).getCapabilitiesStatementQuick();
+
+   context.connectToTSServer(new TerminologyClientR5Factory(), terminologyClient);
+
+    Mockito.verify(terminologyCache, times(0)).getTerminologyCapabilities(address);
+    Mockito.verify(terminologyCache, times(0)).getCapabilityStatement(address);
+
+    Mockito.verify(terminologyClient).getTerminologyCapabilities();
+    Mockito.verify(terminologyClient).getCapabilitiesStatementQuick();
 
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <guava_version>32.0.1-jre</guava_version>
         <hapi_fhir_version>6.4.1</hapi_fhir_version>
-        <validator_test_case_version>1.4.27</validator_test_case_version>
+        <validator_test_case_version>1.4.28-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.16.0</jackson_version>
         <junit_jupiter_version>5.9.2</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <guava_version>32.0.1-jre</guava_version>
         <hapi_fhir_version>6.4.1</hapi_fhir_version>
-        <validator_test_case_version>1.4.28-SNAPSHOT</validator_test_case_version>
+        <validator_test_case_version>1.4.28</validator_test_case_version>
         <jackson_version>2.16.0</jackson_version>
         <junit_jupiter_version>5.9.2</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>


### PR DESCRIPTION
@grahamegrieve these are the test fixes from the cases you had to disable. What follows is why I think we need them.

These tests verify that worker context is using the appropriate mechanism (cache or client) depending on whether or not the caches contain the necessary objects. The mocks here prevent us from having to fully load a context and have these tests run for way longer. 

I believe these were originally added as part of a refactor of terminology caching to ensure nothing broke. They should continue to indicate that it's performing as intended (recognizing what is in the cache, using the cache or the client, etc).

