### PR TITLE
feat: add headless mode check before opening browser in ComparisonService

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ComparisonService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ComparisonService.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.validation.service;
 
 import java.awt.Desktop;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 
@@ -65,8 +66,17 @@ public class ComparisonService {
     ComparisonRenderer cr = new ComparisonRenderer(validator.getContext(), validator.getContext(), dest, session);
     cr.loadTemplates(validator.getContext());
     File htmlFile = cr.render(left, right);
-    Desktop.getDesktop().browse(htmlFile.toURI());
-    System.out.println("Done");
+    // only try to open in browser if not in headless mode
+    if (!GraphicsEnvironment.isHeadless()) {
+      try {
+        Desktop.getDesktop().browse(htmlFile.toURI());
+      } catch (UnsupportedOperationException | IOException e) {
+        System.err.println("Unable to open browser: " + e.getMessage());
+      }
+    } else {
+      System.out.println("Headless environment detected; skipping browser launch.");
+    }
+    System.out.println("Done: " + htmlFile.toURI());
   }
 
 }


### PR DESCRIPTION
This pull request updates the `ComparisonService` class to improve its handling of environments where a graphical user interface is not available. The most notable change ensures that the application does not attempt to open a browser in headless environments, enhancing its robustness and usability in different deployment scenarios.

### Improvements to environment handling:

* Added an import for `GraphicsEnvironment` to detect headless environments in `ComparisonService.java`.
* Updated the `compareStructureDefinitions` method to check if the application is running in a headless environment before attempting to open a browser. If headless, it skips the browser launch and logs a message instead. Additionally, added error handling to log a message if the browser cannot be opened due to an exception.

fixes # 1999