### PR TITLE
fix: also resolve Resources in Context via id

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -2208,6 +2208,8 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
               if (version == null || version == r.getResource().getMeta().getVersionId()) {
                 return (T) r.getResource();
               }
+            } else if(uri.equals(r.getResource() != null ? r.getResource().getResourceType().name() + "/" + r.getResource().getId() : null)) {
+                return (T) r.getResource();
             }
           }            
         }


### PR DESCRIPTION
This PR tries to fix the validation error caused by resolve() not resolving resources by id in the ValidationContext (WorkerContext)

TestCase: https://github.com/FHIR/fhir-test-cases/pull/206