### PR TITLE
Fix for cache init on existing directories

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -210,26 +210,31 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
         Utilities.createDirectory(cacheFolder.getAbsolutePath());
         createIniFile();
       } else {
-        if (!isCacheFolderValid()) {
-          clearCache();
+        if (!iniFileExists()) {
           createIniFile();
-        } else {
-          deleteOldTempDirectories();
         }
+        if (!isIniFileCurrentVersion()) {
+          //Don't do anything but update the ini file version. But we SHOULD be clearing any implementation specific
+          //data added to packages.
+          createIniFile();
+        }
+        deleteOldTempDirectories();
       }
       return null;
     });
   }
 
-  private boolean isCacheFolderValid() throws IOException {
+  private boolean iniFileExists() throws IOException {
     String iniPath = getPackagesIniPath();
     File iniFile = ManagedFileAccess.file(iniPath);
-    if (!(iniFile.exists())) {
-      return false;
-    }
+    return iniFile.exists();
+  }
+
+  private boolean isIniFileCurrentVersion() throws IOException {
+    String iniPath = getPackagesIniPath();
     IniFile ini = new IniFile(iniPath);
-    String v = ini.getStringProperty("cache", "version");
-    return CACHE_VERSION.equals(v);
+    String version = ini.getStringProperty("cache", "version");
+    return CACHE_VERSION.equals(version);
   }
 
   private void deleteOldTempDirectories() throws IOException {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -214,8 +214,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
           createIniFile();
         }
         if (!isIniFileCurrentVersion()) {
-          //Don't do anything but update the ini file version. But we SHOULD be clearing any implementation specific
-          //data added to packages.
+          clearCache();
           createIniFile();
         }
         deleteOldTempDirectories();

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/NpmPackage.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/NpmPackage.java
@@ -648,7 +648,17 @@ public class NpmPackage {
   }
 
 
-
+  /**
+   * Create a package .index.json file for a package folder.
+   * <p>
+   * See <a href="https://hl7.org/fhir/packages.html#2.1.10.4">the FHIR specification</a> for details on .index.json
+   * format and usage.
+   *
+   * @param desc
+   * @param folder
+   * @throws FileNotFoundException
+   * @throws IOException
+   */
   public void indexFolder(String desc, NpmPackageFolder folder) throws FileNotFoundException, IOException {
     List<String> remove = new ArrayList<>();
     NpmPackageIndexBuilder indexer = new NpmPackageIndexBuilder();

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageManagerTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageManagerTests.java
@@ -1,22 +1,25 @@
 package org.hl7.fhir.utilities.npm;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import org.hl7.fhir.utilities.IniFile;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -100,7 +103,6 @@ public class FilesystemPackageManagerTests {
   @DisabledOnOs(OS.WINDOWS)
   public void testSystemCacheDirectory() throws IOException {
     File folder = new FilesystemPackageCacheManager.Builder().withSystemCacheFolder().getCacheFolder();
-
     assertEquals( "/var/lib/.fhir/packages", folder.getAbsolutePath());
   }
 
@@ -122,6 +124,91 @@ public class FilesystemPackageManagerTests {
       params.add(Arguments.of(100, 10));
     }
     return params.stream();
+  }
+
+  private void createDummyTemp(File cacheDirectory, String lowerCase) throws IOException {
+    createDummyPackage(cacheDirectory, lowerCase);
+  }
+
+  private void createDummyPackage(File cacheDirectory, String packageName, String packageVersion) throws IOException {
+    String directoryName = packageName + "#" + packageVersion;
+    createDummyPackage(cacheDirectory, directoryName);
+  }
+
+  private static void createDummyPackage(File cacheDirectory, String directoryName) throws IOException {
+    File packageDirectory = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), directoryName);
+    packageDirectory.mkdirs();
+
+    File dummyContentFile = ManagedFileAccess.file(packageDirectory.getAbsolutePath(), "dummy.txt");
+    FileWriter wr = new FileWriter(dummyContentFile);
+    wr.write("Ain't nobody here but us chickens");
+    wr.flush();
+    wr.close();
+  }
+
+  private void assertThatDummyTempExists(File cacheDirectory, String dummyTempPackage) throws IOException {
+    File dummyTempDirectory = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), dummyTempPackage);
+    assertThat(dummyTempDirectory).exists();
+
+    File dummyContentFile = ManagedFileAccess.file(dummyTempDirectory.getAbsolutePath(), "dummy.txt");
+    assertThat(dummyContentFile).exists();
+  }
+
+  @Test
+  public void testCreatesIniIfDoesntExist() throws IOException {
+    File cacheDirectory = ManagedFileAccess.fromPath(Files.createTempDirectory("fpcm-multithreadingTest"));
+    File cacheIni = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), "packages.ini");
+
+    createDummyPackage(cacheDirectory, "example.fhir.uv.myig", "1.2.3");
+
+    String dummyTempPackage = UUID.randomUUID().toString().toLowerCase();
+    createDummyTemp(cacheDirectory, dummyTempPackage);
+    assertThatDummyTempExists(cacheDirectory, dummyTempPackage);
+
+    assertThat(cacheIni).doesNotExist();
+    FilesystemPackageCacheManager filesystemPackageCacheManager = new FilesystemPackageCacheManager.Builder().withCacheFolder(cacheDirectory.getAbsolutePath()).build();
+    assertInitializedTestCacheIsValid(cacheDirectory);
+  }
+
+
+
+  @Test
+  public void testModifiesIniIfVersionIsWrong() throws IOException {
+    File cacheDirectory = ManagedFileAccess.fromPath(Files.createTempDirectory("fpcm-multithreadingTest"));
+    File cacheIni = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), "packages.ini");
+
+    createDummyPackage(cacheDirectory, "example.fhir.uv.myig", "1.2.3");
+    String dummyTempPackage = UUID.randomUUID().toString().toLowerCase();
+    createDummyTemp(cacheDirectory, dummyTempPackage);
+    assertThatDummyTempExists(cacheDirectory, dummyTempPackage);
+
+
+    IniFile ini = new IniFile(cacheIni.getAbsolutePath());
+    ini.setStringProperty("cache", "version", "2", null);
+    ini.save();
+
+    assertThat(cacheIni).exists();
+    FilesystemPackageCacheManager filesystemPackageCacheManager = new FilesystemPackageCacheManager.Builder().withCacheFolder(cacheDirectory.getAbsolutePath()).build();
+    assertInitializedTestCacheIsValid(cacheDirectory);
+  }
+
+  private void assertInitializedTestCacheIsValid(File cacheDirectory) throws IOException {
+    assertThat(cacheDirectory).exists();
+    File iniFile = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), "packages.ini");
+    assertThat(ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), "packages.ini")).exists();
+    IniFile ini = new IniFile(iniFile.getAbsolutePath());
+    String version = ini.getStringProperty("cache", "version");
+    assertThat(version).isEqualTo("3");
+
+    // Check that only packages.ini and our dummy package are in the cache. Our previous temp should be deleted.
+    File[] files = cacheDirectory.listFiles();
+    assertThat(files).hasSize(2); // packages.ini and example.fhir.uv.myig#1.2.3 (directory)
+
+    File dummyPackage = ManagedFileAccess.file(cacheDirectory.getAbsolutePath(), "example.fhir.uv.myig#1.2.3");
+    assertThat(dummyPackage).exists();
+
+    File dummyContentFile = ManagedFileAccess.file(dummyPackage.getAbsolutePath(), "dummy.txt");
+    assertThat(dummyContentFile).exists();
   }
 
   @MethodSource("packageCacheMultiThreadTestParams")


### PR DESCRIPTION
Cache was being cleared on initialization when the packages.ini file was found to be non-existent, or an older version.

Since the packages.ini is not generated by other tools (firely, etc), this was causing the cache to be cleared of any packages they installed. 

The only case in which the cache should be cleared is if the package cache version contained in packages.ini exists and is older than the current version. 