### PR TITLE
fhirpath `tostring` implementation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ To skip unit tests:
 ```
 mvn -Dmaven.test.skip install
 ```
+> **Note:** If you're on Windows and use PowerShell, The `-` needs to be escaped with a backtick (`)
+> ```
+> mvn `-Dmaven.test.skip install
+> ``` 
 
 To clean and rebuild the terminology server caches:
 

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
@@ -4817,7 +4817,15 @@ public class FHIRPathEngine {
 
   private List<Base> funcToString(ExecutionContext context, List<Base> focus, ExpressionNode exp) {
     List<Base> result = new ArrayList<Base>();
-    result.add(new StringType(convertToString(focus)).noExtensions());
+    for (Base item : focus) {
+      String value = convertToString(item);
+      if (value != null)
+        result.add(new StringType(value).noExtensions());
+    }
+
+    if (result.size() > 1) {
+      throw makeException(exp, I18nConstants.FHIRPATH_NO_COLLECTION, "toString", result.size());
+    }
     return result;
   }
 

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
@@ -4820,7 +4820,15 @@ public class FHIRPathEngine {
 
   private List<Base> funcToString(ExecutionContext context, List<Base> focus, ExpressionNode exp) {
     List<Base> result = new ArrayList<Base>();
-    result.add(new StringType(convertToString(focus)).noExtensions());
+    for (Base item : focus) {
+      String value = convertToString(item);
+      if (value != null)
+        result.add(new StringType(value).noExtensions());
+    }
+
+    if (result.size() > 1) {
+      throw makeException(exp, I18nConstants.FHIRPATH_NO_COLLECTION, "toString", result.size());
+    }
     return result;
   }
 

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/FHIRPathTests.java
@@ -336,4 +336,23 @@ public class FHIRPathTests {
     assertEquals(1, results.size());
     assertEquals("123", results.get(0).toString());
   }
+
+  @Test
+  public void testEvaluate_ToStringOnDateValue() {
+    Patient input = new Patient();
+    var dtv = new DateType("2024");
+    input.setBirthDateElement(dtv);
+    List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
+    assertEquals(1, results.size());
+    assertEquals("2024", results.get(0).toString());
+  }
+
+  @Test
+  public void testEvaluate_ToStringOnExtensionOnlyValue() {
+    Patient input = new Patient();
+    var dtv = new DateType();
+    input.setBirthDateElement(dtv);
+    List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
+    assertEquals(0, results.size());
+  }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -4929,7 +4929,15 @@ public class FHIRPathEngine {
 
   private List<Base> funcToString(ExecutionContext context, List<Base> focus, ExpressionNode exp) {
     List<Base> result = new ArrayList<Base>();
-    result.add(new StringType(convertToString(focus)).noExtensions());
+    for (Base item : focus) {
+      String value = convertToString(item);
+      if (value != null)
+        result.add(new StringType(value).noExtensions());
+    }
+
+    if (result.size() > 1) {
+      throw makeException(exp, I18nConstants.FHIRPATH_NO_COLLECTION, "toString", result.size());
+    }
     return result;
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -337,4 +337,23 @@ public class FHIRPathTests {
     assertEquals(1, results.size());
     assertEquals("123", results.get(0).toString());
   }
+
+  @Test
+  public void testEvaluate_ToStringOnDateValue() {
+    Patient input = new Patient();
+    var dtv = new DateType("2024");
+    input.setBirthDateElement(dtv);
+    List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
+    assertEquals(1, results.size());
+    assertEquals("2024", results.get(0).toString());
+  }
+
+  @Test
+  public void testEvaluate_ToStringOnExtensionOnlyValue() {
+    Patient input = new Patient();
+    var dtv = new DateType();
+    input.setBirthDateElement(dtv);
+    List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
+    assertEquals(0, results.size());
+  }
 }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -262,7 +262,7 @@ public class FHIRPathTests {
 
       List<Element> expected = new ArrayList<Element>();
       XMLUtil.getNamedChildren(test, "output", expected);
-      assertEquals(outcome.size(), expected.size(), String.format("Expected %d objects but found %d for expression %s", expected.size(), outcome.size(), expression));
+      assertEquals(expected.size(), outcome.size(), String.format("Expected %d objects but found %d for expression %s", expected.size(), outcome.size(), expression));
       if ("false".equals(test.getAttribute("ordered"))) {
         for (int i = 0; i < Math.min(outcome.size(), expected.size()); i++) {
           String tn = outcome.get(i).fhirType();


### PR DESCRIPTION
Update the implementation of the `toString` fhirpath function to: **(pending FHIR-48737 decision)**
* not return the text 'null' when no primitive value exists (when extension only)
* throw an error if more than 1 item is to be returned (doesn't support collections)
* return an empty set when no primitive values exist (when extension only)

Applied to the R4, R4B and R5 fhirpath engines.
Includes a unit to test the results

Also some readme notes for windows developers and a fix for the output of a unit test message.