### PR TITLE
Fix deprecated discriminator type warning message

### DIFF
--- a/org.hl7.fhir.utilities/src/main/resources/Messages.properties
+++ b/org.hl7.fhir.utilities/src/main/resources/Messages.properties
@@ -1153,7 +1153,7 @@ CODESYSTEM_CS_COMPLETE_AND_EMPTY = When a CodeSystem has content = ''complete'',
 VALIDATION_VAL_VERSION_NOHASH = Version ''{0}'' contains a ''#'', which as this character is used in some URLs to separate the version and the fragment id. When version does include '#', systems will not be able to parse the URL
 PRIMITIVE_TOO_SHORT = Value ''{0}'' is shorter than permitted minimum length of {1}
 CANONICAL_MULTIPLE_VERSIONS_KNOWN = The version {2} for the {0} {1} is not known. These versions are known: {3}
-SD_PATH_SLICING_DEPRECATED = The discriminator type ''{0}'' has been deprecated. Use type=fixed with a pattern[x] instead
+SD_PATH_SLICING_DEPRECATED = The discriminator type ''{0}'' has been deprecated. Use type=value with a pattern[x] instead
 SD_PATH_NOT_VALID = The discriminator path ''{0}'' does not appear to be valid for the element that is being sliced ''{1}''
 SD_PATH_ERROR = The discriminator path ''{0}'' does not appear to be valid for the element that is being sliced ''{1}'': {2}
 


### PR DESCRIPTION
The warning related to the deprecated `pattern` discriminator type incorrectly said to use `type=fixed`, but `fixed` is not a valid discriminator type. This PR corrects it so it says to use `type=value`.