### PR TITLE
FhirPath parser fix for bug in Line numbering during parsing

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRLexer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRLexer.java
@@ -321,7 +321,8 @@ public class FHIRLexer {
       } else if (Utilities.isWhitespace(source.charAt(cursor))) {
         last13 = currentLocation.checkChar(source.charAt(cursor), last13);
         cursor++;
-        currentLocation.incColumn();
+        // checkChar increments the position
+        // currentLocation.incColumn();
       } else {
         done = true;
       }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathParserTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathParserTests.java
@@ -1,0 +1,158 @@
+package org.hl7.fhir.r5.test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FHIRPathParserTests {
+
+  private static FHIRPathEngine fp;
+  private static SimpleWorkerContext context;
+
+  @BeforeAll
+  public static void setUp() throws FileNotFoundException, FHIRException, IOException {
+    context = new SimpleWorkerContext((SimpleWorkerContext) TestingUtilities.getSharedWorkerContext());
+    if (fp == null) {
+      fp = new FHIRPathEngine(context);
+    }
+  }
+
+  @Test
+  void testFhirPathParserLexer1() {
+      var parseTree = fp.parse("true");
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer2() {
+      var parseTree = fp.parse(" true");
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(2, parseTree.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer3() {
+      var parseTree = fp.parse("\ntrue");
+      Assertions.assertEquals(2, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer4() {
+      var parseTree = fp.parse("\n  true");
+      Assertions.assertEquals(2, parseTree.getStart().getLine());
+      Assertions.assertEquals(3, parseTree.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer5() {
+      var parseTree = fp.parse("true and false");
+      // the true
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+
+      // the and
+      Assertions.assertEquals(1, parseTree.getOpStart().getLine());
+      Assertions.assertEquals(6, parseTree.getOpStart().getColumn());
+
+      // the false
+      var opFalse = parseTree.getOpNext();
+      Assertions.assertEquals(1, opFalse.getStart().getLine());
+      Assertions.assertEquals(10, opFalse.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer6() {
+      var parseTree = fp.parse("true and where(true)");
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+
+      Assertions.assertEquals(1, parseTree.getOpStart().getLine());
+      Assertions.assertEquals(6, parseTree.getOpStart().getColumn());
+
+      var opWhere = parseTree.getOpNext();
+      Assertions.assertEquals(1, opWhere.getStart().getLine());
+      Assertions.assertEquals(10, opWhere.getStart().getColumn());
+
+      // Check the where parameters
+      var opWhereArg = opWhere.getParameters().get(0);
+      Assertions.assertEquals(1, opWhereArg.getStart().getLine());
+      Assertions.assertEquals(16, opWhereArg.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer7() {
+      var parseTree = fp.parse("true and where(  true)");
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+
+      Assertions.assertEquals(1, parseTree.getOpStart().getLine());
+      Assertions.assertEquals(6, parseTree.getOpStart().getColumn());
+
+      var opWhere = parseTree.getOpNext();
+      Assertions.assertEquals(1, opWhere.getStart().getLine());
+      Assertions.assertEquals(10, opWhere.getStart().getColumn());
+
+      // Check the where parameters
+      var opWhereArg = opWhere.getParameters().get(0);
+      Assertions.assertEquals(1, opWhereArg.getStart().getLine());
+      Assertions.assertEquals(18, opWhereArg.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexer8() {
+      var parseTree = fp.parse("true and where(\n  true)");
+      Assertions.assertEquals(1, parseTree.getStart().getLine());
+      Assertions.assertEquals(1, parseTree.getStart().getColumn());
+
+      Assertions.assertEquals(1, parseTree.getOpStart().getLine());
+      Assertions.assertEquals(6, parseTree.getOpStart().getColumn());
+
+      var opWhere = parseTree.getOpNext();
+      Assertions.assertEquals(1, opWhere.getStart().getLine());
+      Assertions.assertEquals(10, opWhere.getStart().getColumn());
+
+      // Check the where parameters
+      var opWhereArg = opWhere.getParameters().get(0);
+      Assertions.assertEquals(2, opWhereArg.getStart().getLine());
+      Assertions.assertEquals(3, opWhereArg.getStart().getColumn());
+  }
+
+  @Test
+  void testFhirPathParserLexerComplex() {
+      var parseTree = fp.parse("\n numerator.where( code=  '[arb\\'U]' )");
+
+      // Check all the line numbering from the parse tree
+      // the numerator
+      var opNumerator = parseTree;
+      Assertions.assertEquals(2, opNumerator.getStart().getLine());
+      Assertions.assertEquals(2, opNumerator.getStart().getColumn());
+
+      // the where
+      var opWhere = opNumerator.getInner();
+      Assertions.assertEquals(2, opWhere.getStart().getLine());
+      Assertions.assertEquals(12, opWhere.getStart().getColumn());
+
+      // the code
+      var opCode = opWhere.getParameters().get(0);
+      Assertions.assertEquals(2, opCode.getStart().getLine());
+      Assertions.assertEquals(19, opCode.getStart().getColumn());
+
+      // the equality operator
+      Assertions.assertEquals(2, opCode.getOpStart().getLine());
+      Assertions.assertEquals(23, opCode.getOpStart().getColumn());
+
+      // the string value
+      var opString = opCode.getOpNext();
+      Assertions.assertEquals(2, opString.getStart().getLine());
+      Assertions.assertEquals(26, opString.getStart().getColumn());
+
+  }
+}


### PR DESCRIPTION
When parsing an expression like this:
```
true
   and
      where(   glarb =   'true')
```
The whitespace isn't counted correctly causing the start positions to be incorrect.
The parser double counts whitespace (effectively calling the incColumn twice for whitespace).
)
Also included unit tests to verify the functionality
