### PR TITLE
Rename http.disabled + refactor proxy setting

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/JavaSystemProxyParamSetter.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/JavaSystemProxyParamSetter.java
@@ -1,0 +1,65 @@
+package org.hl7.fhir.validation;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+public class JavaSystemProxyParamSetter {
+
+  public static final String HTTP_PROXY_HOST = "http.proxyHost";
+  public static final String HTTP_PROXY_PORT = "http.proxyPort";
+
+  public static final String HTTPS_PROXY_HOST = "https.proxyHost";
+
+  public static final String HTTPS_PROXY_PORT = "https.proxyPort";
+  public static final String HTTP_PROXY_USER = "http.proxyUser";
+  public static final String HTTP_PROXY_PASS = "http.proxyPassword";
+  public static final String JAVA_DISABLED_TUNNELING_SCHEMES = "jdk.http.auth.tunneling.disabledSchemes";
+  public static final String JAVA_DISABLED_PROXY_SCHEMES = "jdk.http.auth.proxying.disabledSchemes";
+  public static final String JAVA_USE_SYSTEM_PROXIES = "java.net.useSystemProxies";
+
+  protected static void setJavaSystemProxyParams(String proxy, String httpsProxy, String proxyAuth) {
+    setProxyHostSystemProperties(proxy, HTTP_PROXY_HOST, HTTP_PROXY_PORT);
+    setProxyHostSystemProperties(httpsProxy, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT);
+
+    if (proxyAuth != null) {
+      assert proxy != null || httpsProxy != null: "Cannot set PROXY_AUTH without setting PROXY...";
+      String[] p = proxyAuth.split(":");
+      String authUser = p[0];
+      String authPass = p[1];
+
+      /*
+       * For authentication, use java.net.Authenticator to set proxy's configuration and set the system properties
+       * http.proxyUser and http.proxyPassword
+       */
+      Authenticator.setDefault(
+        new Authenticator() {
+          @Override
+          public PasswordAuthentication getPasswordAuthentication() {
+            return new PasswordAuthentication(authUser, authPass.toCharArray());
+          }
+        }
+      );
+
+      System.setProperty(HTTP_PROXY_USER, authUser);
+      System.setProperty(HTTP_PROXY_PASS, authPass);
+      System.setProperty(JAVA_USE_SYSTEM_PROXIES, "true");
+
+      /*
+       * For Java 1.8 and higher you must set
+       * -Djdk.http.auth.tunneling.disabledSchemes=
+       * to make proxies with Basic Authorization working with https along with Authenticator
+       */
+      System.setProperty(JAVA_DISABLED_TUNNELING_SCHEMES, "");
+      System.setProperty(JAVA_DISABLED_PROXY_SCHEMES, "");
+    }
+  }
+
+  protected static void setProxyHostSystemProperties(String proxy, String httpProxyHostProperty, String httpProxyPortProperty) {
+    if (proxy != null) {
+      String[] p2 = proxy.split(":");
+
+      System.setProperty(httpProxyHostProperty, p2[0]);
+      System.setProperty(httpProxyPortProperty, p2[1]);
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -100,8 +100,6 @@ import org.hl7.fhir.validation.cli.utils.Params;
  */
 public class ValidatorCli {
 
-private static final String NO_WEB_ACCESS = "http.disabled";
-
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
   public static final String HTTP_PROXY_PORT = "http.proxyPort";
 
@@ -158,7 +156,9 @@ private static final String NO_WEB_ACCESS = "http.disabled";
     if (cliContext.getLocale() != null) {
       Locale.setDefault(cliContext.getLocale());
     }
-
+    if (Params.hasParam(args, Params.NO_HTTP_ACCESS)) {
+      ManagedWebAccess.setAccessPolicy(WebAccessPolicy.PROHIBITED);
+    }
     setJavaSystemProxyParamsFromParams(args);
 
     Display.displayVersion(System.out);
@@ -228,10 +228,7 @@ private static final String NO_WEB_ACCESS = "http.disabled";
   }
 
   private static void setJavaSystemProxyParamsFromParams(String[] args) {
-
-    if (Params.hasParam(args, NO_WEB_ACCESS)) {
-      ManagedWebAccess.setAccessPolicy(WebAccessPolicy.PROHIBITED);
-    }
+    
     setJavaSystemProxyHostFromParams(args, Params.PROXY, HTTP_PROXY_HOST, HTTP_PROXY_PORT);
     setJavaSystemProxyHostFromParams(args, Params.HTTPS_PROXY, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT);
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidatorCli.java
@@ -1,7 +1,5 @@
 package org.hl7.fhir.validation;
 
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -99,18 +97,6 @@ import org.hl7.fhir.validation.cli.utils.Params;
  * @author Grahame
  */
 public class ValidatorCli {
-
-  public static final String HTTP_PROXY_HOST = "http.proxyHost";
-  public static final String HTTP_PROXY_PORT = "http.proxyPort";
-
-  public static final String HTTPS_PROXY_HOST = "https.proxyHost";
-
-  public static final String HTTPS_PROXY_PORT = "https.proxyPort";
-  public static final String HTTP_PROXY_USER = "http.proxyUser";
-  public static final String HTTP_PROXY_PASS = "http.proxyPassword";
-  public static final String JAVA_DISABLED_TUNNELING_SCHEMES = "jdk.http.auth.tunneling.disabledSchemes";
-  public static final String JAVA_DISABLED_PROXY_SCHEMES = "jdk.http.auth.proxying.disabledSchemes";
-  public static final String JAVA_USE_SYSTEM_PROXIES = "java.net.useSystemProxies";
 
   private final static ValidationService validationService = new ValidationService();
   
@@ -228,52 +214,11 @@ public class ValidatorCli {
   }
 
   private static void setJavaSystemProxyParamsFromParams(String[] args) {
-    
-    setJavaSystemProxyHostFromParams(args, Params.PROXY, HTTP_PROXY_HOST, HTTP_PROXY_PORT);
-    setJavaSystemProxyHostFromParams(args, Params.HTTPS_PROXY, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT);
 
-    if (Params.hasParam(args, Params.PROXY_AUTH)) {
-      assert Params.getParam(args, Params.PROXY) != null : "Cannot set PROXY_AUTH without setting PROXY...";
-      assert Params.getParam(args, Params.PROXY_AUTH) != null : "PROXY_AUTH arg passed in was NULL...";
-      String[] p = Params.getParam(args, Params.PROXY_AUTH).split(":");
-      String authUser = p[0];
-      String authPass = p[1];
-
-      /*
-       * For authentication, use java.net.Authenticator to set proxy's configuration and set the system properties
-       * http.proxyUser and http.proxyPassword
-       */
-      Authenticator.setDefault(
-        new Authenticator() {
-          @Override
-          public PasswordAuthentication getPasswordAuthentication() {
-            return new PasswordAuthentication(authUser, authPass.toCharArray());
-          }
-        }
-      );
-
-      System.setProperty(HTTP_PROXY_USER, authUser);
-      System.setProperty(HTTP_PROXY_PASS, authPass);
-      System.setProperty(JAVA_USE_SYSTEM_PROXIES, "true");
-
-      /*
-       * For Java 1.8 and higher you must set
-       * -Djdk.http.auth.tunneling.disabledSchemes=
-       * to make proxies with Basic Authorization working with https along with Authenticator
-       */
-      System.setProperty(JAVA_DISABLED_TUNNELING_SCHEMES, "");
-      System.setProperty(JAVA_DISABLED_PROXY_SCHEMES, "");
-    }
-  }
-
-  private static void setJavaSystemProxyHostFromParams(String[] args, String proxyParam, String proxyHostProperty, String proxyPortProperty) {
-    if (Params.hasParam(args, proxyParam)) {
-      assert Params.getParam(args, proxyParam) != null : "PROXY arg passed in was NULL";
-      String[] p = Params.getParam(args, proxyParam).split(":");
-
-      System.setProperty(proxyHostProperty, p[0]);
-      System.setProperty(proxyPortProperty, p[1]);
-    }
+    final String proxy = Params.hasParam(args, Params.PROXY) ? Params.getParam(args, Params.PROXY) : null;
+    final String httpsProxy = Params.hasParam(args, Params.HTTPS_PROXY) ? Params.getParam(args, Params.HTTPS_PROXY) : null;
+    final String proxyAuth = Params.hasParam(args, Params.PROXY_AUTH) ? Params.getParam(args, Params.PROXY_AUTH) : null;
+    JavaSystemProxyParamSetter.setJavaSystemProxyParams(proxy, httpsProxy, proxyAuth);
   }
 
   private static String[] addAdditionalParamsForIpsParam(String[] args) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/utils/Params.java
@@ -135,6 +135,7 @@ public class Params {
   private static final String WATCH_MODE_PARAM = "-watch-mode";
   private static final String WATCH_SCAN_DELAY = "-watch-scan-delay";
   private static final String WATCH_SETTLE_TIME = "-watch-settle-time";
+  public static final String NO_HTTP_ACCESS = "-no-http-access";
 
   /**
    * Checks the list of passed in params to see if it contains the passed in param.

--- a/org.hl7.fhir.validation/src/main/resources/help/help.txt
+++ b/org.hl7.fhir.validation/src/main/resources/help/help.txt
@@ -109,7 +109,10 @@ The following parameters are supported:
     from the URL
 -security-checks: If present, check that string content doesn't include any html
     -like tags that might create problems downstream (though all external input
-    must always be santized by escaping for either html or sql)
+    must always be sanitized by escaping for either html or sql)
+-no-http-access: If present, the validator will not attempt to make connections
+    to the web via http or https. If you do not have all IGs, structure
+    definitions, etc. provided locally, this may result in unexpected failures.
 
 The validator also supports the param -proxy=[address]:[port] for if you use a
 proxy


### PR DESCRIPTION
The CLI param for disabling http access is now renamed to better match the naming patterns of existing CLI params.

In addition, the somewhat confusing and very Java-specific proxy code has been moved to its own class.