### PR TITLE
Remove IPS NZ support

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -287,19 +287,6 @@ public class ValidatorCli {
         res.add("-bundle");
         res.add("Composition:0");
         res.add("http://hl7.org.au/fhir/ips/StructureDefinition/Composition-au-ips");
-      } else if (a.equals("-ips:nz")) {
-        res.add("-version");
-        res.add("4.0");
-        res.add("-check-ips-codes");
-        res.add("-ig");
-        res.add("tewhatuora.fhir.nzps#current");
-        res.add("-profile");
-        res.add("https://standards.digital.health.nz/fhir/StructureDefinition/nzps-bundle");
-        res.add("-extension");
-        res.add("any");
-        res.add("-bundle");
-        res.add("Composition:0");
-        res.add("https://standards.digital.health.nz/fhir/StructureDefinition/nzps-composition");
       } else if (a.equals("-ips#")) {
         res.add("-version");
         res.add("4.0");


### PR DESCRIPTION
IPS NZ is no longer being maintained, so the CLI param to automatically set up IPS NZ validation is no longer needed.