### PR TITLE
add missing description to ci-build package entry

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageList.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageList.java
@@ -290,6 +290,7 @@ public class PackageList {
     }
     cibuild = new PackageListEntry(new JsonObject());
     cibuild.init(version, path, status, status, null);
+    cibuild.describe(desc, null, null);
     json.getJsonArray("list").add(0, cibuild.json);    
   }
 


### PR DESCRIPTION
Creation of a new PackageList was failing to set the description of the ci-bulid entry despite the description parameter being provided.

Now calling PackageListEntry.describe() on the new entry.