### PR TITLE
Fix issue 1848

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -168,6 +168,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
   protected final String TYPE = "type";
   protected final String BUNDLE = "Bundle";
   protected final String LAST_UPDATED = "lastUpdated";
+  protected final String VERSION_ID = "versionId";
 
   protected BaseValidator parent;
   protected IWorkerContext context;
@@ -1054,6 +1055,16 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
             if (list == null) {
               list = new ArrayList<Element>();
               relMap.put(rl, list);
+              boolean versionIdPresent = resource.hasChild(META, false)
+                && resource.getNamedChild(META, false).hasChild(VERSION_ID, false)
+                && resource.getNamedChild(META, false).getNamedChild(VERSION_ID, false).hasValue();
+              if (versionIdPresent){
+                String versionId = resource.getNamedChild(META).getNamedChild(VERSION_ID).getValue();
+                String fullUrlVersioned = fu + "/_history/" + versionId;
+                String relativePathVersioned = rl + "/_history/" + versionId;
+                relMap.put(relativePathVersioned, list);
+                map.put(fullUrlVersioned, list);
+              }
             }
             list.add(entry);
           }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -1049,24 +1049,39 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
         if (resource != null) {
           String et = resource.getType();
           String eid = resource.getNamedChildValue(ID, false);
+          String rl = null;
           if (eid != null) {
-            String rl = et+"/"+eid;
+            rl = et+"/"+eid;
             list = relMap.get(rl);
             if (list == null) {
               list = new ArrayList<Element>();
               relMap.put(rl, list);
-              boolean versionIdPresent = resource.hasChild(META, false)
-                && resource.getNamedChild(META, false).hasChild(VERSION_ID, false)
-                && resource.getNamedChild(META, false).getNamedChild(VERSION_ID, false).hasValue();
-              if (versionIdPresent){
-                String versionId = resource.getNamedChild(META).getNamedChild(VERSION_ID).getValue();
-                String fullUrlVersioned = fu + "/_history/" + versionId;
-                String relativePathVersioned = rl + "/_history/" + versionId;
-                relMap.put(relativePathVersioned, list);
-                map.put(fullUrlVersioned, list);
-              }
             }
             list.add(entry);
+          }
+          boolean versionIdPresent = resource.hasChild(META, false)
+            && resource.getNamedChild(META, false).hasChild(VERSION_ID, false)
+            && resource.getNamedChild(META, false).getNamedChild(VERSION_ID, false).hasValue();
+          if (versionIdPresent){
+            String versionId = resource.getNamedChild(META).getNamedChild(VERSION_ID).getValue();
+            String fullUrlVersioned = fu + "/_history/" + versionId;
+            List<Element> listMapVersioned = null;
+            listMapVersioned = map.get(fullUrlVersioned);
+            if (listMapVersioned == null) {
+              listMapVersioned = new ArrayList<Element>();
+              map.put(fullUrlVersioned, listMapVersioned);
+            }
+            listMapVersioned.add(entry);
+            if (rl != null) {
+              String relativePathVersioned = rl + "/_history/" + versionId;
+              List<Element> listRelMapVersioned = null;
+              listRelMapVersioned = relMap.get(relativePathVersioned);
+              if (listRelMapVersioned == null) {
+                listRelMapVersioned = new ArrayList<Element>();
+                relMap.put(relativePathVersioned, listRelMapVersioned);
+              }
+              listRelMapVersioned.add(entry);
+            }
           }
         }
       }      


### PR DESCRIPTION
Adds the versioned reference to a resource (if meta.versionID is present) to the maps used to resolve entries in the bundle. 

Resolves #1848