### PR TITLE
Workaround for ghcr rate limiting of trivy db downloads

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,6 +18,10 @@ jobs:
 
       - name: Run static analysis
         uses: aquasecurity/trivy-action@master
+        env:
+          # temporary workaround for rate limiting on github
+          TRVIY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRVIY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: 'fs'
           vuln-type: 'library'
@@ -26,13 +30,12 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
-          # temporary workaround for rate limiting on github
-          db-repository: public.ecr.aws/aquasecurity/trivy-db
-          java-db-repository: public.ecr.aws/aquasecurity/trivy-java-db
+
+
 
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'Trivy-security-scan'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run static analysis
         uses: aquasecurity/trivy-action@master
         env:
-          # temporary workaround for rate limiting on github
+          # Workaround for rate limiting on ghcr. Use these two entries for ghcr related TOOMANYREQUESTS errors.
           TRVIY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRVIY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,9 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,HIGH,CRITICAL'
+          # temporary workaround for rate limiting on github
+          db-repository: public.ecr.aws/aquasecurity/trivy-db
+          java-db-repository: public.ecr.aws/aquasecurity/trivy-java-db
 
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run static analysis
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
This is a workaround for errors received attempting to run Trivy security checks:

Example failure: https://github.com/hapifhir/org.hl7.fhir.core/actions/runs/11217339160/job/31178674463
```
init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 1.055926ms, allowed: 44000/minute
```

The workaround is explained here: https://github.com/orgs/community/discussions/139074