### PR TITLE
Fix terminology cache hashing

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -959,7 +959,10 @@ public class TerminologyCache {
   }
 
   public String hashJson(String s) {
-    return String.valueOf(s.trim().hashCode());
+    return String.valueOf(s
+      .trim()
+      .replaceAll("\\r\\n?", "\n")
+      .hashCode());
   }
 
   // management

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/TerminologyCacheTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/context/TerminologyCacheTests.java
@@ -26,7 +26,6 @@ import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome;
 import org.hl7.fhir.r5.terminologies.utilities.TerminologyCache;
 import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
-import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.utilities.tests.ResourceLoaderTests;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
@@ -549,5 +548,39 @@ public class TerminologyCacheTests implements ResourceLoaderTests {
         coding, valueSet, new Parameters());
       assertEquals(expectedName + "_dummyVersion", cacheToken.getName());
     }
+  }
+
+  @Test
+  void testHashJsonHandlesDifferentEndOfLine() throws IOException {
+    TerminologyCache terminologyCache = createTerminologyCache();
+    String newLineJson = "{\n" +
+        "  \"resourceType\": \"ValueSet\",\n" +
+        "  \"id\": \"dummyId\"\n" +
+        "}";
+    String newLineAndCarriageReturnJson = "{\r\n" +
+        "  \"resourceType\": \"ValueSet\",\r\n" +
+        "  \"id\": \"dummyId\"\r\n" +
+        "}";
+    String newLineToken = terminologyCache.hashJson(newLineJson);
+    String newLineAndCarriageReturnToken = terminologyCache.hashJson(newLineAndCarriageReturnJson);
+
+    assertEquals(newLineToken, newLineAndCarriageReturnToken);
+  }
+
+  @Test
+  void testHashJsonHandlesLeadingAndTrailingWhitespace() throws IOException {
+    TerminologyCache terminologyCache = createTerminologyCache();
+    String paddedJson = "   {\n" +
+      "  \"resourceType\": \"ValueSet\",\n" +
+      "  \"id\": \"dummyId\"\n" +
+      "}\n   ";
+    String json = "{\n" +
+      "  \"resourceType\": \"ValueSet\",\n" +
+      "  \"id\": \"dummyId\"\n" +
+      "}";
+    String paddedJsonToken = terminologyCache.hashJson(paddedJson);
+    String jsonToken = terminologyCache.hashJson(json);
+
+    assertEquals(paddedJsonToken, jsonToken);
   }
 }

--- a/org.hl7.fhir.validation/src/test/resources/txCache/org.hl7.fhir.validation/4.0.1/fhir-types.cache
+++ b/org.hl7.fhir.validation/src/test/resources/txCache/org.hl7.fhir.validation/4.0.1/fhir-types.cache
@@ -2,30 +2,6 @@
 {"code" : {
   "system" : "http://hl7.org/fhir/fhir-types",
   "code" : "OperationOutcome"
-}, "valueSet" :null, "langs":"en-CA", "useServer":"true", "useClient":"true", "guessSystem":"false", "activeOnly":"false", "membershipOnly":"false", "displayWarningMode":"false", "versionFlexible":"true", "profile": {
-  "resourceType" : "Parameters",
-  "parameter" : [{
-    "name" : "profile-url",
-    "valueString" : "http://hl7.org/fhir/ExpansionProfile/dc8fd4bc-091a-424a-8a3b-6198ef146891"
-  },
-  {
-    "name" : "displayLanguage",
-    "valueCode" : "en-US"
-  }]
-}}####
-v: {
-  "severity" : "error",
-  "error" : "A definition for CodeSystem 'http://hl7.org/fhir/fhir-types' could not be found, so the code cannot be validated",
-  "class" : "CODESYSTEM_UNSUPPORTED",
-  "issues" : {
-  "resourceType" : "OperationOutcome"
-}
-
-}
--------------------------------------------------------------------------------------
-{"code" : {
-  "system" : "http://hl7.org/fhir/fhir-types",
-  "code" : "OperationOutcome"
 }, "valueSet" :null, "langs":"en-US", "useServer":"true", "useClient":"true", "guessSystem":"false", "activeOnly":"false", "membershipOnly":"false", "displayWarningMode":"false", "versionFlexible":"true", "profile": {
   "resourceType" : "Parameters",
   "parameter" : [{


### PR DESCRIPTION
It's possible for different newline encodings to be introduced to the caches stored in resources. This means that entries can have duplicates produced by other operating systems (one for `\r\n\` and one for `\n`) or will miss if only one exists.

This PR normalizes newlines to `\n` when generating hashes for the Terminology Cache.