### PR TITLE
Make sure JUnit 4 and 5 dependencies are optional in org.hl7.fhir.utilities module

### DIFF
--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -89,7 +89,6 @@
             <optional>true</optional>
         </dependency>
 
-
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
@@ -107,18 +106,21 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -126,12 +128,14 @@
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit_jupiter_version}</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -139,6 +143,7 @@
             <artifactId>junit-platform-launcher</artifactId>
             <version>${junit_platform_launcher_version}</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -146,13 +151,14 @@
             <artifactId>fhir-test-cases</artifactId>
             <version>${validator_test_case_version}</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -161,13 +167,12 @@
             <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
-
 
         <!--
         <dependency>


### PR DESCRIPTION
Also removed duplicate managed versions of JUnit 4.13.2 and mockwebserver 4.11.0.

Fixes #1561