### PR TITLE
Handle hashes

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
@@ -5483,7 +5483,7 @@ public class FHIRPathEngine {
           Property p = context.rootResource.getChildByName("contained");
           if (p != null) {
             for (Base c : p.getValues()) {
-              if (t.equals(c.getIdBase())) {
+              if (chompHash(s).equals(chompHash(c.getIdBase()))) {
                 res = c;
                 break;
               }
@@ -5505,7 +5505,19 @@ public class FHIRPathEngine {
     return result;
   }
 
-  private List<Base> funcExtension(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
+  /**
+   * Strips a leading hashmark (#) if present at the start of a string
+   */
+  private String chompHash(String theId) {
+    String retVal = theId;
+    while (retVal.startsWith("#")) {
+      retVal = retVal.substring(1);
+    }
+    return retVal;
+  }
+
+  private List<Base> funcExtension(ExecutionContext context, List<Base> focus, ExpressionNode exp)
+      throws FHIRException {
     List<Base> result = new ArrayList<Base>();
     List<Base> nl = execute(context, focus, exp.getParameters().get(0), true);
     String url = nl.get(0).primitiveValue();

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
@@ -6671,4 +6671,5 @@ public class FHIRPathEngine {
   public void setAllowDoubleQuotes(boolean allowDoubleQuotes) {
     this.allowDoubleQuotes = allowDoubleQuotes;    
   }
+
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -5485,7 +5485,7 @@ public class FHIRPathEngine {
           Property p = context.rootResource.getChildByName("contained");
           if (p != null) {
             for (Base c : p.getValues()) {
-              if (t.equals(c.getIdBase())) {
+              if (chompHash(s).equals(chompHash(c.getIdBase()))) {
                 res = c;
                 break;
               }
@@ -6929,5 +6929,16 @@ public class FHIRPathEngine {
   public void setEmitSQLonFHIRWarning(boolean emitSQLonFHIRWarning) {
     this.emitSQLonFHIRWarning = emitSQLonFHIRWarning;
   }
-  
+
+  /**
+   * Strips a leading hashmark (#) if present at the start of a string
+   */
+  private String chompHash(String theId) {
+    String retVal = theId;
+    while (retVal.startsWith("#")) {
+      retVal = retVal.substring(1);
+    }
+    return retVal;
+  }
+
 }


### PR DESCRIPTION
Handle FHIRPath `resolve()` function when contained resource IDs include hash mark (as is the case from HAPI's base parser)