### PR TITLE
Introduce backwards compatible constructor in ValidationEngineBuilder and deprecate

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -342,6 +342,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     @With
     private boolean THO = true;
 
+    private static final boolean USE_ECOSYSTEM_DEFAULT = true;
 
     public ValidationEngineBuilder() {
       terminologyCachePath = null;
@@ -356,6 +357,20 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
       loggingService = new SystemOutLoggingService();
     }
 
+    /**
+     * @deprecated This method will be made private in a future release, and should not be used outside of this class.
+     * Use {@link #ValidationEngineBuilder()} instead.
+     */
+    @Deprecated
+    public ValidationEngineBuilder(String terminologyCachePath, String userAgent, String version, String txServer, String txLog, FhirPublication txVersion, TimeTracker timeTracker, boolean canRunWithoutTerminologyServer, ILoggingService loggingService, boolean THO) {
+      this(terminologyCachePath, userAgent, version, txServer, txLog, txVersion, USE_ECOSYSTEM_DEFAULT, timeTracker, canRunWithoutTerminologyServer, loggingService, THO);
+    }
+
+    /**
+     * @deprecated This method will be made private in a future release, and should not be used outside of this class.
+     * Use {@link #ValidationEngineBuilder()} instead.
+     */
+    @Deprecated
     public ValidationEngineBuilder(String terminologyCachePath, String userAgent, String version, String txServer, String txLog, FhirPublication txVersion, boolean useEcosystem, TimeTracker timeTracker, boolean canRunWithoutTerminologyServer, ILoggingService loggingService, boolean THO) {
       this.terminologyCachePath = terminologyCachePath;
       this.userAgent = userAgent;
@@ -366,7 +381,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
       this.timeTracker = timeTracker;
       this.canRunWithoutTerminologyServer = canRunWithoutTerminologyServer;
       this.loggingService = loggingService;
-      this.useEcosystem = true;
+      this.useEcosystem = USE_ECOSYSTEM_DEFAULT;
       this.THO = THO;
     }
 


### PR DESCRIPTION
This re-introduces a previous version of a constructor for backwards compatibility purposes, and deprecates all ValidationEngineBuilder constructors with args, as they should be private and only used internally in that class.

See: https://github.com/hapifhir/org.hl7.fhir.core/commit/60bf358bfa978b95b39041d8412f92ea401cefa9#r143962456