### PR TITLE
cli fhirpath #1650

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -815,7 +815,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     FHIRPathEngine fpe = this.getValidator(null).getFHIRPathEngine();
     Element e = Manager.parseSingle(context, new ByteArrayInputStream(cnt.getFocus().getBytes()), cnt.getCntType());
     ExpressionNode exp = fpe.parse(expression);
-    return fpe.evaluateToString(new ValidationContext(context, e), e, e, e, exp);
+    return fpe.evaluateToString(new ValidationContext(context), e, e, e, exp);
   }
 
   public StructureDefinition snapshot(String source, String version) throws FHIRException, IOException {


### PR DESCRIPTION
adjusts setting up the validationcontext that the exeption is not thrown, see https://github.com/hapifhir/org.hl7.fhir.core/issues/1650

-fhirpath "Patient.maritalStatus.coding.code" -version R4 /Users/oegger/Documents/github/matchbox/matchbox-engine/src/test/resources/mapping-language/pat.json

```
FHIR Validation tool Version 6.3.12-SNAPSHOT (Git# b97065338d09). Built 2024-06-14T23:10:21.682+02:00 (9 hours old)
  Java:   17.0.8.1 from /Applications/Eclipse.app/Contents/Eclipse/plugins/org.eclipse.justj.openjdk.hotspot.jre.full.macosx.aarch64_17.0.8.v20230831-1047/jre on aarch64 (64bit). 8192MB available
  Paths:  Current = /Users/oegger/Documents/github/org.hl7.fhir.core/org.hl7.fhir.validation, Package Cache = /Users/oegger/.fhir/packages
  Params: -fhirpath Patient.maritalStatus.coding.code -version R4 /Users/oegger/Documents/github/matchbox/matchbox-engine/src/test/resources/mapping-language/pat.json
  Locale: Switzerland/CH
  Jurisdiction: Switzerland
Loading
Building new validator engine from CliContext
  Load FHIR v4.0.1 from hl7.fhir.r4.core#4.0.1 - 4576 resources (00:02.896)
  Load hl7.fhir.uv.extensions.r4#1.0.0 - 1328 resources (00:00.988)
  Load hl7.terminology#5.5.0 - 4224 resources (00:00.580)
  Load hl7.terminology.r5#5.5.0 - 4224 resources (00:00.266)
  Load hl7.fhir.uv.extensions#5.1.0 - 1396 resources (00:00.732)
  Terminology server http://tx.fhir.org - Version Connected to Terminology Server at http://tx.fhir.org (00:01.009)
  Package Summary: [hl7.fhir.r4.core#4.0.1, hl7.fhir.xver-extensions#0.1.0, hl7.fhir.uv.extensions.r4#1.0.0, hl7.terminology#5.5.0, hl7.terminology.r5#5.5.0, hl7.fhir.uv.extensions#5.1.0]
  Terminology Cache at /var/folders/l2/kxp46ty52lj3tpdqm59ntp640000gn/T/default-tx-cache
  Get set...  go (00:00.134)
Cached new session. Cache size = 1
 ...evaluating Patient.maritalStatus.coding.code
M
```