### PR TITLE
Update staging plugin

### DIFF
--- a/org.hl7.fhir.report/pom.xml
+++ b/org.hl7.fhir.report/pom.xml
@@ -89,7 +89,7 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <configuration>
-                        <skipStaging>true</skipStaging>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/org.hl7.fhir.validation.cli/pom.xml
+++ b/org.hl7.fhir.validation.cli/pom.xml
@@ -405,7 +405,7 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <configuration>
-                        <skipStaging>true</skipStaging>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -717,7 +717,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>1.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
Update staging plugin and use `skipNexusStagingDeployMojo`, which is functionally similar, but more precisely documented than `skipStaging`

Source: https://help.sonatype.com/en/configuring-your-project-for-deployment.html

> skipNexusStagingDeployMojo
>
>Set to false by default, this flag will cause to skip any execution of the deploy goal of the plugin when set to true similar to maven.deploy.skip. In multi-module builds the staging of all components is performed in the last module based on the reactor order. If this property is set to true in the module, all staging will be skipped. You have to ensure that this property evaluates as true in the last module of the reactor. If necessary, you can add a dummy module.

>skipStaging

>Set to false by default this flag will cause to skip any execution of the plugin when set to true.



