### PR TITLE
Make sure this.messages is always initialized

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -435,7 +435,11 @@ public class ProfileUtilities {
   public ProfileUtilities(IWorkerContext context, List<ValidationMessage> messages, ProfileKnowledgeProvider pkp, FHIRPathEngine fpe) {
     super();
     this.context = context;
-    this.messages = messages;
+    if (messages == null) {
+      this.messages = new ArrayList<ValidationMessage>();
+    } else {
+      this.messages = messages;
+    }
     this.pkp = pkp;
 
     this.fpe = fpe;
@@ -447,7 +451,12 @@ public class ProfileUtilities {
   public ProfileUtilities(IWorkerContext context, List<ValidationMessage> messages, ProfileKnowledgeProvider pkp) {
     super();
     this.context = context;
-    this.messages = messages;
+    if (messages == null) {
+      this.messages = new ArrayList<ValidationMessage>();
+    } else {
+      this.messages = messages;
+    }
+
     this.pkp = pkp;
     if (context != null) {
       this.fpe = new FHIRPathEngine(context, this);


### PR DESCRIPTION
Demonstration for initializing messages in the ProfileUtilities class. See #1740 for details.