### PR TITLE
Output rdf:XMLLiteral datatype for div text in Turtle format

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -323,6 +323,7 @@ public class TurtleParser extends ParserBase {
     }
     
     ttl.prefix("fhir", FHIR_URI_BASE);
+    ttl.prefix("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
     ttl.prefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
     ttl.prefix("owl", "http://www.w3.org/2002/07/owl#");
     ttl.prefix("xsd", "http://www.w3.org/2001/XMLSchema#");
@@ -511,6 +512,8 @@ public class TurtleParser extends ParserBase {
       xst = "^^xsd:base64Binary";
     else if (type.equals("canonical") || type.equals("oid") || type.equals("uri") || type.equals("url") || type.equals("uuid"))
   	  xst = "^^xsd:anyURI";
+    else if (type.equals("xhtml"))
+      xst = "^^rdf:XMLLiteral";
     else if (type.equals("instant"))
       xst = "^^xsd:dateTime";
     else if (type.equals("time"))


### PR DESCRIPTION
Fixes https://github.com/w3c/hcls-fhir-rdf/issues/119

I attached a diff of the result to all FHIR examples after applying this change.
[issue-119-diff.txt.zip](https://github.com/user-attachments/files/18103452/issue-119-diff.txt.zip)
