### PR TITLE
Return null for all toCode enum params that are Enum.NULL (r5)

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Account.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Account.java
@@ -180,7 +180,9 @@ public class Account extends DomainResource {
         throw new FHIRException("Unknown AccountStatus code '"+codeString+"'");
         }
     public String toCode(AccountStatus code) {
-      if (code == AccountStatus.ACTIVE)
+       if (code == AccountStatus.NULL)
+           return null;
+       if (code == AccountStatus.ACTIVE)
         return "active";
       if (code == AccountStatus.INACTIVE)
         return "inactive";
@@ -191,7 +193,7 @@ public class Account extends DomainResource {
       if (code == AccountStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(AccountStatus code) {
       return code.getSystem();
       }
@@ -2507,7 +2509,9 @@ A coverage may only be responsible for specific types of charges, and the sequen
     protected CodeableConcept currency;
 
     /**
-     * The calculated account balances - these are calculated and processed by the finance system.The balances with a `term` that is not current are usually generated/updated by an invoicing or similar process.
+     * The calculated account balances - these are calculated and processed by the finance system.
+
+The balances with a `term` that is not current are usually generated/updated by an invoicing or similar process.
      */
     @Child(name = "balance", type = {}, order=15, min=0, max=Child.MAX_UNLIMITED, modifier=false, summary=false)
     @Description(shortDefinition="Calculated account balance(s)", formalDefinition="The calculated account balances - these are calculated and processed by the finance system.\r\rThe balances with a `term` that is not current are usually generated/updated by an invoicing or similar process." )
@@ -3172,7 +3176,9 @@ A coverage may only be responsible for specific types of charges, and the sequen
     }
 
     /**
-     * @return {@link #balance} (The calculated account balances - these are calculated and processed by the finance system.The balances with a `term` that is not current are usually generated/updated by an invoicing or similar process.)
+     * @return {@link #balance} (The calculated account balances - these are calculated and processed by the finance system.
+
+The balances with a `term` that is not current are usually generated/updated by an invoicing or similar process.)
      */
     public List<AccountBalanceComponent> getBalance() { 
       if (this.balance == null)

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ActivityDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ActivityDefinition.java
@@ -348,7 +348,9 @@ public class ActivityDefinition extends MetadataResource {
         throw new FHIRException("Unknown RequestResourceTypes code '"+codeString+"'");
         }
     public String toCode(RequestResourceTypes code) {
-      if (code == RequestResourceTypes.APPOINTMENT)
+       if (code == RequestResourceTypes.NULL)
+           return null;
+       if (code == RequestResourceTypes.APPOINTMENT)
         return "Appointment";
       if (code == RequestResourceTypes.APPOINTMENTRESPONSE)
         return "AppointmentResponse";
@@ -383,7 +385,7 @@ public class ActivityDefinition extends MetadataResource {
       if (code == RequestResourceTypes.VISIONPRESCRIPTION)
         return "VisionPrescription";
       return "?";
-      }
+   }
     public String toSystem(RequestResourceTypes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Address.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Address.java
@@ -151,14 +151,16 @@ public class Address extends DataType implements ICompositeType {
         throw new FHIRException("Unknown AddressType code '"+codeString+"'");
         }
     public String toCode(AddressType code) {
-      if (code == AddressType.POSTAL)
+       if (code == AddressType.NULL)
+           return null;
+       if (code == AddressType.POSTAL)
         return "postal";
       if (code == AddressType.PHYSICAL)
         return "physical";
       if (code == AddressType.BOTH)
         return "both";
       return "?";
-      }
+   }
     public String toSystem(AddressType code) {
       return code.getSystem();
       }
@@ -291,7 +293,9 @@ public class Address extends DataType implements ICompositeType {
         throw new FHIRException("Unknown AddressUse code '"+codeString+"'");
         }
     public String toCode(AddressUse code) {
-      if (code == AddressUse.HOME)
+       if (code == AddressUse.NULL)
+           return null;
+       if (code == AddressUse.HOME)
         return "home";
       if (code == AddressUse.WORK)
         return "work";
@@ -302,7 +306,7 @@ public class Address extends DataType implements ICompositeType {
       if (code == AddressUse.BILLING)
         return "billing";
       return "?";
-      }
+   }
     public String toSystem(AddressUse code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AdverseEvent.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AdverseEvent.java
@@ -138,12 +138,14 @@ public class AdverseEvent extends DomainResource {
         throw new FHIRException("Unknown AdverseEventActuality code '"+codeString+"'");
         }
     public String toCode(AdverseEventActuality code) {
-      if (code == AdverseEventActuality.ACTUAL)
+       if (code == AdverseEventActuality.NULL)
+           return null;
+       if (code == AdverseEventActuality.ACTUAL)
         return "actual";
       if (code == AdverseEventActuality.POTENTIAL)
         return "potential";
       return "?";
-      }
+   }
     public String toSystem(AdverseEventActuality code) {
       return code.getSystem();
       }
@@ -262,7 +264,9 @@ public class AdverseEvent extends DomainResource {
         throw new FHIRException("Unknown AdverseEventStatus code '"+codeString+"'");
         }
     public String toCode(AdverseEventStatus code) {
-      if (code == AdverseEventStatus.INPROGRESS)
+       if (code == AdverseEventStatus.NULL)
+           return null;
+       if (code == AdverseEventStatus.INPROGRESS)
         return "in-progress";
       if (code == AdverseEventStatus.COMPLETED)
         return "completed";
@@ -271,7 +275,7 @@ public class AdverseEvent extends DomainResource {
       if (code == AdverseEventStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(AdverseEventStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AllergyIntolerance.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AllergyIntolerance.java
@@ -166,7 +166,9 @@ public class AllergyIntolerance extends DomainResource {
         throw new FHIRException("Unknown AllergyIntoleranceCategory code '"+codeString+"'");
         }
     public String toCode(AllergyIntoleranceCategory code) {
-      if (code == AllergyIntoleranceCategory.FOOD)
+       if (code == AllergyIntoleranceCategory.NULL)
+           return null;
+       if (code == AllergyIntoleranceCategory.FOOD)
         return "food";
       if (code == AllergyIntoleranceCategory.MEDICATION)
         return "medication";
@@ -175,7 +177,7 @@ public class AllergyIntolerance extends DomainResource {
       if (code == AllergyIntoleranceCategory.BIOLOGIC)
         return "biologic";
       return "?";
-      }
+   }
     public String toSystem(AllergyIntoleranceCategory code) {
       return code.getSystem();
       }
@@ -280,14 +282,16 @@ public class AllergyIntolerance extends DomainResource {
         throw new FHIRException("Unknown AllergyIntoleranceCriticality code '"+codeString+"'");
         }
     public String toCode(AllergyIntoleranceCriticality code) {
-      if (code == AllergyIntoleranceCriticality.LOW)
+       if (code == AllergyIntoleranceCriticality.NULL)
+           return null;
+       if (code == AllergyIntoleranceCriticality.LOW)
         return "low";
       if (code == AllergyIntoleranceCriticality.HIGH)
         return "high";
       if (code == AllergyIntoleranceCriticality.UNABLETOASSESS)
         return "unable-to-assess";
       return "?";
-      }
+   }
     public String toSystem(AllergyIntoleranceCriticality code) {
       return code.getSystem();
       }
@@ -392,14 +396,16 @@ public class AllergyIntolerance extends DomainResource {
         throw new FHIRException("Unknown AllergyIntoleranceSeverity code '"+codeString+"'");
         }
     public String toCode(AllergyIntoleranceSeverity code) {
-      if (code == AllergyIntoleranceSeverity.MILD)
+       if (code == AllergyIntoleranceSeverity.NULL)
+           return null;
+       if (code == AllergyIntoleranceSeverity.MILD)
         return "mild";
       if (code == AllergyIntoleranceSeverity.MODERATE)
         return "moderate";
       if (code == AllergyIntoleranceSeverity.SEVERE)
         return "severe";
       return "?";
-      }
+   }
     public String toSystem(AllergyIntoleranceSeverity code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Appointment.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Appointment.java
@@ -250,7 +250,9 @@ public class Appointment extends DomainResource {
         throw new FHIRException("Unknown AppointmentStatus code '"+codeString+"'");
         }
     public String toCode(AppointmentStatus code) {
-      if (code == AppointmentStatus.PROPOSED)
+       if (code == AppointmentStatus.NULL)
+           return null;
+       if (code == AppointmentStatus.PROPOSED)
         return "proposed";
       if (code == AppointmentStatus.PENDING)
         return "pending";
@@ -271,7 +273,7 @@ public class Appointment extends DomainResource {
       if (code == AppointmentStatus.WAITLIST)
         return "waitlist";
       return "?";
-      }
+   }
     public String toSystem(AppointmentStatus code) {
       return code.getSystem();
       }
@@ -390,7 +392,9 @@ public class Appointment extends DomainResource {
         throw new FHIRException("Unknown ParticipationStatus code '"+codeString+"'");
         }
     public String toCode(ParticipationStatus code) {
-      if (code == ParticipationStatus.ACCEPTED)
+       if (code == ParticipationStatus.NULL)
+           return null;
+       if (code == ParticipationStatus.ACCEPTED)
         return "accepted";
       if (code == ParticipationStatus.DECLINED)
         return "declined";
@@ -399,7 +403,7 @@ public class Appointment extends DomainResource {
       if (code == ParticipationStatus.NEEDSACTION)
         return "needs-action";
       return "?";
-      }
+   }
     public String toSystem(ParticipationStatus code) {
       return code.getSystem();
       }
@@ -1679,7 +1683,9 @@ public class Appointment extends DomainResource {
         protected BooleanType sunday;
 
         /**
-         * The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
+         * The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.
+
+e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
          */
         @Child(name = "weekInterval", type = {PositiveIntType.class}, order=8, min=0, max=1, modifier=false, summary=false)
         @Description(shortDefinition="Recurs every nth week", formalDefinition="The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.\r\re.g. For recurring every second week this interval would be 2, or every third week the interval would be 3." )
@@ -2010,7 +2016,9 @@ public class Appointment extends DomainResource {
         }
 
         /**
-         * @return {@link #weekInterval} (The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.). This is the underlying object with id, value and extensions. The accessor "getWeekInterval" gives direct access to the value
+         * @return {@link #weekInterval} (The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.
+
+e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.). This is the underlying object with id, value and extensions. The accessor "getWeekInterval" gives direct access to the value
          */
         public PositiveIntType getWeekIntervalElement() { 
           if (this.weekInterval == null)
@@ -2030,7 +2038,9 @@ public class Appointment extends DomainResource {
         }
 
         /**
-         * @param value {@link #weekInterval} (The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.). This is the underlying object with id, value and extensions. The accessor "getWeekInterval" gives direct access to the value
+         * @param value {@link #weekInterval} (The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.
+
+e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.). This is the underlying object with id, value and extensions. The accessor "getWeekInterval" gives direct access to the value
          */
         public AppointmentRecurrenceTemplateWeeklyTemplateComponent setWeekIntervalElement(PositiveIntType value) { 
           this.weekInterval = value;
@@ -2038,14 +2048,18 @@ public class Appointment extends DomainResource {
         }
 
         /**
-         * @return The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
+         * @return The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.
+
+e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
          */
         public int getWeekInterval() { 
           return this.weekInterval == null || this.weekInterval.isEmpty() ? 0 : this.weekInterval.getValue();
         }
 
         /**
-         * @param value The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
+         * @param value The interval defines if the recurrence is every nth week. The default is every week, so it is expected that this value will be 2 or more.
+
+e.g. For recurring every second week this interval would be 2, or every third week the interval would be 3.
          */
         public AppointmentRecurrenceTemplateWeeklyTemplateComponent setWeekInterval(int value) { 
             if (this.weekInterval == null)

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AppointmentResponse.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AppointmentResponse.java
@@ -180,7 +180,9 @@ public class AppointmentResponse extends DomainResource {
         throw new FHIRException("Unknown AppointmentResponseStatus code '"+codeString+"'");
         }
     public String toCode(AppointmentResponseStatus code) {
-      if (code == AppointmentResponseStatus.ACCEPTED)
+       if (code == AppointmentResponseStatus.NULL)
+           return null;
+       if (code == AppointmentResponseStatus.ACCEPTED)
         return "accepted";
       if (code == AppointmentResponseStatus.DECLINED)
         return "declined";
@@ -191,7 +193,7 @@ public class AppointmentResponse extends DomainResource {
       if (code == AppointmentResponseStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(AppointmentResponseStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ArtifactAssessment.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ArtifactAssessment.java
@@ -180,7 +180,9 @@ public class ArtifactAssessment extends DomainResource {
         throw new FHIRException("Unknown ArtifactAssessmentDisposition code '"+codeString+"'");
         }
     public String toCode(ArtifactAssessmentDisposition code) {
-      if (code == ArtifactAssessmentDisposition.UNRESOLVED)
+       if (code == ArtifactAssessmentDisposition.NULL)
+           return null;
+       if (code == ArtifactAssessmentDisposition.UNRESOLVED)
         return "unresolved";
       if (code == ArtifactAssessmentDisposition.NOTPERSUASIVE)
         return "not-persuasive";
@@ -191,7 +193,7 @@ public class ArtifactAssessment extends DomainResource {
       if (code == ArtifactAssessmentDisposition.NOTPERSUASIVEWITHMODIFICATION)
         return "not-persuasive-with-modification";
       return "?";
-      }
+   }
     public String toSystem(ArtifactAssessmentDisposition code) {
       return code.getSystem();
       }
@@ -338,7 +340,9 @@ public class ArtifactAssessment extends DomainResource {
         throw new FHIRException("Unknown ArtifactAssessmentInformationType code '"+codeString+"'");
         }
     public String toCode(ArtifactAssessmentInformationType code) {
-      if (code == ArtifactAssessmentInformationType.COMMENT)
+       if (code == ArtifactAssessmentInformationType.NULL)
+           return null;
+       if (code == ArtifactAssessmentInformationType.COMMENT)
         return "comment";
       if (code == ArtifactAssessmentInformationType.CLASSIFIER)
         return "classifier";
@@ -351,7 +355,7 @@ public class ArtifactAssessment extends DomainResource {
       if (code == ArtifactAssessmentInformationType.CHANGEREQUEST)
         return "change-request";
       return "?";
-      }
+   }
     public String toSystem(ArtifactAssessmentInformationType code) {
       return code.getSystem();
       }
@@ -554,7 +558,9 @@ public class ArtifactAssessment extends DomainResource {
         throw new FHIRException("Unknown ArtifactAssessmentWorkflowStatus code '"+codeString+"'");
         }
     public String toCode(ArtifactAssessmentWorkflowStatus code) {
-      if (code == ArtifactAssessmentWorkflowStatus.SUBMITTED)
+       if (code == ArtifactAssessmentWorkflowStatus.NULL)
+           return null;
+       if (code == ArtifactAssessmentWorkflowStatus.SUBMITTED)
         return "submitted";
       if (code == ArtifactAssessmentWorkflowStatus.TRIAGED)
         return "triaged";
@@ -575,7 +581,7 @@ public class ArtifactAssessment extends DomainResource {
       if (code == ArtifactAssessmentWorkflowStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(ArtifactAssessmentWorkflowStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AuditEvent.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/AuditEvent.java
@@ -180,7 +180,9 @@ public class AuditEvent extends DomainResource {
         throw new FHIRException("Unknown AuditEventAction code '"+codeString+"'");
         }
     public String toCode(AuditEventAction code) {
-      if (code == AuditEventAction.C)
+       if (code == AuditEventAction.NULL)
+           return null;
+       if (code == AuditEventAction.C)
         return "C";
       if (code == AuditEventAction.R)
         return "R";
@@ -191,7 +193,7 @@ public class AuditEvent extends DomainResource {
       if (code == AuditEventAction.E)
         return "E";
       return "?";
-      }
+   }
     public String toSystem(AuditEventAction code) {
       return code.getSystem();
       }
@@ -366,7 +368,9 @@ public class AuditEvent extends DomainResource {
         throw new FHIRException("Unknown AuditEventSeverity code '"+codeString+"'");
         }
     public String toCode(AuditEventSeverity code) {
-      if (code == AuditEventSeverity.EMERGENCY)
+       if (code == AuditEventSeverity.NULL)
+           return null;
+       if (code == AuditEventSeverity.EMERGENCY)
         return "emergency";
       if (code == AuditEventSeverity.ALERT)
         return "alert";
@@ -383,7 +387,7 @@ public class AuditEvent extends DomainResource {
       if (code == AuditEventSeverity.DEBUG)
         return "debug";
       return "?";
-      }
+   }
     public String toSystem(AuditEventSeverity code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BiologicallyDerivedProductDispense.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/BiologicallyDerivedProductDispense.java
@@ -222,7 +222,9 @@ public class BiologicallyDerivedProductDispense extends DomainResource {
         throw new FHIRException("Unknown BiologicallyDerivedProductDispenseCodes code '"+codeString+"'");
         }
     public String toCode(BiologicallyDerivedProductDispenseCodes code) {
-      if (code == BiologicallyDerivedProductDispenseCodes.PREPARATION)
+       if (code == BiologicallyDerivedProductDispenseCodes.NULL)
+           return null;
+       if (code == BiologicallyDerivedProductDispenseCodes.PREPARATION)
         return "preparation";
       if (code == BiologicallyDerivedProductDispenseCodes.INPROGRESS)
         return "in-progress";
@@ -239,7 +241,7 @@ public class BiologicallyDerivedProductDispense extends DomainResource {
       if (code == BiologicallyDerivedProductDispenseCodes.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(BiologicallyDerivedProductDispenseCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Bundle.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Bundle.java
@@ -252,7 +252,9 @@ public class Bundle extends Resource implements IBaseBundle {
         throw new FHIRException("Unknown BundleType code '"+codeString+"'");
         }
     public String toCode(BundleType code) {
-      if (code == BundleType.DOCUMENT)
+       if (code == BundleType.NULL)
+           return null;
+       if (code == BundleType.DOCUMENT)
         return "document";
       if (code == BundleType.MESSAGE)
         return "message";
@@ -273,7 +275,7 @@ public class Bundle extends Resource implements IBaseBundle {
       if (code == BundleType.SUBSCRIPTIONNOTIFICATION)
         return "subscription-notification";
       return "?";
-      }
+   }
     public String toSystem(BundleType code) {
       return code.getSystem();
       }
@@ -420,7 +422,9 @@ public class Bundle extends Resource implements IBaseBundle {
         throw new FHIRException("Unknown HTTPVerb code '"+codeString+"'");
         }
     public String toCode(HTTPVerb code) {
-      if (code == HTTPVerb.GET)
+       if (code == HTTPVerb.NULL)
+           return null;
+       if (code == HTTPVerb.GET)
         return "GET";
       if (code == HTTPVerb.HEAD)
         return "HEAD";
@@ -433,7 +437,7 @@ public class Bundle extends Resource implements IBaseBundle {
       if (code == HTTPVerb.PATCH)
         return "PATCH";
       return "?";
-      }
+   }
     public String toSystem(HTTPVerb code) {
       return code.getSystem();
       }
@@ -2176,7 +2180,9 @@ public class Bundle extends Resource implements IBaseBundle {
         throw new FHIRException("Unknown LinkRelationTypes code '"+codeString+"'");
         }
     public String toCode(LinkRelationTypes code) {
-      if (code == LinkRelationTypes.ABOUT)
+       if (code == LinkRelationTypes.NULL)
+           return null;
+       if (code == LinkRelationTypes.ABOUT)
         return "about";
       if (code == LinkRelationTypes.ACL)
         return "acl";
@@ -2417,7 +2423,7 @@ public class Bundle extends Resource implements IBaseBundle {
       if (code == LinkRelationTypes.WORKINGCOPYOF)
         return "working-copy-of";
       return "?";
-      }
+   }
     public String toSystem(LinkRelationTypes code) {
       return code.getSystem();
       }
@@ -2522,14 +2528,16 @@ public class Bundle extends Resource implements IBaseBundle {
         throw new FHIRException("Unknown SearchEntryMode code '"+codeString+"'");
         }
     public String toCode(SearchEntryMode code) {
-      if (code == SearchEntryMode.MATCH)
+       if (code == SearchEntryMode.NULL)
+           return null;
+       if (code == SearchEntryMode.MATCH)
         return "match";
       if (code == SearchEntryMode.INCLUDE)
         return "include";
       if (code == SearchEntryMode.OUTCOME)
         return "outcome";
       return "?";
-      }
+   }
     public String toSystem(SearchEntryMode code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CapabilityStatement.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CapabilityStatement.java
@@ -153,14 +153,16 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown ConditionalDeleteStatus code '"+codeString+"'");
         }
     public String toCode(ConditionalDeleteStatus code) {
-      if (code == ConditionalDeleteStatus.NOTSUPPORTED)
+       if (code == ConditionalDeleteStatus.NULL)
+           return null;
+       if (code == ConditionalDeleteStatus.NOTSUPPORTED)
         return "not-supported";
       if (code == ConditionalDeleteStatus.SINGLE)
         return "single";
       if (code == ConditionalDeleteStatus.MULTIPLE)
         return "multiple";
       return "?";
-      }
+   }
     public String toSystem(ConditionalDeleteStatus code) {
       return code.getSystem();
       }
@@ -279,7 +281,9 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown ConditionalReadStatus code '"+codeString+"'");
         }
     public String toCode(ConditionalReadStatus code) {
-      if (code == ConditionalReadStatus.NOTSUPPORTED)
+       if (code == ConditionalReadStatus.NULL)
+           return null;
+       if (code == ConditionalReadStatus.NOTSUPPORTED)
         return "not-supported";
       if (code == ConditionalReadStatus.MODIFIEDSINCE)
         return "modified-since";
@@ -288,7 +292,7 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
       if (code == ConditionalReadStatus.FULLSUPPORT)
         return "full-support";
       return "?";
-      }
+   }
     public String toSystem(ConditionalReadStatus code) {
       return code.getSystem();
       }
@@ -379,12 +383,14 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown DocumentMode code '"+codeString+"'");
         }
     public String toCode(DocumentMode code) {
-      if (code == DocumentMode.PRODUCER)
+       if (code == DocumentMode.NULL)
+           return null;
+       if (code == DocumentMode.PRODUCER)
         return "producer";
       if (code == DocumentMode.CONSUMER)
         return "consumer";
       return "?";
-      }
+   }
     public String toSystem(DocumentMode code) {
       return code.getSystem();
       }
@@ -475,12 +481,14 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown EventCapabilityMode code '"+codeString+"'");
         }
     public String toCode(EventCapabilityMode code) {
-      if (code == EventCapabilityMode.SENDER)
+       if (code == EventCapabilityMode.NULL)
+           return null;
+       if (code == EventCapabilityMode.SENDER)
         return "sender";
       if (code == EventCapabilityMode.RECEIVER)
         return "receiver";
       return "?";
-      }
+   }
     public String toSystem(EventCapabilityMode code) {
       return code.getSystem();
       }
@@ -613,7 +621,9 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown ReferenceHandlingPolicy code '"+codeString+"'");
         }
     public String toCode(ReferenceHandlingPolicy code) {
-      if (code == ReferenceHandlingPolicy.LITERAL)
+       if (code == ReferenceHandlingPolicy.NULL)
+           return null;
+       if (code == ReferenceHandlingPolicy.LITERAL)
         return "literal";
       if (code == ReferenceHandlingPolicy.LOGICAL)
         return "logical";
@@ -624,7 +634,7 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
       if (code == ReferenceHandlingPolicy.LOCAL)
         return "local";
       return "?";
-      }
+   }
     public String toSystem(ReferenceHandlingPolicy code) {
       return code.getSystem();
       }
@@ -729,14 +739,16 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown ResourceVersionPolicy code '"+codeString+"'");
         }
     public String toCode(ResourceVersionPolicy code) {
-      if (code == ResourceVersionPolicy.NOVERSION)
+       if (code == ResourceVersionPolicy.NULL)
+           return null;
+       if (code == ResourceVersionPolicy.NOVERSION)
         return "no-version";
       if (code == ResourceVersionPolicy.VERSIONED)
         return "versioned";
       if (code == ResourceVersionPolicy.VERSIONEDUPDATE)
         return "versioned-update";
       return "?";
-      }
+   }
     public String toSystem(ResourceVersionPolicy code) {
       return code.getSystem();
       }
@@ -827,12 +839,14 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown RestfulCapabilityMode code '"+codeString+"'");
         }
     public String toCode(RestfulCapabilityMode code) {
-      if (code == RestfulCapabilityMode.CLIENT)
+       if (code == RestfulCapabilityMode.NULL)
+           return null;
+       if (code == RestfulCapabilityMode.CLIENT)
         return "client";
       if (code == RestfulCapabilityMode.SERVER)
         return "server";
       return "?";
-      }
+   }
     public String toSystem(RestfulCapabilityMode code) {
       return code.getSystem();
       }
@@ -951,7 +965,9 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown SystemRestfulInteraction code '"+codeString+"'");
         }
     public String toCode(SystemRestfulInteraction code) {
-      if (code == SystemRestfulInteraction.TRANSACTION)
+       if (code == SystemRestfulInteraction.NULL)
+           return null;
+       if (code == SystemRestfulInteraction.TRANSACTION)
         return "transaction";
       if (code == SystemRestfulInteraction.BATCH)
         return "batch";
@@ -960,7 +976,7 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
       if (code == SystemRestfulInteraction.HISTORYSYSTEM)
         return "history-system";
       return "?";
-      }
+   }
     public String toSystem(SystemRestfulInteraction code) {
       return code.getSystem();
       }
@@ -1149,7 +1165,9 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
         throw new FHIRException("Unknown TypeRestfulInteraction code '"+codeString+"'");
         }
     public String toCode(TypeRestfulInteraction code) {
-      if (code == TypeRestfulInteraction.READ)
+       if (code == TypeRestfulInteraction.NULL)
+           return null;
+       if (code == TypeRestfulInteraction.READ)
         return "read";
       if (code == TypeRestfulInteraction.VREAD)
         return "vread";
@@ -1168,7 +1186,7 @@ public class CapabilityStatement extends CanonicalResource implements IBaseConfo
       if (code == TypeRestfulInteraction.SEARCHTYPE)
         return "search-type";
       return "?";
-      }
+   }
     public String toSystem(TypeRestfulInteraction code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CarePlan.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CarePlan.java
@@ -180,7 +180,9 @@ public class CarePlan extends DomainResource {
         throw new FHIRException("Unknown CarePlanIntent code '"+codeString+"'");
         }
     public String toCode(CarePlanIntent code) {
-      if (code == CarePlanIntent.PROPOSAL)
+       if (code == CarePlanIntent.NULL)
+           return null;
+       if (code == CarePlanIntent.PROPOSAL)
         return "proposal";
       if (code == CarePlanIntent.PLAN)
         return "plan";
@@ -191,7 +193,7 @@ public class CarePlan extends DomainResource {
       if (code == CarePlanIntent.DIRECTIVE)
         return "directive";
       return "?";
-      }
+   }
     public String toSystem(CarePlanIntent code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CareTeam.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CareTeam.java
@@ -180,7 +180,9 @@ public class CareTeam extends DomainResource {
         throw new FHIRException("Unknown CareTeamStatus code '"+codeString+"'");
         }
     public String toCode(CareTeamStatus code) {
-      if (code == CareTeamStatus.PROPOSED)
+       if (code == CareTeamStatus.NULL)
+           return null;
+       if (code == CareTeamStatus.PROPOSED)
         return "proposed";
       if (code == CareTeamStatus.ACTIVE)
         return "active";
@@ -191,7 +193,7 @@ public class CareTeam extends DomainResource {
       if (code == CareTeamStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(CareTeamStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ChargeItem.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ChargeItem.java
@@ -208,7 +208,9 @@ public class ChargeItem extends DomainResource {
         throw new FHIRException("Unknown ChargeItemStatus code '"+codeString+"'");
         }
     public String toCode(ChargeItemStatus code) {
-      if (code == ChargeItemStatus.PLANNED)
+       if (code == ChargeItemStatus.NULL)
+           return null;
+       if (code == ChargeItemStatus.PLANNED)
         return "planned";
       if (code == ChargeItemStatus.BILLABLE)
         return "billable";
@@ -223,7 +225,7 @@ public class ChargeItem extends DomainResource {
       if (code == ChargeItemStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(ChargeItemStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Citation.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Citation.java
@@ -642,7 +642,9 @@ public class Citation extends MetadataResource {
         throw new FHIRException("Unknown RelatedArtifactTypeExpanded code '"+codeString+"'");
         }
     public String toCode(RelatedArtifactTypeExpanded code) {
-      if (code == RelatedArtifactTypeExpanded.DOCUMENTATION)
+       if (code == RelatedArtifactTypeExpanded.NULL)
+           return null;
+       if (code == RelatedArtifactTypeExpanded.DOCUMENTATION)
         return "documentation";
       if (code == RelatedArtifactTypeExpanded.JUSTIFICATION)
         return "justification";
@@ -719,7 +721,7 @@ public class Citation extends MetadataResource {
       if (code == RelatedArtifactTypeExpanded.REPRINTOF)
         return "reprint-of";
       return "?";
-      }
+   }
     public String toSystem(RelatedArtifactTypeExpanded code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ClinicalUseDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ClinicalUseDefinition.java
@@ -180,7 +180,9 @@ public class ClinicalUseDefinition extends DomainResource {
         throw new FHIRException("Unknown ClinicalUseDefinitionType code '"+codeString+"'");
         }
     public String toCode(ClinicalUseDefinitionType code) {
-      if (code == ClinicalUseDefinitionType.INDICATION)
+       if (code == ClinicalUseDefinitionType.NULL)
+           return null;
+       if (code == ClinicalUseDefinitionType.INDICATION)
         return "indication";
       if (code == ClinicalUseDefinitionType.CONTRAINDICATION)
         return "contraindication";
@@ -191,7 +193,7 @@ public class ClinicalUseDefinition extends DomainResource {
       if (code == ClinicalUseDefinitionType.WARNING)
         return "warning";
       return "?";
-      }
+   }
     public String toSystem(ClinicalUseDefinitionType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CodeSystem.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CodeSystem.java
@@ -166,7 +166,9 @@ public class CodeSystem extends MetadataResource {
         throw new FHIRException("Unknown CodeSystemHierarchyMeaning code '"+codeString+"'");
         }
     public String toCode(CodeSystemHierarchyMeaning code) {
-      if (code == CodeSystemHierarchyMeaning.GROUPEDBY)
+       if (code == CodeSystemHierarchyMeaning.NULL)
+           return null;
+       if (code == CodeSystemHierarchyMeaning.GROUPEDBY)
         return "grouped-by";
       if (code == CodeSystemHierarchyMeaning.ISA)
         return "is-a";
@@ -175,7 +177,7 @@ public class CodeSystem extends MetadataResource {
       if (code == CodeSystemHierarchyMeaning.CLASSIFIEDWITH)
         return "classified-with";
       return "?";
-      }
+   }
     public String toSystem(CodeSystemHierarchyMeaning code) {
       return code.getSystem();
       }
@@ -336,7 +338,9 @@ public class CodeSystem extends MetadataResource {
         throw new FHIRException("Unknown PropertyType code '"+codeString+"'");
         }
     public String toCode(PropertyType code) {
-      if (code == PropertyType.CODE)
+       if (code == PropertyType.NULL)
+           return null;
+       if (code == PropertyType.CODE)
         return "code";
       if (code == PropertyType.CODING)
         return "Coding";
@@ -351,7 +355,7 @@ public class CodeSystem extends MetadataResource {
       if (code == PropertyType.DECIMAL)
         return "decimal";
       return "?";
-      }
+   }
     public String toSystem(PropertyType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConceptMap.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConceptMap.java
@@ -180,7 +180,9 @@ public class ConceptMap extends MetadataResource {
         throw new FHIRException("Unknown ConceptMapAttributeType code '"+codeString+"'");
         }
     public String toCode(ConceptMapAttributeType code) {
-      if (code == ConceptMapAttributeType.CODE)
+       if (code == ConceptMapAttributeType.NULL)
+           return null;
+       if (code == ConceptMapAttributeType.CODE)
         return "code";
       if (code == ConceptMapAttributeType.CODING)
         return "Coding";
@@ -191,7 +193,7 @@ public class ConceptMap extends MetadataResource {
       if (code == ConceptMapAttributeType.QUANTITY)
         return "Quantity";
       return "?";
-      }
+   }
     public String toSystem(ConceptMapAttributeType code) {
       return code.getSystem();
       }
@@ -296,14 +298,16 @@ public class ConceptMap extends MetadataResource {
         throw new FHIRException("Unknown ConceptMapGroupUnmappedMode code '"+codeString+"'");
         }
     public String toCode(ConceptMapGroupUnmappedMode code) {
-      if (code == ConceptMapGroupUnmappedMode.USESOURCECODE)
+       if (code == ConceptMapGroupUnmappedMode.NULL)
+           return null;
+       if (code == ConceptMapGroupUnmappedMode.USESOURCECODE)
         return "use-source-code";
       if (code == ConceptMapGroupUnmappedMode.FIXED)
         return "fixed";
       if (code == ConceptMapGroupUnmappedMode.OTHERMAP)
         return "other-map";
       return "?";
-      }
+   }
     public String toSystem(ConceptMapGroupUnmappedMode code) {
       return code.getSystem();
       }
@@ -464,7 +468,9 @@ public class ConceptMap extends MetadataResource {
         throw new FHIRException("Unknown ConceptMapPropertyType code '"+codeString+"'");
         }
     public String toCode(ConceptMapPropertyType code) {
-      if (code == ConceptMapPropertyType.CODING)
+       if (code == ConceptMapPropertyType.NULL)
+           return null;
+       if (code == ConceptMapPropertyType.CODING)
         return "Coding";
       if (code == ConceptMapPropertyType.STRING)
         return "string";
@@ -479,7 +485,7 @@ public class ConceptMap extends MetadataResource {
       if (code == ConceptMapPropertyType.CODE)
         return "code";
       return "?";
-      }
+   }
     public String toSystem(ConceptMapPropertyType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConditionDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ConditionDefinition.java
@@ -138,12 +138,14 @@ public class ConditionDefinition extends MetadataResource {
         throw new FHIRException("Unknown ConditionPreconditionType code '"+codeString+"'");
         }
     public String toCode(ConditionPreconditionType code) {
-      if (code == ConditionPreconditionType.SENSITIVE)
+       if (code == ConditionPreconditionType.NULL)
+           return null;
+       if (code == ConditionPreconditionType.SENSITIVE)
         return "sensitive";
       if (code == ConditionPreconditionType.SPECIFIC)
         return "specific";
       return "?";
-      }
+   }
     public String toSystem(ConditionPreconditionType code) {
       return code.getSystem();
       }
@@ -248,14 +250,16 @@ public class ConditionDefinition extends MetadataResource {
         throw new FHIRException("Unknown ConditionQuestionnairePurpose code '"+codeString+"'");
         }
     public String toCode(ConditionQuestionnairePurpose code) {
-      if (code == ConditionQuestionnairePurpose.PREADMIT)
+       if (code == ConditionQuestionnairePurpose.NULL)
+           return null;
+       if (code == ConditionQuestionnairePurpose.PREADMIT)
         return "preadmit";
       if (code == ConditionQuestionnairePurpose.DIFFDIAGNOSIS)
         return "diff-diagnosis";
       if (code == ConditionQuestionnairePurpose.OUTCOME)
         return "outcome";
       return "?";
-      }
+   }
     public String toSystem(ConditionQuestionnairePurpose code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Consent.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Consent.java
@@ -194,7 +194,9 @@ public class Consent extends DomainResource {
         throw new FHIRException("Unknown ConsentState code '"+codeString+"'");
         }
     public String toCode(ConsentState code) {
-      if (code == ConsentState.DRAFT)
+       if (code == ConsentState.NULL)
+           return null;
+       if (code == ConsentState.DRAFT)
         return "draft";
       if (code == ConsentState.ACTIVE)
         return "active";
@@ -207,7 +209,7 @@ public class Consent extends DomainResource {
       if (code == ConsentState.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(ConsentState code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ContactPoint.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ContactPoint.java
@@ -206,7 +206,9 @@ public class ContactPoint extends DataType implements ICompositeType {
         throw new FHIRException("Unknown ContactPointSystem code '"+codeString+"'");
         }
     public String toCode(ContactPointSystem code) {
-      if (code == ContactPointSystem.PHONE)
+       if (code == ContactPointSystem.NULL)
+           return null;
+       if (code == ContactPointSystem.PHONE)
         return "phone";
       if (code == ContactPointSystem.FAX)
         return "fax";
@@ -221,7 +223,7 @@ public class ContactPoint extends DataType implements ICompositeType {
       if (code == ContactPointSystem.OTHER)
         return "other";
       return "?";
-      }
+   }
     public String toSystem(ContactPointSystem code) {
       return code.getSystem();
       }
@@ -354,7 +356,9 @@ public class ContactPoint extends DataType implements ICompositeType {
         throw new FHIRException("Unknown ContactPointUse code '"+codeString+"'");
         }
     public String toCode(ContactPointUse code) {
-      if (code == ContactPointUse.HOME)
+       if (code == ContactPointUse.NULL)
+           return null;
+       if (code == ContactPointUse.HOME)
         return "home";
       if (code == ContactPointUse.WORK)
         return "work";
@@ -365,7 +369,7 @@ public class ContactPoint extends DataType implements ICompositeType {
       if (code == ContactPointUse.MOBILE)
         return "mobile";
       return "?";
-      }
+   }
     public String toSystem(ContactPointUse code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Contract.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Contract.java
@@ -321,7 +321,9 @@ public class Contract extends DomainResource {
         throw new FHIRException("Unknown ContractResourcePublicationStatusCodes code '"+codeString+"'");
         }
     public String toCode(ContractResourcePublicationStatusCodes code) {
-      if (code == ContractResourcePublicationStatusCodes.AMENDED)
+       if (code == ContractResourcePublicationStatusCodes.NULL)
+           return null;
+       if (code == ContractResourcePublicationStatusCodes.AMENDED)
         return "amended";
       if (code == ContractResourcePublicationStatusCodes.APPENDED)
         return "appended";
@@ -352,7 +354,7 @@ public class Contract extends DomainResource {
       if (code == ContractResourcePublicationStatusCodes.TERMINATED)
         return "terminated";
       return "?";
-      }
+   }
     public String toSystem(ContractResourcePublicationStatusCodes code) {
       return code.getSystem();
       }
@@ -625,7 +627,9 @@ public class Contract extends DomainResource {
         throw new FHIRException("Unknown ContractResourceStatusCodes code '"+codeString+"'");
         }
     public String toCode(ContractResourceStatusCodes code) {
-      if (code == ContractResourceStatusCodes.AMENDED)
+       if (code == ContractResourceStatusCodes.NULL)
+           return null;
+       if (code == ContractResourceStatusCodes.AMENDED)
         return "amended";
       if (code == ContractResourceStatusCodes.APPENDED)
         return "appended";
@@ -656,7 +660,7 @@ public class Contract extends DomainResource {
       if (code == ContractResourceStatusCodes.TERMINATED)
         return "terminated";
       return "?";
-      }
+   }
     public String toSystem(ContractResourceStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Contributor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Contributor.java
@@ -164,7 +164,9 @@ public class Contributor extends DataType implements ICompositeType {
         throw new FHIRException("Unknown ContributorType code '"+codeString+"'");
         }
     public String toCode(ContributorType code) {
-      if (code == ContributorType.AUTHOR)
+       if (code == ContributorType.NULL)
+           return null;
+       if (code == ContributorType.AUTHOR)
         return "author";
       if (code == ContributorType.EDITOR)
         return "editor";
@@ -173,7 +175,7 @@ public class Contributor extends DataType implements ICompositeType {
       if (code == ContributorType.ENDORSER)
         return "endorser";
       return "?";
-      }
+   }
     public String toSystem(ContributorType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Coverage.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Coverage.java
@@ -152,14 +152,16 @@ public class Coverage extends DomainResource {
         throw new FHIRException("Unknown Kind code '"+codeString+"'");
         }
     public String toCode(Kind code) {
-      if (code == Kind.INSURANCE)
+       if (code == Kind.NULL)
+           return null;
+       if (code == Kind.INSURANCE)
         return "insurance";
       if (code == Kind.SELFPAY)
         return "self-pay";
       if (code == Kind.OTHER)
         return "other";
       return "?";
-      }
+   }
     public String toSystem(Kind code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CoverageEligibilityRequest.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CoverageEligibilityRequest.java
@@ -166,7 +166,9 @@ public class CoverageEligibilityRequest extends DomainResource {
         throw new FHIRException("Unknown EligibilityRequestPurpose code '"+codeString+"'");
         }
     public String toCode(EligibilityRequestPurpose code) {
-      if (code == EligibilityRequestPurpose.AUTHREQUIREMENTS)
+       if (code == EligibilityRequestPurpose.NULL)
+           return null;
+       if (code == EligibilityRequestPurpose.AUTHREQUIREMENTS)
         return "auth-requirements";
       if (code == EligibilityRequestPurpose.BENEFITS)
         return "benefits";
@@ -175,7 +177,7 @@ public class CoverageEligibilityRequest extends DomainResource {
       if (code == EligibilityRequestPurpose.VALIDATION)
         return "validation";
       return "?";
-      }
+   }
     public String toSystem(EligibilityRequestPurpose code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CoverageEligibilityResponse.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/CoverageEligibilityResponse.java
@@ -166,7 +166,9 @@ public class CoverageEligibilityResponse extends DomainResource {
         throw new FHIRException("Unknown EligibilityOutcome code '"+codeString+"'");
         }
     public String toCode(EligibilityOutcome code) {
-      if (code == EligibilityOutcome.QUEUED)
+       if (code == EligibilityOutcome.NULL)
+           return null;
+       if (code == EligibilityOutcome.QUEUED)
         return "queued";
       if (code == EligibilityOutcome.COMPLETE)
         return "complete";
@@ -175,7 +177,7 @@ public class CoverageEligibilityResponse extends DomainResource {
       if (code == EligibilityOutcome.PARTIAL)
         return "partial";
       return "?";
-      }
+   }
     public String toSystem(EligibilityOutcome code) {
       return code.getSystem();
       }
@@ -294,7 +296,9 @@ public class CoverageEligibilityResponse extends DomainResource {
         throw new FHIRException("Unknown EligibilityResponsePurpose code '"+codeString+"'");
         }
     public String toCode(EligibilityResponsePurpose code) {
-      if (code == EligibilityResponsePurpose.AUTHREQUIREMENTS)
+       if (code == EligibilityResponsePurpose.NULL)
+           return null;
+       if (code == EligibilityResponsePurpose.AUTHREQUIREMENTS)
         return "auth-requirements";
       if (code == EligibilityResponsePurpose.BENEFITS)
         return "benefits";
@@ -303,7 +307,7 @@ public class CoverageEligibilityResponse extends DomainResource {
       if (code == EligibilityResponsePurpose.VALIDATION)
         return "validation";
       return "?";
-      }
+   }
     public String toSystem(EligibilityResponsePurpose code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DataRequirement.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DataRequirement.java
@@ -136,12 +136,14 @@ public class DataRequirement extends DataType implements ICompositeType {
         throw new FHIRException("Unknown SortDirection code '"+codeString+"'");
         }
     public String toCode(SortDirection code) {
-      if (code == SortDirection.ASCENDING)
+       if (code == SortDirection.NULL)
+           return null;
+       if (code == SortDirection.ASCENDING)
         return "ascending";
       if (code == SortDirection.DESCENDING)
         return "descending";
       return "?";
-      }
+   }
     public String toSystem(SortDirection code) {
       return code.getSystem();
       }
@@ -302,7 +304,9 @@ public class DataRequirement extends DataType implements ICompositeType {
         throw new FHIRException("Unknown ValueFilterComparator code '"+codeString+"'");
         }
     public String toCode(ValueFilterComparator code) {
-      if (code == ValueFilterComparator.EQ)
+       if (code == ValueFilterComparator.NULL)
+           return null;
+       if (code == ValueFilterComparator.EQ)
         return "eq";
       if (code == ValueFilterComparator.GT)
         return "gt";
@@ -317,7 +321,7 @@ public class DataRequirement extends DataType implements ICompositeType {
       if (code == ValueFilterComparator.EB)
         return "eb";
       return "?";
-      }
+   }
     public String toSystem(ValueFilterComparator code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DetectedIssue.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DetectedIssue.java
@@ -152,14 +152,16 @@ public class DetectedIssue extends DomainResource {
         throw new FHIRException("Unknown DetectedIssueSeverity code '"+codeString+"'");
         }
     public String toCode(DetectedIssueSeverity code) {
-      if (code == DetectedIssueSeverity.HIGH)
+       if (code == DetectedIssueSeverity.NULL)
+           return null;
+       if (code == DetectedIssueSeverity.HIGH)
         return "high";
       if (code == DetectedIssueSeverity.MODERATE)
         return "moderate";
       if (code == DetectedIssueSeverity.LOW)
         return "low";
       return "?";
-      }
+   }
     public String toSystem(DetectedIssueSeverity code) {
       return code.getSystem();
       }
@@ -278,7 +280,9 @@ public class DetectedIssue extends DomainResource {
         throw new FHIRException("Unknown DetectedIssueStatus code '"+codeString+"'");
         }
     public String toCode(DetectedIssueStatus code) {
-      if (code == DetectedIssueStatus.PRELIMINARY)
+       if (code == DetectedIssueStatus.NULL)
+           return null;
+       if (code == DetectedIssueStatus.PRELIMINARY)
         return "preliminary";
       if (code == DetectedIssueStatus.FINAL)
         return "final";
@@ -287,7 +291,7 @@ public class DetectedIssue extends DomainResource {
       if (code == DetectedIssueStatus.MITIGATED)
         return "mitigated";
       return "?";
-      }
+   }
     public String toSystem(DetectedIssueStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Device.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Device.java
@@ -152,14 +152,16 @@ public class Device extends DomainResource {
         throw new FHIRException("Unknown FHIRDeviceStatus code '"+codeString+"'");
         }
     public String toCode(FHIRDeviceStatus code) {
-      if (code == FHIRDeviceStatus.ACTIVE)
+       if (code == FHIRDeviceStatus.NULL)
+           return null;
+       if (code == FHIRDeviceStatus.ACTIVE)
         return "active";
       if (code == FHIRDeviceStatus.INACTIVE)
         return "inactive";
       if (code == FHIRDeviceStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(FHIRDeviceStatus code) {
       return code.getSystem();
       }
@@ -320,7 +322,9 @@ public class Device extends DomainResource {
         throw new FHIRException("Unknown UDIEntryType code '"+codeString+"'");
         }
     public String toCode(UDIEntryType code) {
-      if (code == UDIEntryType.BARCODE)
+       if (code == UDIEntryType.NULL)
+           return null;
+       if (code == UDIEntryType.BARCODE)
         return "barcode";
       if (code == UDIEntryType.RFID)
         return "rfid";
@@ -335,7 +339,7 @@ public class Device extends DomainResource {
       if (code == UDIEntryType.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(UDIEntryType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceDefinition.java
@@ -152,14 +152,16 @@ public class DeviceDefinition extends DomainResource {
         throw new FHIRException("Unknown DeviceCorrectiveActionScope code '"+codeString+"'");
         }
     public String toCode(DeviceCorrectiveActionScope code) {
-      if (code == DeviceCorrectiveActionScope.MODEL)
+       if (code == DeviceCorrectiveActionScope.NULL)
+           return null;
+       if (code == DeviceCorrectiveActionScope.MODEL)
         return "model";
       if (code == DeviceCorrectiveActionScope.LOTNUMBERS)
         return "lot-numbers";
       if (code == DeviceCorrectiveActionScope.SERIALNUMBERS)
         return "serial-numbers";
       return "?";
-      }
+   }
     public String toSystem(DeviceCorrectiveActionScope code) {
       return code.getSystem();
       }
@@ -264,14 +266,16 @@ public class DeviceDefinition extends DomainResource {
         throw new FHIRException("Unknown DeviceDefinitionRegulatoryIdentifierType code '"+codeString+"'");
         }
     public String toCode(DeviceDefinitionRegulatoryIdentifierType code) {
-      if (code == DeviceDefinitionRegulatoryIdentifierType.BASIC)
+       if (code == DeviceDefinitionRegulatoryIdentifierType.NULL)
+           return null;
+       if (code == DeviceDefinitionRegulatoryIdentifierType.BASIC)
         return "basic";
       if (code == DeviceDefinitionRegulatoryIdentifierType.MASTER)
         return "master";
       if (code == DeviceDefinitionRegulatoryIdentifierType.LICENSE)
         return "license";
       return "?";
-      }
+   }
     public String toSystem(DeviceDefinitionRegulatoryIdentifierType code) {
       return code.getSystem();
       }
@@ -418,7 +422,9 @@ public class DeviceDefinition extends DomainResource {
         throw new FHIRException("Unknown DeviceProductionIdentifierInUDI code '"+codeString+"'");
         }
     public String toCode(DeviceProductionIdentifierInUDI code) {
-      if (code == DeviceProductionIdentifierInUDI.LOTNUMBER)
+       if (code == DeviceProductionIdentifierInUDI.NULL)
+           return null;
+       if (code == DeviceProductionIdentifierInUDI.LOTNUMBER)
         return "lot-number";
       if (code == DeviceProductionIdentifierInUDI.MANUFACTUREDDATE)
         return "manufactured-date";
@@ -431,7 +437,7 @@ public class DeviceDefinition extends DomainResource {
       if (code == DeviceProductionIdentifierInUDI.SOFTWAREVERSION)
         return "software-version";
       return "?";
-      }
+   }
     public String toSystem(DeviceProductionIdentifierInUDI code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceDispense.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceDispense.java
@@ -236,7 +236,9 @@ public class DeviceDispense extends DomainResource {
         throw new FHIRException("Unknown DeviceDispenseStatusCodes code '"+codeString+"'");
         }
     public String toCode(DeviceDispenseStatusCodes code) {
-      if (code == DeviceDispenseStatusCodes.PREPARATION)
+       if (code == DeviceDispenseStatusCodes.NULL)
+           return null;
+       if (code == DeviceDispenseStatusCodes.PREPARATION)
         return "preparation";
       if (code == DeviceDispenseStatusCodes.INPROGRESS)
         return "in-progress";
@@ -255,7 +257,7 @@ public class DeviceDispense extends DomainResource {
       if (code == DeviceDispenseStatusCodes.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(DeviceDispenseStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceMetric.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceMetric.java
@@ -166,7 +166,9 @@ public class DeviceMetric extends DomainResource {
         throw new FHIRException("Unknown DeviceMetricCalibrationState code '"+codeString+"'");
         }
     public String toCode(DeviceMetricCalibrationState code) {
-      if (code == DeviceMetricCalibrationState.NOTCALIBRATED)
+       if (code == DeviceMetricCalibrationState.NULL)
+           return null;
+       if (code == DeviceMetricCalibrationState.NOTCALIBRATED)
         return "not-calibrated";
       if (code == DeviceMetricCalibrationState.CALIBRATIONREQUIRED)
         return "calibration-required";
@@ -175,7 +177,7 @@ public class DeviceMetric extends DomainResource {
       if (code == DeviceMetricCalibrationState.UNSPECIFIED)
         return "unspecified";
       return "?";
-      }
+   }
     public String toSystem(DeviceMetricCalibrationState code) {
       return code.getSystem();
       }
@@ -294,7 +296,9 @@ public class DeviceMetric extends DomainResource {
         throw new FHIRException("Unknown DeviceMetricCalibrationType code '"+codeString+"'");
         }
     public String toCode(DeviceMetricCalibrationType code) {
-      if (code == DeviceMetricCalibrationType.UNSPECIFIED)
+       if (code == DeviceMetricCalibrationType.NULL)
+           return null;
+       if (code == DeviceMetricCalibrationType.UNSPECIFIED)
         return "unspecified";
       if (code == DeviceMetricCalibrationType.OFFSET)
         return "offset";
@@ -303,7 +307,7 @@ public class DeviceMetric extends DomainResource {
       if (code == DeviceMetricCalibrationType.TWOPOINT)
         return "two-point";
       return "?";
-      }
+   }
     public String toSystem(DeviceMetricCalibrationType code) {
       return code.getSystem();
       }
@@ -422,7 +426,9 @@ public class DeviceMetric extends DomainResource {
         throw new FHIRException("Unknown DeviceMetricCategory code '"+codeString+"'");
         }
     public String toCode(DeviceMetricCategory code) {
-      if (code == DeviceMetricCategory.MEASUREMENT)
+       if (code == DeviceMetricCategory.NULL)
+           return null;
+       if (code == DeviceMetricCategory.MEASUREMENT)
         return "measurement";
       if (code == DeviceMetricCategory.SETTING)
         return "setting";
@@ -431,7 +437,7 @@ public class DeviceMetric extends DomainResource {
       if (code == DeviceMetricCategory.UNSPECIFIED)
         return "unspecified";
       return "?";
-      }
+   }
     public String toSystem(DeviceMetricCategory code) {
       return code.getSystem();
       }
@@ -550,7 +556,9 @@ public class DeviceMetric extends DomainResource {
         throw new FHIRException("Unknown DeviceMetricOperationalStatus code '"+codeString+"'");
         }
     public String toCode(DeviceMetricOperationalStatus code) {
-      if (code == DeviceMetricOperationalStatus.ON)
+       if (code == DeviceMetricOperationalStatus.NULL)
+           return null;
+       if (code == DeviceMetricOperationalStatus.ON)
         return "on";
       if (code == DeviceMetricOperationalStatus.OFF)
         return "off";
@@ -559,7 +567,7 @@ public class DeviceMetric extends DomainResource {
       if (code == DeviceMetricOperationalStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(DeviceMetricOperationalStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceUsage.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DeviceUsage.java
@@ -208,7 +208,9 @@ public class DeviceUsage extends DomainResource {
         throw new FHIRException("Unknown DeviceUsageStatus code '"+codeString+"'");
         }
     public String toCode(DeviceUsageStatus code) {
-      if (code == DeviceUsageStatus.ACTIVE)
+       if (code == DeviceUsageStatus.NULL)
+           return null;
+       if (code == DeviceUsageStatus.ACTIVE)
         return "active";
       if (code == DeviceUsageStatus.COMPLETED)
         return "completed";
@@ -223,7 +225,7 @@ public class DeviceUsage extends DomainResource {
       if (code == DeviceUsageStatus.ONHOLD)
         return "on-hold";
       return "?";
-      }
+   }
     public String toSystem(DeviceUsageStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DiagnosticReport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DiagnosticReport.java
@@ -264,7 +264,9 @@ public class DiagnosticReport extends DomainResource {
         throw new FHIRException("Unknown DiagnosticReportStatus code '"+codeString+"'");
         }
     public String toCode(DiagnosticReportStatus code) {
-      if (code == DiagnosticReportStatus.REGISTERED)
+       if (code == DiagnosticReportStatus.NULL)
+           return null;
+       if (code == DiagnosticReportStatus.REGISTERED)
         return "registered";
       if (code == DiagnosticReportStatus.PARTIAL)
         return "partial";
@@ -287,7 +289,7 @@ public class DiagnosticReport extends DomainResource {
       if (code == DiagnosticReportStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(DiagnosticReportStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DocumentReference.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/DocumentReference.java
@@ -152,14 +152,16 @@ public class DocumentReference extends DomainResource {
         throw new FHIRException("Unknown DocumentReferenceStatus code '"+codeString+"'");
         }
     public String toCode(DocumentReferenceStatus code) {
-      if (code == DocumentReferenceStatus.CURRENT)
+       if (code == DocumentReferenceStatus.NULL)
+           return null;
+       if (code == DocumentReferenceStatus.CURRENT)
         return "current";
       if (code == DocumentReferenceStatus.SUPERSEDED)
         return "superseded";
       if (code == DocumentReferenceStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(DocumentReferenceStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ElementDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ElementDefinition.java
@@ -254,7 +254,9 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown AdditionalBindingPurposeVS code '"+codeString+"'");
         }
     public String toCode(AdditionalBindingPurposeVS code) {
-      if (code == AdditionalBindingPurposeVS.MAXIMUM)
+       if (code == AdditionalBindingPurposeVS.NULL)
+           return null;
+       if (code == AdditionalBindingPurposeVS.MAXIMUM)
         return "maximum";
       if (code == AdditionalBindingPurposeVS.MINIMUM)
         return "minimum";
@@ -275,7 +277,7 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
       if (code == AdditionalBindingPurposeVS.COMPONENT)
         return "component";
       return "?";
-      }
+   }
     public String toSystem(AdditionalBindingPurposeVS code) {
       return code.getSystem();
       }
@@ -380,14 +382,16 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown AggregationMode code '"+codeString+"'");
         }
     public String toCode(AggregationMode code) {
-      if (code == AggregationMode.CONTAINED)
+       if (code == AggregationMode.NULL)
+           return null;
+       if (code == AggregationMode.CONTAINED)
         return "contained";
       if (code == AggregationMode.REFERENCED)
         return "referenced";
       if (code == AggregationMode.BUNDLED)
         return "bundled";
       return "?";
-      }
+   }
     public String toSystem(AggregationMode code) {
       return code.getSystem();
       }
@@ -478,12 +482,14 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown ConstraintSeverity code '"+codeString+"'");
         }
     public String toCode(ConstraintSeverity code) {
-      if (code == ConstraintSeverity.ERROR)
+       if (code == ConstraintSeverity.NULL)
+           return null;
+       if (code == ConstraintSeverity.ERROR)
         return "error";
       if (code == ConstraintSeverity.WARNING)
         return "warning";
       return "?";
-      }
+   }
     public String toSystem(ConstraintSeverity code) {
       return code.getSystem();
       }
@@ -630,7 +636,9 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown DiscriminatorType code '"+codeString+"'");
         }
     public String toCode(DiscriminatorType code) {
-      if (code == DiscriminatorType.VALUE)
+       if (code == DiscriminatorType.NULL)
+           return null;
+       if (code == DiscriminatorType.VALUE)
         return "value";
       if (code == DiscriminatorType.EXISTS)
         return "exists";
@@ -643,7 +651,7 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
       if (code == DiscriminatorType.POSITION)
         return "position";
       return "?";
-      }
+   }
     public String toSystem(DiscriminatorType code) {
       return code.getSystem();
       }
@@ -776,7 +784,9 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown PropertyRepresentation code '"+codeString+"'");
         }
     public String toCode(PropertyRepresentation code) {
-      if (code == PropertyRepresentation.XMLATTR)
+       if (code == PropertyRepresentation.NULL)
+           return null;
+       if (code == PropertyRepresentation.XMLATTR)
         return "xmlAttr";
       if (code == PropertyRepresentation.XMLTEXT)
         return "xmlText";
@@ -787,7 +797,7 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
       if (code == PropertyRepresentation.XHTML)
         return "xhtml";
       return "?";
-      }
+   }
     public String toSystem(PropertyRepresentation code) {
       return code.getSystem();
       }
@@ -892,14 +902,16 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown ReferenceVersionRules code '"+codeString+"'");
         }
     public String toCode(ReferenceVersionRules code) {
-      if (code == ReferenceVersionRules.EITHER)
+       if (code == ReferenceVersionRules.NULL)
+           return null;
+       if (code == ReferenceVersionRules.EITHER)
         return "either";
       if (code == ReferenceVersionRules.INDEPENDENT)
         return "independent";
       if (code == ReferenceVersionRules.SPECIFIC)
         return "specific";
       return "?";
-      }
+   }
     public String toSystem(ReferenceVersionRules code) {
       return code.getSystem();
       }
@@ -1004,14 +1016,16 @@ public class ElementDefinition extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown SlicingRules code '"+codeString+"'");
         }
     public String toCode(SlicingRules code) {
-      if (code == SlicingRules.CLOSED)
+       if (code == SlicingRules.NULL)
+           return null;
+       if (code == SlicingRules.CLOSED)
         return "closed";
       if (code == SlicingRules.OPEN)
         return "open";
       if (code == SlicingRules.OPENATEND)
         return "openAtEnd";
       return "?";
-      }
+   }
     public String toSystem(SlicingRules code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Encounter.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Encounter.java
@@ -166,7 +166,9 @@ public class Encounter extends DomainResource {
         throw new FHIRException("Unknown EncounterLocationStatus code '"+codeString+"'");
         }
     public String toCode(EncounterLocationStatus code) {
-      if (code == EncounterLocationStatus.PLANNED)
+       if (code == EncounterLocationStatus.NULL)
+           return null;
+       if (code == EncounterLocationStatus.PLANNED)
         return "planned";
       if (code == EncounterLocationStatus.ACTIVE)
         return "active";
@@ -175,7 +177,7 @@ public class Encounter extends DomainResource {
       if (code == EncounterLocationStatus.COMPLETED)
         return "completed";
       return "?";
-      }
+   }
     public String toSystem(EncounterLocationStatus code) {
       return code.getSystem();
       }
@@ -1929,7 +1931,9 @@ public class Encounter extends DomainResource {
     protected DateTimeType plannedEndDate;
 
     /**
-     * Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.When missing it is the time in between the start and end values.
+     * Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.
+
+When missing it is the time in between the start and end values.
      */
     @Child(name = "length", type = {Duration.class}, order=19, min=0, max=1, modifier=false, summary=false)
     @Description(shortDefinition="Actual quantity of time the encounter lasted (less time absent)", formalDefinition="Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.\r\rWhen missing it is the time in between the start and end values." )
@@ -1981,7 +1985,9 @@ public class Encounter extends DomainResource {
     protected List<CodeableConcept> specialCourtesy;
 
     /**
-     * Details about the stay during which a healthcare service is provided.This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.
+     * Details about the stay during which a healthcare service is provided.
+
+This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.
      */
     @Child(name = "admission", type = {}, order=26, min=0, max=1, modifier=false, summary=false)
     @Description(shortDefinition="Details about the admission to a healthcare service", formalDefinition="Details about the stay during which a healthcare service is provided.\r\rThis does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge." )
@@ -2829,7 +2835,9 @@ public class Encounter extends DomainResource {
     }
 
     /**
-     * @return {@link #length} (Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.When missing it is the time in between the start and end values.)
+     * @return {@link #length} (Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.
+
+When missing it is the time in between the start and end values.)
      */
     public Duration getLength() { 
       if (this.length == null)
@@ -2845,7 +2853,9 @@ public class Encounter extends DomainResource {
     }
 
     /**
-     * @param value {@link #length} (Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.When missing it is the time in between the start and end values.)
+     * @param value {@link #length} (Actual quantity of time the encounter lasted. This excludes the time during leaves of absence.
+
+When missing it is the time in between the start and end values.)
      */
     public Encounter setLength(Duration value) { 
       this.length = value;
@@ -3171,7 +3181,9 @@ public class Encounter extends DomainResource {
     }
 
     /**
-     * @return {@link #admission} (Details about the stay during which a healthcare service is provided.This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.)
+     * @return {@link #admission} (Details about the stay during which a healthcare service is provided.
+
+This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.)
      */
     public EncounterAdmissionComponent getAdmission() { 
       if (this.admission == null)
@@ -3187,7 +3199,9 @@ public class Encounter extends DomainResource {
     }
 
     /**
-     * @param value {@link #admission} (Details about the stay during which a healthcare service is provided.This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.)
+     * @param value {@link #admission} (Details about the stay during which a healthcare service is provided.
+
+This does not describe the event of admitting the patient, but rather any information that is relevant from the time of admittance until the time of discharge.)
      */
     public Encounter setAdmission(EncounterAdmissionComponent value) { 
       this.admission = value;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Endpoint.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Endpoint.java
@@ -180,7 +180,9 @@ public class Endpoint extends DomainResource {
         throw new FHIRException("Unknown EndpointStatus code '"+codeString+"'");
         }
     public String toCode(EndpointStatus code) {
-      if (code == EndpointStatus.ACTIVE)
+       if (code == EndpointStatus.NULL)
+           return null;
+       if (code == EndpointStatus.ACTIVE)
         return "active";
       if (code == EndpointStatus.SUSPENDED)
         return "suspended";
@@ -191,7 +193,7 @@ public class Endpoint extends DomainResource {
       if (code == EndpointStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(EndpointStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EnrollmentResponse.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EnrollmentResponse.java
@@ -166,7 +166,9 @@ public class EnrollmentResponse extends DomainResource {
         throw new FHIRException("Unknown EnrollmentOutcome code '"+codeString+"'");
         }
     public String toCode(EnrollmentOutcome code) {
-      if (code == EnrollmentOutcome.QUEUED)
+       if (code == EnrollmentOutcome.NULL)
+           return null;
+       if (code == EnrollmentOutcome.QUEUED)
         return "queued";
       if (code == EnrollmentOutcome.COMPLETE)
         return "complete";
@@ -175,7 +177,7 @@ public class EnrollmentResponse extends DomainResource {
       if (code == EnrollmentOutcome.PARTIAL)
         return "partial";
       return "?";
-      }
+   }
     public String toSystem(EnrollmentOutcome code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Enumerations.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Enumerations.java
@@ -177,12 +177,14 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionCardinalityBehavior code '"+codeString+"'");
         }
     public String toCode(ActionCardinalityBehavior code) {
-      if (code == ActionCardinalityBehavior.SINGLE)
+       if (code == ActionCardinalityBehavior.NULL)
+           return null;
+       if (code == ActionCardinalityBehavior.SINGLE)
         return "single";
       if (code == ActionCardinalityBehavior.MULTIPLE)
         return "multiple";
       return "?";
-      }
+   }
     public String toSystem(ActionCardinalityBehavior code) {
       return code.getSystem();
       }
@@ -290,14 +292,16 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionConditionKind code '"+codeString+"'");
         }
     public String toCode(ActionConditionKind code) {
-      if (code == ActionConditionKind.APPLICABILITY)
+       if (code == ActionConditionKind.NULL)
+           return null;
+       if (code == ActionConditionKind.APPLICABILITY)
         return "applicability";
       if (code == ActionConditionKind.START)
         return "start";
       if (code == ActionConditionKind.STOP)
         return "stop";
       return "?";
-      }
+   }
     public String toSystem(ActionConditionKind code) {
       return code.getSystem();
       }
@@ -405,14 +409,16 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionGroupingBehavior code '"+codeString+"'");
         }
     public String toCode(ActionGroupingBehavior code) {
-      if (code == ActionGroupingBehavior.VISUALGROUP)
+       if (code == ActionGroupingBehavior.NULL)
+           return null;
+       if (code == ActionGroupingBehavior.VISUALGROUP)
         return "visual-group";
       if (code == ActionGroupingBehavior.LOGICALGROUP)
         return "logical-group";
       if (code == ActionGroupingBehavior.SENTENCEGROUP)
         return "sentence-group";
       return "?";
-      }
+   }
     public String toSystem(ActionGroupingBehavior code) {
       return code.getSystem();
       }
@@ -618,7 +624,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionParticipantType code '"+codeString+"'");
         }
     public String toCode(ActionParticipantType code) {
-      if (code == ActionParticipantType.CARETEAM)
+       if (code == ActionParticipantType.NULL)
+           return null;
+       if (code == ActionParticipantType.CARETEAM)
         return "careteam";
       if (code == ActionParticipantType.DEVICE)
         return "device";
@@ -639,7 +647,7 @@ public class Enumerations {
       if (code == ActionParticipantType.RELATEDPERSON)
         return "relatedperson";
       return "?";
-      }
+   }
     public String toSystem(ActionParticipantType code) {
       return code.getSystem();
       }
@@ -733,12 +741,14 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionPrecheckBehavior code '"+codeString+"'");
         }
     public String toCode(ActionPrecheckBehavior code) {
-      if (code == ActionPrecheckBehavior.YES)
+       if (code == ActionPrecheckBehavior.NULL)
+           return null;
+       if (code == ActionPrecheckBehavior.YES)
         return "yes";
       if (code == ActionPrecheckBehavior.NO)
         return "no";
       return "?";
-      }
+   }
     public String toSystem(ActionPrecheckBehavior code) {
       return code.getSystem();
       }
@@ -930,7 +940,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionRelationshipType code '"+codeString+"'");
         }
     public String toCode(ActionRelationshipType code) {
-      if (code == ActionRelationshipType.BEFORE)
+       if (code == ActionRelationshipType.NULL)
+           return null;
+       if (code == ActionRelationshipType.BEFORE)
         return "before";
       if (code == ActionRelationshipType.BEFORESTART)
         return "before-start";
@@ -949,7 +961,7 @@ public class Enumerations {
       if (code == ActionRelationshipType.AFTEREND)
         return "after-end";
       return "?";
-      }
+   }
     public String toSystem(ActionRelationshipType code) {
       return code.getSystem();
       }
@@ -1057,14 +1069,16 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionRequiredBehavior code '"+codeString+"'");
         }
     public String toCode(ActionRequiredBehavior code) {
-      if (code == ActionRequiredBehavior.MUST)
+       if (code == ActionRequiredBehavior.NULL)
+           return null;
+       if (code == ActionRequiredBehavior.MUST)
         return "must";
       if (code == ActionRequiredBehavior.COULD)
         return "could";
       if (code == ActionRequiredBehavior.MUSTUNLESSDOCUMENTED)
         return "must-unless-documented";
       return "?";
-      }
+   }
     public String toSystem(ActionRequiredBehavior code) {
       return code.getSystem();
       }
@@ -1214,7 +1228,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ActionSelectionBehavior code '"+codeString+"'");
         }
     public String toCode(ActionSelectionBehavior code) {
-      if (code == ActionSelectionBehavior.ANY)
+       if (code == ActionSelectionBehavior.NULL)
+           return null;
+       if (code == ActionSelectionBehavior.ANY)
         return "any";
       if (code == ActionSelectionBehavior.ALL)
         return "all";
@@ -1227,7 +1243,7 @@ public class Enumerations {
       if (code == ActionSelectionBehavior.ONEORMORE)
         return "one-or-more";
       return "?";
-      }
+   }
     public String toSystem(ActionSelectionBehavior code) {
       return code.getSystem();
       }
@@ -1349,7 +1365,9 @@ public class Enumerations {
         throw new FHIRException("Unknown AdministrativeGender code '"+codeString+"'");
         }
     public String toCode(AdministrativeGender code) {
-      if (code == AdministrativeGender.MALE)
+       if (code == AdministrativeGender.NULL)
+           return null;
+       if (code == AdministrativeGender.MALE)
         return "male";
       if (code == AdministrativeGender.FEMALE)
         return "female";
@@ -1358,7 +1376,7 @@ public class Enumerations {
       if (code == AdministrativeGender.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(AdministrativeGender code) {
       return code.getSystem();
       }
@@ -1424,8 +1442,10 @@ public class Enumerations {
         throw new FHIRException("Unknown AllLanguages code '"+codeString+"'");
         }
     public String toCode(AllLanguages code) {
-      return "?";
-      }
+       if (code == AllLanguages.NULL)
+           return null;
+       return "?";
+   }
     public String toSystem(AllLanguages code) {
       return code.getSystem();
       }
@@ -1547,7 +1567,9 @@ public class Enumerations {
         throw new FHIRException("Unknown BindingStrength code '"+codeString+"'");
         }
     public String toCode(BindingStrength code) {
-      if (code == BindingStrength.REQUIRED)
+       if (code == BindingStrength.NULL)
+           return null;
+       if (code == BindingStrength.REQUIRED)
         return "required";
       if (code == BindingStrength.EXTENSIBLE)
         return "extensible";
@@ -1556,7 +1578,7 @@ public class Enumerations {
       if (code == BindingStrength.EXAMPLE)
         return "example";
       return "?";
-      }
+   }
     public String toSystem(BindingStrength code) {
       return code.getSystem();
       }
@@ -1664,14 +1686,16 @@ public class Enumerations {
         throw new FHIRException("Unknown CapabilityStatementKind code '"+codeString+"'");
         }
     public String toCode(CapabilityStatementKind code) {
-      if (code == CapabilityStatementKind.INSTANCE)
+       if (code == CapabilityStatementKind.NULL)
+           return null;
+       if (code == CapabilityStatementKind.INSTANCE)
         return "instance";
       if (code == CapabilityStatementKind.CAPABILITY)
         return "capability";
       if (code == CapabilityStatementKind.REQUIREMENTS)
         return "requirements";
       return "?";
-      }
+   }
     public String toSystem(CapabilityStatementKind code) {
       return code.getSystem();
       }
@@ -1793,7 +1817,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ClaimProcessingCodes code '"+codeString+"'");
         }
     public String toCode(ClaimProcessingCodes code) {
-      if (code == ClaimProcessingCodes.QUEUED)
+       if (code == ClaimProcessingCodes.NULL)
+           return null;
+       if (code == ClaimProcessingCodes.QUEUED)
         return "queued";
       if (code == ClaimProcessingCodes.COMPLETE)
         return "complete";
@@ -1802,7 +1828,7 @@ public class Enumerations {
       if (code == ClaimProcessingCodes.PARTIAL)
         return "partial";
       return "?";
-      }
+   }
     public String toSystem(ClaimProcessingCodes code) {
       return code.getSystem();
       }
@@ -1938,7 +1964,9 @@ public class Enumerations {
         throw new FHIRException("Unknown CodeSystemContentMode code '"+codeString+"'");
         }
     public String toCode(CodeSystemContentMode code) {
-      if (code == CodeSystemContentMode.NOTPRESENT)
+       if (code == CodeSystemContentMode.NULL)
+           return null;
+       if (code == CodeSystemContentMode.NOTPRESENT)
         return "not-present";
       if (code == CodeSystemContentMode.EXAMPLE)
         return "example";
@@ -1949,7 +1977,7 @@ public class Enumerations {
       if (code == CodeSystemContentMode.SUPPLEMENT)
         return "supplement";
       return "?";
-      }
+   }
     public String toSystem(CodeSystemContentMode code) {
       return code.getSystem();
       }
@@ -3163,7 +3191,9 @@ public class Enumerations {
         throw new FHIRException("Unknown CommonLanguages code '"+codeString+"'");
         }
     public String toCode(CommonLanguages code) {
-      if (code == CommonLanguages.AR)
+       if (code == CommonLanguages.NULL)
+           return null;
+       if (code == CommonLanguages.AR)
         return "ar";
       if (code == CommonLanguages.BG)
         return "bg";
@@ -3328,7 +3358,7 @@ public class Enumerations {
       if (code == CommonLanguages.ZHTW)
         return "zh-TW";
       return "?";
-      }
+   }
     public String toSystem(CommonLanguages code) {
       return code.getSystem();
       }
@@ -3478,7 +3508,9 @@ public class Enumerations {
         throw new FHIRException("Unknown CompartmentType code '"+codeString+"'");
         }
     public String toCode(CompartmentType code) {
-      if (code == CompartmentType.PATIENT)
+       if (code == CompartmentType.NULL)
+           return null;
+       if (code == CompartmentType.PATIENT)
         return "Patient";
       if (code == CompartmentType.ENCOUNTER)
         return "Encounter";
@@ -3491,7 +3523,7 @@ public class Enumerations {
       if (code == CompartmentType.EPISODEOFCARE)
         return "EpisodeOfCare";
       return "?";
-      }
+   }
     public String toSystem(CompartmentType code) {
       return code.getSystem();
       }
@@ -3711,7 +3743,9 @@ public class Enumerations {
         throw new FHIRException("Unknown CompositionStatus code '"+codeString+"'");
         }
     public String toCode(CompositionStatus code) {
-      if (code == CompositionStatus.REGISTERED)
+       if (code == CompositionStatus.NULL)
+           return null;
+       if (code == CompositionStatus.REGISTERED)
         return "registered";
       if (code == CompositionStatus.PARTIAL)
         return "partial";
@@ -3734,7 +3768,7 @@ public class Enumerations {
       if (code == CompositionStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(CompositionStatus code) {
       return code.getSystem();
       }
@@ -3881,7 +3915,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ConceptMapRelationship code '"+codeString+"'");
         }
     public String toCode(ConceptMapRelationship code) {
-      if (code == ConceptMapRelationship.RELATEDTO)
+       if (code == ConceptMapRelationship.NULL)
+           return null;
+       if (code == ConceptMapRelationship.RELATEDTO)
         return "related-to";
       if (code == ConceptMapRelationship.EQUIVALENT)
         return "equivalent";
@@ -3892,7 +3928,7 @@ public class Enumerations {
       if (code == ConceptMapRelationship.NOTRELATEDTO)
         return "not-related-to";
       return "?";
-      }
+   }
     public String toSystem(ConceptMapRelationship code) {
       return code.getSystem();
       }
@@ -4014,7 +4050,9 @@ public class Enumerations {
         throw new FHIRException("Unknown ConsentDataMeaning code '"+codeString+"'");
         }
     public String toCode(ConsentDataMeaning code) {
-      if (code == ConsentDataMeaning.INSTANCE)
+       if (code == ConsentDataMeaning.NULL)
+           return null;
+       if (code == ConsentDataMeaning.INSTANCE)
         return "instance";
       if (code == ConsentDataMeaning.RELATED)
         return "related";
@@ -4023,7 +4061,7 @@ public class Enumerations {
       if (code == ConsentDataMeaning.AUTHOREDBY)
         return "authoredby";
       return "?";
-      }
+   }
     public String toSystem(ConsentDataMeaning code) {
       return code.getSystem();
       }
@@ -4117,12 +4155,14 @@ public class Enumerations {
         throw new FHIRException("Unknown ConsentProvisionType code '"+codeString+"'");
         }
     public String toCode(ConsentProvisionType code) {
-      if (code == ConsentProvisionType.DENY)
+       if (code == ConsentProvisionType.NULL)
+           return null;
+       if (code == ConsentProvisionType.DENY)
         return "deny";
       if (code == ConsentProvisionType.PERMIT)
         return "permit";
       return "?";
-      }
+   }
     public String toSystem(ConsentProvisionType code) {
       return code.getSystem();
       }
@@ -6736,7 +6776,9 @@ public class Enumerations {
         throw new FHIRException("Unknown Currencies code '"+codeString+"'");
         }
     public String toCode(Currencies code) {
-      if (code == Currencies.AED)
+       if (code == Currencies.NULL)
+           return null;
+       if (code == Currencies.AED)
         return "AED";
       if (code == Currencies.AFN)
         return "AFN";
@@ -7101,7 +7143,7 @@ public class Enumerations {
       if (code == Currencies.ZWL)
         return "ZWL";
       return "?";
-      }
+   }
     public String toSystem(Currencies code) {
       return code.getSystem();
       }
@@ -7265,7 +7307,9 @@ public class Enumerations {
         throw new FHIRException("Unknown DaysOfWeek code '"+codeString+"'");
         }
     public String toCode(DaysOfWeek code) {
-      if (code == DaysOfWeek.MON)
+       if (code == DaysOfWeek.NULL)
+           return null;
+       if (code == DaysOfWeek.MON)
         return "mon";
       if (code == DaysOfWeek.TUE)
         return "tue";
@@ -7280,7 +7324,7 @@ public class Enumerations {
       if (code == DaysOfWeek.SUN)
         return "sun";
       return "?";
-      }
+   }
     public String toSystem(DaysOfWeek code) {
       return code.getSystem();
       }
@@ -7388,14 +7432,16 @@ public class Enumerations {
         throw new FHIRException("Unknown DeviceNameType code '"+codeString+"'");
         }
     public String toCode(DeviceNameType code) {
-      if (code == DeviceNameType.REGISTEREDNAME)
+       if (code == DeviceNameType.NULL)
+           return null;
+       if (code == DeviceNameType.REGISTEREDNAME)
         return "registered-name";
       if (code == DeviceNameType.USERFRIENDLYNAME)
         return "user-friendly-name";
       if (code == DeviceNameType.PATIENTREPORTEDNAME)
         return "patient-reported-name";
       return "?";
-      }
+   }
     public String toSystem(DeviceNameType code) {
       return code.getSystem();
       }
@@ -7587,7 +7633,9 @@ public class Enumerations {
         throw new FHIRException("Unknown EncounterStatus code '"+codeString+"'");
         }
     public String toCode(EncounterStatus code) {
-      if (code == EncounterStatus.PLANNED)
+       if (code == EncounterStatus.NULL)
+           return null;
+       if (code == EncounterStatus.PLANNED)
         return "planned";
       if (code == EncounterStatus.INPROGRESS)
         return "in-progress";
@@ -7606,7 +7654,7 @@ public class Enumerations {
       if (code == EncounterStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(EncounterStatus code) {
       return code.getSystem();
       }
@@ -7784,7 +7832,9 @@ public class Enumerations {
         throw new FHIRException("Unknown EventStatus code '"+codeString+"'");
         }
     public String toCode(EventStatus code) {
-      if (code == EventStatus.PREPARATION)
+       if (code == EventStatus.NULL)
+           return null;
+       if (code == EventStatus.PREPARATION)
         return "preparation";
       if (code == EventStatus.INPROGRESS)
         return "in-progress";
@@ -7801,7 +7851,7 @@ public class Enumerations {
       if (code == EventStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(EventStatus code) {
       return code.getSystem();
       }
@@ -7923,7 +7973,9 @@ public class Enumerations {
         throw new FHIRException("Unknown EvidenceVariableHandling code '"+codeString+"'");
         }
     public String toCode(EvidenceVariableHandling code) {
-      if (code == EvidenceVariableHandling.CONTINUOUS)
+       if (code == EvidenceVariableHandling.NULL)
+           return null;
+       if (code == EvidenceVariableHandling.CONTINUOUS)
         return "continuous";
       if (code == EvidenceVariableHandling.DICHOTOMOUS)
         return "dichotomous";
@@ -7932,7 +7984,7 @@ public class Enumerations {
       if (code == EvidenceVariableHandling.POLYCHOTOMOUS)
         return "polychotomous";
       return "?";
-      }
+   }
     public String toSystem(EvidenceVariableHandling code) {
       return code.getSystem();
       }
@@ -8026,12 +8078,14 @@ public class Enumerations {
         throw new FHIRException("Unknown ExampleScenarioActorType code '"+codeString+"'");
         }
     public String toCode(ExampleScenarioActorType code) {
-      if (code == ExampleScenarioActorType.PERSON)
+       if (code == ExampleScenarioActorType.NULL)
+           return null;
+       if (code == ExampleScenarioActorType.PERSON)
         return "person";
       if (code == ExampleScenarioActorType.SYSTEM)
         return "system";
       return "?";
-      }
+   }
     public String toSystem(ExampleScenarioActorType code) {
       return code.getSystem();
       }
@@ -11334,7 +11388,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown FHIRTypes code '"+codeString+"'");
         }
     public String toCode(FHIRTypes code) {
-      if (code == FHIRTypes.BASE)
+       if (code == FHIRTypes.NULL)
+           return null;
+       if (code == FHIRTypes.BASE)
         return "Base";
       if (code == FHIRTypes.ELEMENT)
         return "Element";
@@ -11797,7 +11853,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == FHIRTypes.PARAMETERS)
         return "Parameters";
       return "?";
-      }
+   }
     public String toSystem(FHIRTypes code) {
       return code.getSystem();
       }
@@ -12717,7 +12773,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown FHIRVersion code '"+codeString+"'");        
         }
     public String toCode(FHIRVersion code) {
-      if (code == FHIRVersion._0_01)
+       if (code == FHIRVersion.NULL)
+           return null;
+       if (code == FHIRVersion._0_01)
         return "0.01";
       if (code == FHIRVersion._0_05)
         return "0.05";
@@ -12839,7 +12897,7 @@ The primary difference between a medicationstatement and a medicationadministrat
         return "6.0.0-ballot1";
       }
       return "?";
-      }
+   }
     public String toSystem(FHIRVersion code) {
       return code.getSystem();
       }
@@ -13059,7 +13117,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown FilterOperator code '"+codeString+"'");
         }
     public String toCode(FilterOperator code) {
-      if (code == FilterOperator.EQUAL)
+       if (code == FilterOperator.NULL)
+           return null;
+       if (code == FilterOperator.EQUAL)
         return "=";
       if (code == FilterOperator.ISA)
         return "is-a";
@@ -13082,7 +13142,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == FilterOperator.EXISTS)
         return "exists";
       return "?";
-      }
+   }
     public String toSystem(FilterOperator code) {
       return code.getSystem();
       }
@@ -13204,7 +13264,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown FinancialResourceStatusCodes code '"+codeString+"'");
         }
     public String toCode(FinancialResourceStatusCodes code) {
-      if (code == FinancialResourceStatusCodes.ACTIVE)
+       if (code == FinancialResourceStatusCodes.NULL)
+           return null;
+       if (code == FinancialResourceStatusCodes.ACTIVE)
         return "active";
       if (code == FinancialResourceStatusCodes.CANCELLED)
         return "cancelled";
@@ -13213,7 +13275,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == FinancialResourceStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(FinancialResourceStatusCodes code) {
       return code.getSystem();
       }
@@ -13321,14 +13383,16 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown ListMode code '"+codeString+"'");
         }
     public String toCode(ListMode code) {
-      if (code == ListMode.WORKING)
+       if (code == ListMode.NULL)
+           return null;
+       if (code == ListMode.WORKING)
         return "working";
       if (code == ListMode.SNAPSHOT)
         return "snapshot";
       if (code == ListMode.CHANGES)
         return "changes";
       return "?";
-      }
+   }
     public String toSystem(ListMode code) {
       return code.getSystem();
       }
@@ -13422,12 +13486,14 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown MeasureImprovementNotation code '"+codeString+"'");
         }
     public String toCode(MeasureImprovementNotation code) {
-      if (code == MeasureImprovementNotation.INCREASE)
+       if (code == MeasureImprovementNotation.NULL)
+           return null;
+       if (code == MeasureImprovementNotation.INCREASE)
         return "increase";
       if (code == MeasureImprovementNotation.DECREASE)
         return "decrease";
       return "?";
-      }
+   }
     public String toSystem(MeasureImprovementNotation code) {
       return code.getSystem();
       }
@@ -13493,8 +13559,10 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown MimeTypes code '"+codeString+"'");
         }
     public String toCode(MimeTypes code) {
-      return "?";
-      }
+       if (code == MimeTypes.NULL)
+           return null;
+       return "?";
+   }
     public String toSystem(MimeTypes code) {
       return code.getSystem();
       }
@@ -13672,7 +13740,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown ObservationStatus code '"+codeString+"'");
         }
     public String toCode(ObservationStatus code) {
-      if (code == ObservationStatus.REGISTERED)
+       if (code == ObservationStatus.NULL)
+           return null;
+       if (code == ObservationStatus.REGISTERED)
         return "registered";
       if (code == ObservationStatus.PRELIMINARY)
         return "preliminary";
@@ -13689,7 +13759,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == ObservationStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(ObservationStatus code) {
       return code.getSystem();
       }
@@ -13783,12 +13853,14 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown OperationParameterUse code '"+codeString+"'");
         }
     public String toCode(OperationParameterUse code) {
-      if (code == OperationParameterUse.IN)
+       if (code == OperationParameterUse.NULL)
+           return null;
+       if (code == OperationParameterUse.IN)
         return "in";
       if (code == OperationParameterUse.OUT)
         return "out";
       return "?";
-      }
+   }
     public String toSystem(OperationParameterUse code) {
       return code.getSystem();
       }
@@ -13910,7 +13982,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown PublicationStatus code '"+codeString+"'");
         }
     public String toCode(PublicationStatus code) {
-      if (code == PublicationStatus.DRAFT)
+       if (code == PublicationStatus.NULL)
+           return null;
+       if (code == PublicationStatus.DRAFT)
         return "draft";
       if (code == PublicationStatus.ACTIVE)
         return "active";
@@ -13919,7 +13993,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == PublicationStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(PublicationStatus code) {
       return code.getSystem();
       }
@@ -14055,7 +14129,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown QuantityComparator code '"+codeString+"'");
         }
     public String toCode(QuantityComparator code) {
-      if (code == QuantityComparator.LESS_THAN)
+       if (code == QuantityComparator.NULL)
+           return null;
+       if (code == QuantityComparator.LESS_THAN)
         return "<";
       if (code == QuantityComparator.LESS_OR_EQUAL)
         return "<=";
@@ -14066,7 +14142,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == QuantityComparator.AD)
         return "ad";
       return "?";
-      }
+   }
     public String toSystem(QuantityComparator code) {
       return code.getSystem();
       }
@@ -14258,7 +14334,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown RequestIntent code '"+codeString+"'");
         }
     public String toCode(RequestIntent code) {
-      if (code == RequestIntent.PROPOSAL)
+       if (code == RequestIntent.NULL)
+           return null;
+       if (code == RequestIntent.PROPOSAL)
         return "proposal";
       if (code == RequestIntent.PLAN)
         return "plan";
@@ -14277,7 +14355,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == RequestIntent.OPTION)
         return "option";
       return "?";
-      }
+   }
     public String toSystem(RequestIntent code) {
       return code.getSystem();
       }
@@ -14399,7 +14477,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown RequestPriority code '"+codeString+"'");
         }
     public String toCode(RequestPriority code) {
-      if (code == RequestPriority.ROUTINE)
+       if (code == RequestPriority.NULL)
+           return null;
+       if (code == RequestPriority.ROUTINE)
         return "routine";
       if (code == RequestPriority.URGENT)
         return "urgent";
@@ -14408,7 +14488,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == RequestPriority.STAT)
         return "stat";
       return "?";
-      }
+   }
     public String toSystem(RequestPriority code) {
       return code.getSystem();
       }
@@ -14572,7 +14652,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown RequestStatus code '"+codeString+"'");
         }
     public String toCode(RequestStatus code) {
-      if (code == RequestStatus.DRAFT)
+       if (code == RequestStatus.NULL)
+           return null;
+       if (code == RequestStatus.DRAFT)
         return "draft";
       if (code == RequestStatus.ACTIVE)
         return "active";
@@ -14587,7 +14669,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == RequestStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(RequestStatus code) {
       return code.getSystem();
       }
@@ -16867,7 +16949,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown ResourceTypeEnum code '"+codeString+"'");
         }
     public String toCode(ResourceTypeEnum code) {
-      if (code == ResourceTypeEnum.ACCOUNT)
+       if (code == ResourceTypeEnum.NULL)
+           return null;
+       if (code == ResourceTypeEnum.ACCOUNT)
         return "Account";
       if (code == ResourceTypeEnum.ACTIVITYDEFINITION)
         return "ActivityDefinition";
@@ -17184,7 +17268,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == ResourceTypeEnum.VISIONPRESCRIPTION)
         return "VisionPrescription";
       return "?";
-      }
+   }
     public String toSystem(ResourceTypeEnum code) {
       return code.getSystem();
       }
@@ -17376,7 +17460,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown SearchComparator code '"+codeString+"'");
         }
     public String toCode(SearchComparator code) {
-      if (code == SearchComparator.EQ)
+       if (code == SearchComparator.NULL)
+           return null;
+       if (code == SearchComparator.EQ)
         return "eq";
       if (code == SearchComparator.NE)
         return "ne";
@@ -17395,7 +17481,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == SearchComparator.AP)
         return "ap";
       return "?";
-      }
+   }
     public String toSystem(SearchComparator code) {
       return code.getSystem();
       }
@@ -17671,7 +17757,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown SearchModifierCode code '"+codeString+"'");
         }
     public String toCode(SearchModifierCode code) {
-      if (code == SearchModifierCode.MISSING)
+       if (code == SearchModifierCode.NULL)
+           return null;
+       if (code == SearchModifierCode.MISSING)
         return "missing";
       if (code == SearchModifierCode.EXACT)
         return "exact";
@@ -17702,7 +17790,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == SearchModifierCode.ITERATE)
         return "iterate";
       return "?";
-      }
+   }
     public String toSystem(SearchModifierCode code) {
       return code.getSystem();
       }
@@ -17894,7 +17982,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown SearchParamType code '"+codeString+"'");
         }
     public String toCode(SearchParamType code) {
-      if (code == SearchParamType.NUMBER)
+       if (code == SearchParamType.NULL)
+           return null;
+       if (code == SearchParamType.NUMBER)
         return "number";
       if (code == SearchParamType.DATE)
         return "date";
@@ -17913,7 +18003,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == SearchParamType.SPECIAL)
         return "special";
       return "?";
-      }
+   }
     public String toSystem(SearchParamType code) {
       return code.getSystem();
       }
@@ -18049,7 +18139,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown SubscriptionStatusCodes code '"+codeString+"'");
         }
     public String toCode(SubscriptionStatusCodes code) {
-      if (code == SubscriptionStatusCodes.REQUESTED)
+       if (code == SubscriptionStatusCodes.NULL)
+           return null;
+       if (code == SubscriptionStatusCodes.REQUESTED)
         return "requested";
       if (code == SubscriptionStatusCodes.ACTIVE)
         return "active";
@@ -18060,7 +18152,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == SubscriptionStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(SubscriptionStatusCodes code) {
       return code.getSystem();
       }
@@ -18168,14 +18260,16 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown Use code '"+codeString+"'");
         }
     public String toCode(Use code) {
-      if (code == Use.CLAIM)
+       if (code == Use.NULL)
+           return null;
+       if (code == Use.CLAIM)
         return "claim";
       if (code == Use.PREAUTHORIZATION)
         return "preauthorization";
       if (code == Use.PREDETERMINATION)
         return "predetermination";
       return "?";
-      }
+   }
     public String toSystem(Use code) {
       return code.getSystem();
       }
@@ -21085,7 +21179,9 @@ The primary difference between a medicationstatement and a medicationadministrat
         throw new FHIRException("Unknown VersionIndependentResourceTypesAll code '"+codeString+"'");
         }
     public String toCode(VersionIndependentResourceTypesAll code) {
-      if (code == VersionIndependentResourceTypesAll.ACCOUNT)
+       if (code == VersionIndependentResourceTypesAll.NULL)
+           return null;
+       if (code == VersionIndependentResourceTypesAll.ACCOUNT)
         return "Account";
       if (code == VersionIndependentResourceTypesAll.ACTIVITYDEFINITION)
         return "ActivityDefinition";
@@ -21492,7 +21588,7 @@ The primary difference between a medicationstatement and a medicationadministrat
       if (code == VersionIndependentResourceTypesAll.SUBSTANCESPECIFICATION)
         return "SubstanceSpecification";
       return "?";
-      }
+   }
     public String toSystem(VersionIndependentResourceTypesAll code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EpisodeOfCare.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EpisodeOfCare.java
@@ -208,7 +208,9 @@ public class EpisodeOfCare extends DomainResource {
         throw new FHIRException("Unknown EpisodeOfCareStatus code '"+codeString+"'");
         }
     public String toCode(EpisodeOfCareStatus code) {
-      if (code == EpisodeOfCareStatus.PLANNED)
+       if (code == EpisodeOfCareStatus.NULL)
+           return null;
+       if (code == EpisodeOfCareStatus.PLANNED)
         return "planned";
       if (code == EpisodeOfCareStatus.WAITLIST)
         return "waitlist";
@@ -223,7 +225,7 @@ public class EpisodeOfCare extends DomainResource {
       if (code == EpisodeOfCareStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(EpisodeOfCareStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceReport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceReport.java
@@ -222,7 +222,9 @@ public class EvidenceReport extends MetadataResource {
         throw new FHIRException("Unknown ReportRelationshipType code '"+codeString+"'");
         }
     public String toCode(ReportRelationshipType code) {
-      if (code == ReportRelationshipType.REPLACES)
+       if (code == ReportRelationshipType.NULL)
+           return null;
+       if (code == ReportRelationshipType.REPLACES)
         return "replaces";
       if (code == ReportRelationshipType.AMENDS)
         return "amends";
@@ -239,7 +241,7 @@ public class EvidenceReport extends MetadataResource {
       if (code == ReportRelationshipType.TRANSFORMEDWITH)
         return "transformedWith";
       return "?";
-      }
+   }
     public String toSystem(ReportRelationshipType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceVariable.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/EvidenceVariable.java
@@ -208,7 +208,9 @@ public class EvidenceVariable extends MetadataResource {
         throw new FHIRException("Unknown CharacteristicCombination code '"+codeString+"'");
         }
     public String toCode(CharacteristicCombination code) {
-      if (code == CharacteristicCombination.ALLOF)
+       if (code == CharacteristicCombination.NULL)
+           return null;
+       if (code == CharacteristicCombination.ALLOF)
         return "all-of";
       if (code == CharacteristicCombination.ANYOF)
         return "any-of";
@@ -223,7 +225,7 @@ public class EvidenceVariable extends MetadataResource {
       if (code == CharacteristicCombination.DATASET)
         return "dataset";
       return "?";
-      }
+   }
     public String toSystem(CharacteristicCombination code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExplanationOfBenefit.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ExplanationOfBenefit.java
@@ -167,7 +167,9 @@ public class ExplanationOfBenefit extends DomainResource {
         throw new FHIRException("Unknown ExplanationOfBenefitStatus code '"+codeString+"'");
         }
     public String toCode(ExplanationOfBenefitStatus code) {
-      if (code == ExplanationOfBenefitStatus.ACTIVE)
+       if (code == ExplanationOfBenefitStatus.NULL)
+           return null;
+       if (code == ExplanationOfBenefitStatus.ACTIVE)
         return "active";
       if (code == ExplanationOfBenefitStatus.CANCELLED)
         return "cancelled";
@@ -176,7 +178,7 @@ public class ExplanationOfBenefit extends DomainResource {
       if (code == ExplanationOfBenefitStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(ExplanationOfBenefitStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/FamilyMemberHistory.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/FamilyMemberHistory.java
@@ -166,7 +166,9 @@ public class FamilyMemberHistory extends DomainResource {
         throw new FHIRException("Unknown FamilyHistoryStatus code '"+codeString+"'");
         }
     public String toCode(FamilyHistoryStatus code) {
-      if (code == FamilyHistoryStatus.PARTIAL)
+       if (code == FamilyHistoryStatus.NULL)
+           return null;
+       if (code == FamilyHistoryStatus.PARTIAL)
         return "partial";
       if (code == FamilyHistoryStatus.COMPLETED)
         return "completed";
@@ -175,7 +177,7 @@ public class FamilyMemberHistory extends DomainResource {
       if (code == FamilyHistoryStatus.HEALTHUNKNOWN)
         return "health-unknown";
       return "?";
-      }
+   }
     public String toSystem(FamilyHistoryStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Flag.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Flag.java
@@ -152,14 +152,16 @@ public class Flag extends DomainResource {
         throw new FHIRException("Unknown FlagStatus code '"+codeString+"'");
         }
     public String toCode(FlagStatus code) {
-      if (code == FlagStatus.ACTIVE)
+       if (code == FlagStatus.NULL)
+           return null;
+       if (code == FlagStatus.ACTIVE)
         return "active";
       if (code == FlagStatus.INACTIVE)
         return "inactive";
       if (code == FlagStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(FlagStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/FormularyItem.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/FormularyItem.java
@@ -152,14 +152,16 @@ public class FormularyItem extends DomainResource {
         throw new FHIRException("Unknown FormularyItemStatusCodes code '"+codeString+"'");
         }
     public String toCode(FormularyItemStatusCodes code) {
-      if (code == FormularyItemStatusCodes.ACTIVE)
+       if (code == FormularyItemStatusCodes.NULL)
+           return null;
+       if (code == FormularyItemStatusCodes.ACTIVE)
         return "active";
       if (code == FormularyItemStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       if (code == FormularyItemStatusCodes.INACTIVE)
         return "inactive";
       return "?";
-      }
+   }
     public String toSystem(FormularyItemStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GenomicStudy.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GenomicStudy.java
@@ -180,7 +180,9 @@ public class GenomicStudy extends DomainResource {
         throw new FHIRException("Unknown GenomicStudyStatus code '"+codeString+"'");
         }
     public String toCode(GenomicStudyStatus code) {
-      if (code == GenomicStudyStatus.REGISTERED)
+       if (code == GenomicStudyStatus.NULL)
+           return null;
+       if (code == GenomicStudyStatus.REGISTERED)
         return "registered";
       if (code == GenomicStudyStatus.AVAILABLE)
         return "available";
@@ -191,7 +193,7 @@ public class GenomicStudy extends DomainResource {
       if (code == GenomicStudyStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(GenomicStudyStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Goal.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Goal.java
@@ -236,7 +236,9 @@ public class Goal extends DomainResource {
         throw new FHIRException("Unknown GoalLifecycleStatus code '"+codeString+"'");
         }
     public String toCode(GoalLifecycleStatus code) {
-      if (code == GoalLifecycleStatus.PROPOSED)
+       if (code == GoalLifecycleStatus.NULL)
+           return null;
+       if (code == GoalLifecycleStatus.PROPOSED)
         return "proposed";
       if (code == GoalLifecycleStatus.PLANNED)
         return "planned";
@@ -255,7 +257,7 @@ public class Goal extends DomainResource {
       if (code == GoalLifecycleStatus.REJECTED)
         return "rejected";
       return "?";
-      }
+   }
     public String toSystem(GoalLifecycleStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GraphDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GraphDefinition.java
@@ -166,7 +166,9 @@ public class GraphDefinition extends CanonicalResource {
         throw new FHIRException("Unknown GraphCompartmentRule code '"+codeString+"'");
         }
     public String toCode(GraphCompartmentRule code) {
-      if (code == GraphCompartmentRule.IDENTICAL)
+       if (code == GraphCompartmentRule.NULL)
+           return null;
+       if (code == GraphCompartmentRule.IDENTICAL)
         return "identical";
       if (code == GraphCompartmentRule.MATCHING)
         return "matching";
@@ -175,7 +177,7 @@ public class GraphDefinition extends CanonicalResource {
       if (code == GraphCompartmentRule.CUSTOM)
         return "custom";
       return "?";
-      }
+   }
     public String toSystem(GraphCompartmentRule code) {
       return code.getSystem();
       }
@@ -266,12 +268,14 @@ public class GraphDefinition extends CanonicalResource {
         throw new FHIRException("Unknown GraphCompartmentUse code '"+codeString+"'");
         }
     public String toCode(GraphCompartmentUse code) {
-      if (code == GraphCompartmentUse.WHERE)
+       if (code == GraphCompartmentUse.NULL)
+           return null;
+       if (code == GraphCompartmentUse.WHERE)
         return "where";
       if (code == GraphCompartmentUse.REQUIRES)
         return "requires";
       return "?";
-      }
+   }
     public String toSystem(GraphCompartmentUse code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Group.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Group.java
@@ -138,12 +138,14 @@ public class Group extends DomainResource {
         throw new FHIRException("Unknown GroupMembershipBasis code '"+codeString+"'");
         }
     public String toCode(GroupMembershipBasis code) {
-      if (code == GroupMembershipBasis.DEFINITIONAL)
+       if (code == GroupMembershipBasis.NULL)
+           return null;
+       if (code == GroupMembershipBasis.DEFINITIONAL)
         return "definitional";
       if (code == GroupMembershipBasis.ENUMERATED)
         return "enumerated";
       return "?";
-      }
+   }
     public String toSystem(GroupMembershipBasis code) {
       return code.getSystem();
       }
@@ -346,7 +348,9 @@ public class Group extends DomainResource {
         throw new FHIRException("Unknown GroupType code '"+codeString+"'");
         }
     public String toCode(GroupType code) {
-      if (code == GroupType.PERSON)
+       if (code == GroupType.NULL)
+           return null;
+       if (code == GroupType.PERSON)
         return "person";
       if (code == GroupType.ANIMAL)
         return "animal";
@@ -367,7 +371,7 @@ public class Group extends DomainResource {
       if (code == GroupType.SPECIMEN)
         return "specimen";
       return "?";
-      }
+   }
     public String toSystem(GroupType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GuidanceResponse.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/GuidanceResponse.java
@@ -194,7 +194,9 @@ public class GuidanceResponse extends DomainResource {
         throw new FHIRException("Unknown GuidanceResponseStatus code '"+codeString+"'");
         }
     public String toCode(GuidanceResponseStatus code) {
-      if (code == GuidanceResponseStatus.SUCCESS)
+       if (code == GuidanceResponseStatus.NULL)
+           return null;
+       if (code == GuidanceResponseStatus.SUCCESS)
         return "success";
       if (code == GuidanceResponseStatus.DATAREQUESTED)
         return "data-requested";
@@ -207,7 +209,7 @@ public class GuidanceResponse extends DomainResource {
       if (code == GuidanceResponseStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(GuidanceResponseStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/HumanName.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/HumanName.java
@@ -208,7 +208,9 @@ public class HumanName extends DataType implements ICompositeType {
         throw new FHIRException("Unknown NameUse code '"+codeString+"'");
         }
     public String toCode(NameUse code) {
-      if (code == NameUse.USUAL)
+       if (code == NameUse.NULL)
+           return null;
+       if (code == NameUse.USUAL)
         return "usual";
       if (code == NameUse.OFFICIAL)
         return "official";
@@ -223,7 +225,7 @@ public class HumanName extends DataType implements ICompositeType {
       if (code == NameUse.MAIDEN)
         return "maiden";
       return "?";
-      }
+   }
     public String toSystem(NameUse code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Identifier.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Identifier.java
@@ -178,7 +178,9 @@ public class Identifier extends DataType implements ICompositeType {
         throw new FHIRException("Unknown IdentifierUse code '"+codeString+"'");
         }
     public String toCode(IdentifierUse code) {
-      if (code == IdentifierUse.USUAL)
+       if (code == IdentifierUse.NULL)
+           return null;
+       if (code == IdentifierUse.USUAL)
         return "usual";
       if (code == IdentifierUse.OFFICIAL)
         return "official";
@@ -189,7 +191,7 @@ public class Identifier extends DataType implements ICompositeType {
       if (code == IdentifierUse.OLD)
         return "old";
       return "?";
-      }
+   }
     public String toSystem(IdentifierUse code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImagingSelection.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImagingSelection.java
@@ -181,7 +181,9 @@ public class ImagingSelection extends DomainResource {
         throw new FHIRException("Unknown ImagingSelection2DGraphicType code '"+codeString+"'");
         }
     public String toCode(ImagingSelection2DGraphicType code) {
-      if (code == ImagingSelection2DGraphicType.POINT)
+       if (code == ImagingSelection2DGraphicType.NULL)
+           return null;
+       if (code == ImagingSelection2DGraphicType.POINT)
         return "point";
       if (code == ImagingSelection2DGraphicType.POLYLINE)
         return "polyline";
@@ -192,7 +194,7 @@ public class ImagingSelection extends DomainResource {
       if (code == ImagingSelection2DGraphicType.ELLIPSE)
         return "ellipse";
       return "?";
-      }
+   }
     public String toSystem(ImagingSelection2DGraphicType code) {
       return code.getSystem();
       }
@@ -339,7 +341,9 @@ public class ImagingSelection extends DomainResource {
         throw new FHIRException("Unknown ImagingSelection3DGraphicType code '"+codeString+"'");
         }
     public String toCode(ImagingSelection3DGraphicType code) {
-      if (code == ImagingSelection3DGraphicType.POINT)
+       if (code == ImagingSelection3DGraphicType.NULL)
+           return null;
+       if (code == ImagingSelection3DGraphicType.POINT)
         return "point";
       if (code == ImagingSelection3DGraphicType.MULTIPOINT)
         return "multipoint";
@@ -352,7 +356,7 @@ public class ImagingSelection extends DomainResource {
       if (code == ImagingSelection3DGraphicType.ELLIPSOID)
         return "ellipsoid";
       return "?";
-      }
+   }
     public String toSystem(ImagingSelection3DGraphicType code) {
       return code.getSystem();
       }
@@ -457,14 +461,16 @@ public class ImagingSelection extends DomainResource {
         throw new FHIRException("Unknown ImagingSelectionStatus code '"+codeString+"'");
         }
     public String toCode(ImagingSelectionStatus code) {
-      if (code == ImagingSelectionStatus.AVAILABLE)
+       if (code == ImagingSelectionStatus.NULL)
+           return null;
+       if (code == ImagingSelectionStatus.AVAILABLE)
         return "available";
       if (code == ImagingSelectionStatus.ENTEREDINERROR)
         return "entered-in-error";
       if (code == ImagingSelectionStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(ImagingSelectionStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImagingStudy.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImagingStudy.java
@@ -180,7 +180,9 @@ public class ImagingStudy extends DomainResource {
         throw new FHIRException("Unknown ImagingStudyStatus code '"+codeString+"'");
         }
     public String toCode(ImagingStudyStatus code) {
-      if (code == ImagingStudyStatus.REGISTERED)
+       if (code == ImagingStudyStatus.NULL)
+           return null;
+       if (code == ImagingStudyStatus.REGISTERED)
         return "registered";
       if (code == ImagingStudyStatus.AVAILABLE)
         return "available";
@@ -191,7 +193,7 @@ public class ImagingStudy extends DomainResource {
       if (code == ImagingStudyStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(ImagingStudyStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Immunization.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Immunization.java
@@ -152,14 +152,16 @@ public class Immunization extends DomainResource {
         throw new FHIRException("Unknown ImmunizationStatusCodes code '"+codeString+"'");
         }
     public String toCode(ImmunizationStatusCodes code) {
-      if (code == ImmunizationStatusCodes.COMPLETED)
+       if (code == ImmunizationStatusCodes.NULL)
+           return null;
+       if (code == ImmunizationStatusCodes.COMPLETED)
         return "completed";
       if (code == ImmunizationStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       if (code == ImmunizationStatusCodes.NOTDONE)
         return "not-done";
       return "?";
-      }
+   }
     public String toSystem(ImmunizationStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImmunizationEvaluation.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImmunizationEvaluation.java
@@ -138,12 +138,14 @@ public class ImmunizationEvaluation extends DomainResource {
         throw new FHIRException("Unknown ImmunizationEvaluationStatusCodes code '"+codeString+"'");
         }
     public String toCode(ImmunizationEvaluationStatusCodes code) {
-      if (code == ImmunizationEvaluationStatusCodes.COMPLETED)
+       if (code == ImmunizationEvaluationStatusCodes.NULL)
+           return null;
+       if (code == ImmunizationEvaluationStatusCodes.COMPLETED)
         return "completed";
       if (code == ImmunizationEvaluationStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(ImmunizationEvaluationStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImplementationGuide.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ImplementationGuide.java
@@ -166,7 +166,9 @@ public class ImplementationGuide extends CanonicalResource {
       throw new FHIRException("Unknown GuidePageGeneration code '"+codeString+"'");
     }
     public String toCode(GuidePageGeneration code) {
-      if (code == GuidePageGeneration.HTML)
+       if (code == GuidePageGeneration.NULL)
+           return null;
+       if (code == GuidePageGeneration.HTML)
         return "html";
       if (code == GuidePageGeneration.MARKDOWN)
         return "markdown";
@@ -175,7 +177,7 @@ public class ImplementationGuide extends CanonicalResource {
       if (code == GuidePageGeneration.GENERATED)
         return "generated";
       return "?";
-    }
+   }
     public String toSystem(GuidePageGeneration code) {
       return code.getSystem();
     }
@@ -8053,7 +8055,9 @@ public class ImplementationGuide extends CanonicalResource {
         throw new FHIRException("Unknown SPDXLicense code '"+codeString+"'");
         }
     public String toCode(SPDXLicense code) {
-      if (code == SPDXLicense._0BSD)
+       if (code == SPDXLicense.NULL)
+           return null;
+       if (code == SPDXLicense._0BSD)
         return "0BSD";
       if (code == SPDXLicense.AAL)
         return "AAL";
@@ -9170,7 +9174,7 @@ public class ImplementationGuide extends CanonicalResource {
       if (code == SPDXLicense.ZPL_2_1)
         return "ZPL-2.1";
       return "?";
-      }
+   }
     public String toSystem(SPDXLicense code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Ingredient.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Ingredient.java
@@ -152,14 +152,16 @@ public class Ingredient extends DomainResource {
         throw new FHIRException("Unknown IngredientManufacturerRole code '"+codeString+"'");
         }
     public String toCode(IngredientManufacturerRole code) {
-      if (code == IngredientManufacturerRole.ALLOWED)
+       if (code == IngredientManufacturerRole.NULL)
+           return null;
+       if (code == IngredientManufacturerRole.ALLOWED)
         return "allowed";
       if (code == IngredientManufacturerRole.POSSIBLE)
         return "possible";
       if (code == IngredientManufacturerRole.ACTUAL)
         return "actual";
       return "?";
-      }
+   }
     public String toSystem(IngredientManufacturerRole code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/InventoryItem.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/InventoryItem.java
@@ -166,7 +166,9 @@ public class InventoryItem extends DomainResource {
         throw new FHIRException("Unknown InventoryItemStatusCodes code '"+codeString+"'");
         }
     public String toCode(InventoryItemStatusCodes code) {
-      if (code == InventoryItemStatusCodes.ACTIVE)
+       if (code == InventoryItemStatusCodes.NULL)
+           return null;
+       if (code == InventoryItemStatusCodes.ACTIVE)
         return "active";
       if (code == InventoryItemStatusCodes.INACTIVE)
         return "inactive";
@@ -175,7 +177,7 @@ public class InventoryItem extends DomainResource {
       if (code == InventoryItemStatusCodes.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(InventoryItemStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/InventoryReport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/InventoryReport.java
@@ -138,12 +138,14 @@ public class InventoryReport extends DomainResource {
         throw new FHIRException("Unknown InventoryCountType code '"+codeString+"'");
         }
     public String toCode(InventoryCountType code) {
-      if (code == InventoryCountType.SNAPSHOT)
+       if (code == InventoryCountType.NULL)
+           return null;
+       if (code == InventoryCountType.SNAPSHOT)
         return "snapshot";
       if (code == InventoryCountType.DIFFERENCE)
         return "difference";
       return "?";
-      }
+   }
     public String toSystem(InventoryCountType code) {
       return code.getSystem();
       }
@@ -262,7 +264,9 @@ public class InventoryReport extends DomainResource {
         throw new FHIRException("Unknown InventoryReportStatus code '"+codeString+"'");
         }
     public String toCode(InventoryReportStatus code) {
-      if (code == InventoryReportStatus.DRAFT)
+       if (code == InventoryReportStatus.NULL)
+           return null;
+       if (code == InventoryReportStatus.DRAFT)
         return "draft";
       if (code == InventoryReportStatus.REQUESTED)
         return "requested";
@@ -271,7 +275,7 @@ public class InventoryReport extends DomainResource {
       if (code == InventoryReportStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(InventoryReportStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Invoice.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Invoice.java
@@ -180,7 +180,9 @@ public class Invoice extends DomainResource {
         throw new FHIRException("Unknown InvoiceStatus code '"+codeString+"'");
         }
     public String toCode(InvoiceStatus code) {
-      if (code == InvoiceStatus.DRAFT)
+       if (code == InvoiceStatus.NULL)
+           return null;
+       if (code == InvoiceStatus.DRAFT)
         return "draft";
       if (code == InvoiceStatus.ISSUED)
         return "issued";
@@ -191,7 +193,7 @@ public class Invoice extends DomainResource {
       if (code == InvoiceStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(InvoiceStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Linkage.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Linkage.java
@@ -152,14 +152,16 @@ public class Linkage extends DomainResource {
         throw new FHIRException("Unknown LinkageType code '"+codeString+"'");
         }
     public String toCode(LinkageType code) {
-      if (code == LinkageType.SOURCE)
+       if (code == LinkageType.NULL)
+           return null;
+       if (code == LinkageType.SOURCE)
         return "source";
       if (code == LinkageType.ALTERNATE)
         return "alternate";
       if (code == LinkageType.HISTORICAL)
         return "historical";
       return "?";
-      }
+   }
     public String toSystem(LinkageType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ListResource.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ListResource.java
@@ -152,14 +152,16 @@ public class ListResource extends DomainResource {
         throw new FHIRException("Unknown ListStatus code '"+codeString+"'");
         }
     public String toCode(ListStatus code) {
-      if (code == ListStatus.CURRENT)
+       if (code == ListStatus.NULL)
+           return null;
+       if (code == ListStatus.CURRENT)
         return "current";
       if (code == ListStatus.RETIRED)
         return "retired";
       if (code == ListStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(ListStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Location.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Location.java
@@ -139,12 +139,14 @@ public class Location extends DomainResource {
         throw new FHIRException("Unknown LocationMode code '"+codeString+"'");
         }
     public String toCode(LocationMode code) {
-      if (code == LocationMode.INSTANCE)
+       if (code == LocationMode.NULL)
+           return null;
+       if (code == LocationMode.INSTANCE)
         return "instance";
       if (code == LocationMode.KIND)
         return "kind";
       return "?";
-      }
+   }
     public String toSystem(LocationMode code) {
       return code.getSystem();
       }
@@ -249,14 +251,16 @@ public class Location extends DomainResource {
         throw new FHIRException("Unknown LocationStatus code '"+codeString+"'");
         }
     public String toCode(LocationStatus code) {
-      if (code == LocationStatus.ACTIVE)
+       if (code == LocationStatus.NULL)
+           return null;
+       if (code == LocationStatus.ACTIVE)
         return "active";
       if (code == LocationStatus.SUSPENDED)
         return "suspended";
       if (code == LocationStatus.INACTIVE)
         return "inactive";
       return "?";
-      }
+   }
     public String toSystem(LocationStatus code) {
       return code.getSystem();
       }
@@ -2250,7 +2254,9 @@ public class Location extends DomainResource {
    * <p>
    * Description: <b>Search for locations where the location.position is near to, or within a specified distance of, the provided coordinates expressed as [latitude]|[longitude]|[distance]|[units] (using the WGS84 datum, see notes).
 
-Servers which support the near parameter SHALL support the unit string 'km' for kilometers and SHOULD support '[mi_us]' for miles, support for other units is optional. If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant).If the server is unable to understand the units (and does support the near search parameter), it MIGHT return an OperationOutcome and fail the search with a http status 400 BadRequest. If the server does not support the near parameter, the parameter MIGHT report the unused parameter in a bundled OperationOutcome and still perform the search ignoring the near parameter.
+Servers which support the near parameter SHALL support the unit string 'km' for kilometers and SHOULD support '[mi_us]' for miles, support for other units is optional. If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant).
+
+If the server is unable to understand the units (and does support the near search parameter), it MIGHT return an OperationOutcome and fail the search with a http status 400 BadRequest. If the server does not support the near parameter, the parameter MIGHT report the unused parameter in a bundled OperationOutcome and still perform the search ignoring the near parameter.
 
 Note: The algorithm to determine the distance is not defined by the specification, and systems might have different engines that calculate things differently. They could consider geographic point to point, or path via road, or including current traffic conditions, or just simple neighboring postcodes/localities if that's all it had access to.</b><br>
    * Type: <b>special</b><br>
@@ -2264,7 +2270,9 @@ Note: The algorithm to determine the distance is not defined by the specificatio
    * <p>
    * Description: <b>Search for locations where the location.position is near to, or within a specified distance of, the provided coordinates expressed as [latitude]|[longitude]|[distance]|[units] (using the WGS84 datum, see notes).
 
-Servers which support the near parameter SHALL support the unit string 'km' for kilometers and SHOULD support '[mi_us]' for miles, support for other units is optional. If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant).If the server is unable to understand the units (and does support the near search parameter), it MIGHT return an OperationOutcome and fail the search with a http status 400 BadRequest. If the server does not support the near parameter, the parameter MIGHT report the unused parameter in a bundled OperationOutcome and still perform the search ignoring the near parameter.
+Servers which support the near parameter SHALL support the unit string 'km' for kilometers and SHOULD support '[mi_us]' for miles, support for other units is optional. If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant).
+
+If the server is unable to understand the units (and does support the near search parameter), it MIGHT return an OperationOutcome and fail the search with a http status 400 BadRequest. If the server does not support the near parameter, the parameter MIGHT report the unused parameter in a bundled OperationOutcome and still perform the search ignoring the near parameter.
 
 Note: The algorithm to determine the distance is not defined by the specification, and systems might have different engines that calculate things differently. They could consider geographic point to point, or path via road, or including current traffic conditions, or just simple neighboring postcodes/localities if that's all it had access to.</b><br>
    * Type: <b>special</b><br>

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MeasureReport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MeasureReport.java
@@ -152,14 +152,16 @@ public class MeasureReport extends DomainResource {
         throw new FHIRException("Unknown MeasureReportStatus code '"+codeString+"'");
         }
     public String toCode(MeasureReportStatus code) {
-      if (code == MeasureReportStatus.COMPLETE)
+       if (code == MeasureReportStatus.NULL)
+           return null;
+       if (code == MeasureReportStatus.COMPLETE)
         return "complete";
       if (code == MeasureReportStatus.PENDING)
         return "pending";
       if (code == MeasureReportStatus.ERROR)
         return "error";
       return "?";
-      }
+   }
     public String toSystem(MeasureReportStatus code) {
       return code.getSystem();
       }
@@ -278,7 +280,9 @@ public class MeasureReport extends DomainResource {
         throw new FHIRException("Unknown MeasureReportType code '"+codeString+"'");
         }
     public String toCode(MeasureReportType code) {
-      if (code == MeasureReportType.INDIVIDUAL)
+       if (code == MeasureReportType.NULL)
+           return null;
+       if (code == MeasureReportType.INDIVIDUAL)
         return "individual";
       if (code == MeasureReportType.SUBJECTLIST)
         return "subject-list";
@@ -287,7 +291,7 @@ public class MeasureReport extends DomainResource {
       if (code == MeasureReportType.DATAEXCHANGE)
         return "data-exchange";
       return "?";
-      }
+   }
     public String toSystem(MeasureReportType code) {
       return code.getSystem();
       }
@@ -378,12 +382,14 @@ public class MeasureReport extends DomainResource {
         throw new FHIRException("Unknown SubmitDataUpdateType code '"+codeString+"'");
         }
     public String toCode(SubmitDataUpdateType code) {
-      if (code == SubmitDataUpdateType.INCREMENTAL)
+       if (code == SubmitDataUpdateType.NULL)
+           return null;
+       if (code == SubmitDataUpdateType.INCREMENTAL)
         return "incremental";
       if (code == SubmitDataUpdateType.SNAPSHOT)
         return "snapshot";
       return "?";
-      }
+   }
     public String toSystem(SubmitDataUpdateType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Medication.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Medication.java
@@ -152,14 +152,16 @@ public class Medication extends DomainResource {
         throw new FHIRException("Unknown MedicationStatusCodes code '"+codeString+"'");
         }
     public String toCode(MedicationStatusCodes code) {
-      if (code == MedicationStatusCodes.ACTIVE)
+       if (code == MedicationStatusCodes.NULL)
+           return null;
+       if (code == MedicationStatusCodes.ACTIVE)
         return "active";
       if (code == MedicationStatusCodes.INACTIVE)
         return "inactive";
       if (code == MedicationStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(MedicationStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationAdministration.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationAdministration.java
@@ -208,7 +208,9 @@ public class MedicationAdministration extends DomainResource {
         throw new FHIRException("Unknown MedicationAdministrationStatusCodes code '"+codeString+"'");
         }
     public String toCode(MedicationAdministrationStatusCodes code) {
-      if (code == MedicationAdministrationStatusCodes.INPROGRESS)
+       if (code == MedicationAdministrationStatusCodes.NULL)
+           return null;
+       if (code == MedicationAdministrationStatusCodes.INPROGRESS)
         return "in-progress";
       if (code == MedicationAdministrationStatusCodes.NOTDONE)
         return "not-done";
@@ -223,7 +225,7 @@ public class MedicationAdministration extends DomainResource {
       if (code == MedicationAdministrationStatusCodes.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(MedicationAdministrationStatusCodes code) {
       return code.getSystem();
       }
@@ -453,7 +455,9 @@ public class MedicationAdministration extends DomainResource {
     @Block()
     public static class MedicationAdministrationDosageComponent extends BackboneElement implements IBaseBackboneElement {
         /**
-         * Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.The dosage instructions should reflect the dosage of the medication that was administered.
+         * Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.
+
+The dosage instructions should reflect the dosage of the medication that was administered.
          */
         @Child(name = "text", type = {StringType.class}, order=1, min=0, max=1, modifier=false, summary=false)
         @Description(shortDefinition="Free text dosage instructions e.g. SIG", formalDefinition="Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.\r\rThe dosage instructions should reflect the dosage of the medication that was administered." )
@@ -507,7 +511,9 @@ public class MedicationAdministration extends DomainResource {
       }
 
         /**
-         * @return {@link #text} (Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.The dosage instructions should reflect the dosage of the medication that was administered.). This is the underlying object with id, value and extensions. The accessor "getText" gives direct access to the value
+         * @return {@link #text} (Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.
+
+The dosage instructions should reflect the dosage of the medication that was administered.). This is the underlying object with id, value and extensions. The accessor "getText" gives direct access to the value
          */
         public StringType getTextElement() { 
           if (this.text == null)
@@ -527,7 +533,9 @@ public class MedicationAdministration extends DomainResource {
         }
 
         /**
-         * @param value {@link #text} (Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.The dosage instructions should reflect the dosage of the medication that was administered.). This is the underlying object with id, value and extensions. The accessor "getText" gives direct access to the value
+         * @param value {@link #text} (Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.
+
+The dosage instructions should reflect the dosage of the medication that was administered.). This is the underlying object with id, value and extensions. The accessor "getText" gives direct access to the value
          */
         public MedicationAdministrationDosageComponent setTextElement(StringType value) { 
           this.text = value;
@@ -535,14 +543,18 @@ public class MedicationAdministration extends DomainResource {
         }
 
         /**
-         * @return Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.The dosage instructions should reflect the dosage of the medication that was administered.
+         * @return Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.
+
+The dosage instructions should reflect the dosage of the medication that was administered.
          */
         public String getText() { 
           return this.text == null ? null : this.text.getValue();
         }
 
         /**
-         * @param value Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.The dosage instructions should reflect the dosage of the medication that was administered.
+         * @param value Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.
+
+The dosage instructions should reflect the dosage of the medication that was administered.
          */
         public MedicationAdministrationDosageComponent setText(String value) { 
           if (Utilities.noString(value))

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationDispense.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationDispense.java
@@ -236,7 +236,9 @@ public class MedicationDispense extends DomainResource {
         throw new FHIRException("Unknown MedicationDispenseStatusCodes code '"+codeString+"'");
         }
     public String toCode(MedicationDispenseStatusCodes code) {
-      if (code == MedicationDispenseStatusCodes.PREPARATION)
+       if (code == MedicationDispenseStatusCodes.NULL)
+           return null;
+       if (code == MedicationDispenseStatusCodes.PREPARATION)
         return "preparation";
       if (code == MedicationDispenseStatusCodes.INPROGRESS)
         return "in-progress";
@@ -255,7 +257,7 @@ public class MedicationDispense extends DomainResource {
       if (code == MedicationDispenseStatusCodes.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(MedicationDispenseStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationKnowledge.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationKnowledge.java
@@ -152,14 +152,16 @@ public class MedicationKnowledge extends DomainResource {
         throw new FHIRException("Unknown MedicationKnowledgeStatusCodes code '"+codeString+"'");
         }
     public String toCode(MedicationKnowledgeStatusCodes code) {
-      if (code == MedicationKnowledgeStatusCodes.ACTIVE)
+       if (code == MedicationKnowledgeStatusCodes.NULL)
+           return null;
+       if (code == MedicationKnowledgeStatusCodes.ACTIVE)
         return "active";
       if (code == MedicationKnowledgeStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       if (code == MedicationKnowledgeStatusCodes.INACTIVE)
         return "inactive";
       return "?";
-      }
+   }
     public String toSystem(MedicationKnowledgeStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationRequest.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationRequest.java
@@ -222,7 +222,9 @@ public class MedicationRequest extends DomainResource {
         throw new FHIRException("Unknown MedicationRequestIntent code '"+codeString+"'");
         }
     public String toCode(MedicationRequestIntent code) {
-      if (code == MedicationRequestIntent.PROPOSAL)
+       if (code == MedicationRequestIntent.NULL)
+           return null;
+       if (code == MedicationRequestIntent.PROPOSAL)
         return "proposal";
       if (code == MedicationRequestIntent.PLAN)
         return "plan";
@@ -239,7 +241,7 @@ public class MedicationRequest extends DomainResource {
       if (code == MedicationRequestIntent.OPTION)
         return "option";
       return "?";
-      }
+   }
     public String toSystem(MedicationRequestIntent code) {
       return code.getSystem();
       }
@@ -428,7 +430,9 @@ public class MedicationRequest extends DomainResource {
         throw new FHIRException("Unknown MedicationrequestStatus code '"+codeString+"'");
         }
     public String toCode(MedicationrequestStatus code) {
-      if (code == MedicationrequestStatus.ACTIVE)
+       if (code == MedicationrequestStatus.NULL)
+           return null;
+       if (code == MedicationrequestStatus.ACTIVE)
         return "active";
       if (code == MedicationrequestStatus.ONHOLD)
         return "on-hold";
@@ -447,7 +451,7 @@ public class MedicationRequest extends DomainResource {
       if (code == MedicationrequestStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(MedicationrequestStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationStatement.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MedicationStatement.java
@@ -154,14 +154,16 @@ public class MedicationStatement extends DomainResource {
         throw new FHIRException("Unknown MedicationStatementStatusCodes code '"+codeString+"'");
         }
     public String toCode(MedicationStatementStatusCodes code) {
-      if (code == MedicationStatementStatusCodes.RECORDED)
+       if (code == MedicationStatementStatusCodes.NULL)
+           return null;
+       if (code == MedicationStatementStatusCodes.RECORDED)
         return "recorded";
       if (code == MedicationStatementStatusCodes.ENTEREDINERROR)
         return "entered-in-error";
       if (code == MedicationStatementStatusCodes.DRAFT)
         return "draft";
       return "?";
-      }
+   }
     public String toSystem(MedicationStatementStatusCodes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MessageDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MessageDefinition.java
@@ -152,14 +152,16 @@ public class MessageDefinition extends CanonicalResource {
         throw new FHIRException("Unknown MessageSignificanceCategory code '"+codeString+"'");
         }
     public String toCode(MessageSignificanceCategory code) {
-      if (code == MessageSignificanceCategory.CONSEQUENCE)
+       if (code == MessageSignificanceCategory.NULL)
+           return null;
+       if (code == MessageSignificanceCategory.CONSEQUENCE)
         return "consequence";
       if (code == MessageSignificanceCategory.CURRENCY)
         return "currency";
       if (code == MessageSignificanceCategory.NOTIFICATION)
         return "notification";
       return "?";
-      }
+   }
     public String toSystem(MessageSignificanceCategory code) {
       return code.getSystem();
       }
@@ -278,7 +280,9 @@ public class MessageDefinition extends CanonicalResource {
         throw new FHIRException("Unknown MessageheaderResponseRequest code '"+codeString+"'");
         }
     public String toCode(MessageheaderResponseRequest code) {
-      if (code == MessageheaderResponseRequest.ALWAYS)
+       if (code == MessageheaderResponseRequest.NULL)
+           return null;
+       if (code == MessageheaderResponseRequest.ALWAYS)
         return "always";
       if (code == MessageheaderResponseRequest.ONERROR)
         return "on-error";
@@ -287,7 +291,7 @@ public class MessageDefinition extends CanonicalResource {
       if (code == MessageheaderResponseRequest.ONSUCCESS)
         return "on-success";
       return "?";
-      }
+   }
     public String toSystem(MessageheaderResponseRequest code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MessageHeader.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MessageHeader.java
@@ -152,14 +152,16 @@ public class MessageHeader extends DomainResource {
         throw new FHIRException("Unknown ResponseType code '"+codeString+"'");
         }
     public String toCode(ResponseType code) {
-      if (code == ResponseType.OK)
+       if (code == ResponseType.NULL)
+           return null;
+       if (code == ResponseType.OK)
         return "ok";
       if (code == ResponseType.TRANSIENTERROR)
         return "transient-error";
       if (code == ResponseType.FATALERROR)
         return "fatal-error";
       return "?";
-      }
+   }
     public String toSystem(ResponseType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MolecularSequence.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MolecularSequence.java
@@ -138,12 +138,14 @@ public class MolecularSequence extends DomainResource {
         throw new FHIRException("Unknown OrientationType code '"+codeString+"'");
         }
     public String toCode(OrientationType code) {
-      if (code == OrientationType.SENSE)
+       if (code == OrientationType.NULL)
+           return null;
+       if (code == OrientationType.SENSE)
         return "sense";
       if (code == OrientationType.ANTISENSE)
         return "antisense";
       return "?";
-      }
+   }
     public String toSystem(OrientationType code) {
       return code.getSystem();
       }
@@ -248,14 +250,16 @@ public class MolecularSequence extends DomainResource {
         throw new FHIRException("Unknown SequenceType code '"+codeString+"'");
         }
     public String toCode(SequenceType code) {
-      if (code == SequenceType.AA)
+       if (code == SequenceType.NULL)
+           return null;
+       if (code == SequenceType.AA)
         return "aa";
       if (code == SequenceType.DNA)
         return "dna";
       if (code == SequenceType.RNA)
         return "rna";
       return "?";
-      }
+   }
     public String toSystem(SequenceType code) {
       return code.getSystem();
       }
@@ -346,12 +350,14 @@ public class MolecularSequence extends DomainResource {
         throw new FHIRException("Unknown StrandType code '"+codeString+"'");
         }
     public String toCode(StrandType code) {
-      if (code == StrandType.WATSON)
+       if (code == StrandType.NULL)
+           return null;
+       if (code == StrandType.WATSON)
         return "watson";
       if (code == StrandType.CRICK)
         return "crick";
       return "?";
-      }
+   }
     public String toSystem(StrandType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MonetaryComponent.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/MonetaryComponent.java
@@ -193,7 +193,9 @@ public class MonetaryComponent extends DataType implements ICompositeType {
         throw new FHIRException("Unknown PriceComponentType code '"+codeString+"'");
         }
     public String toCode(PriceComponentType code) {
-      if (code == PriceComponentType.BASE)
+       if (code == PriceComponentType.NULL)
+           return null;
+       if (code == PriceComponentType.BASE)
         return "base";
       if (code == PriceComponentType.SURCHARGE)
         return "surcharge";
@@ -206,7 +208,7 @@ public class MonetaryComponent extends DataType implements ICompositeType {
       if (code == PriceComponentType.INFORMATIONAL)
         return "informational";
       return "?";
-      }
+   }
     public String toSystem(PriceComponentType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/NamingSystem.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/NamingSystem.java
@@ -194,7 +194,9 @@ public class NamingSystem extends MetadataResource {
         throw new FHIRException("Unknown NamingSystemIdentifierType code '"+codeString+"'");
         }
     public String toCode(NamingSystemIdentifierType code) {
-      if (code == NamingSystemIdentifierType.OID)
+       if (code == NamingSystemIdentifierType.NULL)
+           return null;
+       if (code == NamingSystemIdentifierType.OID)
         return "oid";
       if (code == NamingSystemIdentifierType.UUID)
         return "uuid";
@@ -207,7 +209,7 @@ public class NamingSystem extends MetadataResource {
       if (code == NamingSystemIdentifierType.OTHER)
         return "other";
       return "?";
-      }
+   }
     public String toSystem(NamingSystemIdentifierType code) {
       return code.getSystem();
       }
@@ -312,7 +314,9 @@ public class NamingSystem extends MetadataResource {
         throw new FHIRException("Unknown NamingSystemType code '"+codeString+"'");
         }
     public String toCode(NamingSystemType code) {
-      if (code == NamingSystemType.NULL)
+       if (code == NamingSystemType.NULL)
+           return null;
+       if (code == NamingSystemType.NULL)
         return null;
       if (code == NamingSystemType.CODESYSTEM)
         return "codesystem";
@@ -321,7 +325,7 @@ public class NamingSystem extends MetadataResource {
       if (code == NamingSystemType.ROOT)
         return "root";
       return "?";
-      }
+   }
     public String toSystem(NamingSystemType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Narrative.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Narrative.java
@@ -167,7 +167,9 @@ public class Narrative extends BaseNarrative implements INarrative {
         throw new FHIRException("Unknown NarrativeStatus code '"+codeString+"'");
         }
     public String toCode(NarrativeStatus code) {
-      if (code == NarrativeStatus.GENERATED)
+       if (code == NarrativeStatus.NULL)
+           return null;
+       if (code == NarrativeStatus.GENERATED)
         return "generated";
       if (code == NarrativeStatus.EXTENSIONS)
         return "extensions";
@@ -176,7 +178,7 @@ public class Narrative extends BaseNarrative implements INarrative {
       if (code == NarrativeStatus.EMPTY)
         return "empty";
       return "?";
-      }
+   }
     public String toSystem(NarrativeStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/NutritionProduct.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/NutritionProduct.java
@@ -152,14 +152,16 @@ public class NutritionProduct extends DomainResource {
         throw new FHIRException("Unknown NutritionProductStatus code '"+codeString+"'");
         }
     public String toCode(NutritionProductStatus code) {
-      if (code == NutritionProductStatus.ACTIVE)
+       if (code == NutritionProductStatus.NULL)
+           return null;
+       if (code == NutritionProductStatus.ACTIVE)
         return "active";
       if (code == NutritionProductStatus.INACTIVE)
         return "inactive";
       if (code == NutritionProductStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(NutritionProductStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Observation.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Observation.java
@@ -152,14 +152,16 @@ public class Observation extends DomainResource {
         throw new FHIRException("Unknown TriggeredBytype code '"+codeString+"'");
         }
     public String toCode(TriggeredBytype code) {
-      if (code == TriggeredBytype.REFLEX)
+       if (code == TriggeredBytype.NULL)
+           return null;
+       if (code == TriggeredBytype.REFLEX)
         return "reflex";
       if (code == TriggeredBytype.REPEAT)
         return "repeat";
       if (code == TriggeredBytype.RERUN)
         return "re-run";
       return "?";
-      }
+   }
     public String toSystem(TriggeredBytype code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ObservationDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/ObservationDefinition.java
@@ -264,7 +264,9 @@ public class ObservationDefinition extends DomainResource {
         throw new FHIRException("Unknown ObservationDataType code '"+codeString+"'");
         }
     public String toCode(ObservationDataType code) {
-      if (code == ObservationDataType.QUANTITY)
+       if (code == ObservationDataType.NULL)
+           return null;
+       if (code == ObservationDataType.QUANTITY)
         return "Quantity";
       if (code == ObservationDataType.CODEABLECONCEPT)
         return "CodeableConcept";
@@ -287,7 +289,7 @@ public class ObservationDefinition extends DomainResource {
       if (code == ObservationDataType.PERIOD)
         return "Period";
       return "?";
-      }
+   }
     public String toSystem(ObservationDataType code) {
       return code.getSystem();
       }
@@ -392,14 +394,16 @@ public class ObservationDefinition extends DomainResource {
         throw new FHIRException("Unknown ObservationRangeCategory code '"+codeString+"'");
         }
     public String toCode(ObservationRangeCategory code) {
-      if (code == ObservationRangeCategory.REFERENCE)
+       if (code == ObservationRangeCategory.NULL)
+           return null;
+       if (code == ObservationRangeCategory.REFERENCE)
         return "reference";
       if (code == ObservationRangeCategory.CRITICAL)
         return "critical";
       if (code == ObservationRangeCategory.ABSOLUTE)
         return "absolute";
       return "?";
-      }
+   }
     public String toSystem(ObservationRangeCategory code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/OperationDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/OperationDefinition.java
@@ -138,12 +138,14 @@ public class OperationDefinition extends CanonicalResource {
         throw new FHIRException("Unknown OperationKind code '"+codeString+"'");
         }
     public String toCode(OperationKind code) {
-      if (code == OperationKind.OPERATION)
+       if (code == OperationKind.NULL)
+           return null;
+       if (code == OperationKind.OPERATION)
         return "operation";
       if (code == OperationKind.QUERY)
         return "query";
       return "?";
-      }
+   }
     public String toSystem(OperationKind code) {
       return code.getSystem();
       }
@@ -248,14 +250,16 @@ public class OperationDefinition extends CanonicalResource {
         throw new FHIRException("Unknown OperationParameterScope code '"+codeString+"'");
         }
     public String toCode(OperationParameterScope code) {
-      if (code == OperationParameterScope.INSTANCE)
+       if (code == OperationParameterScope.NULL)
+           return null;
+       if (code == OperationParameterScope.INSTANCE)
         return "instance";
       if (code == OperationParameterScope.TYPE)
         return "type";
       if (code == OperationParameterScope.SYSTEM)
         return "system";
       return "?";
-      }
+   }
     public String toSystem(OperationParameterScope code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/OperationOutcome.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/OperationOutcome.java
@@ -185,7 +185,9 @@ public class OperationOutcome extends DomainResource implements IBaseOperationOu
         throw new FHIRException("Unknown IssueSeverity code '"+codeString+"'");
         }
     public String toCode(IssueSeverity code) {
-      if (code == IssueSeverity.FATAL)
+       if (code == IssueSeverity.NULL)
+           return null;
+       if (code == IssueSeverity.FATAL)
         return "fatal";
       if (code == IssueSeverity.ERROR)
         return "error";
@@ -196,7 +198,7 @@ public class OperationOutcome extends DomainResource implements IBaseOperationOu
       if (code == IssueSeverity.SUCCESS)
         return "success";
       return "?";
-      }
+   }
     public String toSystem(IssueSeverity code) {
       return code.getSystem();
       }
@@ -721,7 +723,9 @@ public class OperationOutcome extends DomainResource implements IBaseOperationOu
         throw new FHIRException("Unknown IssueType code '"+codeString+"'");
         }
     public String toCode(IssueType code) {
-      if (code == IssueType.INVALID)
+       if (code == IssueType.NULL)
+           return null;
+       if (code == IssueType.INVALID)
         return "invalid";
       if (code == IssueType.STRUCTURE)
         return "structure";
@@ -788,7 +792,7 @@ public class OperationOutcome extends DomainResource implements IBaseOperationOu
       if (code == IssueType.SUCCESS)
         return "success";
       return "?";
-      }
+   }
     public String toSystem(IssueType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Patient.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Patient.java
@@ -166,7 +166,9 @@ public class Patient extends DomainResource {
         throw new FHIRException("Unknown LinkType code '"+codeString+"'");
         }
     public String toCode(LinkType code) {
-      if (code == LinkType.REPLACEDBY)
+       if (code == LinkType.NULL)
+           return null;
+       if (code == LinkType.REPLACEDBY)
         return "replaced-by";
       if (code == LinkType.REPLACES)
         return "replaces";
@@ -175,7 +177,7 @@ public class Patient extends DomainResource {
       if (code == LinkType.SEEALSO)
         return "seealso";
       return "?";
-      }
+   }
     public String toSystem(LinkType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/PaymentReconciliation.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/PaymentReconciliation.java
@@ -152,14 +152,16 @@ public class PaymentReconciliation extends DomainResource {
         throw new FHIRException("Unknown NoteType code '"+codeString+"'");
         }
     public String toCode(NoteType code) {
-      if (code == NoteType.DISPLAY)
+       if (code == NoteType.NULL)
+           return null;
+       if (code == NoteType.DISPLAY)
         return "display";
       if (code == NoteType.PRINT)
         return "print";
       if (code == NoteType.PRINTOPER)
         return "printoper";
       return "?";
-      }
+   }
     public String toSystem(NoteType code) {
       return code.getSystem();
       }
@@ -278,7 +280,9 @@ public class PaymentReconciliation extends DomainResource {
         throw new FHIRException("Unknown PaymentOutcome code '"+codeString+"'");
         }
     public String toCode(PaymentOutcome code) {
-      if (code == PaymentOutcome.QUEUED)
+       if (code == PaymentOutcome.NULL)
+           return null;
+       if (code == PaymentOutcome.QUEUED)
         return "queued";
       if (code == PaymentOutcome.COMPLETE)
         return "complete";
@@ -287,7 +291,7 @@ public class PaymentReconciliation extends DomainResource {
       if (code == PaymentOutcome.PARTIAL)
         return "partial";
       return "?";
-      }
+   }
     public String toSystem(PaymentOutcome code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Permission.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Permission.java
@@ -194,7 +194,9 @@ public class Permission extends DomainResource {
         throw new FHIRException("Unknown PermissionRuleCombining code '"+codeString+"'");
         }
     public String toCode(PermissionRuleCombining code) {
-      if (code == PermissionRuleCombining.DENYOVERRIDES)
+       if (code == PermissionRuleCombining.NULL)
+           return null;
+       if (code == PermissionRuleCombining.DENYOVERRIDES)
         return "deny-overrides";
       if (code == PermissionRuleCombining.PERMITOVERRIDES)
         return "permit-overrides";
@@ -207,7 +209,7 @@ public class Permission extends DomainResource {
       if (code == PermissionRuleCombining.PERMITUNLESSDENY)
         return "permit-unless-deny";
       return "?";
-      }
+   }
     public String toSystem(PermissionRuleCombining code) {
       return code.getSystem();
       }
@@ -326,7 +328,9 @@ public class Permission extends DomainResource {
         throw new FHIRException("Unknown PermissionStatus code '"+codeString+"'");
         }
     public String toCode(PermissionStatus code) {
-      if (code == PermissionStatus.ACTIVE)
+       if (code == PermissionStatus.NULL)
+           return null;
+       if (code == PermissionStatus.ACTIVE)
         return "active";
       if (code == PermissionStatus.ENTEREDINERROR)
         return "entered-in-error";
@@ -335,7 +339,7 @@ public class Permission extends DomainResource {
       if (code == PermissionStatus.REJECTED)
         return "rejected";
       return "?";
-      }
+   }
     public String toSystem(PermissionStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Person.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Person.java
@@ -166,7 +166,9 @@ public class Person extends DomainResource {
         throw new FHIRException("Unknown IdentityAssuranceLevel code '"+codeString+"'");
         }
     public String toCode(IdentityAssuranceLevel code) {
-      if (code == IdentityAssuranceLevel.LEVEL1)
+       if (code == IdentityAssuranceLevel.NULL)
+           return null;
+       if (code == IdentityAssuranceLevel.LEVEL1)
         return "level1";
       if (code == IdentityAssuranceLevel.LEVEL2)
         return "level2";
@@ -175,7 +177,7 @@ public class Person extends DomainResource {
       if (code == IdentityAssuranceLevel.LEVEL4)
         return "level4";
       return "?";
-      }
+   }
     public String toSystem(IdentityAssuranceLevel code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Provenance.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Provenance.java
@@ -180,7 +180,9 @@ public class Provenance extends DomainResource {
         throw new FHIRException("Unknown ProvenanceEntityRole code '"+codeString+"'");
         }
     public String toCode(ProvenanceEntityRole code) {
-      if (code == ProvenanceEntityRole.REVISION)
+       if (code == ProvenanceEntityRole.NULL)
+           return null;
+       if (code == ProvenanceEntityRole.REVISION)
         return "revision";
       if (code == ProvenanceEntityRole.QUOTATION)
         return "quotation";
@@ -191,7 +193,7 @@ public class Provenance extends DomainResource {
       if (code == ProvenanceEntityRole.REMOVAL)
         return "removal";
       return "?";
-      }
+   }
     public String toSystem(ProvenanceEntityRole code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Questionnaire.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Questionnaire.java
@@ -138,12 +138,14 @@ public class Questionnaire extends MetadataResource {
         throw new FHIRException("Unknown EnableWhenBehavior code '"+codeString+"'");
         }
     public String toCode(EnableWhenBehavior code) {
-      if (code == EnableWhenBehavior.ALL)
+       if (code == EnableWhenBehavior.NULL)
+           return null;
+       if (code == EnableWhenBehavior.ALL)
         return "all";
       if (code == EnableWhenBehavior.ANY)
         return "any";
       return "?";
-      }
+   }
     public String toSystem(EnableWhenBehavior code) {
       return code.getSystem();
       }
@@ -248,14 +250,16 @@ public class Questionnaire extends MetadataResource {
         throw new FHIRException("Unknown QuestionnaireAnswerConstraint code '"+codeString+"'");
         }
     public String toCode(QuestionnaireAnswerConstraint code) {
-      if (code == QuestionnaireAnswerConstraint.OPTIONSONLY)
+       if (code == QuestionnaireAnswerConstraint.NULL)
+           return null;
+       if (code == QuestionnaireAnswerConstraint.OPTIONSONLY)
         return "optionsOnly";
       if (code == QuestionnaireAnswerConstraint.OPTIONSORTYPE)
         return "optionsOrType";
       if (code == QuestionnaireAnswerConstraint.OPTIONSORSTRING)
         return "optionsOrString";
       return "?";
-      }
+   }
     public String toSystem(QuestionnaireAnswerConstraint code) {
       return code.getSystem();
       }
@@ -346,12 +350,14 @@ public class Questionnaire extends MetadataResource {
         throw new FHIRException("Unknown QuestionnaireItemDisabledDisplay code '"+codeString+"'");
         }
     public String toCode(QuestionnaireItemDisabledDisplay code) {
-      if (code == QuestionnaireItemDisabledDisplay.HIDDEN)
+       if (code == QuestionnaireItemDisabledDisplay.NULL)
+           return null;
+       if (code == QuestionnaireItemDisabledDisplay.HIDDEN)
         return "hidden";
       if (code == QuestionnaireItemDisabledDisplay.PROTECTED)
         return "protected";
       return "?";
-      }
+   }
     public String toSystem(QuestionnaireItemDisabledDisplay code) {
       return code.getSystem();
       }
@@ -512,7 +518,9 @@ public class Questionnaire extends MetadataResource {
         throw new FHIRException("Unknown QuestionnaireItemOperator code '"+codeString+"'");
         }
     public String toCode(QuestionnaireItemOperator code) {
-      if (code == QuestionnaireItemOperator.EXISTS)
+       if (code == QuestionnaireItemOperator.NULL)
+           return null;
+       if (code == QuestionnaireItemOperator.EXISTS)
         return "exists";
       if (code == QuestionnaireItemOperator.EQUAL)
         return "=";
@@ -527,7 +535,7 @@ public class Questionnaire extends MetadataResource {
       if (code == QuestionnaireItemOperator.LESS_OR_EQUAL)
         return "<=";
       return "?";
-      }
+   }
     public String toSystem(QuestionnaireItemOperator code) {
       return code.getSystem();
       }
@@ -814,7 +822,9 @@ public class Questionnaire extends MetadataResource {
         throw new FHIRException("Unknown QuestionnaireItemType code '"+codeString+"'");
         }
     public String toCode(QuestionnaireItemType code) {
-      if (code == QuestionnaireItemType.GROUP)
+       if (code == QuestionnaireItemType.NULL)
+           return null;
+       if (code == QuestionnaireItemType.GROUP)
         return "group";
       if (code == QuestionnaireItemType.DISPLAY)
         return "display";
@@ -847,7 +857,7 @@ public class Questionnaire extends MetadataResource {
       if (code == QuestionnaireItemType.QUANTITY)
         return "quantity";
       return "?";
-      }
+   }
     public String toSystem(QuestionnaireItemType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/QuestionnaireResponse.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/QuestionnaireResponse.java
@@ -180,7 +180,9 @@ public class QuestionnaireResponse extends DomainResource {
         throw new FHIRException("Unknown QuestionnaireResponseStatus code '"+codeString+"'");
         }
     public String toCode(QuestionnaireResponseStatus code) {
-      if (code == QuestionnaireResponseStatus.INPROGRESS)
+       if (code == QuestionnaireResponseStatus.NULL)
+           return null;
+       if (code == QuestionnaireResponseStatus.INPROGRESS)
         return "in-progress";
       if (code == QuestionnaireResponseStatus.COMPLETED)
         return "completed";
@@ -191,7 +193,7 @@ public class QuestionnaireResponse extends DomainResource {
       if (code == QuestionnaireResponseStatus.STOPPED)
         return "stopped";
       return "?";
-      }
+   }
     public String toSystem(QuestionnaireResponseStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/RelatedArtifact.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/RelatedArtifact.java
@@ -612,7 +612,9 @@ public class RelatedArtifact extends DataType implements ICompositeType {
         throw new FHIRException("Unknown RelatedArtifactType code '"+codeString+"'");
         }
     public String toCode(RelatedArtifactType code) {
-      if (code == RelatedArtifactType.DOCUMENTATION)
+       if (code == RelatedArtifactType.NULL)
+           return null;
+       if (code == RelatedArtifactType.DOCUMENTATION)
         return "documentation";
       if (code == RelatedArtifactType.JUSTIFICATION)
         return "justification";
@@ -685,7 +687,7 @@ public class RelatedArtifact extends DataType implements ICompositeType {
       if (code == RelatedArtifactType.CITEAS)
         return "cite-as";
       return "?";
-      }
+   }
     public String toSystem(RelatedArtifactType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Requirements.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Requirements.java
@@ -166,7 +166,9 @@ public class Requirements extends CanonicalResource {
         throw new FHIRException("Unknown ConformanceExpectation code '"+codeString+"'");
         }
     public String toCode(ConformanceExpectation code) {
-      if (code == ConformanceExpectation.SHALL)
+       if (code == ConformanceExpectation.NULL)
+           return null;
+       if (code == ConformanceExpectation.SHALL)
         return "SHALL";
       if (code == ConformanceExpectation.SHOULD)
         return "SHOULD";
@@ -175,7 +177,7 @@ public class Requirements extends CanonicalResource {
       if (code == ConformanceExpectation.SHOULDNOT)
         return "SHOULD-NOT";
       return "?";
-      }
+   }
     public String toSystem(ConformanceExpectation code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SearchParameter.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SearchParameter.java
@@ -152,14 +152,16 @@ public class SearchParameter extends CanonicalResource {
         throw new FHIRException("Unknown SearchProcessingModeType code '"+codeString+"'");
         }
     public String toCode(SearchProcessingModeType code) {
-      if (code == SearchProcessingModeType.NORMAL)
+       if (code == SearchProcessingModeType.NULL)
+           return null;
+       if (code == SearchProcessingModeType.NORMAL)
         return "normal";
       if (code == SearchProcessingModeType.PHONETIC)
         return "phonetic";
       if (code == SearchProcessingModeType.OTHER)
         return "other";
       return "?";
-      }
+   }
     public String toSystem(SearchProcessingModeType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Slot.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Slot.java
@@ -180,7 +180,9 @@ public class Slot extends DomainResource {
         throw new FHIRException("Unknown SlotStatus code '"+codeString+"'");
         }
     public String toCode(SlotStatus code) {
-      if (code == SlotStatus.BUSY)
+       if (code == SlotStatus.NULL)
+           return null;
+       if (code == SlotStatus.BUSY)
         return "busy";
       if (code == SlotStatus.FREE)
         return "free";
@@ -191,7 +193,7 @@ public class Slot extends DomainResource {
       if (code == SlotStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(SlotStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Specimen.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Specimen.java
@@ -138,12 +138,14 @@ public class Specimen extends DomainResource {
         throw new FHIRException("Unknown SpecimenCombined code '"+codeString+"'");
         }
     public String toCode(SpecimenCombined code) {
-      if (code == SpecimenCombined.GROUPED)
+       if (code == SpecimenCombined.NULL)
+           return null;
+       if (code == SpecimenCombined.GROUPED)
         return "grouped";
       if (code == SpecimenCombined.POOLED)
         return "pooled";
       return "?";
-      }
+   }
     public String toSystem(SpecimenCombined code) {
       return code.getSystem();
       }
@@ -262,7 +264,9 @@ public class Specimen extends DomainResource {
         throw new FHIRException("Unknown SpecimenStatus code '"+codeString+"'");
         }
     public String toCode(SpecimenStatus code) {
-      if (code == SpecimenStatus.AVAILABLE)
+       if (code == SpecimenStatus.NULL)
+           return null;
+       if (code == SpecimenStatus.AVAILABLE)
         return "available";
       if (code == SpecimenStatus.UNAVAILABLE)
         return "unavailable";
@@ -271,7 +275,7 @@ public class Specimen extends DomainResource {
       if (code == SpecimenStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(SpecimenStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SpecimenDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SpecimenDefinition.java
@@ -138,12 +138,14 @@ public class SpecimenDefinition extends DomainResource {
         throw new FHIRException("Unknown SpecimenContainedPreference code '"+codeString+"'");
         }
     public String toCode(SpecimenContainedPreference code) {
-      if (code == SpecimenContainedPreference.PREFERRED)
+       if (code == SpecimenContainedPreference.NULL)
+           return null;
+       if (code == SpecimenContainedPreference.PREFERRED)
         return "preferred";
       if (code == SpecimenContainedPreference.ALTERNATE)
         return "alternate";
       return "?";
-      }
+   }
     public String toSystem(SpecimenContainedPreference code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/StructureDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/StructureDefinition.java
@@ -152,14 +152,16 @@ public class StructureDefinition extends CanonicalResource {
         throw new FHIRException("Unknown ExtensionContextType code '"+codeString+"'");
         }
     public String toCode(ExtensionContextType code) {
-      if (code == ExtensionContextType.FHIRPATH)
+       if (code == ExtensionContextType.NULL)
+           return null;
+       if (code == ExtensionContextType.FHIRPATH)
         return "fhirpath";
       if (code == ExtensionContextType.ELEMENT)
         return "element";
       if (code == ExtensionContextType.EXTENSION)
         return "extension";
       return "?";
-      }
+   }
     public String toSystem(ExtensionContextType code) {
       return code.getSystem();
       }
@@ -278,7 +280,9 @@ public class StructureDefinition extends CanonicalResource {
         throw new FHIRException("Unknown StructureDefinitionKind code '"+codeString+"'");
         }
     public String toCode(StructureDefinitionKind code) {
-      if (code == StructureDefinitionKind.PRIMITIVETYPE)
+       if (code == StructureDefinitionKind.NULL)
+           return null;
+       if (code == StructureDefinitionKind.PRIMITIVETYPE)
         return "primitive-type";
       if (code == StructureDefinitionKind.COMPLEXTYPE)
         return "complex-type";
@@ -287,7 +291,7 @@ public class StructureDefinition extends CanonicalResource {
       if (code == StructureDefinitionKind.LOGICAL)
         return "logical";
       return "?";
-      }
+   }
     public String toSystem(StructureDefinitionKind code) {
       return code.getSystem();
       }
@@ -378,12 +382,14 @@ public class StructureDefinition extends CanonicalResource {
         throw new FHIRException("Unknown TypeDerivationRule code '"+codeString+"'");
         }
     public String toCode(TypeDerivationRule code) {
-      if (code == TypeDerivationRule.SPECIALIZATION)
+       if (code == TypeDerivationRule.NULL)
+           return null;
+       if (code == TypeDerivationRule.SPECIALIZATION)
         return "specialization";
       if (code == TypeDerivationRule.CONSTRAINT)
         return "constraint";
       return "?";
-      }
+   }
     public String toSystem(TypeDerivationRule code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/StructureMap.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/StructureMap.java
@@ -139,12 +139,14 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapGroupTypeMode code '"+codeString+"'");
         }
     public String toCode(StructureMapGroupTypeMode code) {
-      if (code == StructureMapGroupTypeMode.TYPES)
+       if (code == StructureMapGroupTypeMode.NULL)
+           return null;
+       if (code == StructureMapGroupTypeMode.TYPES)
         return "types";
       if (code == StructureMapGroupTypeMode.TYPEANDTYPES)
         return "type-and-types";
       return "?";
-      }
+   }
     public String toSystem(StructureMapGroupTypeMode code) {
       return code.getSystem();
       }
@@ -235,12 +237,14 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapInputMode code '"+codeString+"'");
         }
     public String toCode(StructureMapInputMode code) {
-      if (code == StructureMapInputMode.SOURCE)
+       if (code == StructureMapInputMode.NULL)
+           return null;
+       if (code == StructureMapInputMode.SOURCE)
         return "source";
       if (code == StructureMapInputMode.TARGET)
         return "target";
       return "?";
-      }
+   }
     public String toSystem(StructureMapInputMode code) {
       return code.getSystem();
       }
@@ -359,7 +363,9 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapModelMode code '"+codeString+"'");
         }
     public String toCode(StructureMapModelMode code) {
-      if (code == StructureMapModelMode.SOURCE)
+       if (code == StructureMapModelMode.NULL)
+           return null;
+       if (code == StructureMapModelMode.SOURCE)
         return "source";
       if (code == StructureMapModelMode.QUERIED)
         return "queried";
@@ -368,7 +374,7 @@ public class StructureMap extends CanonicalResource {
       if (code == StructureMapModelMode.PRODUCED)
         return "produced";
       return "?";
-      }
+   }
     public String toSystem(StructureMapModelMode code) {
       return code.getSystem();
       }
@@ -501,7 +507,9 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapSourceListMode code '"+codeString+"'");
         }
     public String toCode(StructureMapSourceListMode code) {
-      if (code == StructureMapSourceListMode.FIRST)
+       if (code == StructureMapSourceListMode.NULL)
+           return null;
+       if (code == StructureMapSourceListMode.FIRST)
         return "first";
       if (code == StructureMapSourceListMode.NOTFIRST)
         return "not_first";
@@ -512,7 +520,7 @@ public class StructureMap extends CanonicalResource {
       if (code == StructureMapSourceListMode.ONLYONE)
         return "only_one";
       return "?";
-      }
+   }
     public String toSystem(StructureMapSourceListMode code) {
       return code.getSystem();
       }
@@ -631,7 +639,9 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapTargetListMode code '"+codeString+"'");
         }
     public String toCode(StructureMapTargetListMode code) {
-      if (code == StructureMapTargetListMode.FIRST)
+       if (code == StructureMapTargetListMode.NULL)
+           return null;
+       if (code == StructureMapTargetListMode.FIRST)
         return "first";
       if (code == StructureMapTargetListMode.SHARE)
         return "share";
@@ -640,7 +650,7 @@ public class StructureMap extends CanonicalResource {
       if (code == StructureMapTargetListMode.SINGLE)
         return "single";
       return "?";
-      }
+   }
     public String toSystem(StructureMapTargetListMode code) {
       return code.getSystem();
       }
@@ -941,7 +951,9 @@ public class StructureMap extends CanonicalResource {
         throw new FHIRException("Unknown StructureMapTransform code '"+codeString+"'");
         }
     public String toCode(StructureMapTransform code) {
-      if (code == StructureMapTransform.CREATE)
+       if (code == StructureMapTransform.NULL)
+           return null;
+       if (code == StructureMapTransform.CREATE)
         return "create";
       if (code == StructureMapTransform.COPY)
         return "copy";
@@ -976,7 +988,7 @@ public class StructureMap extends CanonicalResource {
       if (code == StructureMapTransform.CP)
         return "cp";
       return "?";
-      }
+   }
     public String toSystem(StructureMapTransform code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Subscription.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Subscription.java
@@ -152,14 +152,16 @@ public class Subscription extends DomainResource {
         throw new FHIRException("Unknown SubscriptionPayloadContent code '"+codeString+"'");
         }
     public String toCode(SubscriptionPayloadContent code) {
-      if (code == SubscriptionPayloadContent.EMPTY)
+       if (code == SubscriptionPayloadContent.NULL)
+           return null;
+       if (code == SubscriptionPayloadContent.EMPTY)
         return "empty";
       if (code == SubscriptionPayloadContent.IDONLY)
         return "id-only";
       if (code == SubscriptionPayloadContent.FULLRESOURCE)
         return "full-resource";
       return "?";
-      }
+   }
     public String toSystem(SubscriptionPayloadContent code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SubscriptionStatus.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SubscriptionStatus.java
@@ -180,7 +180,9 @@ public class SubscriptionStatus extends DomainResource {
         throw new FHIRException("Unknown SubscriptionNotificationType code '"+codeString+"'");
         }
     public String toCode(SubscriptionNotificationType code) {
-      if (code == SubscriptionNotificationType.HANDSHAKE)
+       if (code == SubscriptionNotificationType.NULL)
+           return null;
+       if (code == SubscriptionNotificationType.HANDSHAKE)
         return "handshake";
       if (code == SubscriptionNotificationType.HEARTBEAT)
         return "heartbeat";
@@ -191,7 +193,7 @@ public class SubscriptionStatus extends DomainResource {
       if (code == SubscriptionNotificationType.QUERYEVENT)
         return "query-event";
       return "?";
-      }
+   }
     public String toSystem(SubscriptionNotificationType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SubscriptionTopic.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SubscriptionTopic.java
@@ -138,12 +138,14 @@ public class SubscriptionTopic extends CanonicalResource {
         throw new FHIRException("Unknown CriteriaNotExistsBehavior code '"+codeString+"'");
         }
     public String toCode(CriteriaNotExistsBehavior code) {
-      if (code == CriteriaNotExistsBehavior.TESTPASSES)
+       if (code == CriteriaNotExistsBehavior.NULL)
+           return null;
+       if (code == CriteriaNotExistsBehavior.TESTPASSES)
         return "test-passes";
       if (code == CriteriaNotExistsBehavior.TESTFAILS)
         return "test-fails";
       return "?";
-      }
+   }
     public String toSystem(CriteriaNotExistsBehavior code) {
       return code.getSystem();
       }
@@ -248,14 +250,16 @@ public class SubscriptionTopic extends CanonicalResource {
         throw new FHIRException("Unknown InteractionTrigger code '"+codeString+"'");
         }
     public String toCode(InteractionTrigger code) {
-      if (code == InteractionTrigger.CREATE)
+       if (code == InteractionTrigger.NULL)
+           return null;
+       if (code == InteractionTrigger.CREATE)
         return "create";
       if (code == InteractionTrigger.UPDATE)
         return "update";
       if (code == InteractionTrigger.DELETE)
         return "delete";
       return "?";
-      }
+   }
     public String toSystem(InteractionTrigger code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Substance.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Substance.java
@@ -152,14 +152,16 @@ public class Substance extends DomainResource {
         throw new FHIRException("Unknown FHIRSubstanceStatus code '"+codeString+"'");
         }
     public String toCode(FHIRSubstanceStatus code) {
-      if (code == FHIRSubstanceStatus.ACTIVE)
+       if (code == FHIRSubstanceStatus.NULL)
+           return null;
+       if (code == FHIRSubstanceStatus.ACTIVE)
         return "active";
       if (code == FHIRSubstanceStatus.INACTIVE)
         return "inactive";
       if (code == FHIRSubstanceStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(FHIRSubstanceStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SupplyDelivery.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SupplyDelivery.java
@@ -166,7 +166,9 @@ public class SupplyDelivery extends DomainResource {
         throw new FHIRException("Unknown SupplyDeliveryStatus code '"+codeString+"'");
         }
     public String toCode(SupplyDeliveryStatus code) {
-      if (code == SupplyDeliveryStatus.INPROGRESS)
+       if (code == SupplyDeliveryStatus.NULL)
+           return null;
+       if (code == SupplyDeliveryStatus.INPROGRESS)
         return "in-progress";
       if (code == SupplyDeliveryStatus.COMPLETED)
         return "completed";
@@ -175,7 +177,7 @@ public class SupplyDelivery extends DomainResource {
       if (code == SupplyDeliveryStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(SupplyDeliveryStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SupplyRequest.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/SupplyRequest.java
@@ -208,7 +208,9 @@ public class SupplyRequest extends DomainResource {
         throw new FHIRException("Unknown SupplyRequestStatus code '"+codeString+"'");
         }
     public String toCode(SupplyRequestStatus code) {
-      if (code == SupplyRequestStatus.DRAFT)
+       if (code == SupplyRequestStatus.NULL)
+           return null;
+       if (code == SupplyRequestStatus.DRAFT)
         return "draft";
       if (code == SupplyRequestStatus.ACTIVE)
         return "active";
@@ -223,7 +225,7 @@ public class SupplyRequest extends DomainResource {
       if (code == SupplyRequestStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(SupplyRequestStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Task.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Task.java
@@ -236,7 +236,9 @@ public class Task extends DomainResource {
         throw new FHIRException("Unknown TaskIntent code '"+codeString+"'");
         }
     public String toCode(TaskIntent code) {
-      if (code == TaskIntent.UNKNOWN)
+       if (code == TaskIntent.NULL)
+           return null;
+       if (code == TaskIntent.UNKNOWN)
         return "unknown";
       if (code == TaskIntent.PROPOSAL)
         return "proposal";
@@ -255,7 +257,7 @@ public class Task extends DomainResource {
       if (code == TaskIntent.OPTION)
         return "option";
       return "?";
-      }
+   }
     public String toSystem(TaskIntent code) {
       return code.getSystem();
       }
@@ -486,7 +488,9 @@ public class Task extends DomainResource {
         throw new FHIRException("Unknown TaskStatus code '"+codeString+"'");
         }
     public String toCode(TaskStatus code) {
-      if (code == TaskStatus.DRAFT)
+       if (code == TaskStatus.NULL)
+           return null;
+       if (code == TaskStatus.DRAFT)
         return "draft";
       if (code == TaskStatus.REQUESTED)
         return "requested";
@@ -511,7 +515,7 @@ public class Task extends DomainResource {
       if (code == TaskStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(TaskStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TerminologyCapabilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TerminologyCapabilities.java
@@ -152,14 +152,16 @@ public class TerminologyCapabilities extends CanonicalResource {
         throw new FHIRException("Unknown CodeSearchSupport code '"+codeString+"'");
         }
     public String toCode(CodeSearchSupport code) {
-      if (code == CodeSearchSupport.INCOMPOSE)
+       if (code == CodeSearchSupport.NULL)
+           return null;
+       if (code == CodeSearchSupport.INCOMPOSE)
         return "in-compose";
       if (code == CodeSearchSupport.INEXPANSION)
         return "in-expansion";
       if (code == CodeSearchSupport.INCOMPOSEOREXPANSION)
         return "in-compose-or-expansion";
       return "?";
-      }
+   }
     public String toSystem(CodeSearchSupport code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TestReport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TestReport.java
@@ -181,7 +181,9 @@ public class TestReport extends DomainResource {
         throw new FHIRException("Unknown TestReportActionResult code '"+codeString+"'");
         }
     public String toCode(TestReportActionResult code) {
-      if (code == TestReportActionResult.PASS)
+       if (code == TestReportActionResult.NULL)
+           return null;
+       if (code == TestReportActionResult.PASS)
         return "pass";
       if (code == TestReportActionResult.SKIP)
         return "skip";
@@ -192,7 +194,7 @@ public class TestReport extends DomainResource {
       if (code == TestReportActionResult.ERROR)
         return "error";
       return "?";
-      }
+   }
     public String toSystem(TestReportActionResult code) {
       return code.getSystem();
       }
@@ -297,14 +299,16 @@ public class TestReport extends DomainResource {
         throw new FHIRException("Unknown TestReportParticipantType code '"+codeString+"'");
         }
     public String toCode(TestReportParticipantType code) {
-      if (code == TestReportParticipantType.TESTENGINE)
+       if (code == TestReportParticipantType.NULL)
+           return null;
+       if (code == TestReportParticipantType.TESTENGINE)
         return "test-engine";
       if (code == TestReportParticipantType.CLIENT)
         return "client";
       if (code == TestReportParticipantType.SERVER)
         return "server";
       return "?";
-      }
+   }
     public String toSystem(TestReportParticipantType code) {
       return code.getSystem();
       }
@@ -409,14 +413,16 @@ public class TestReport extends DomainResource {
         throw new FHIRException("Unknown TestReportResult code '"+codeString+"'");
         }
     public String toCode(TestReportResult code) {
-      if (code == TestReportResult.PASS)
+       if (code == TestReportResult.NULL)
+           return null;
+       if (code == TestReportResult.PASS)
         return "pass";
       if (code == TestReportResult.FAIL)
         return "fail";
       if (code == TestReportResult.PENDING)
         return "pending";
       return "?";
-      }
+   }
     public String toSystem(TestReportResult code) {
       return code.getSystem();
       }
@@ -549,7 +555,9 @@ public class TestReport extends DomainResource {
         throw new FHIRException("Unknown TestReportStatus code '"+codeString+"'");
         }
     public String toCode(TestReportStatus code) {
-      if (code == TestReportStatus.COMPLETED)
+       if (code == TestReportStatus.NULL)
+           return null;
+       if (code == TestReportStatus.COMPLETED)
         return "completed";
       if (code == TestReportStatus.INPROGRESS)
         return "in-progress";
@@ -560,7 +568,7 @@ public class TestReport extends DomainResource {
       if (code == TestReportStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(TestReportStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TestScript.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TestScript.java
@@ -138,12 +138,14 @@ public class TestScript extends CanonicalResource {
         throw new FHIRException("Unknown AssertionDirectionType code '"+codeString+"'");
         }
     public String toCode(AssertionDirectionType code) {
-      if (code == AssertionDirectionType.RESPONSE)
+       if (code == AssertionDirectionType.NULL)
+           return null;
+       if (code == AssertionDirectionType.RESPONSE)
         return "response";
       if (code == AssertionDirectionType.REQUEST)
         return "request";
       return "?";
-      }
+   }
     public String toSystem(AssertionDirectionType code) {
       return code.getSystem();
       }
@@ -262,7 +264,9 @@ public class TestScript extends CanonicalResource {
         throw new FHIRException("Unknown AssertionManualCompletionType code '"+codeString+"'");
         }
     public String toCode(AssertionManualCompletionType code) {
-      if (code == AssertionManualCompletionType.FAIL)
+       if (code == AssertionManualCompletionType.NULL)
+           return null;
+       if (code == AssertionManualCompletionType.FAIL)
         return "fail";
       if (code == AssertionManualCompletionType.PASS)
         return "pass";
@@ -271,7 +275,7 @@ public class TestScript extends CanonicalResource {
       if (code == AssertionManualCompletionType.STOP)
         return "stop";
       return "?";
-      }
+   }
     public String toSystem(AssertionManualCompletionType code) {
       return code.getSystem();
       }
@@ -502,7 +506,9 @@ public class TestScript extends CanonicalResource {
         throw new FHIRException("Unknown AssertionOperatorType code '"+codeString+"'");
         }
     public String toCode(AssertionOperatorType code) {
-      if (code == AssertionOperatorType.EQUALS)
+       if (code == AssertionOperatorType.NULL)
+           return null;
+       if (code == AssertionOperatorType.EQUALS)
         return "equals";
       if (code == AssertionOperatorType.NOTEQUALS)
         return "notEquals";
@@ -527,7 +533,7 @@ public class TestScript extends CanonicalResource {
       if (code == AssertionOperatorType.MANUALEVAL)
         return "manualEval";
       return "?";
-      }
+   }
     public String toSystem(AssertionOperatorType code) {
       return code.getSystem();
       }
@@ -1206,7 +1212,9 @@ public class TestScript extends CanonicalResource {
         throw new FHIRException("Unknown AssertionResponseTypes code '"+codeString+"'");
         }
     public String toCode(AssertionResponseTypes code) {
-      if (code == AssertionResponseTypes.CONTINUE)
+       if (code == AssertionResponseTypes.NULL)
+           return null;
+       if (code == AssertionResponseTypes.CONTINUE)
         return "continue";
       if (code == AssertionResponseTypes.SWITCHINGPROTOCOLS)
         return "switchingProtocols";
@@ -1295,7 +1303,7 @@ public class TestScript extends CanonicalResource {
       if (code == AssertionResponseTypes.HTTPVERSIONNOTSUPPORTED)
         return "httpVersionNotSupported";
       return "?";
-      }
+   }
     public String toSystem(AssertionResponseTypes code) {
       return code.getSystem();
       }
@@ -1456,7 +1464,9 @@ public class TestScript extends CanonicalResource {
         throw new FHIRException("Unknown TestScriptRequestMethodCode code '"+codeString+"'");
         }
     public String toCode(TestScriptRequestMethodCode code) {
-      if (code == TestScriptRequestMethodCode.DELETE)
+       if (code == TestScriptRequestMethodCode.NULL)
+           return null;
+       if (code == TestScriptRequestMethodCode.DELETE)
         return "delete";
       if (code == TestScriptRequestMethodCode.GET)
         return "get";
@@ -1471,7 +1481,7 @@ public class TestScript extends CanonicalResource {
       if (code == TestScriptRequestMethodCode.HEAD)
         return "head";
       return "?";
-      }
+   }
     public String toSystem(TestScriptRequestMethodCode code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Timing.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Timing.java
@@ -487,7 +487,9 @@ public class Timing extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown EventTiming code '"+codeString+"'");
         }
     public String toCode(EventTiming code) {
-      if (code == EventTiming.MORN)
+       if (code == EventTiming.NULL)
+           return null;
+       if (code == EventTiming.MORN)
         return "MORN";
       if (code == EventTiming.MORN_EARLY)
         return "MORN.early";
@@ -542,7 +544,7 @@ public class Timing extends BackboneType implements ICompositeType {
       if (code == EventTiming.PCV)
         return "PCV";
       return "?";
-      }
+   }
     public String toSystem(EventTiming code) {
       return code.getSystem();
       }
@@ -703,7 +705,9 @@ public class Timing extends BackboneType implements ICompositeType {
         throw new FHIRException("Unknown UnitsOfTime code '"+codeString+"'");
         }
     public String toCode(UnitsOfTime code) {
-      if (code == UnitsOfTime.S)
+       if (code == UnitsOfTime.NULL)
+           return null;
+       if (code == UnitsOfTime.S)
         return "s";
       if (code == UnitsOfTime.MIN)
         return "min";
@@ -718,7 +722,7 @@ public class Timing extends BackboneType implements ICompositeType {
       if (code == UnitsOfTime.A)
         return "a";
       return "?";
-      }
+   }
     public String toSystem(UnitsOfTime code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Transport.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/Transport.java
@@ -236,7 +236,9 @@ public class Transport extends DomainResource {
         throw new FHIRException("Unknown TransportIntent code '"+codeString+"'");
         }
     public String toCode(TransportIntent code) {
-      if (code == TransportIntent.UNKNOWN)
+       if (code == TransportIntent.NULL)
+           return null;
+       if (code == TransportIntent.UNKNOWN)
         return "unknown";
       if (code == TransportIntent.PROPOSAL)
         return "proposal";
@@ -255,7 +257,7 @@ public class Transport extends DomainResource {
       if (code == TransportIntent.OPTION)
         return "option";
       return "?";
-      }
+   }
     public String toSystem(TransportIntent code) {
       return code.getSystem();
       }
@@ -402,7 +404,9 @@ public class Transport extends DomainResource {
         throw new FHIRException("Unknown TransportStatus code '"+codeString+"'");
         }
     public String toCode(TransportStatus code) {
-      if (code == TransportStatus.INPROGRESS)
+       if (code == TransportStatus.NULL)
+           return null;
+       if (code == TransportStatus.INPROGRESS)
         return "in-progress";
       if (code == TransportStatus.COMPLETED)
         return "completed";
@@ -415,7 +419,7 @@ public class Transport extends DomainResource {
       if (code == TransportStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(TransportStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TriggerDefinition.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/TriggerDefinition.java
@@ -220,7 +220,9 @@ public class TriggerDefinition extends DataType implements ICompositeType {
         throw new FHIRException("Unknown TriggerType code '"+codeString+"'");
         }
     public String toCode(TriggerType code) {
-      if (code == TriggerType.NAMEDEVENT)
+       if (code == TriggerType.NULL)
+           return null;
+       if (code == TriggerType.NAMEDEVENT)
         return "named-event";
       if (code == TriggerType.PERIODIC)
         return "periodic";
@@ -237,7 +239,7 @@ public class TriggerDefinition extends DataType implements ICompositeType {
       if (code == TriggerType.DATAACCESSENDED)
         return "data-access-ended";
       return "?";
-      }
+   }
     public String toSystem(TriggerType code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/VerificationResult.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/VerificationResult.java
@@ -208,7 +208,9 @@ public class VerificationResult extends DomainResource {
         throw new FHIRException("Unknown VerificationResultStatus code '"+codeString+"'");
         }
     public String toCode(VerificationResultStatus code) {
-      if (code == VerificationResultStatus.ATTESTED)
+       if (code == VerificationResultStatus.NULL)
+           return null;
+       if (code == VerificationResultStatus.ATTESTED)
         return "attested";
       if (code == VerificationResultStatus.VALIDATED)
         return "validated";
@@ -223,7 +225,7 @@ public class VerificationResult extends DomainResource {
       if (code == VerificationResultStatus.ENTEREDINERROR)
         return "entered-in-error";
       return "?";
-      }
+   }
     public String toSystem(VerificationResultStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/VisionPrescription.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/model/VisionPrescription.java
@@ -167,7 +167,9 @@ public class VisionPrescription extends DomainResource {
         throw new FHIRException("Unknown VisionBase code '"+codeString+"'");
         }
     public String toCode(VisionBase code) {
-      if (code == VisionBase.UP)
+       if (code == VisionBase.NULL)
+           return null;
+       if (code == VisionBase.UP)
         return "up";
       if (code == VisionBase.DOWN)
         return "down";
@@ -176,7 +178,7 @@ public class VisionPrescription extends DomainResource {
       if (code == VisionBase.OUT)
         return "out";
       return "?";
-      }
+   }
     public String toSystem(VisionBase code) {
       return code.getSystem();
       }
@@ -267,12 +269,14 @@ public class VisionPrescription extends DomainResource {
         throw new FHIRException("Unknown VisionEyes code '"+codeString+"'");
         }
     public String toCode(VisionEyes code) {
-      if (code == VisionEyes.RIGHT)
+       if (code == VisionEyes.NULL)
+           return null;
+       if (code == VisionEyes.RIGHT)
         return "right";
       if (code == VisionEyes.LEFT)
         return "left";
       return "?";
-      }
+   }
     public String toSystem(VisionEyes code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Event.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Event.java
@@ -228,7 +228,9 @@ public interface Event extends PatternBase {
         throw new FHIRException("Unknown EventStatus code '"+codeString+"'");
         }
     public String toCode(EventStatus code) {
-      if (code == EventStatus.PREPARATION)
+       if (code == EventStatus.NULL)
+           return null;
+       if (code == EventStatus.PREPARATION)
         return "preparation";
       if (code == EventStatus.INPROGRESS)
         return "in-progress";
@@ -245,7 +247,7 @@ public interface Event extends PatternBase {
       if (code == EventStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(EventStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Fivews.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Fivews.java
@@ -548,7 +548,9 @@ public interface Fivews extends PatternBase {
         throw new FHIRException("Unknown CanonicalStatus code '"+codeString+"'");
         }
     public String toCode(CanonicalStatus code) {
-      if (code == CanonicalStatus.ERROR)
+       if (code == CanonicalStatus.NULL)
+           return null;
+       if (code == CanonicalStatus.ERROR)
         return "error";
       if (code == CanonicalStatus.PROPOSED)
         return "proposed";
@@ -611,7 +613,7 @@ public interface Fivews extends PatternBase {
       if (code == CanonicalStatus.HWDISCON)
         return "hw-discon";
       return "?";
-      }
+   }
     public String toSystem(CanonicalStatus code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Request.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/patterns/Request.java
@@ -214,7 +214,9 @@ public interface Request extends PatternBase {
         throw new FHIRException("Unknown RequestStatus code '"+codeString+"'");
         }
     public String toCode(RequestStatus code) {
-      if (code == RequestStatus.DRAFT)
+       if (code == RequestStatus.NULL)
+           return null;
+       if (code == RequestStatus.DRAFT)
         return "draft";
       if (code == RequestStatus.ACTIVE)
         return "active";
@@ -229,7 +231,7 @@ public interface Request extends PatternBase {
       if (code == RequestStatus.UNKNOWN)
         return "unknown";
       return "?";
-      }
+   }
     public String toSystem(RequestStatus code) {
       return code.getSystem();
       }
@@ -418,7 +420,9 @@ public interface Request extends PatternBase {
         throw new FHIRException("Unknown RequestIntent code '"+codeString+"'");
         }
     public String toCode(RequestIntent code) {
-      if (code == RequestIntent.PROPOSAL)
+       if (code == RequestIntent.NULL)
+           return null;
+       if (code == RequestIntent.PROPOSAL)
         return "proposal";
       if (code == RequestIntent.PLAN)
         return "plan";
@@ -437,7 +441,7 @@ public interface Request extends PatternBase {
       if (code == RequestIntent.OPTION)
         return "option";
       return "?";
-      }
+   }
     public String toSystem(RequestIntent code) {
       return code.getSystem();
       }
@@ -556,7 +560,9 @@ public interface Request extends PatternBase {
         throw new FHIRException("Unknown RequestPriority code '"+codeString+"'");
         }
     public String toCode(RequestPriority code) {
-      if (code == RequestPriority.ROUTINE)
+       if (code == RequestPriority.NULL)
+           return null;
+       if (code == RequestPriority.ROUTINE)
         return "routine";
       if (code == RequestPriority.URGENT)
         return "urgent";
@@ -565,7 +571,7 @@ public interface Request extends PatternBase {
       if (code == RequestPriority.STAT)
         return "stat";
       return "?";
-      }
+   }
     public String toSystem(RequestPriority code) {
       return code.getSystem();
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GuideParameterCode.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GuideParameterCode.java
@@ -201,7 +201,9 @@ public enum GuideParameterCode {
       throw new FHIRException("Unknown GuideParameterCode code '"+codeString+"'");
     }
     public String toCode(GuideParameterCode code) {
-      if (code == GuideParameterCode.APPLY)
+       if (code == GuideParameterCode.NULL)
+           return null;
+       if (code == GuideParameterCode.APPLY)
         return "apply";
       if (code == GuideParameterCode.PATHRESOURCE)
         return "path-resource";
@@ -222,7 +224,7 @@ public enum GuideParameterCode {
       if (code == GuideParameterCode.HTMLTEMPLATE)
         return "html-template";
       return "?";
-    }
+   }
     public String toSystem(GuideParameterCode code) {
       return code.getSystem();
     }


### PR DESCRIPTION
This adds the following null handling for any null Enums in toCode methods:

```java
if (code == null)
        return null;
```