### PR TITLE
Output type triple for any [x] property.

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -424,7 +424,7 @@ public class TurtleParser extends ParserBase {
 	  } else {
 	    t = ctxt.linkedPredicate("fhir:"+en, linkResolver == null ? null : linkResolver.resolveProperty(element.getProperty()), comment, element.getProperty().isList());
 	  }
-	if (element.getProperty().getName().endsWith("[x]") && !element.hasValue()) {
+	if (element.getProperty().getName().endsWith("[x]")) {
 	  t.linkedPredicate("a", "fhir:" + element.fhirType(), linkResolver == null ? null : linkResolver.resolveType(element.fhirType()), null);
 	}
     if (element.getSpecial() != null)


### PR DESCRIPTION
Fixes https://github.com/w3c/hcls-fhir-rdf/issues/122

I attached a diff of the result to all FHIR examples after applying this change.
[issue-122-diff.txt](https://github.com/user-attachments/files/18101341/issue-122-diff.txt)
