### PR TITLE
feat: allow .json5 file extension for advisor files in Params

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
@@ -463,7 +463,7 @@ public class Params {
         File f = ManagedFileAccess.file(validationContext.getAdvisorFile());
         if (!f.exists()) {
           throw new Error("Cannot find advisor file "+ validationContext.getAdvisorFile());
-        } else if (!Utilities.existsInList(Utilities.getFileExtension(f.getName()), "json", "txt")) {
+        } else if (!Utilities.existsInList(Utilities.getFileExtension(f.getName()), "json", "txt", "json5")) {
           throw new Error("Advisor file "+ validationContext.getAdvisorFile()+" must be a .json or a .txt file");
         }
       } else if (args[i].equals(SCAN)) {


### PR DESCRIPTION
This pull request introduces a minor enhancement to the file validation logic in `Params.java` by expanding the list of acceptable file extensions for advisor files.

Validation logic update:

* [`org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java`](diffhunk://#diff-c680b8a0c94ab2d061f47151b3a17bedd24bac6116dc1e1f91f624306b8986a4L466-R466): Added support for `json5` file extension in the advisor file validation check, allowing `.json5` files to be used alongside `.json` and `.txt` files.