### PR TITLE
Fix for single quote escapes in I18n

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
@@ -125,7 +125,7 @@ public abstract class I18nBase {
       if (Objects.nonNull(theMessageArguments) && theMessageArguments.length > 0) {
         message = MessageFormat.format(messages.getString(theMessage).trim(), theMessageArguments);
       } else {
-        message = messages.getString(theMessage).trim();
+        message = MessageFormat.format(messages.getString(theMessage).trim(), null);
       }
     }
     return message;

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/i18n/I18nBaseTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/i18n/I18nBaseTest.java
@@ -110,6 +110,20 @@ class I18nBaseTest {
   }
 
   @Test
+  @DisplayName("Test double single quotes behaviour.")
+  void testDoubleSingleQuotes() {
+    I18nTestClass testClass = new I18nTestClass();
+    testClass.setLocale(Locale.US);
+    String actualMessageA = testClass.formatMessage(I18nConstants.VALUESET_EXAMPLE_SYSTEM_HINT, "Mazooma");
+    assertEquals("Example System 'Mazooma' specified, so Concepts and Filters can't be checked", actualMessageA);
+
+    String actualMessageB = testClass.formatMessage(I18nConstants.VALUESET_NO_SYSTEM_WARNING);
+    System.out.println(actualMessageB);
+    assertEquals("No System specified, so Concepts and Filters can't be checked", actualMessageB);
+  }
+
+
+  @Test
   @DisplayName("Test German localization file contains no umlauts.")
   void testThatNoOneHasMessedWithTheGermans() {
     I18nTestClass testClass = new I18nTestClass();


### PR DESCRIPTION
Single quote escapes in messages without message arguments were being treated as regular strings, which bypassed single quote escapes in MessageFormat.