### PR TITLE
Fix copy of BaseWorkerContext.libraries into itself

### DIFF
--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/context/BaseWorkerContext.java
@@ -287,7 +287,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       guides.copy(other.guides);
       capstmts.copy(other.capstmts);
       measures.copy(other.measures);
-      libraries.copy(libraries);
+      libraries.copy(other.libraries);
 
       allowLoadingDuplicates = other.allowLoadingDuplicates;
       tsServer = other.tsServer;

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -401,7 +401,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       guides.copy(other.guides);
       capstmts.copy(other.capstmts);
       measures.copy(other.measures);
-      libraries.copy(libraries);
+      libraries.copy(other.libraries);
 
       allowLoadingDuplicates = other.allowLoadingDuplicates;
       name = other.name;


### PR DESCRIPTION
There's a typo in `BaseWorkerContext` in R4B and R5, the `copy` method will copy the `libraries` field into itself instead of copying from the `other` instance.