### PR TITLE
Add automated Crowdin integration

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,6 +3,7 @@ name: Crowdin Action
 on:
   push: # instantly push new source strings to Crowdin for translators
     branches: [ master ]
+    paths: '**.po'
 
   schedule: # check for translations from Crowdin every 12h
     - cron: '0 */12 * * *'

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -29,7 +29,7 @@ jobs:
           create_pull_request: true
           pull_request_title: 'New Crowdin translations'
           pull_request_body: 'New Crowdin pull request with translations'
-          pull_request_base_branch_name: 'main'
+          pull_request_base_branch_name: 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,36 @@
+name: Crowdin Action
+
+on:
+  push: # instantly push new source strings to Crowdin for translators
+    branches: [ master ]
+
+  schedule: # check for translations from Crowdin every 12h
+    - cron: '0 */12 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: true
+          download_translations: true
+          localization_branch_name: l10n_crowdin_translations
+
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,16 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "src/main/resources/source/rendering-phrases-en.po",
+    "translation": "src/main/resources/source/rendering-phrases-%two_letters_code%.po"
+  },
+  {
+    "source": "src/main/resources/source/validator-messages-en.po",
+    "translation": "src/main/resources/source/validator-messages-%two_letters_code%.po"
+  }
+]


### PR DESCRIPTION
This PR adds automated string uploads into [our Crowdin project](https://crowdin.com/project/orghl7fhircore), and regular translation downloads from Crowdin in forms of PRs.

Crowdin is a pretty nice Ukrainian platform to manage translations on - it offers options for AI translations, manual approvals, translation memory to keep messages consistent and so on.

This is my first go at setting up the integration using a github action - so chances are we'll need a few rounds of iteration to smooth everything out.