### PR TITLE
fix: add null check for derived definition in ProfileUtilities

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -2656,7 +2656,7 @@ public class ProfileUtilities {
       }
 
       if (derived.hasDefinitionElement()) {
-        if (derived.getDefinition().startsWith("..."))
+        if (derived.getDefinition() != null && derived.getDefinition().startsWith("..."))
           base.setDefinition(Utilities.appendDerivedTextToBase(base.getDefinition(), derived.getDefinition()));
         else if (!Base.compareDeep(derived.getDefinitionElement(), base.getDefinitionElement(), false)) {
           base.setDefinitionElement(derived.getDefinitionElement().copy());


### PR DESCRIPTION
This pull request includes a minor but important fix in the `ProfileUtilities` class to prevent potential `NullPointerException` issues when working with definitions.

### Bug Fix:
* [`org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java`](diffhunk://#diff-a27adb8a11d63e6114eca412d4118f84d9a8ae1eab4a07e903076130e5171ef3L2659-R2659): Updated the condition in `else if (derived.hasShortElement())` to check if `derived.getDefinition()` is not null before calling `.startsWith("...")`. This ensures safe handling of null values and prevents runtime errors.

fixes #1979