### PR TITLE
Fixed error with OperationDefinition Parameter cross-validation:

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/OperationDefinitionValidator.java
@@ -135,9 +135,6 @@ public class OperationDefinitionValidator extends BaseValidator {
       for (TypeRefComponent tr : resDefn.current().getType()) {
         String t = tr.getWorkingCode();
         profileTypes.add(t);
-        for (CanonicalType ct : tr.getProfile()) {
-          profileTargets.add(ct.asStringValue());
-        }
         ok = rule(errors, "2025-04-08", IssueType.INVALID, nsp, allowedTypes.contains(t), I18nConstants.OPDEF_PROFILE_TYPE_NOT_IN_PARAMS, use, paramName, t, CommaSeparatedStringBuilder.join2(",", " and ", allowedTypes)) && ok;
       }
     }
@@ -149,8 +146,14 @@ public class OperationDefinitionValidator extends BaseValidator {
       ok = rule(errors, "2025-04-08", IssueType.INVALID, nsp, profileTargets.contains(t), I18nConstants.OPDEF_PROFILE_PROFILE_NOT_IN_PARAMS, use, paramName, t, CommaSeparatedStringBuilder.join2(",", " and ", profileTargets)) && ok;        
     }
     
-    for (String t : profileTargets) {
-      ok = rule(errors, "2025-04-08", IssueType.INVALID, nsp, allowedTargets.contains(t), I18nConstants.OPDEF_PROFILE_PROFILE_NOT_IN_PROFILE, use, paramName, t, CommaSeparatedStringBuilder.join2(",", " and ", allowedTargets)) && ok;        
+    String paramType = param.getNamedChildValue("type");
+    if (paramType!=null && !paramType.equals("Element")) {
+      // If the type is Element, then it's a polymorphic type and target profiles can't be declared in the operation because doing so
+      // would violate opd-3: 'A targetProfile can only be specified for parameters of type Reference or Canonical'
+      // Therefore, we can't check.  (Also, the parameter could be a mix of Reference and canonical, and each could have different targets.)
+      for (String t : profileTargets) {
+        ok = rule(errors, "2025-04-08", IssueType.INVALID, nsp, allowedTargets.contains(t), I18nConstants.OPDEF_PROFILE_PROFILE_NOT_IN_PROFILE, use, paramName, t, CommaSeparatedStringBuilder.join2(",", " and ", allowedTargets)) && ok;        
+      }
     }
     
 //    type / allowedType / extension


### PR DESCRIPTION
- Can't have target profiles if the type is Element due to existing OperationDefinition invariant
- Old code was sticking profiles into targetProfiles, which generated spurious errors