### PR TITLE
FML transform performance tuning

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
@@ -950,6 +950,8 @@ public class Element extends Base implements NamedItem {
         child.sort();
         if (child.isEmpty())
           remove.add(child);
+        else
+          child.numberChildren();
       }
       children.removeAll(remove);
       children.sort(new ElementSortComparator(this, this.property));

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
@@ -563,7 +563,6 @@ public class Element extends Base implements NamedItem {
         } else {
           Element ne = new Element(child).setFormat(format);
           children.add(ne);
-          numberChildren();
           return ne;
         }
       }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Element.java
@@ -475,7 +475,7 @@ public class Element extends Base implements NamedItem {
         } else {
           Element ne = new Element(child).setFormat(format);
           children.add(ne);
-          numberChildren();
+          ne.index = children.getSizeByName(ne.getListName()) - 1;
           childForValue = ne;
           break;
         }
@@ -563,6 +563,7 @@ public class Element extends Base implements NamedItem {
         } else {
           Element ne = new Element(child).setFormat(format);
           children.add(ne);
+          ne.index = children.getSizeByName(ne.getListName()) - 1;
           return ne;
         }
       }
@@ -572,6 +573,7 @@ public class Element extends Base implements NamedItem {
       if (p.getName().equals(name)) {
         Element ne = new Element(name, p).setFormat(format);
         children.add(ne);
+        ne.index = children.getSizeByName(ne.getListName()) - 1;
         return ne;
       } else if (p.getDefinition().isChoice() && name.startsWith(p.getName().replace("[x]", ""))) {
         String type = name.substring(p.getName().length()-3);
@@ -581,6 +583,7 @@ public class Element extends Base implements NamedItem {
         Element ne = new Element(name, p).setFormat(format);
         ne.setType(type);
         children.add(ne);
+        ne.index = children.getSizeByName(ne.getListName()) - 1;
         return ne;
         
       }
@@ -604,6 +607,7 @@ public class Element extends Base implements NamedItem {
       if (p.getName().equals(name)) {
         Element ne = new Element(name, p).setFormat(format);
         children.add(ne);
+        ne.index = children.getSizeByName(ne.getListName()) - 1;
         return ne;
       }
     }
@@ -950,8 +954,6 @@ public class Element extends Base implements NamedItem {
         child.sort();
         if (child.isEmpty())
           remove.add(child);
-        else
-          child.numberChildren();
       }
       children.removeAll(remove);
       children.sort(new ElementSortComparator(this, this.property));

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Manager.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/Manager.java
@@ -39,8 +39,9 @@ import java.util.List;
 import org.hl7.fhir.exceptions.DefinitionException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.FHIRFormatError;
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
+import org.hl7.fhir.r5.context.ContextUtilities;
 import org.hl7.fhir.r5.context.IWorkerContext;
-import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
 import org.hl7.fhir.r5.formats.IParser.OutputStyle;
 import org.hl7.fhir.r5.model.StructureDefinition;
 
@@ -144,7 +145,11 @@ public class Manager {
   }
   
   public static Element build(IWorkerContext context, StructureDefinition sd) {
-    Property p = new Property(context, sd.getSnapshot().getElementFirstRep(), sd);
+    return build(context, sd, new ProfileUtilities(context, null, null));
+  }
+  
+  public static Element build(IWorkerContext context, StructureDefinition sd, ProfileUtilities profileUtilities) {
+    Property p = new Property(context, sd.getSnapshot().getElementFirstRep(), sd, profileUtilities, new ContextUtilities(context));
     Element e = new Element(p.getName(), p);
     e.setPath(sd.getType());
     return e;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/ITransformerServices.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/ITransformerServices.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.r5.utils.structuremap;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.Coding;
 
@@ -10,7 +11,7 @@ public interface ITransformerServices {
   //    public boolean validateByValueSet(Coding code, String valuesetId);
   public void log(String message); // log internal progress
 
-  public Base createType(Object appInfo, String name) throws FHIRException;
+  public Base createType(Object appInfo, String name, ProfileUtilities profileUtilities) throws FHIRException;
 
   public Base createResource(Object appInfo, Base res, boolean atRootofTransform); // an already created resource is provided; this is to identify/store it
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -1787,7 +1787,7 @@ public class StructureMapUtilities {
               }
             }
           }
-          Base res = services != null ? services.createType(context.getAppInfo(), tn) : typeFactory(tn);
+          Base res = services != null ? services.createType(context.getAppInfo(), tn, profileUtilities) : typeFactory(tn);
           if (res.isResource() && !res.fhirType().equals("Parameters")) {
 //	        res.setIdBase(tgt.getParameter().size() > 1 ? getParamString(vars, tgt.getParameter().get(0)) : UUID.randomUUID().toString().toLowerCase());
             if (services != null)
@@ -1928,7 +1928,7 @@ public class StructureMapUtilities {
       if (sd == null) {
         throw new FHIRException("Unable to create type "+tn);
       } else {
-        return Manager.build(worker, sd);
+        return Manager.build(worker, sd, profileUtilities);
       }
     } else {
       return ResourceFactory.createResourceOrType(tn);

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.elementmodel.Manager;
@@ -140,7 +141,7 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
   }
 
   @Override
-  public Base createType(Object appInfo, String name) throws FHIRException {
+  public Base createType(Object appInfo, String name, ProfileUtilities profileUtilities) throws FHIRException {
     return null;
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesTest.java
@@ -53,6 +53,7 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     StructureMap structureMap = scu.parse(fileMap, "cast");
     Element target = Manager.build(context, scu.getTargetType(structureMap));
     scu.transform(null, source, structureMap, target);
+    checkNumberChildren(target, "");
     FHIRPathEngine fp = new FHIRPathEngine(context);
     Assertions.assertEquals("implicit",fp.evaluateToString(target, "extension[0].value"));
     Assertions.assertEquals("explicit",fp.evaluateToString(target, "extension[1].value"));
@@ -68,6 +69,7 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     StructureMap structureMap = scu.parse(fileMap, "qr2patfordates");
     Element target = Manager.build(context, scu.getTargetType(structureMap));
     scu.transform(null, source, structureMap, target);
+    checkNumberChildren(target, "");
     FHIRPathEngine fp = new FHIRPathEngine(context);
     assertEquals("2023-10-26", fp.evaluateToString(target, "birthDate"));
     assertEquals("2023-09-20T13:19:13.502Z", fp.evaluateToString(target, "deceased"));
@@ -82,6 +84,7 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
       StructureMap structureMap = scu.parse(fileMap, "whereclause");
       Element target = Manager.build(context, scu.getTargetType(structureMap));
       scu.transform(null, source, structureMap, target);
+      checkNumberChildren(target, "");
       FHIRPathEngine fp = new FHIRPathEngine(context);
       assertEquals("true", fp.evaluateToString(target, "rest.resource.interaction.where(code='create').exists()"));
   }
@@ -135,6 +138,30 @@ public class StructureMapUtilitiesTest implements ITransformerServices {
     Assertions.assertEquals("-quote", structureMap.getGroup().get(0).getRule().get(1).getSourceFirstRep().getElement());
     Assertions.assertEquals("-backtick", structureMap.getGroup().get(0).getRule().get(2).getSourceFirstRep().getElement());
   }
+  
+  // assert indices are equal to Element.numberChildren()
+  private void checkNumberChildren(Element e, String indent) {
+    System.out.println(indent + e + ", index: " + e.getIndex());
+    String last = "";
+    int index = 0;
+    for (Element child : e.getChildren()) {
+      if (child.getProperty().isList()) {
+        if (last.equals(child.getName())) {
+          index++;
+        } else {
+          last = child.getName();
+          index = 0;
+        }
+        // child.index = index;
+        Assertions.assertEquals(index, child.getIndex());
+      } else {
+        // child.index = -1;
+        Assertions.assertEquals(-1, child.getIndex());
+      }
+      checkNumberChildren(child, indent + "  ");
+    }
+  }
+  
 
   @Override
   public void log(String message) {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/NamedItemList.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/NamedItemList.java
@@ -53,12 +53,12 @@ public class NamedItemList<T extends org.hl7.fhir.utilities.NamedItemList.NamedI
 
   @Override
   public boolean add(T e) {
-    map = null;  
+    addToMap(e);
     return list.add(e);
   }
   public void add(int index, T e) {
+    addToMap(e);
     list.add(index, e);
-    map = null;  
   }
 
   @Override
@@ -74,7 +74,9 @@ public class NamedItemList<T extends org.hl7.fhir.utilities.NamedItemList.NamedI
 
   @Override
   public boolean addAll(Collection<? extends T> c) {
-    map = null;  
+    for(T e : c) {
+      addToMap(e);
+    }
     return list.addAll(c);
   }
 
@@ -115,6 +117,14 @@ public class NamedItemList<T extends org.hl7.fhir.utilities.NamedItemList.NamedI
     }
     return res;
   }
+  
+  public int getSizeByName(String name) {
+    if (map == null) {
+      buildMap();
+    }
+    List<T> l = map.get(name);
+    return l == null ? 0 : l.size();
+  }
 
   public T get(int c) {
     return list.get(c);
@@ -123,14 +133,22 @@ public class NamedItemList<T extends org.hl7.fhir.utilities.NamedItemList.NamedI
   private void buildMap() {
     map = new HashMap<>();
     for (T child : list) {
-      String n = child.getListName();
-      List<T> l = map.get(n);
-      if (l == null) {
-        l = new ArrayList<>();
-        map.put(n,l);
-      }
-      l.add(child);         
+      addToMap(child);
     }
+  }
+  
+  private void addToMap(T child) {
+    if (map == null) {
+      // map will be re-built anyway in next call to getByName
+      return;
+    }
+    String n = child.getListName();
+    List<T> l = map.get(n);
+    if (l == null) {
+      l = new ArrayList<>();
+      map.put(n,l);
+    }
+    l.add(child);
   }
 
   public void sort(Comparator<? super T> sorter) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/TransformSupportServices.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/TransformSupportServices.java
@@ -4,6 +4,7 @@ import java.io.PrintWriter;
 import java.util.List;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.model.Base;
@@ -34,9 +35,9 @@ public class TransformSupportServices implements ITransformerServices {
   }
 
   @Override
-  public Base createType(Object appInfo, String name) throws FHIRException {
+  public Base createType(Object appInfo, String name, ProfileUtilities profileUtilities) throws FHIRException {
     StructureDefinition sd = context.fetchResource(StructureDefinition.class, name);
-    return Manager.build(context, sd);
+    return Manager.build(context, sd, profileUtilities);
   }
 
   @Override


### PR DESCRIPTION
Imrove performance of FML transform, especially for data with large lists.

- Skip numberChildren() when adding an element to a list: https://github.com/hapifhir/org.hl7.fhir.core/issues/1699
- Avoid creating new FHIRPathEngine in every new Property: https://github.com/hapifhir/org.hl7.fhir.core/issues/1703

For large amount of input/output data, FML transform is > 1000x faster and using less memory.