### PR TITLE
Fix: invariants with identical expressions but different severities should be reevaluated

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -7708,6 +7708,30 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       return IdStatus.REQUIRED;
   }
 
+  private static class ExecutedConstraintCacheKey {
+    private String expression;
+    private ConstraintSeverity severity;
+
+    public ExecutedConstraintCacheKey(String fixedExpr, ConstraintSeverity severity) {
+      this.expression = fixedExpr;
+      this.severity = severity;
+    }
+
+    @Override
+    public int hashCode() {
+      return severity.hashCode() * (expression == null ? 0 : expression.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null) return false;
+      if (this.getClass() != o.getClass()) return false;
+      ExecutedConstraintCacheKey otherKey = (ExecutedConstraintCacheKey) o;
+      return StringUtils.equals(expression, otherKey.expression) && severity == otherKey.severity;
+    }
+  }
+
   private boolean checkInvariants(ValidationContext valContext, List<ValidationMessage> errors, String path, StructureDefinition profile, ElementDefinition ed, String typename, String typeProfile, Element resource, Element element, boolean onlyNonInherited) throws FHIRException, FHIRException {
     if (noInvariantChecks) {
       return true;
@@ -7717,7 +7741,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     for (ElementDefinitionConstraintComponent inv : ed.getConstraint()) {
       if (inv.hasExpression() && (!onlyNonInherited || !inv.hasSource() || (!isInheritedProfile(profile, inv.getSource()) && !isInheritedProfile(ed.getType(), inv.getSource())) )) {
         @SuppressWarnings("unchecked")
-        Map<String, List<ValidationMessage>> invMap = executionId.equals(element.getUserString(EXECUTION_ID)) ? (Map<String, List<ValidationMessage>>) element.getUserData(EXECUTED_CONSTRAINT_LIST) : null;
+        Map<ExecutedConstraintCacheKey, List<ValidationMessage>> invMap = executionId.equals(element.getUserString(EXECUTION_ID)) ? (Map<ExecutedConstraintCacheKey, List<ValidationMessage>>) element.getUserData(EXECUTED_CONSTRAINT_LIST) : null;
         if (invMap == null) {
           invMap = new HashMap<>();
           element.setUserData(EXECUTED_CONSTRAINT_LIST, invMap);
@@ -7725,7 +7749,9 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
         }
         List<ValidationMessage> invErrors = null;
         // We key based on inv.expression rather than inv.key because expressions can change in derived profiles and aren't guaranteed to be consistent across profiles.
-        String key = FHIRPathExpressionFixer.fixExpr(inv.getExpression(), inv.getKey(), context.getVersion());
+        String fixedExpr = FHIRPathExpressionFixer.fixExpr(inv.getExpression(), inv.getKey(), context.getVersion());
+        ConstraintSeverity severity = inv.getSeverity();
+        ExecutedConstraintCacheKey key = new ExecutedConstraintCacheKey(fixedExpr, severity);
         if (!invMap.keySet().contains(key)) {
           invErrors = new ArrayList<ValidationMessage>();
           invMap.put(key, invErrors);


### PR DESCRIPTION
### Bug description

If a profile for a datatype has an invariant constraint, and is used in a resource profile, which has an identical invariant but with different severity, the invariant from the resource profile doesn't get executed. This is, however, crucial, if the invariant in the resource profile has a higher severity, e.g. ERROR instead od WARNING in the base profile.

Example:
1. The identifier profile https://simplifier.net/packages/de.basisprofil.r4/1.5.2/files/2720744/~xml defines the constraint _ik-1_ with severity WARNING
2. The resource profile https://simplifier.net/FOR/KBV_PR_FOR_Organization/~xml uses the above profile and defines the constraint _-for-laengeIK_ on the sliced element _Organization.identifier:Institutionskennzeichen.value_

While checking conformance of a resource to the above resource profile, the validator doesn't evaluate the _-for-laengeIK_ constraint but the _ik-1_ only.

### Steps to reproduce
Run the validator CLI on the following input resource, which violates the both constraints above [coverage.xml.txt](https://github.com/user-attachments/files/20009425/coverage.xml.txt):

```shell
java -jar .\validator_cli.jar -version 4.0 -ig kbv.ita.for#1.2.0 "C:\Dev\referencevalidator\coverage.xml"
FHIR Validation tool Version 6.5.19 (Git# e13d94c86167). Built 2025-04-17T08:12:51.603Z (15 days old)
  Java:   21.0.6 from C:\Program Files\Eclipse Adoptium\jdk-21.0.6.7-hotspot on amd64 (64bit). 8136MB available
  Paths:  Current = C:\Dev\referencevalidator\hl7 fhir validator\6.5.19, Package Cache = C:\Users\alexey.tschudnowsky\.fhir\packages
  Params: -version 4.0 -ig kbv.ita.for#1.2.0 C:\Dev\referencevalidator\coverage.xml
  Locale: /
  Jurisdiction: United States of America
Loading
  Load FHIR v4.0 from hl7.fhir.r4.core#4.0.1  Load hl7.terminology.r4#6.2.0 - 4287 resources (00:08.549)
  Load hl7.fhir.uv.extensions.r4#5.2.0 - 758 resources (00:03.109)
 - 8265 resources (00:00.000)
Installing hl7.terminology#6.3.0 to the package cache
  Fetching:

Installing hl7.terminology#6.3.0
 done.
  Load hl7.fhir.uv.extensions.r5#5.2.0 - 758 resources (00:20.880)
  Load hl7.terminology#6.3.0 - 4338 resources (00:00.809)
  Load hl7.terminology.r5#6.2.0 - 4287 resources (00:02.394)
  Load hl7.fhir.uv.extensions#5.2.0 - 758 resources (00:00.009)
  Terminology server http://tx.fhir.org - Version Connected to Terminology Server at http://tx.fhir.org (00:01.461)
  Load de.basisprofil.r4#1.5.2 - 185 resources (00:00.096)
  Load kbv.basis#1.7.0 - 156 resources (00:00.002)
  Load kbv.ita.for#1.2.0 - 20 resources (00:00.000)
  Package Summary: [hl7.fhir.r4.core#4.0.1, hl7.fhir.xver-extensions#0.1.0, hl7.terminology.r4#6.2.0, hl7.fhir.uv.extensions.r4#5.2.0, hl7.fhir.uv.extensions.r5#5.2.0, hl7.terminology#6.3.0, hl7.terminology.r5#6.2.0, hl7.fhir.uv.extensions#5.2.0, de.basisprofil.r4#1.5.2, kbv.basis#1.7.0, kbv.ita.for#1.2.0]
  Terminology Cache at c:\temp\default-tx-cache
  Get set... Unable to generate snapshot @2 for Definition from noname because Profile Definition (http://hl7.org/fhir/StructureDefinition/Definition) has no base and no snapshot
Unable to generate snapshot @2 for Event from noname because Profile Event (http://hl7.org/fhir/StructureDefinition/Event) has no base and no snapshot
Unable to generate snapshot @2 for FiveWs from noname because Profile FiveWs (http://hl7.org/fhir/StructureDefinition/FiveWs) has no base and no snapshot
Unable to generate snapshot @2 for Request from noname because Profile Request (http://hl7.org/fhir/StructureDefinition/Request) has no base and no snapshot
 go (00:09.887)
Cached new session. Cache size = 1
Validating
  Validate C:\Dev\referencevalidator\coverage.xml
Validate Coverage against http://hl7.org/fhir/StructureDefinition/Coverage|4.0.1..........20..........40..........60..........80.........|
Validate Coverage against https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Coverage..........20..........40..........60..........80..........100|
 00:02.714
Done. Times: Loading: 00:47.556, validation: 00:02.715. Memory = 713Mb

Success: 0 errors, 6 warnings, 5 notes
  Information @ Coverage.type (line 31, col11): None of the codings provided are in the value set 'Coverage Type and Self-Pay Codes' (http://hl7.org/fhir/ValueSet/coverage-type|4.0.1), and a coding is recommended to come from this value set (codes = http://fhir.de/CodeSystem/versicherungsart-de-basis#GKV)
  Information @ Coverage.extension[0].value.ofType(Coding) (line 7, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_PERSONENGRUPPE' could not be found, so the code cannot be validated
  Information @ Coverage.extension[1].value.ofType(Coding) (line 13, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DMP' could not be found, so the code cannot be validated
  Information @ Coverage.extension[2].value.ofType(Coding) (line 19, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_ITA_WOP' could not be found, so the code cannot be validated
  Information @ Coverage.extension[3].value.ofType(Coding) (line 25, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_VERSICHERTENSTATUS' could not be found, so the code cannot be validated
  Warning @ Coverage.extension[0].value.ofType(Coding) (line 7, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_PERSONENGRUPPE' not found
  Warning @ Coverage.extension[1].value.ofType(Coding) (line 13, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_DMP' not found
  Warning @ Coverage.extension[2].value.ofType(Coding) (line 19, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_ITA_WOP' not found
  Warning @ Coverage.extension[3].value.ofType(Coding) (line 25, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_VERSICHERTENSTATUS' not found
  Warning @ Coverage (line 1, col39): Constraint failed: dom-6: 'A resource should have narrative for robust management' (defined in http://hl7.org/fhir/StructureDefinition/DomainResource) (Best Practice Recommendation)
  Warning @ Coverage.payor[0].identifier.value (line 43, col43): Constraint failed: ik-1: 'Eine IK muss eine numerische 9-stellige Zeichenkette (mit Prüfziffer) sein' (defined in http://fhir.de/StructureDefinition/identifier-iknr)
Done. Times: Loading: 00:47.556, validation: 00:02.715. Max Memory = 7Gb
```
Expected outcome: 
```shell
*FAILURE*: 1 errors, 6 warnings, 5 notes
  Error @ Coverage.payor[0].identifier.value (line 43, col43): Constraint failed: -for-laengeIK: 'Die IK-Nummer muss 9-stellig numerisch sein.'
  Information @ Coverage.type (line 31, col11): None of the codings provided are in the value set 'Coverage Type and Self-Pay Codes' (http://hl7.org/fhir/ValueSet/coverage-type|4.0.1), and a coding is recommended to come from this value set (codes = http://fhir.de/CodeSystem/versicherungsart-de-basis#GKV)
  Information @ Coverage.extension[0].value.ofType(Coding) (line 7, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_PERSONENGRUPPE' could not be found, so the code cannot be validated
  Information @ Coverage.extension[1].value.ofType(Coding) (line 13, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DMP' could not be found, so the code cannot be validated
  Information @ Coverage.extension[2].value.ofType(Coding) (line 19, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_ITA_WOP' could not be found, so the code cannot be validated
  Information @ Coverage.extension[3].value.ofType(Coding) (line 25, col22): A definition for CodeSystem 'https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_VERSICHERTENSTATUS' could not be found, so the code cannot be validated
  Warning @ Coverage.extension[0].value.ofType(Coding) (line 7, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_PERSONENGRUPPE' not found
  Warning @ Coverage.extension[1].value.ofType(Coding) (line 13, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_DMP' not found
  Warning @ Coverage.extension[2].value.ofType(Coding) (line 19, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_ITA_WOP' not found
  Warning @ Coverage.extension[3].value.ofType(Coding) (line 25, col22): ValueSet 'https://fhir.kbv.de/ValueSet/KBV_VS_SFHIR_KBV_VERSICHERTENSTATUS' not found
  Warning @ Coverage (line 1, col39): Constraint failed: dom-6: 'A resource should have narrative for robust management' (defined in http://hl7.org/fhir/StructureDefinition/DomainResource) (Best Practice Recommendation)
  Warning @ Coverage.payor[0].identifier.value (line 43, col43): Constraint failed: ik-1: 'Eine IK muss eine numerische 9-stellige Zeichenkette (mit Prüfziffer) sein' (defined in http://fhir.de/StructureDefinition/identifier-iknr)
```

### Proposed solution
There seems to be a caching mechanism in InstanceValidator for evaluated invariants to improve performance. However, it uses the invariant expression as a key. The problem can be solved by extending the key to include the invariant severity additionally to the expression.