### PR TITLE
If a base is not provided for Turtle generation, default to the fhir namespace

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -309,12 +309,15 @@ public class TurtleParser extends ParserBase {
   
   @Override
   public void compose(Element e, OutputStream stream, OutputStyle style, String base) throws IOException, FHIRException {
-    this.base = base;
+	if (base != null) {
+		this.base = base;	
+	} else {
+		this.base = "http://hl7.org/fhir/";
+	}
     this.style = style;
-    
-		Turtle ttl = new Turtle();
-		compose(e, ttl, base);
-		ttl.commit(stream, false);
+	Turtle ttl = new Turtle();
+	compose(e, ttl, base);
+	ttl.commit(stream, false);
   }
 
   public void compose(Element e, Turtle ttl, String base) throws FHIRException {


### PR DESCRIPTION
This matches the RDF output found in the R4 Turtle examples, rather than using a blank node for the main resource. This also fixes output of missing `fhir:link` values (fixes https://github.com/w3c/hcls-fhir-rdf/issues/121).

I attached a diff of the output for all FHIR examples: 
[issue-121-diff.txt](https://github.com/user-attachments/files/18116246/issue-121-diff.txt)

I am also attaching a folder of all the Turtle outputs from this change:
[fhir-examples-out-issue-121.zip](https://github.com/user-attachments/files/18116258/fhir-examples-out-issue-121.zip)
