### PR TITLE
Add Australian CDA name prefix & uri

### DIFF
--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/elementmodel/XmlParser.java
@@ -233,6 +233,8 @@ public class XmlParser extends ParserBase {
       return "sdtc:";
     if (ns.equals("urn:ihe:pharm"))
       return "pharm:";
+    if (ns.equals("http://ns.electronichealth.net.au/Ci/Cda/Extensions/3.0"))
+      return "ext:";
     return "?:";
   }
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/XmlParser.java
@@ -255,6 +255,8 @@ public class XmlParser extends ParserBase {
       return "sdtc:";
     if (ns.equals("urn:ihe:pharm"))
       return "pharm:";
+    if (ns.equals("http://ns.electronichealth.net.au/Ci/Cda/Extensions/3.0"))
+      return "ext:";
     return "?:";
   }
 


### PR DESCRIPTION
Added AU CDA namespace prefix `ext` and associated uri `http://ns.electronichealth.net.au/Ci/Cda/Extensions/3.0` to the R4b and R5 XmlParser libraries pathPrefix function, emulating what other CDA namespaces have.

Regarding the [R4 library pathPrefix function](https://github.com/hapifhir/org.hl7.fhir.core/blob/master/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/elementmodel/XmlParser.java#L195C18-L204) - the AU namespace was _not_ added here on the basis that neither `sdtc` nor `pharm` are present.

As a first time contributer to this repo, I'm not sure whether the PR pipeline checks are sufficient or if I'm expected to run local build/checks etc.

Thank you!

Fixes #1613