### PR TITLE
Fixes an NPE and other issues in ViewDefinition validator

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/sql/Runner.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/sql/Runner.java
@@ -25,6 +25,7 @@ import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 
 
 public class Runner implements IEvaluationContext {
@@ -84,7 +85,14 @@ public class Runner implements IEvaluationContext {
     if (storage == null) {
       throw new FHIRException("No storage provided");
     }
-    Validator validator = new Validator(context, fpe, prohibitedNames, storage.supportsArrays(), storage.supportsComplexTypes(), storage.needsName());
+    Validator validator =
+        new Validator(
+            context,
+            fpe,
+            prohibitedNames,
+            storage.supportsArrays() ? IssueSeverity.NULL : IssueSeverity.ERROR,
+            storage.supportsComplexTypes() ? IssueSeverity.NULL : IssueSeverity.ERROR,
+            storage.needsName() ? IssueSeverity.ERROR : IssueSeverity.NULL);
     validator.checkViewDefinition(path, viewDefinition);
     issues = validator.getIssues();
     validator.dump();

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/sql/SQLOnFhirTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/sql/SQLOnFhirTests.java
@@ -88,6 +88,7 @@ public class SQLOnFhirTests {
 
   public static Stream<Arguments> data() throws ParserConfigurationException, SAXException, IOException {
     List<Arguments> objects = new ArrayList<>();
+    // TODO: These test files should be added to the repository.
     File dir = ManagedFileAccess.file("/Users/grahamegrieve/work/sql-on-fhir-v2/tests/content");
     for (File f : dir.listFiles()) {
       if (f.getName().endsWith(".json")) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -5714,7 +5714,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       } else if ("http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition".equals(element.getProperty().getStructure().getUrl())) {
         if (element.getNativeObject() != null && element.getNativeObject() instanceof JsonObject) {
           JsonObject json = (JsonObject) element.getNativeObject();
-          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), null, null, null);
+          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), true, true, false);
           sqlv.checkViewDefinition(stack.getLiteralPath(), json);
           errors.addAll(sqlv.getIssues());
           ok = sqlv.isOk() && ok;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -5754,7 +5754,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       } else if ("http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition".equals(element.getProperty().getStructure().getUrl())) {
         if (element.getNativeObject() != null && element.getNativeObject() instanceof JsonObject) {
           JsonObject json = (JsonObject) element.getNativeObject();
-          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), null, null, null);
+          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), IssueSeverity.WARNING, IssueSeverity.WARNING, IssueSeverity.WARNING);
           sqlv.checkViewDefinition(stack.getLiteralPath(), json);
           errors.addAll(sqlv.getIssues());
           ok = sqlv.isOk() && ok;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -5754,7 +5754,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       } else if ("http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition".equals(element.getProperty().getStructure().getUrl())) {
         if (element.getNativeObject() != null && element.getNativeObject() instanceof JsonObject) {
           JsonObject json = (JsonObject) element.getNativeObject();
-          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), true, true, false);
+          Validator sqlv = new Validator(context, fpe, new ArrayList<>(), null, null, null);
           sqlv.checkViewDefinition(stack.getLiteralPath(), json);
           errors.addAll(sqlv.getIssues());
           ok = sqlv.isOk() && ok;


### PR DESCRIPTION
When adding new examples to the SQL-on-FHIR-v2 repo, the validator was failing with the NPE below. I have tried to fix this and some other minor issues in this PR. Also some TODOs are added for issues I found but did not fix.

To test, I built `publisher.jar` in [fhir-ig-publisher](https://github.com/HL7/fhir-ig-publisher) locally and ran on my SoF changes.

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "this.complexTypes" is null
        at org.hl7.fhir.r5.utils.sql.Validator.checkColumn(Validator.java:349)
        at org.hl7.fhir.r5.utils.sql.Validator.checkSelect(Validator.java:145)
        at org.hl7.fhir.r5.utils.sql.Validator.checkViewDefinition(Validator.java:111)
        at org.hl7.fhir.validation.instance.InstanceValidator.checkSpecials(InstanceValidator.java:5718)
        at org.hl7.fhir.validation.instance.InstanceValidator.startInner(InstanceValidator.java:5654)
        at org.hl7.fhir.validation.instance.InstanceValidator.start(InstanceValidator.java:5391)
        at org.hl7.fhir.validation.instance.InstanceValidator.validateResource(InstanceValidator.java:7246)
        at org.hl7.fhir.validation.instance.InstanceValidator.validate(InstanceValidator.java:986)
        at org.hl7.fhir.validation.instance.InstanceValidator.validate(InstanceValidator.java:823)
        at org.hl7.fhir.validation.instance.InstanceValidator.validate(InstanceValidator.java:750)
        at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:7194)
        at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:7487)
        at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:7139)
        at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:1183)
        at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:1018)
        at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:13036)
```