### PR TITLE
feat: enhance JsonDrivenPolicyAdvisor to support JSON5

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/json/parser/JsonParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/json/parser/JsonParser.java
@@ -80,6 +80,13 @@ public class JsonParser {
     }
     return new JsonParser().setSourceName(source.getAbsolutePath()).parseJsonObject(FileUtilities.fileToString(source), false, false);
   }
+
+  public static JsonObject parseObject(File source, boolean isJson5) throws IOException, JsonException {
+    if (!source.exists()) {
+      throw new IOException("File "+source+" not found");
+    }
+    return new JsonParser().setSourceName(source.getAbsolutePath()).parseJsonObject(FileUtilities.fileToString(source), isJson5, false);
+  }
   
   public static JsonObject parseObjectFromFile(String source) throws IOException, JsonException {
     return new JsonParser().setSourceName(source).parseJsonObject(FileUtilities.fileToString(source), false, false);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/JsonDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/JsonDrivenPolicyAdvisor.java
@@ -16,7 +16,7 @@ public class JsonDrivenPolicyAdvisor extends RulesDrivenPolicyAdvisor {
 
   public JsonDrivenPolicyAdvisor(IValidationPolicyAdvisor base, File source) throws JsonException, IOException {
     super(base);
-    load(JsonParser.parseObject(source));
+    load(JsonParser.parseObject(source, true));
   }
 
   public JsonDrivenPolicyAdvisor(ReferenceValidationPolicy refpol, File source) throws JsonException, IOException {


### PR DESCRIPTION
This pull request introduces an enhancement to the JSON parsing functionality by adding support for JSON5 format. The most important changes include adding a new overloaded method in the `JsonParser` class to handle JSON5 parsing and updating the `JsonDrivenPolicyAdvisor` class to utilize this new functionality.

### Enhancements to JSON Parsing:

* [`org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/json/parser/JsonParser.java`](diffhunk://#diff-3b12d95adad09aec80c49cc3e83bbd7716689455a5ca803de18f264eb6c3cf88R84-R90): Added a new overloaded method `parseObject(File source, boolean isJson5)` to support parsing files with JSON5 format. This method includes logic to check if the file exists and throws an `IOException` if it does not.

* [`org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/JsonDrivenPolicyAdvisor.java`](diffhunk://#diff-0b3db1a977588efea81c4b44614f7aaca29ec0ac580543232683144d291dfd69L19-R19): Updated the constructor of `JsonDrivenPolicyAdvisor` to call the new `parseObject(File source, boolean isJson5)` method with `isJson5` set to `true`, enabling JSON5 support when loading JSON-driven policies.