### PR TITLE
Log validation session counts

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java
@@ -473,10 +473,12 @@ public class ValidationService {
       if (sessionId != null) {
         System.out.println("No such cached session exists for session id " + sessionId + ", re-instantiating validator.");
       }
+        System.out.println("Building new validator engine from CliContext");
       ValidationEngine validator = buildValidationEngine(cliContext, definitions, tt);
       sessionId = sessionCache.cacheSession(validator);
+      System.out.println("Cached new session. Cache size = " + sessionCache.getSessionIds().size());
     } else {
-      System.out.println("Cached session exists for session id " + sessionId + ", returning stored validator session id.");
+      System.out.println("Cached session exists for session id " + sessionId + ", returning stored validator session id. Cache size = " + sessionCache.getSessionIds().size());
     }
     return sessionId;
   }


### PR DESCRIPTION
Adds additional logging indicating the number of sessions currently in the session cache. Useful for evaluating current ValidatorService resource usage in the wild.