### PR TITLE
Add Japanese editor name

### DIFF
--- a/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
+++ b/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
@@ -4,7 +4,7 @@ Editors for the various languages (git tags):
 * DE: ?
 * ES: Diego Kaminker ()
 * FR: Nicolas Riss (nriss)
-* JA: Hisashi Osanai (osanai-hisashi)
+* JA: Hisashi Osanai (hosanai)
 * NL: Alexander Henket (ahenket)
 * PT:  Jose Costa Teixeira (costateixeira)
 * PT_BR: ?

--- a/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
+++ b/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
@@ -4,8 +4,8 @@ Editors for the various languages (git tags):
 * DE: ?
 * ES: Diego Kaminker ()
 * FR: Nicolas Riss (nriss)
-* JA: ?
+* JA: Hisashi Osanai (osanai-hisashi)
 * NL: Alexander Henket (ahenket)
 * PT:  Jose Costa Teixeira (costateixeira)
 * PT_BR: ?
-* RU: Vadim Peretokin ()
+* RU: Vadim Peretokin (vadi2)


### PR DESCRIPTION
I met @hosanai (Hisashi Osanai) at Devdays and he mentioned he was the one who did the existing Japanese translation a few years ago, and he was interested in continuing it too.