### PR TITLE
Fix OperationDefinition Validation check on outputProfile

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
@@ -35,7 +35,7 @@ public class OperationDefinitionValidator extends BaseValidator {
       ok = validateProfile(errors, stack.push(od.getNamedChild("inputProfile"), -1, null, null), od, od.getNamedChildValue("inputProfile"), "in") && ok;
     }
     if (od.hasChild("outputProfile")) {
-      ok = validateProfile(errors, stack.push(od.getNamedChild("inputProfile"), -1, null, null), od, od.getNamedChildValue("outputProfile"), "out") && ok;      
+      ok = validateProfile(errors, stack.push(od.getNamedChild("outputProfile"), -1, null, null), od, od.getNamedChildValue("outputProfile"), "out") && ok;      
     }
 
     return ok;


### PR DESCRIPTION
Fix a possible copy/paste issue in the OperationDefinition validation. The issue results in a failed build if an OperationDefinition has an outputProfile but no inputProfile (may not have an input parameter as is the case here: https://build.fhir.org/ig/HL7/davinci-pct/OperationDefinition-GFE-retrieve.html).

Build log example: https://build.fhir.org/ig/HL7/davinci-pct/branches/master/failure/build.log
**Relevant output from build**
Publishing Content Failed: Cannot invoke "org.hl7.fhir.r5.elementmodel.Element.getProperty()" because "element" is null (00:20.292 / 02:10.173, 2Gb)
                                                                                                     (00:00.000 / 02:10.173, 2Gb)
Use -? to get command line help                                                                      (00:00.000 / 02:10.173, 2Gb)
                                                                                                     (00:00.000 / 02:10.173, 2Gb)
Stack Dump (for debugging):                                                                          (00:00.000 / 02:10.173, 2Gb)
java.lang.NullPointerException: Cannot invoke "org.hl7.fhir.r5.elementmodel.Element.getProperty()" because "element" is null
	at org.hl7.fhir.validation.instance.utils.NodeStack.pushInternal(NodeStack.java:123)
	at org.hl7.fhir.validation.instance.utils.NodeStack.push(NodeStack.java:119)
	at org.hl7.fhir.validation.instance.type.OperationDefinitionValidator.validateOperationDefinition(OperationDefinitionValidator.java:38)
	at org.hl7.fhir.validation.instance.InstanceValidator.checkSpecials(InstanceValidator.java:6261)
	at org.hl7.fhir.validation.instance.InstanceValidator.startInner(InstanceValidator.java:6202)
	at org.hl7.fhir.validation.instance.InstanceValidator.start(InstanceValidator.java:5939)
	at org.hl7.fhir.validation.instance.InstanceValidator.validateResource(InstanceValidator.java:7923)
	at org.hl7.fhir.validation.instance.InstanceValidator.validate(InstanceValidator.java:1002)
	at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:8263)
	at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:8580)
	at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:6425)
	at org.hl7.fhir.igtools.publisher.Publisher.loadConformance2(Publisher.java:6372)
	at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:1224)
	at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:1083)
	at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:15399)