### PR TITLE
Fix split logic of canonical into url and version in several places

### DIFF
--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/ConceptMapRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/ConceptMapRenderer.java
@@ -152,8 +152,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
           td = tr.td();
           td.addText(ccl.getCode());
           display = ccl.hasDisplay() ? ccl.getDisplay()
-              : getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()),
-                  ccl.getCode());
+              : getDisplayForConcept(grp.getSource(), ccl.getCode());
           if (display != null && !isSameCodeAndDisplay(ccl.getCode(), display))
             td.tx(" (" + display + ")");
           TargetElementComponent ccm = ccl.getTarget().get(0);
@@ -166,8 +165,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
           td = tr.td();
           td.addText(ccm.getCode());
           display = ccm.hasDisplay() ? ccm.getDisplay()
-              : getDisplayForConcept(systemFromCanonical(grp.getTarget()), versionFromCanonical(grp.getTarget()),
-                  ccm.getCode());
+              : getDisplayForConcept(grp.getTarget(), ccm.getCode());
           if (display != null && !isSameCodeAndDisplay(ccm.getCode(), display))
             td.tx(" (" + display + ")");
           if (comment)
@@ -247,8 +245,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
               td.addText(ccl.getCode());
             else
               td.addText(grp.getSource() + " / " + ccl.getCode());
-            display = getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()),
-                ccl.getCode());
+            display = getDisplayForConcept(grp.getSource(), ccl.getCode());
             tr.td().style("border-left-width: 0px").tx(display == null ? "" : display);
             tr.td().colspan("4").style("background-color: #efefef").tx("(not mapped)");
 
@@ -270,8 +267,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
                 else
                   td.addText(grp.getSource() + " / " + ccl.getCode());
                 display = ccl.hasDisplay() ? ccl.getDisplay()
-                    : getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()),
-                        ccl.getCode());
+                    : getDisplayForConcept(grp.getSource(), ccl.getCode());
                 td = tr.td();
                 if (!last)
                   td.style("border-left-width: 0px; border-bottom-style: none");
@@ -311,7 +307,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
               else
                 td.addText(grp.getTarget() + " / " + ccm.getCode());
               display = ccm.hasDisplay() ? ccm.getDisplay()
-                  : getDisplayForConcept(systemFromCanonical(grp.getTarget()), versionFromCanonical(grp.getTarget()),
+                  : getDisplayForConcept(grp.getTarget(),
                       ccm.getCode());
               tr.td().style("border-left-width: 0px").tx(display == null ? "" : display);
 

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/DataRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/DataRenderer.java
@@ -1731,24 +1731,5 @@ public class DataRenderer extends Renderer {
     return b.toString();
   }
 
-  protected String versionFromCanonical(String system) {
-    if (system == null) {
-      return null;
-    } else if (system.contains("|")) {
-      return system.substring(0, system.indexOf("|"));
-    } else {
-      return null;
-    }
-  }
-
-  protected String systemFromCanonical(String system) {
-    if (system == null) {
-      return null;
-    } else if (system.contains("|")) {
-      return system.substring(system.indexOf("|") + 1);
-    } else {
-      return system;
-    }
-  }
 
 }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/TerminologyRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/TerminologyRenderer.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.r4b.renderers.utils.RenderingContext;
 import org.hl7.fhir.r4b.renderers.utils.Resolver.ResourceContext;
 import org.hl7.fhir.r4b.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r4b.utils.ToolingExtensions;
+import org.hl7.fhir.utilities.CanonicalPair;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -325,8 +326,14 @@ public abstract class TerminologyRenderer extends ResourceRenderer {
       }
     }
   }
+  
 
-  protected String getDisplayForConcept(String system, String version, String value) {
+  protected String getDisplayForConcept(String canonical, String value) {
+    var split = CanonicalPair.of(canonical);
+    return getDisplayForConcept(split.getUrl(), split.getVersion(), value);
+  }
+
+  private String getDisplayForConcept(String system, String version, String value) {
     if (value == null || system == null)
       return null;
     ValidationResult cl = getContext().getWorker().validateCode(

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/ConceptMapRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/ConceptMapRenderer.java
@@ -428,7 +428,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
           tr = tbl.tr();
           XhtmlNode td = tr.td();
           td.addText(ccl.getCode());
-          display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()), ccl.getCode());
+          display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(grp.getSource(), ccl.getCode());
           if (display != null && !isSameCodeAndDisplay(ccl.getCode(), display))
             td.tx(" ("+display+")");
           if (ccl.getNoMap()) {
@@ -447,7 +447,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
             }
             td = tr.td();
             td.addText(ccm.getCode());
-            display = ccm.hasDisplay() ? ccm.getDisplay() : getDisplayForConcept(systemFromCanonical(grp.getTarget()), versionFromCanonical(grp.getTarget()), ccm.getCode());
+            display = ccm.hasDisplay() ? ccm.getDisplay() : getDisplayForConcept(grp.getTarget(), ccm.getCode());
             if (display != null && !isSameCodeAndDisplay(ccm.getCode(), display))
               td.tx(" ("+display+")");
             if (comment)
@@ -539,7 +539,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
               td.addText(ccl.getCode());
             else
               td.addText(grp.getSource()+" / "+ccl.getCode());
-            display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()), ccl.getCode());
+            display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(grp.getSource(), ccl.getCode());
             tr.td().style("border-left-width: 0px").tx(display == null ? "" : display);
             tr.td().colspan("4").style("background-color: #efefef").tx("(not mapped)");
 
@@ -560,7 +560,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
                   td.addText(ccl.getCode());
                 else
                   td.addText(grp.getSource()+" / "+ccl.getCode());
-                display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(systemFromCanonical(grp.getSource()), versionFromCanonical(grp.getSource()), ccl.getCode());
+                display = ccl.hasDisplay() ? ccl.getDisplay() : getDisplayForConcept(grp.getSource(), ccl.getCode());
                 td = tr.td();
                 if (!last)
                   td.style("border-left-width: 0px; border-bottom-style: none");
@@ -603,7 +603,7 @@ public class ConceptMapRenderer extends TerminologyRenderer {
                 td.addText(ccm.getCode());
               else
                 td.addText(grp.getTarget()+" / "+ccm.getCode());
-              display = ccm.hasDisplay() ? ccm.getDisplay() : getDisplayForConcept(systemFromCanonical(grp.getTarget()), versionFromCanonical(grp.getTarget()), ccm.getCode());
+              display = ccm.hasDisplay() ? ccm.getDisplay() : getDisplayForConcept(grp.getSource(), ccm.getCode());
               tr.td().style("border-left-width: 0px").tx(display == null ? "" : display);
 
               for (String s : targets.keySet()) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/DataRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/DataRenderer.java
@@ -1976,25 +1976,5 @@ public class DataRenderer extends Renderer implements CodeResolver {
     return b.toString();
   }
 
-  protected String versionFromCanonical(String system) {
-    if (system == null) {
-      return null;
-    } else if (system.contains("|")) {
-      return system.substring(0, system.indexOf("|"));
-    } else {
-      return null;
-    }
-  }
-
-  protected String systemFromCanonical(String system) {
-    if (system == null) {
-      return null;
-    } else if (system.contains("|")) {
-      return system.substring(system.indexOf("|")+1);
-    } else {
-      return system;
-    }
-  }
-
 
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/TerminologyRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/TerminologyRenderer.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.r5.renderers.utils.Resolver.ResourceContext;
 import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
+import org.hl7.fhir.utilities.CanonicalPair;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -320,6 +321,11 @@ public abstract class TerminologyRenderer extends ResourceRenderer {
     }
   }
 
+  protected String getDisplayForConcept(String canonical, String value) {
+    var split = CanonicalPair.of(canonical);
+    return getDisplayForConcept(split.getUrl(), split.getVersion(), value);
+  }
+  
   protected String getDisplayForConcept(String system, String version, String value) {
     if (value == null || system == null)
       return null;

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <commons_compress_version>1.26.0</commons_compress_version>
         <guava_version>32.0.1-jre</guava_version>
         <hapi_fhir_version>6.4.1</hapi_fhir_version>
-        <validator_test_case_version>1.5.7</validator_test_case_version>
+        <validator_test_case_version>1.5.8-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.17.0</jackson_version>
         <junit_jupiter_version>5.9.2</junit_jupiter_version>
         <junit_platform_launcher_version>1.8.2</junit_platform_launcher_version>


### PR DESCRIPTION
Removed
- org.hl7.fhir.r4b.renderers.DataRenderer#versionFromCanonical
- org.hl7.fhir.r4b.renderers.DataRenderer#systemFromCanonical
- org.hl7.fhir.r5.renderers.DataRenderer#versionFromCanonical
- org.hl7.fhir.r5.renderers.DataRenderer#systemFromCanonical

The logic of these methods is wrong, the functionality of extracting the version and the system URL have been swapped.

Therefore, all usages of aforementioned methods were replaced by the use of `org.hl7.fhir.utilities.CanonicalPair` in `org.hl7.fhir.r4b.renderers.TerminologyRenderer` and `org.hl7.fhir.r5.renderers.TerminologyRenderer`. This not only fixes the problem, but also reduces duplicated functionality.

The test case for this change was proposed to the test repository in PR https://github.com/FHIR/fhir-test-cases/pull/172 .
This PR closes the second round of errors found in issue #1611 . After this PR, all found bugs are taken care of.