### PR TITLE
Try using reportgenerator task to get better line coverage in Azure Pipeline

### DIFF
--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -156,12 +156,12 @@ jobs:
           jdkArchitectureOption: 'x64'
           goals: 'jacoco:report-aggregate'
 
-      - task: PublishCodeCoverageResults@1
-        displayName: 'Publish JaCoCo test results'
+      - task: reportgenerator@5
+        displayName: ReportGenerator
         inputs:
-          codeCoverageTool: 'JaCoCo'
-          summaryFileLocation: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/jacoco.xml'
-          reportDirectory: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/'
+          reports: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/jacoco.xml'
+          targetdir: '$(System.DefaultWorkingDirectory)/org.hl7.fhir.report/target/site/jacoco-aggregate/'
+          publishCodeCoverageResults: true
 
       - bash: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov


### PR DESCRIPTION
PublishCodeCoverageResults version 1 is being deprecated, and version 2 doesn't display detailed line coverage like version 1 did. 

The suggested workaround is to directly use the reportgenerator task that version 1 used to use, but to trigger it directly, removing the need for PublishCodeCoverageResults:

https://marketplace.visualstudio.com/items?itemName=Palmmedia.reportgenerator