### PR TITLE
Convert DocumentReference.date/indexed/created conform fhir specs

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
@@ -72,6 +72,7 @@ public class VersionConvertorConstants {
   public static final String EXT_NOT_GIVEN_EXTENSION_URL = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Immunization.notGiven";
   public static final String EXT_IG_DEPENDSON_PACKAGE_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ImplementationGuide.dependsOn.packageId";
   public static final String EXT_MED_REQ_ONBEHALF = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationRequest.requester.onBehalfOf";
+  public static final String EXT_DOC_REF_CREATED = "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created";
 
   public static String refToVS(String url) {
     if (url == null)

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/datatypes30_40/primitivetypes30_40/DateTime30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/datatypes30_40/primitivetypes30_40/DateTime30_40.java
@@ -10,7 +10,19 @@ public class DateTime30_40 {
     return tgt;
   }
 
+  public static org.hl7.fhir.r4.model.DateTimeType convertDateTime(org.hl7.fhir.dstu3.model.BaseDateTimeType src) throws FHIRException {
+    org.hl7.fhir.r4.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.r4.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.r4.model.DateTimeType();
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    return tgt;
+  }
+
   public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.DateTimeType src) throws FHIRException {
+    org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.DateTimeType convertDateTime(org.hl7.fhir.r4.model.BaseDateTimeType src) throws FHIRException {
     org.hl7.fhir.dstu3.model.DateTimeType tgt = src.hasValue() ? new org.hl7.fhir.dstu3.model.DateTimeType(src.getValueAsString()) : new org.hl7.fhir.dstu3.model.DateTimeType();
     ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
     return tgt;

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -404,7 +404,7 @@ public class DocumentReference30_40 {
   }
 
   public static org.hl7.fhir.r4.model.Extension getExtensionForDocumentReferenceCreated(Date created) {
-    org.hl7.fhir.r4.model.Extension extension = new  org.hl7.fhir.r4.model.Extension();
+    org.hl7.fhir.r4.model.Extension extension = new org.hl7.fhir.r4.model.Extension();
     extension.setUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED);
     extension.setValue(new org.hl7.fhir.r4.model.InstantType(created));
     return extension;

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -3,18 +3,13 @@ package org.hl7.fhir.convertors.conv30_40.resources30_40;
 import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Attachment30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.CodeableConcept30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Coding30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Identifier30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Period30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.*;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Instant30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
 import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.Enumeration;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r4.model.InstantType;
 
 import java.util.Date;
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -16,11 +16,15 @@ import java.util.Date;
 
 public class DocumentReference30_40 {
 
+  private static final String[] IGNORED_EXTENSION_URLS = new String[]{
+    VersionConvertorConstants.EXT_DOC_REF_CREATED
+  };
+
   public static org.hl7.fhir.dstu3.model.DocumentReference convertDocumentReference(org.hl7.fhir.r4.model.DocumentReference src) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.DocumentReference tgt = new org.hl7.fhir.dstu3.model.DocumentReference();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt, IGNORED_EXTENSION_URLS);
     if (src.hasMasterIdentifier())
       tgt.setMasterIdentifier(Identifier30_40.convertIdentifier(src.getMasterIdentifier()));
     for (org.hl7.fhir.r4.model.Identifier t : src.getIdentifier())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -4,6 +4,7 @@ import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.*;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Instant30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
 import org.hl7.fhir.dstu3.model.DocumentReference;
@@ -14,12 +15,6 @@ import org.hl7.fhir.exceptions.FHIRException;
 import java.util.Date;
 
 public class DocumentReference30_40 {
-
-  public static org.hl7.fhir.r4.model.InstantType convertDateTimeToInstant(org.hl7.fhir.dstu3.model.DateTimeType src) throws FHIRException {
-    org.hl7.fhir.r4.model.InstantType tgt = new org.hl7.fhir.r4.model.InstantType(src.getValueAsString());
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-    return tgt;
-  }
 
   public static org.hl7.fhir.dstu3.model.DocumentReference convertDocumentReference(org.hl7.fhir.r4.model.DocumentReference src) throws FHIRException {
     if (src == null)
@@ -43,7 +38,7 @@ public class DocumentReference30_40 {
     if (src.hasDateElement())
       tgt.setIndexedElement(Instant30_40.convertInstant(src.getDateElement()));
     if (src.hasExtension(VersionConvertorConstants.EXT_DOC_REF_CREATED))
-      tgt.setCreated(convertCreatedExtension(src));
+      tgt.setCreatedElement(convertCreatedExtension(src));
     if (src.hasAuthenticator())
       tgt.setAuthenticator(Reference30_40.convertReference(src.getAuthenticator()));
     if (src.hasCustodian())
@@ -397,23 +392,12 @@ public class DocumentReference30_40 {
   }
 
 
-  private static Date convertCreatedExtension(org.hl7.fhir.r4.model.DocumentReference src) {
+  private static org.hl7.fhir.dstu3.model.DateTimeType convertCreatedExtension(org.hl7.fhir.r4.model.DocumentReference src) {
     org.hl7.fhir.r4.model.Extension extension = src.getExtensionByUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED);
-    if (extension == null) {
+    if (extension == null || !extension.isDateTime()) {
       return null;
     }
-
-    org.hl7.fhir.r4.model.Type value = extension.getValue();
-    if (value == null || value.isEmpty()) {
-      return null;
-    }
-
-    org.hl7.fhir.r4.model.BaseDateTimeType datetimeValue = value.dateTimeValue();
-    if (datetimeValue == null || datetimeValue.isEmpty()) {
-      return null;
-    }
-
-    return datetimeValue.getValue();
+    return DateTime30_40.convertDateTime(extension.dateTimeValue());
   }
 
   public static org.hl7.fhir.r4.model.Extension getExtensionForDocumentReferenceCreated(Date created) {

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -394,10 +394,13 @@ public class DocumentReference30_40 {
 
   private static org.hl7.fhir.dstu3.model.DateTimeType convertCreatedExtension(org.hl7.fhir.r4.model.DocumentReference src) {
     org.hl7.fhir.r4.model.Extension extension = src.getExtensionByUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED);
-    if (extension == null || !extension.isDateTime()) {
+    if (extension == null || extension.isEmpty()) {
       return null;
     }
-    return DateTime30_40.convertDateTime(extension.dateTimeValue());
+    if (extension.getValue() == null || extension.getValue().isEmpty()) {
+      return null;
+    }
+    return DateTime30_40.convertDateTime(extension.getValue().dateTimeValue());
   }
 
   public static org.hl7.fhir.r4.model.Extension getExtensionForDocumentReferenceCreated(Date created) {

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -47,7 +47,7 @@ public class DocumentReference30_40 {
     if (src.hasDateElement())
       tgt.setIndexed(src.getDateElement().getValue());
     if (src.hasExtension(VersionConvertorConstants.EXT_DOC_REF_CREATED))
-      tgt.setCreated(src.getExtensionByUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED).getValue().dateTimeValue().getValue());
+      tgt.setCreated(convertCreatedExtension(src));
     if (src.hasAuthenticator())
       tgt.setAuthenticator(Reference30_40.convertReference(src.getAuthenticator()));
     if (src.hasCustodian())
@@ -400,6 +400,25 @@ public class DocumentReference30_40 {
     return tgt;
   }
 
+
+  private static Date convertCreatedExtension(org.hl7.fhir.r4.model.DocumentReference src) {
+    org.hl7.fhir.r4.model.Extension extension = src.getExtensionByUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED);
+    if (extension == null) {
+      return null;
+    }
+
+    org.hl7.fhir.r4.model.Type value = extension.getValue();
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+
+    org.hl7.fhir.r4.model.BaseDateTimeType datetimeValue = value.dateTimeValue();
+    if (datetimeValue == null || datetimeValue.isEmpty()) {
+      return null;
+    }
+
+    return datetimeValue.getValue();
+  }
 
   public static org.hl7.fhir.r4.model.Extension getExtensionForDocumentReferenceCreated(Date created) {
     org.hl7.fhir.r4.model.Extension extension = new  org.hl7.fhir.r4.model.Extension();

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -8,6 +8,7 @@ import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Codeab
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Coding30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Identifier30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Period30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Instant30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
 import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.Enumeration;
@@ -45,7 +46,7 @@ public class DocumentReference30_40 {
     if (src.hasSubject())
       tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
     if (src.hasDateElement())
-      tgt.setIndexed(src.getDateElement().getValue());
+      tgt.setIndexedElement(Instant30_40.convertInstant(src.getDateElement()));
     if (src.hasExtension(VersionConvertorConstants.EXT_DOC_REF_CREATED))
       tgt.setCreated(convertCreatedExtension(src));
     if (src.hasAuthenticator())
@@ -87,7 +88,7 @@ public class DocumentReference30_40 {
     if (src.hasSubject())
       tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
     if (src.hasIndexed())
-      tgt.setDateElement(new InstantType(src.getIndexed()));
+      tgt.setDateElement(Instant30_40.convertInstant(src.getIndexedElement()));
     if (src.hasCreated())
       tgt.addExtension(getExtensionForDocumentReferenceCreated(src.getCreated()));
     if (src.hasAuthenticator())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/DocumentReference30_40.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
+import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Attachment30_40;
@@ -12,6 +13,9 @@ import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.Enumeration;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.InstantType;
+
+import java.util.Date;
 
 public class DocumentReference30_40 {
 
@@ -41,7 +45,9 @@ public class DocumentReference30_40 {
     if (src.hasSubject())
       tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
     if (src.hasDateElement())
-      tgt.setCreatedElement(convertInstantToDateTime(src.getDateElement()));
+      tgt.setIndexed(src.getDateElement().getValue());
+    if (src.hasExtension(VersionConvertorConstants.EXT_DOC_REF_CREATED))
+      tgt.setCreated(src.getExtensionByUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED).getValue().dateTimeValue().getValue());
     if (src.hasAuthenticator())
       tgt.setAuthenticator(Reference30_40.convertReference(src.getAuthenticator()));
     if (src.hasCustodian())
@@ -80,8 +86,10 @@ public class DocumentReference30_40 {
       tgt.addCategory(CodeableConcept30_40.convertCodeableConcept(src.getClass_()));
     if (src.hasSubject())
       tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
+    if (src.hasIndexed())
+      tgt.setDateElement(new InstantType(src.getIndexed()));
     if (src.hasCreated())
-      tgt.setDateElement(convertDateTimeToInstant(src.getCreatedElement()));
+      tgt.addExtension(getExtensionForDocumentReferenceCreated(src.getCreated()));
     if (src.hasAuthenticator())
       tgt.setAuthenticator(Reference30_40.convertReference(src.getAuthenticator()));
     if (src.hasCustodian())
@@ -390,5 +398,13 @@ public class DocumentReference30_40 {
        }
 }
     return tgt;
+  }
+
+
+  public static org.hl7.fhir.r4.model.Extension getExtensionForDocumentReferenceCreated(Date created) {
+    org.hl7.fhir.r4.model.Extension extension = new  org.hl7.fhir.r4.model.Extension();
+    extension.setUrl(VersionConvertorConstants.EXT_DOC_REF_CREATED);
+    extension.setValue(new org.hl7.fhir.r4.model.InstantType(created));
+    return extension;
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Device30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Device30_40Test.java
@@ -39,6 +39,6 @@ public class Device30_40Test {
     org.hl7.fhir.dstu3.model.Resource dstu3_expected = dstu3_parser.parse(dstu3_expected_output);
 
     Assertions.assertTrue(dstu3_expected.equalsDeep(dstu3_conv),
-      "Failed comparing\n" + dstu3_parser.composeString(dstu3_expected) + "\nand\n" + dstu3_parser.composeString(dstu3_expected));
+      "Failed comparing\n" + dstu3_parser.composeString(dstu3_expected) + "\nand\n" + dstu3_parser.composeString(dstu3_conv));
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/DocumentReference30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/DocumentReference30_40Test.java
@@ -1,9 +1,16 @@
 package org.hl7.fhir.convertors.conv30_40;
 
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_30_40;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
 
 
+import org.hl7.fhir.r4.elementmodel.Manager;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -16,5 +23,36 @@ public class DocumentReference30_40Test {
     org.hl7.fhir.dstu3.model.DocumentReference tgt = (org.hl7.fhir.dstu3.model.DocumentReference) VersionConvertorFactory_30_40.convertResource(src);
     assertThat(tgt.getDocStatus()).isNull();
     assertThat(tgt.getDocStatusElement().getExtensionString("http://example.org/dummy-extension")).isEqualTo("true");
+  }
+
+  @Test
+  public void testDocumentReferenceConversion30To40() throws IOException {
+
+    InputStream r4_input = this.getClass().getResourceAsStream("/document_reference_30.json");
+    InputStream dstu3_expected_output = this.getClass().getResourceAsStream("/document_reference_30_converted_to_40.json");
+
+    org.hl7.fhir.dstu3.model.DocumentReference dstu3_actual = (org.hl7.fhir.dstu3.model.DocumentReference) new org.hl7.fhir.dstu3.formats.JsonParser().parse(r4_input);
+    org.hl7.fhir.r4.model.Resource r4_conv = VersionConvertorFactory_30_40.convertResource(dstu3_actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4_parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4_expected = r4_parser.parse(dstu3_expected_output);
+
+    Assertions.assertTrue(r4_expected.equalsDeep(r4_conv),
+      "Failed comparing\n" + r4_parser.composeString(r4_expected) + "\nand\n" + r4_parser.composeString(r4_conv));
+  }
+
+  @Test
+  void testDocumentReferenceConversion40To30() throws IOException {
+    InputStream r4_input = this.getClass().getResourceAsStream("/document_reference_40.json");
+    InputStream dstu3_expected_output = this.getClass().getResourceAsStream("/document_reference_40_converted_to_30.json");
+
+    org.hl7.fhir.r4.model.DocumentReference r4_actual = (org.hl7.fhir.r4.model.DocumentReference) new org.hl7.fhir.r4.formats.JsonParser().parse(r4_input);
+    org.hl7.fhir.dstu3.model.Resource dstu3_conv = VersionConvertorFactory_30_40.convertResource(r4_actual);
+
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3_parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3_expected = dstu3_parser.parse(dstu3_expected_output);
+
+    Assertions.assertTrue(dstu3_expected.equalsDeep(dstu3_conv),
+      "Failed comparing\n" + dstu3_parser.composeString(dstu3_expected) + "\nand\n" + dstu3_parser.composeString(dstu3_conv));
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/DocumentReference30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/DocumentReference30_40Test.java
@@ -1,11 +1,6 @@
 package org.hl7.fhir.convertors.conv30_40;
 
-import ca.uhn.fhir.context.FhirContext;
-import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_30_40;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
-
-
-import org.hl7.fhir.r4.elementmodel.Manager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,31 +23,31 @@ public class DocumentReference30_40Test {
   @Test
   public void testDocumentReferenceConversion30To40() throws IOException {
 
-    InputStream r4_input = this.getClass().getResourceAsStream("/document_reference_30.json");
-    InputStream dstu3_expected_output = this.getClass().getResourceAsStream("/document_reference_30_converted_to_40.json");
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/document_reference_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/document_reference_30_converted_to_40.json");
 
-    org.hl7.fhir.dstu3.model.DocumentReference dstu3_actual = (org.hl7.fhir.dstu3.model.DocumentReference) new org.hl7.fhir.dstu3.formats.JsonParser().parse(r4_input);
-    org.hl7.fhir.r4.model.Resource r4_conv = VersionConvertorFactory_30_40.convertResource(dstu3_actual);
+    org.hl7.fhir.dstu3.model.DocumentReference dstu3Input = (org.hl7.fhir.dstu3.model.DocumentReference) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Input);
 
-    org.hl7.fhir.r4.formats.JsonParser r4_parser = new org.hl7.fhir.r4.formats.JsonParser();
-    org.hl7.fhir.r4.model.Resource r4_expected = r4_parser.parse(dstu3_expected_output);
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
 
-    Assertions.assertTrue(r4_expected.equalsDeep(r4_conv),
-      "Failed comparing\n" + r4_parser.composeString(r4_expected) + "\nand\n" + r4_parser.composeString(r4_conv));
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
   }
 
   @Test
   void testDocumentReferenceConversion40To30() throws IOException {
-    InputStream r4_input = this.getClass().getResourceAsStream("/document_reference_40.json");
-    InputStream dstu3_expected_output = this.getClass().getResourceAsStream("/document_reference_40_converted_to_30.json");
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/document_reference_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/document_reference_40_converted_to_30.json");
 
-    org.hl7.fhir.r4.model.DocumentReference r4_actual = (org.hl7.fhir.r4.model.DocumentReference) new org.hl7.fhir.r4.formats.JsonParser().parse(r4_input);
-    org.hl7.fhir.dstu3.model.Resource dstu3_conv = VersionConvertorFactory_30_40.convertResource(r4_actual);
+    org.hl7.fhir.r4.model.DocumentReference r4input = (org.hl7.fhir.r4.model.DocumentReference) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4input);
 
-    org.hl7.fhir.dstu3.formats.JsonParser dstu3_parser = new org.hl7.fhir.dstu3.formats.JsonParser();
-    org.hl7.fhir.dstu3.model.Resource dstu3_expected = dstu3_parser.parse(dstu3_expected_output);
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3Expected = dstu3Parser.parse(dstu3ExpectedOutputJson);
 
-    Assertions.assertTrue(dstu3_expected.equalsDeep(dstu3_conv),
-      "Failed comparing\n" + dstu3_parser.composeString(dstu3_expected) + "\nand\n" + dstu3_parser.composeString(dstu3_conv));
+    Assertions.assertTrue(dstu3Expected.equalsDeep(dstu3Converted),
+      "Failed comparing\n" + dstu3Parser.composeString(dstu3Expected) + "\nand\n" + dstu3Parser.composeString(dstu3Converted));
   }
 }

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_30.json
@@ -50,7 +50,7 @@
   "subject": {
     "reference": "Patient/xcda"
   },
-  "indexed": "2005-12-24T09:43:41+11:00",
+  "indexed": "2005-12-23T23:43:41.000+11:00",
   "created": "2005-12-25T06:01:12+11:00",
   "author": [
     {

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_30.json
@@ -1,0 +1,157 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "example",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>contained</b>: </p><p><b>masterIdentifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: current</p><p><b>docStatus</b>: preliminary</p><p><b>type</b>: Outpatient Note <span>(Details : {LOINC code '34108-1' = 'Outpatient Note', given as 'Outpatient Note'})</span></p><p><b>category</b>: History and Physical <span>(Details : {http://ihe.net/xds/connectathon/classCodes code 'History and Physical' = 'History and Physical', given as 'History and Physical'})</span></p><p><b>subject</b>: <a>Patient/xcda</a></p><p><b>date</b>: 24/12/2005 9:43:41 AM</p><p><b>author</b>: </p><ul><li><a>Practitioner/xcda1</a></li><li>id: a2; Gerald Smitty </li></ul><p><b>authenticator</b>: <a>Organization/f001</a></p><p><b>custodian</b>: <a>Organization/f001</a></p><h3>RelatesTos</h3><table><tr><td>-</td><td><b>Code</b></td><td><b>Target</b></td></tr><tr><td>*</td><td>appends</td><td><a>DocumentReference/example</a></td></tr></table><p><b>description</b>: Physical</p><p><b>securityLabel</b>: very restricted <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-Confidentiality code 'V' = 'very restricted', given as 'very restricted'})</span></p><h3>Contents</h3><table><tr><td>-</td><td><b>Attachment</b></td><td><b>Format</b></td></tr><tr><td>*</td><td/><td>History and Physical Specification (Details: urn:oid:1.3.6.1.4.1.19376.1.2.3 code urn:ihe:pcc:handp:2008 = 'urn:ihe:pcc:handp:2008', stated as 'History and Physical Specification')</td></tr></table><h3>Contexts</h3><table><tr><td>-</td><td><b>Encounter</b></td><td><b>Event</b></td><td><b>Period</b></td><td><b>FacilityType</b></td><td><b>PracticeSetting</b></td><td><b>SourcePatientInfo</b></td><td><b>Related</b></td></tr><tr><td>*</td><td><a>Encounter/xcda</a></td><td>Arm <span>(Details : {http://ihe.net/xds/connectathon/eventCodes code 'T-D8200' = 'T-D8200', given as 'Arm'})</span></td><td>23/12/2004 8:00:00 AM --&gt; 23/12/2004 8:01:00 AM</td><td>Outpatient <span>(Details : {http://www.ihe.net/xds/connectathon/healthcareFacilityTypeCodes code 'Outpatient' = 'Outpatient', given as 'Outpatient'})</span></td><td>General Medicine <span>(Details : {http://www.ihe.net/xds/connectathon/practiceSettingCodes code 'General Medicine' = 'General Medicine', given as 'General Medicine'})</span></td><td><a>Patient/xcda</a></td><td><a>Patient/xcda</a></td></tr></table></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "a2",
+      "name": [
+        {
+          "family": "Smitty",
+          "given": ["Gerald"]
+        }
+      ]
+    }
+  ],
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7"
+  },
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+    }
+  ],
+  "status": "current",
+  "docStatus": "preliminary",
+  "type": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "34108-1",
+        "display": "Outpatient Note"
+      }
+    ]
+  },
+  "class": {
+    "coding": [
+      {
+        "system": "http://ihe.net/xds/connectathon/classCodes",
+        "code": "History and Physical",
+        "display": "History and Physical"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/xcda"
+  },
+  "indexed": "2005-12-24T09:43:41+11:00",
+  "created": "2005-12-25T06:01:12+11:00",
+  "author": [
+    {
+      "reference": "Practitioner/xcda1"
+    },
+    {
+      "reference": "#a2"
+    }
+  ],
+  "authenticator": {
+    "reference": "Organization/f001"
+  },
+  "custodian": {
+    "reference": "Organization/f001"
+  },
+  "relatesTo": [
+    {
+      "code": "appends",
+      "target": {
+        "reference": "DocumentReference/example"
+      }
+    }
+  ],
+  "description": "Physical",
+  "securityLabel": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+          "code": "V",
+          "display": "very restricted"
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "attachment": {
+        "contentType": "application/hl7-v3+xml",
+        "language": "en-US",
+        "url": "http://example.org/xds/mhd/Binary/07a6483f-732b-461e-86b6-edb665c45510",
+        "size": 3654,
+        "hash": "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+        "title": "Physical",
+        "creation": "2005-12-24T09:35:00+11:00"
+      },
+      "format": {
+        "system": "urn:oid:1.3.6.1.4.1.19376.1.2.3",
+        "code": "urn:ihe:pcc:handp:2008",
+        "display": "History and Physical Specification"
+      }
+    }
+  ],
+  "context": {
+    "encounter": {
+      "reference": "Encounter/xcda"
+    },
+    "event": [
+      {
+        "coding": [
+          {
+            "system": "http://ihe.net/xds/connectathon/eventCodes",
+            "code": "T-D8200",
+            "display": "Arm"
+          }
+        ]
+      }
+    ],
+    "period": {
+      "start": "2004-12-23T08:00:00+11:00",
+      "end": "2004-12-23T08:01:00+11:00"
+    },
+    "facilityType": {
+      "coding": [
+        {
+          "system": "http://www.ihe.net/xds/connectathon/healthcareFacilityTypeCodes",
+          "code": "Outpatient",
+          "display": "Outpatient"
+        }
+      ]
+    },
+    "practiceSetting": {
+      "coding": [
+        {
+          "system": "http://www.ihe.net/xds/connectathon/practiceSettingCodes",
+          "code": "General Medicine",
+          "display": "General Medicine"
+        }
+      ]
+    },
+    "sourcePatientInfo": {
+      "reference": "Patient/xcda"
+    },
+    "related": [
+      {
+        "identifier": {
+          "system": "urn:ietf:rfc:3986",
+          "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.2345"
+        },
+        "ref": { "reference": "Patient/xcda" }
+      }
+    ]
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_30_converted_to_40.json
@@ -1,0 +1,129 @@
+{
+  "resourceType" : "DocumentReference",
+  "id" : "example",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>contained</b>: </p><p><b>masterIdentifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7</p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234</p><p><b>status</b>: current</p><p><b>docStatus</b>: preliminary</p><p><b>type</b>: Outpatient Note <span>(Details : {LOINC code '34108-1' = 'Outpatient Note', given as 'Outpatient Note'})</span></p><p><b>category</b>: History and Physical <span>(Details : {http://ihe.net/xds/connectathon/classCodes code 'History and Physical' = 'History and Physical', given as 'History and Physical'})</span></p><p><b>subject</b>: <a>Patient/xcda</a></p><p><b>date</b>: 24/12/2005 9:43:41 AM</p><p><b>author</b>: </p><ul><li><a>Practitioner/xcda1</a></li><li>id: a2; Gerald Smitty </li></ul><p><b>authenticator</b>: <a>Organization/f001</a></p><p><b>custodian</b>: <a>Organization/f001</a></p><h3>RelatesTos</h3><table><tr><td>-</td><td><b>Code</b></td><td><b>Target</b></td></tr><tr><td>*</td><td>appends</td><td><a>DocumentReference/example</a></td></tr></table><p><b>description</b>: Physical</p><p><b>securityLabel</b>: very restricted <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-Confidentiality code 'V' = 'very restricted', given as 'very restricted'})</span></p><h3>Contents</h3><table><tr><td>-</td><td><b>Attachment</b></td><td><b>Format</b></td></tr><tr><td>*</td><td/><td>History and Physical Specification (Details: urn:oid:1.3.6.1.4.1.19376.1.2.3 code urn:ihe:pcc:handp:2008 = 'urn:ihe:pcc:handp:2008', stated as 'History and Physical Specification')</td></tr></table><h3>Contexts</h3><table><tr><td>-</td><td><b>Encounter</b></td><td><b>Event</b></td><td><b>Period</b></td><td><b>FacilityType</b></td><td><b>PracticeSetting</b></td><td><b>SourcePatientInfo</b></td><td><b>Related</b></td></tr><tr><td>*</td><td><a>Encounter/xcda</a></td><td>Arm <span>(Details : {http://ihe.net/xds/connectathon/eventCodes code 'T-D8200' = 'T-D8200', given as 'Arm'})</span></td><td>23/12/2004 8:00:00 AM --&gt; 23/12/2004 8:01:00 AM</td><td>Outpatient <span>(Details : {http://www.ihe.net/xds/connectathon/healthcareFacilityTypeCodes code 'Outpatient' = 'Outpatient', given as 'Outpatient'})</span></td><td>General Medicine <span>(Details : {http://www.ihe.net/xds/connectathon/practiceSettingCodes code 'General Medicine' = 'General Medicine', given as 'General Medicine'})</span></td><td><a>Patient/xcda</a></td><td><a>Patient/xcda</a></td></tr></table></div>"
+  },
+  "contained" : [ {
+    "resourceType" : "Practitioner",
+    "id" : "a2",
+    "name" : [ {
+      "family" : "Smitty",
+      "given" : [ "Gerald" ]
+    } ]
+  } ],
+  "extension" : [ {
+    "url" : "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created",
+    "valueInstant" : "2005-12-25T06:01:12+11:00"
+  } ],
+  "masterIdentifier" : {
+    "system" : "urn:ietf:rfc:3986",
+    "value" : "urn:oid:1.3.6.1.4.1.21367.2005.3.7"
+  },
+  "identifier" : [ {
+    "system" : "urn:ietf:rfc:3986",
+    "value" : "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
+  } ],
+  "status" : "current",
+  "docStatus" : "preliminary",
+  "type" : {
+    "coding" : [ {
+      "system" : "http://loinc.org",
+      "code" : "34108-1",
+      "display" : "Outpatient Note"
+    } ]
+  },
+  "category" : [ {
+    "coding" : [ {
+      "system" : "http://ihe.net/xds/connectathon/classCodes",
+      "code" : "History and Physical",
+      "display" : "History and Physical"
+    } ]
+  } ],
+  "subject" : {
+    "reference" : "Patient/xcda"
+  },
+  "date" : "2005-12-23T23:43:41.000+01:00",
+  "author" : [ {
+    "reference" : "Practitioner/xcda1"
+  }, {
+    "reference" : "#a2"
+  } ],
+  "authenticator" : {
+    "reference" : "Organization/f001"
+  },
+  "custodian" : {
+    "reference" : "Organization/f001"
+  },
+  "relatesTo" : [ {
+    "code" : "appends",
+    "target" : {
+      "reference" : "DocumentReference/example"
+    }
+  } ],
+  "description" : "Physical",
+  "securityLabel" : [ {
+    "coding" : [ {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+      "code" : "V",
+      "display" : "very restricted"
+    } ]
+  } ],
+  "content" : [ {
+    "attachment" : {
+      "contentType" : "application/hl7-v3+xml",
+      "language" : "en-US",
+      "url" : "http://example.org/xds/mhd/Binary/07a6483f-732b-461e-86b6-edb665c45510",
+      "size" : 3654,
+      "hash" : "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+      "title" : "Physical",
+      "creation" : "2005-12-24T09:35:00+11:00"
+    },
+    "format" : {
+      "system" : "urn:oid:1.3.6.1.4.1.19376.1.2.3",
+      "code" : "urn:ihe:pcc:handp:2008",
+      "display" : "History and Physical Specification"
+    }
+  } ],
+  "context" : {
+    "encounter" : [ {
+      "reference" : "Encounter/xcda"
+    } ],
+    "event" : [ {
+      "coding" : [ {
+        "system" : "http://ihe.net/xds/connectathon/eventCodes",
+        "code" : "T-D8200",
+        "display" : "Arm"
+      } ]
+    } ],
+    "period" : {
+      "start" : "2004-12-23T08:00:00+11:00",
+      "end" : "2004-12-23T08:01:00+11:00"
+    },
+    "facilityType" : {
+      "coding" : [ {
+        "system" : "http://www.ihe.net/xds/connectathon/healthcareFacilityTypeCodes",
+        "code" : "Outpatient",
+        "display" : "Outpatient"
+      } ]
+    },
+    "practiceSetting" : {
+      "coding" : [ {
+        "system" : "http://www.ihe.net/xds/connectathon/practiceSettingCodes",
+        "code" : "General Medicine",
+        "display" : "General Medicine"
+      } ]
+    },
+    "sourcePatientInfo" : {
+      "reference" : "Patient/xcda"
+    },
+    "related" : [ {
+      "reference" : "Patient/xcda",
+      "identifier" : {
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "urn:oid:1.3.6.1.4.1.21367.2005.3.7.2345"
+      }
+    } ]
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_30_converted_to_40.json
@@ -44,7 +44,7 @@
   "subject" : {
     "reference" : "Patient/xcda"
   },
-  "date" : "2005-12-23T23:43:41.000+01:00",
+  "date": "2005-12-23T23:43:41.000+11:00",
   "author" : [ {
     "reference" : "Practitioner/xcda1"
   }, {

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_40.json
@@ -1,0 +1,95 @@
+{
+  "resourceType": "DocumentReference",
+  "meta": {
+    "lastUpdated": "2013-07-01T13:11:33Z"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created",
+      "valueInstant": "2013-07-02T08:00:00+10:00"
+    }
+  ],
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\n\t\t\t\t\t\t<a href=\"http://localhost:9556/svc/fhir/Binary/1e404af3-077f-4bee-b7a6-a9be97e1ce32\">Document: urn:oid:129.6.58.92.88336</a>undefined, created 24/12/2005\n\t\t\t\t\t</div>"
+  },
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:129.6.58.92.88336"
+  },
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "system": "http://ihe.net/connectathon/classCodes",
+        "code": "History and Physical",
+        "display": "History and Physical"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "47039-3",
+          "display": "Inpatient Admission history and physical note"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/a2"
+  },
+  "date": "2013-07-01T23:11:33+10:00",
+  "author": [
+    {
+      "reference": "Practitioner/a3"
+    },
+    {
+      "reference": "Practitioner/a4"
+    }
+  ],
+  "description": "Physical",
+  "securityLabel": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+          "code": "N",
+          "display": "normal"
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/plain",
+        "language": "en-US",
+        "url": "http://localhost:9556/svc/fhir/Binary/1e404af3-077f-4bee-b7a6-a9be97e1ce32",
+        "title": "Physical",
+        "creation": "2005-12-24"
+      },
+      "format": {
+        "system": "urn:oid:1.3.6.1.4.1.19376.1.2.3",
+        "code": "urn:ihe:pcc:handp:2008"
+      }
+    }
+  ],
+  "context": {
+    "period": {
+      "start": "2004-12-23T08:00:00+10:00",
+      "end": "2004-12-23T08:01:00+10:00"
+    },
+    "practiceSetting": {
+      "coding": [
+        {
+          "system": "http://ihe.net/connectathon/practiceSettingCodes",
+          "code": "General Medicine",
+          "display": "General Medicine"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
@@ -7,12 +7,6 @@
     "status": "generated",
     "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\n\t\t\t\t\t\t<a href=\"http://localhost:9556/svc/fhir/Binary/1e404af3-077f-4bee-b7a6-a9be97e1ce32\">Document: urn:oid:129.6.58.92.88336</a>undefined, created 24/12/2005\n\t\t\t\t\t</div>"
   },
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created",
-      "valueInstant": "2013-07-02T08:00:00+10:00"
-    }
-  ],
   "masterIdentifier": {
     "system": "urn:ietf:rfc:3986",
     "value": "urn:oid:129.6.58.92.88336"

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
@@ -1,0 +1,94 @@
+{
+  "resourceType": "DocumentReference",
+  "meta": {
+    "lastUpdated": "2013-07-01T13:11:33Z"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\n\t\t\t\t\t\t<a href=\"http://localhost:9556/svc/fhir/Binary/1e404af3-077f-4bee-b7a6-a9be97e1ce32\">Document: urn:oid:129.6.58.92.88336</a>undefined, created 24/12/2005\n\t\t\t\t\t</div>"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created",
+      "valueInstant": "2013-07-02T08:00:00+10:00"
+    }
+  ],
+  "masterIdentifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:129.6.58.92.88336"
+  },
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "system": "http://ihe.net/connectathon/classCodes",
+        "code": "History and Physical",
+        "display": "History and Physical"
+      }
+    ]
+  },
+  "class": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "47039-3",
+        "display": "Inpatient Admission history and physical note"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/a2"
+  },
+  "created": "2013-07-02T00:00:00+02:00",
+  "indexed": "2013-07-01T15:11:33.000+02:00",
+  "author": [
+    {
+      "reference": "Practitioner/a3"
+    },
+    {
+      "reference": "Practitioner/a4"
+    }
+  ],
+  "description": "Physical",
+  "securityLabel": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+          "code": "N",
+          "display": "normal"
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/plain",
+        "language": "en-US",
+        "url": "http://localhost:9556/svc/fhir/Binary/1e404af3-077f-4bee-b7a6-a9be97e1ce32",
+        "title": "Physical",
+        "creation": "2005-12-24"
+      },
+      "format": {
+        "system": "urn:oid:1.3.6.1.4.1.19376.1.2.3",
+        "code": "urn:ihe:pcc:handp:2008"
+      }
+    }
+  ],
+  "context": {
+    "period": {
+      "start": "2004-12-23T08:00:00+10:00",
+      "end": "2004-12-23T08:01:00+10:00"
+    },
+    "practiceSetting": {
+      "coding": [
+        {
+          "system": "http://ihe.net/connectathon/practiceSettingCodes",
+          "code": "General Medicine",
+          "display": "General Medicine"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/document_reference_40_converted_to_30.json
@@ -39,8 +39,8 @@
   "subject": {
     "reference": "Patient/a2"
   },
-  "created": "2013-07-02T00:00:00+02:00",
-  "indexed": "2013-07-01T15:11:33.000+02:00",
+  "created": "2013-07-02T08:00:00+10:00",
+  "indexed": "2013-07-01T23:11:33+10:00",
   "author": [
     {
       "reference": "Practitioner/a3"


### PR DESCRIPTION
Following the FHIR docs for the conversion of DocumentReference between r3 and r4, `date` should be mapped from/to `indexed`.
At the moment `date` is mapped to `created` and `indexed` isn't mapped at all.

https://hl7.org/fhir/R4/documentreference-version-maps.html

### R3 to R4
```
  src.indexed -> tgt.date;
  src.created as vs ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created',  ext.value = vs;
```

### R4 to R3
```
  src.date -> tgt.indexed;
  src.extension as ext where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created' then {
    ext.value as vs0 -> tgt.created = vs0 "created2";
  } "created";
```

Also `indexed` is a required field in r3, so with the current mapping there is never a valid r3 model created
![afbeelding](https://github.com/user-attachments/assets/9e9d3532-c0c1-4e3b-9329-319516c43e28)
https://hl7.org/fhir/STU3/documentreference.html