### PR TITLE
Subscription topic current rendering

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/SubscriptionTopicRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/SubscriptionTopicRenderer.java
@@ -65,7 +65,7 @@ public class SubscriptionTopicRenderer extends ResourceRenderer {
             md.append(context.formatPhrase(RenderingContext.SUB_TOPIC_CREATE, qc.primitiveValue("resultForCreate")+"\r\n")+" ");
           }
           if (qc.has("current")) {
-            md.append(context.formatPhrase(RenderingContext.SUB_TOPIC_CREATE, qc.primitiveValue("current")+"\r\n")+" ");
+            md.append(context.formatPhrase(RenderingContext.SUB_TOPIC_CURR, qc.primitiveValue("current")+"\r\n")+" ");
           }
           if (qc.has("previous")) {
             md.append(context.formatPhrase(RenderingContext.SUB_TOPIC_DELETE, qc.primitiveValue("resultForDelete")+"\r\n")+" ");

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/RenderingI18nContext.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/RenderingI18nContext.java
@@ -804,6 +804,7 @@ public class RenderingI18nContext extends I18nBase {
   public static final String SUB_TOPIC_FILT_PAR = "SUB_TOPIC_FILT_PAR";
   public static final String SUB_TOPIC_INCL = "SUB_TOPIC_INCL";
   public static final String SUB_TOPIC_INT = "SUB_TOPIC_INT";
+  public static final String SUB_TOPIC_CURR = "SUB_TOPIC_CURR";
   public static final String SUB_TOPIC_PREV = "SUB_TOPIC_PREV";
   public static final String SUB_TOPIC_REQ = "SUB_TOPIC_REQ";
   public static final String SUB_TOPIC_RES_TRIG = "SUB_TOPIC_RES_TRIG";

--- a/org.hl7.fhir.utilities/src/main/resources/rendering-phrases.properties
+++ b/org.hl7.fhir.utilities/src/main/resources/rendering-phrases.properties
@@ -793,6 +793,7 @@ SUB_TOPIC_FILT_DEF = Filter Definition
 SUB_TOPIC_FILT_PAR = Filter Parameter
 SUB_TOPIC_INCL = Includes
 SUB_TOPIC_INT = Interactions
+SUB_TOPIC_CURR = * current = {0}
 SUB_TOPIC_PREV = * previous = {0}
 SUB_TOPIC_REQ = * require both = {0}
 SUB_TOPIC_RES_TRIG = Resource Triggers

--- a/org.hl7.fhir.utilities/src/main/resources/rendering-phrases_nl.properties
+++ b/org.hl7.fhir.utilities/src/main/resources/rendering-phrases_nl.properties
@@ -798,6 +798,7 @@ SUB_TOPIC_FILT_DEF = Filterdefinitie
 SUB_TOPIC_FILT_PAR = Filterparameter
 SUB_TOPIC_INCL = Inclusies
 SUB_TOPIC_INT = Interacties
+SUB_TOPIC_CURR = * huidig = {0}
 SUB_TOPIC_PREV = * vorige = {0}
 SUB_TOPIC_REQ = * vereis beide = {0}
 SUB_TOPIC_RES_TRIG = Resource triggers

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-de.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-de.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-en.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-en.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-es.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-es.po
@@ -4210,6 +4210,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-ja.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-ja.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-nl.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-nl.po
@@ -4204,6 +4204,11 @@ msgstr "Inclusies"
 msgid "Interactions"
 msgstr "Interacties"
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr "* huidig = {0}"
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-pt_BR.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-pt_BR.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/rendering-phrases-en.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/rendering-phrases-en.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-de.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-de.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-es.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-es.po
@@ -4210,6 +4210,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-fr.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-fr.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-ja.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-ja.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-nl.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-nl.po
@@ -4204,6 +4204,11 @@ msgstr "Inclusies"
 msgid "Interactions"
 msgstr "Interacties"
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr "* huidig = {0}"
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-pt_BR.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/transifex/translations/rendering-phrases-pt_BR.po
@@ -4204,6 +4204,11 @@ msgstr ""
 msgid "Interactions"
 msgstr ""
 
+# SUB_TOPIC_CURR
+#: SUB_TOPIC_CURR
+msgid "* current = {0}"
+msgstr ""
+
 # SUB_TOPIC_PREV
 #: SUB_TOPIC_PREV
 msgid "* previous = {0}"

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
@@ -35,7 +35,7 @@ public class OperationDefinitionValidator extends BaseValidator {
       ok = validateProfile(errors, stack.push(od.getNamedChild("inputProfile"), -1, null, null), od, od.getNamedChildValue("inputProfile"), "in") && ok;
     }
     if (od.hasChild("outputProfile")) {
-      ok = validateProfile(errors, stack.push(od.getNamedChild("inputProfile"), -1, null, null), od, od.getNamedChildValue("outputProfile"), "out") && ok;      
+      ok = validateProfile(errors, stack.push(od.getNamedChild("outputProfile"), -1, null, null), od, od.getNamedChildValue("outputProfile"), "out") && ok;      
     }
 
     return ok;


### PR DESCRIPTION
SubscriptionTopic redndering of trigger.queryCriteria.current uses a label of 'create {0}'. This PR adds the current label in the same pattern as 'previous', 'current: {0}'. 
An example rendering:
![image](https://github.com/user-attachments/assets/c2aa144a-8bd1-4a91-90fc-569fb5cdb249)

Can be found here: 
https://build.fhir.org/ig/HL7/davinci-pct/SubscriptionTopic-davinci-pct-aeob-available-author-subscriptiontopic.html