### PR TITLE
Fix: Conversion MedicationRequest 30-40 unmapped fields

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationRequest30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationRequest30_40.java
@@ -1,18 +1,12 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
+import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Dosage30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Annotation30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.CodeableConcept30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Duration30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Identifier30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Period30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.SimpleQuantity30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.*;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Boolean30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
-import org.hl7.fhir.dstu3.model.Enumeration;
-import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.exceptions.FHIRException;
 
 public class MedicationRequest30_40 {
@@ -68,11 +62,68 @@ public class MedicationRequest30_40 {
     return tgt;
   }
 
+  public static org.hl7.fhir.r4.model.MedicationRequest convertMedicationRequest(org.hl7.fhir.dstu3.model.MedicationRequest src) throws FHIRException {
+    if (src == null)
+      return null;
+    org.hl7.fhir.r4.model.MedicationRequest tgt = new org.hl7.fhir.r4.model.MedicationRequest();
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+    for (org.hl7.fhir.dstu3.model.Identifier t : src.getIdentifier())
+      tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
+    if (src.hasGroupIdentifier())
+      tgt.setGroupIdentifier(Identifier30_40.convertIdentifier(src.getGroupIdentifier()));
+    if (src.hasStatus())
+      tgt.setStatusElement(MedicationRequest30_40.convertMedicationRequestStatus(src.getStatusElement()));
+    if (src.hasIntent())
+      tgt.setIntentElement(MedicationRequest30_40.convertMedicationRequestIntent(src.getIntentElement()));
+    if (src.hasPriority())
+      tgt.setPriorityElement(MedicationRequest30_40.convertMedicationRequestPriority(src.getPriorityElement()));
+    if (src.hasMedication())
+      tgt.setMedication(ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(src.getMedication()));
+    if (src.hasSubject())
+      tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
+    if (src.hasContext())
+      tgt.setEncounter(Reference30_40.convertReference(src.getContext()));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getSupportingInformation())
+      tgt.addSupportingInformation(Reference30_40.convertReference(t));
+    if (src.hasAuthoredOn())
+      tgt.setAuthoredOnElement(DateTime30_40.convertDateTime(src.getAuthoredOnElement()));
+    if (src.hasRecorder())
+      tgt.setRecorder(Reference30_40.convertReference(src.getRecorder()));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getReasonCode())
+      tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getReasonReference())
+      tgt.addReasonReference(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Annotation t : src.getNote()) tgt.addNote(Annotation30_40.convertAnnotation(t));
+    for (org.hl7.fhir.dstu3.model.Dosage t : src.getDosageInstruction())
+      tgt.addDosageInstruction(Dosage30_40.convertDosage(t));
+    if (src.hasDispenseRequest())
+      tgt.setDispenseRequest(MedicationRequest30_40.convertMedicationRequestDispenseRequestComponent(src.getDispenseRequest()));
+    if (src.hasSubstitution())
+      tgt.setSubstitution(MedicationRequest30_40.convertMedicationRequestSubstitutionComponent(src.getSubstitution()));
+    if (src.hasPriorPrescription())
+      tgt.setPriorPrescription(Reference30_40.convertReference(src.getPriorPrescription()));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getDetectedIssue())
+      tgt.addDetectedIssue(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getEventHistory())
+      tgt.addEventHistory(Reference30_40.convertReference(t));
+    if (src.hasRequester()) {
+      if (src.getRequester().hasAgent()) {
+        tgt.setRequester(Reference30_40.convertReference(src.getRequester().getAgent()));
+      }
+      if (src.getRequester().hasOnBehalfOf()) {
+        tgt.addExtension(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF,
+          Reference30_40.convertReference(src.getRequester().getOnBehalfOf()));
+      }
+    }
+    return tgt;
+  }
+
   public static org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestDispenseRequestComponent convertMedicationRequestDispenseRequestComponent(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestDispenseRequestComponent src) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestDispenseRequestComponent tgt = new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestDispenseRequestComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasValidityPeriod())
       tgt.setValidityPeriod(Period30_40.convertPeriod(src.getValidityPeriod()));
     if (src.hasNumberOfRepeatsAllowed())
@@ -90,7 +141,7 @@ public class MedicationRequest30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestDispenseRequestComponent tgt = new org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestDispenseRequestComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasValidityPeriod())
       tgt.setValidityPeriod(Period30_40.convertPeriod(src.getValidityPeriod()));
     if (src.hasNumberOfRepeatsAllowed())
@@ -105,208 +156,208 @@ public class MedicationRequest30_40 {
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent> convertMedicationRequestIntent(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      Enumeration<MedicationRequest.MedicationRequestIntent> tgt = new Enumeration<>(new MedicationRequest.MedicationRequestIntentEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case PROPOSAL:
-                  tgt.setValue(MedicationRequest.MedicationRequestIntent.PROPOSAL);
-                  break;
-              case PLAN:
-                  tgt.setValue(MedicationRequest.MedicationRequestIntent.PLAN);
-                  break;
-              case ORDER:
-                  tgt.setValue(MedicationRequest.MedicationRequestIntent.ORDER);
-                  break;
-              case INSTANCEORDER:
-                  tgt.setValue(MedicationRequest.MedicationRequestIntent.INSTANCEORDER);
-                  break;
-              default:
-                  tgt.setValue(MedicationRequest.MedicationRequestIntent.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntentEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case PROPOSAL:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.PROPOSAL);
+          break;
+        case PLAN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.PLAN);
+          break;
+        case ORDER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.ORDER);
+          break;
+        case INSTANCEORDER:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.INSTANCEORDER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent> convertMedicationRequestIntent(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntentEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case PROPOSAL:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.PROPOSAL);
-                  break;
-              case PLAN:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.PLAN);
-                  break;
-              case ORDER:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.ORDER);
-                  break;
-              case INSTANCEORDER:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.INSTANCEORDER);
-                  break;
-              default:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntentEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case PROPOSAL:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.PROPOSAL);
+          break;
+        case PLAN:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.PLAN);
+          break;
+        case ORDER:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.ORDER);
+          break;
+        case INSTANCEORDER:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.INSTANCEORDER);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestIntent.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority> convertMedicationRequestPriority(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriorityEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ROUTINE:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.ROUTINE);
-                  break;
-              case URGENT:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.URGENT);
-                  break;
-              case STAT:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.STAT);
-                  break;
-              case ASAP:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.ASAP);
-                  break;
-              default:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriorityEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ROUTINE:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.ROUTINE);
+          break;
+        case URGENT:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.URGENT);
+          break;
+        case STAT:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.STAT);
+          break;
+        case ASAP:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.ASAP);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority> convertMedicationRequestPriority(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestPriority> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      Enumeration<MedicationRequest.MedicationRequestPriority> tgt = new Enumeration<>(new MedicationRequest.MedicationRequestPriorityEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ROUTINE:
-                  tgt.setValue(MedicationRequest.MedicationRequestPriority.ROUTINE);
-                  break;
-              case URGENT:
-                  tgt.setValue(MedicationRequest.MedicationRequestPriority.URGENT);
-                  break;
-              case STAT:
-                  tgt.setValue(MedicationRequest.MedicationRequestPriority.STAT);
-                  break;
-              case ASAP:
-                  tgt.setValue(MedicationRequest.MedicationRequestPriority.ASAP);
-                  break;
-              default:
-                  tgt.setValue(MedicationRequest.MedicationRequestPriority.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriorityEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ROUTINE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority.ROUTINE);
+          break;
+        case URGENT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority.URGENT);
+          break;
+        case STAT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority.STAT);
+          break;
+        case ASAP:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority.ASAP);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestPriority.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus> convertMedicationRequestStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ACTIVE);
-                  break;
-              case ONHOLD:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ONHOLD);
-                  break;
-              case CANCELLED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.CANCELLED);
-                  break;
-              case COMPLETED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.COMPLETED);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ENTEREDINERROR);
-                  break;
-              case STOPPED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.STOPPED);
-                  break;
-              case DRAFT:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.DRAFT);
-                  break;
-              case UNKNOWN:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.UNKNOWN);
-                  break;
-              default:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ACTIVE);
+          break;
+        case ONHOLD:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ONHOLD);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.CANCELLED);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.COMPLETED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.ENTEREDINERROR);
+          break;
+        case STOPPED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.STOPPED);
+          break;
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.DRAFT);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus> convertMedicationRequestStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      Enumeration<MedicationRequest.MedicationRequestStatus> tgt = new Enumeration<>(new MedicationRequest.MedicationRequestStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.ACTIVE);
-                  break;
-              case ONHOLD:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.ONHOLD);
-                  break;
-              case CANCELLED:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.CANCELLED);
-                  break;
-              case COMPLETED:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.COMPLETED);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.ENTEREDINERROR);
-                  break;
-              case STOPPED:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.STOPPED);
-                  break;
-              case DRAFT:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.DRAFT);
-                  break;
-              case UNKNOWN:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.UNKNOWN);
-                  break;
-              default:
-                  tgt.setValue(MedicationRequest.MedicationRequestStatus.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.ACTIVE);
+          break;
+        case ONHOLD:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.ONHOLD);
+          break;
+        case CANCELLED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.CANCELLED);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.COMPLETED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.ENTEREDINERROR);
+          break;
+        case STOPPED:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.STOPPED);
+          break;
+        case DRAFT:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.DRAFT);
+          break;
+        case UNKNOWN:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.UNKNOWN);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestSubstitutionComponent convertMedicationRequestSubstitutionComponent(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestSubstitutionComponent src) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestSubstitutionComponent tgt = new org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestSubstitutionComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasAllowedBooleanType())
       tgt.setAllowedElement(Boolean30_40.convertBoolean(src.getAllowedBooleanType()));
     if (src.hasReason())
@@ -318,7 +369,7 @@ public class MedicationRequest30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestSubstitutionComponent tgt = new org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestSubstitutionComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasAllowed())
       tgt.setAllowed(Boolean30_40.convertBoolean(src.getAllowedElement()));
     if (src.hasReason())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationRequest30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationRequest30_40.java
@@ -9,22 +9,32 @@ import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Bool
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
 import org.hl7.fhir.exceptions.FHIRException;
 
+/**
+ * Medication Request Conversion between dstu3 and r4
+ * Conversion is based on mapping defined at https://hl7.org/fhir/R4/medicationrequest-version-maps.html
+ */
 public class MedicationRequest30_40 {
 
   public static org.hl7.fhir.dstu3.model.MedicationRequest convertMedicationRequest(org.hl7.fhir.r4.model.MedicationRequest src) throws FHIRException {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.MedicationRequest tgt = new org.hl7.fhir.dstu3.model.MedicationRequest();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt, VersionConvertorConstants.EXT_MED_REQ_ONBEHALF);
+
     for (org.hl7.fhir.r4.model.Identifier t : src.getIdentifier())
       tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
-    for (org.hl7.fhir.r4.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.r4.model.CanonicalType t : src.getInstantiatesCanonical())
+      tgt.getDefinition().add(Reference30_40.convertCanonicalToReference(t));
+    for (org.hl7.fhir.r4.model.Reference t : src.getBasedOn())
+      tgt.addBasedOn(Reference30_40.convertReference(t));
     if (src.hasGroupIdentifier())
       tgt.setGroupIdentifier(Identifier30_40.convertIdentifier(src.getGroupIdentifier()));
     if (src.hasStatus())
       tgt.setStatusElement(convertMedicationRequestStatus(src.getStatusElement()));
     if (src.hasIntent())
       tgt.setIntentElement(convertMedicationRequestIntent(src.getIntentElement()));
+    if (src.hasCategory())
+      tgt.setCategory(CodeableConcept30_40.convertCodeableConcept(src.getCategory().get(0)));
     if (src.hasPriority())
       tgt.setPriorityElement(convertMedicationRequestPriority(src.getPriorityElement()));
     if (src.hasMedication())
@@ -37,13 +47,23 @@ public class MedicationRequest30_40 {
       tgt.addSupportingInformation(Reference30_40.convertReference(t));
     if (src.hasAuthoredOn())
       tgt.setAuthoredOnElement(DateTime30_40.convertDateTime(src.getAuthoredOnElement()));
+    if (src.hasRequester()) {
+      tgt.getRequester().setAgent(Reference30_40.convertReference(src.getRequester()));
+      if (src.hasExtension(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF)) {
+        org.hl7.fhir.r4.model.Extension extension = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF);
+        if (extension.getValue() instanceof org.hl7.fhir.r4.model.Reference) {
+          tgt.getRequester().setOnBehalfOf(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) extension.getValue()));
+        }
+      }
+    }
     if (src.hasRecorder())
       tgt.setRecorder(Reference30_40.convertReference(src.getRecorder()));
     for (org.hl7.fhir.r4.model.CodeableConcept t : src.getReasonCode())
       tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
     for (org.hl7.fhir.r4.model.Reference t : src.getReasonReference())
       tgt.addReasonReference(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.r4.model.Annotation t : src.getNote()) tgt.addNote(Annotation30_40.convertAnnotation(t));
+    for (org.hl7.fhir.r4.model.Annotation t : src.getNote())
+      tgt.addNote(Annotation30_40.convertAnnotation(t));
     for (org.hl7.fhir.r4.model.Dosage t : src.getDosageInstruction())
       tgt.addDosageInstruction(Dosage30_40.convertDosage(t));
     if (src.hasDispenseRequest())
@@ -56,9 +76,7 @@ public class MedicationRequest30_40 {
       tgt.addDetectedIssue(Reference30_40.convertReference(t));
     for (org.hl7.fhir.r4.model.Reference t : src.getEventHistory())
       tgt.addEventHistory(Reference30_40.convertReference(t));
-    if (src.hasRequester()) {
-      tgt.getRequester().setAgent(Reference30_40.convertReference(src.getRequester()));
-    }
+
     return tgt;
   }
 
@@ -67,15 +85,21 @@ public class MedicationRequest30_40 {
       return null;
     org.hl7.fhir.r4.model.MedicationRequest tgt = new org.hl7.fhir.r4.model.MedicationRequest();
     ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+
     for (org.hl7.fhir.dstu3.model.Identifier t : src.getIdentifier())
       tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getDefinition())
+      tgt.getInstantiatesCanonical().add(Reference30_40.convertReferenceToCanonical(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn())
+      tgt.addBasedOn(Reference30_40.convertReference(t));
     if (src.hasGroupIdentifier())
       tgt.setGroupIdentifier(Identifier30_40.convertIdentifier(src.getGroupIdentifier()));
     if (src.hasStatus())
       tgt.setStatusElement(MedicationRequest30_40.convertMedicationRequestStatus(src.getStatusElement()));
     if (src.hasIntent())
       tgt.setIntentElement(MedicationRequest30_40.convertMedicationRequestIntent(src.getIntentElement()));
+    if (src.hasCategory())
+      tgt.addCategory(CodeableConcept30_40.convertCodeableConcept(src.getCategory()));
     if (src.hasPriority())
       tgt.setPriorityElement(MedicationRequest30_40.convertMedicationRequestPriority(src.getPriorityElement()));
     if (src.hasMedication())
@@ -88,6 +112,15 @@ public class MedicationRequest30_40 {
       tgt.addSupportingInformation(Reference30_40.convertReference(t));
     if (src.hasAuthoredOn())
       tgt.setAuthoredOnElement(DateTime30_40.convertDateTime(src.getAuthoredOnElement()));
+    if (src.hasRequester()) {
+      if (src.getRequester().hasAgent()) {
+        tgt.setRequester(Reference30_40.convertReference(src.getRequester().getAgent()));
+      }
+      if (src.getRequester().hasOnBehalfOf()) {
+        tgt.addExtension(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF,
+          Reference30_40.convertReference(src.getRequester().getOnBehalfOf()));
+      }
+    }
     if (src.hasRecorder())
       tgt.setRecorder(Reference30_40.convertReference(src.getRecorder()));
     for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getReasonCode())
@@ -107,15 +140,7 @@ public class MedicationRequest30_40 {
       tgt.addDetectedIssue(Reference30_40.convertReference(t));
     for (org.hl7.fhir.dstu3.model.Reference t : src.getEventHistory())
       tgt.addEventHistory(Reference30_40.convertReference(t));
-    if (src.hasRequester()) {
-      if (src.getRequester().hasAgent()) {
-        tgt.setRequester(Reference30_40.convertReference(src.getRequester().getAgent()));
-      }
-      if (src.getRequester().hasOnBehalfOf()) {
-        tgt.addExtension(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF,
-          Reference30_40.convertReference(src.getRequester().getOnBehalfOf()));
-      }
-    }
+
     return tgt;
   }
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Resource30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Resource30_40.java
@@ -1,13 +1,10 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
-import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_30_40;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.*;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Annotation30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.CodeableConcept30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Identifier30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Extension30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Meta30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Narrative30_40;
 import org.hl7.fhir.exceptions.FHIRException;
 
 import java.util.Arrays;
@@ -139,7 +136,7 @@ public class Resource30_40 {
     if (src instanceof org.hl7.fhir.dstu3.model.MedicationDispense)
       return MedicationDispense30_40.convertMedicationDispense((org.hl7.fhir.dstu3.model.MedicationDispense) src);
     if (src instanceof org.hl7.fhir.dstu3.model.MedicationRequest)
-      return Resource30_40.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
+      return MedicationRequest30_40.convertMedicationRequest((org.hl7.fhir.dstu3.model.MedicationRequest) src);
     if (src instanceof org.hl7.fhir.dstu3.model.MedicationStatement)
       return MedicationStatement30_40.convertMedicationStatement((org.hl7.fhir.dstu3.model.MedicationStatement) src);
     if (src instanceof org.hl7.fhir.dstu3.model.MessageDefinition)
@@ -438,62 +435,5 @@ public class Resource30_40 {
       .filter(extension -> !advisor.ignoreExtension("", extension))//TODO add path
       .map(Extension30_40::convertExtension)
       .forEach(tgt::addModifierExtension);
-  }
-
-  public static org.hl7.fhir.r4.model.MedicationRequest convertMedicationRequest(org.hl7.fhir.dstu3.model.MedicationRequest src) throws FHIRException {
-    if (src == null)
-      return null;
-    org.hl7.fhir.r4.model.MedicationRequest tgt = new org.hl7.fhir.r4.model.MedicationRequest();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
-    for (org.hl7.fhir.dstu3.model.Identifier t : src.getIdentifier())
-      tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
-    if (src.hasGroupIdentifier())
-      tgt.setGroupIdentifier(Identifier30_40.convertIdentifier(src.getGroupIdentifier()));
-    if (src.hasStatus())
-      tgt.setStatusElement(MedicationRequest30_40.convertMedicationRequestStatus(src.getStatusElement()));
-    if (src.hasIntent())
-      tgt.setIntentElement(MedicationRequest30_40.convertMedicationRequestIntent(src.getIntentElement()));
-    if (src.hasPriority())
-      tgt.setPriorityElement(MedicationRequest30_40.convertMedicationRequestPriority(src.getPriorityElement()));
-    if (src.hasMedication())
-      tgt.setMedication(ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(src.getMedication()));
-    if (src.hasSubject())
-      tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
-    if (src.hasContext())
-      tgt.setEncounter(Reference30_40.convertReference(src.getContext()));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getSupportingInformation())
-      tgt.addSupportingInformation(Reference30_40.convertReference(t));
-    if (src.hasAuthoredOn())
-      tgt.setAuthoredOnElement(DateTime30_40.convertDateTime(src.getAuthoredOnElement()));
-    if (src.hasRecorder())
-      tgt.setRecorder(Reference30_40.convertReference(src.getRecorder()));
-    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getReasonCode())
-      tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getReasonReference())
-      tgt.addReasonReference(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.dstu3.model.Annotation t : src.getNote()) tgt.addNote(Annotation30_40.convertAnnotation(t));
-    for (org.hl7.fhir.dstu3.model.Dosage t : src.getDosageInstruction())
-      tgt.addDosageInstruction(Dosage30_40.convertDosage(t));
-    if (src.hasDispenseRequest())
-      tgt.setDispenseRequest(MedicationRequest30_40.convertMedicationRequestDispenseRequestComponent(src.getDispenseRequest()));
-    if (src.hasSubstitution())
-      tgt.setSubstitution(MedicationRequest30_40.convertMedicationRequestSubstitutionComponent(src.getSubstitution()));
-    if (src.hasPriorPrescription())
-      tgt.setPriorPrescription(Reference30_40.convertReference(src.getPriorPrescription()));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getDetectedIssue())
-      tgt.addDetectedIssue(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getEventHistory())
-      tgt.addEventHistory(Reference30_40.convertReference(t));
-    if (src.hasRequester()) {
-      if (src.getRequester().hasAgent()) {
-        tgt.setRequester(Reference30_40.convertReference(src.getRequester().getAgent()));
-      }
-      if (src.getRequester().hasOnBehalfOf()) {
-        tgt.addExtension(VersionConvertorConstants.EXT_MED_REQ_ONBEHALF,
-          Reference30_40.convertReference(src.getRequester().getOnBehalfOf()));
-      }
-    }
-    return tgt;
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationRequest30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationRequest30_40Test.java
@@ -8,15 +8,15 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class CommunicationRequest30_40Test {
+public class MedicationRequest30_40Test {
 
   @Test
-  public void convertCommunicationRequest30to40() throws IOException {
+  public void convertMedicationRequest30to40() throws IOException {
 
-    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/communication_request_30.json");
-    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_30_converted_to_40.json");
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/medication_request_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_request_30_converted_to_40.json");
 
-    org.hl7.fhir.dstu3.model.CommunicationRequest dstu3Actual = (org.hl7.fhir.dstu3.model.CommunicationRequest) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.dstu3.model.MedicationRequest dstu3Actual = (org.hl7.fhir.dstu3.model.MedicationRequest) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
     org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Actual);
 
     org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
@@ -27,11 +27,11 @@ public class CommunicationRequest30_40Test {
   }
 
   @Test
-  void testCommunicationRequestConversion40To30() throws IOException {
-    InputStream r4InputJson = this.getClass().getResourceAsStream("/communication_request_40.json");
-    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_40_converted_to_30.json");
+  void testMedicationRequestConversion40To30() throws IOException {
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/medication_request_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_request_40_converted_to_30.json");
 
-    org.hl7.fhir.r4.model.CommunicationRequest r4Actual = (org.hl7.fhir.r4.model.CommunicationRequest) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.r4.model.MedicationRequest r4Actual = (org.hl7.fhir.r4.model.MedicationRequest) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
     org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4Actual);
 
     org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationRequest30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationRequest30_40Test.java
@@ -1,0 +1,43 @@
+package org.hl7.fhir.convertors.conv30_40;
+
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CommunicationRequest30_40Test {
+
+  @Test
+  public void convertCommunicationRequest30to40() throws IOException {
+
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/communication_request_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_30_converted_to_40.json");
+
+    org.hl7.fhir.dstu3.model.CommunicationRequest dstu3Actual = (org.hl7.fhir.dstu3.model.CommunicationRequest) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
+
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
+  }
+
+  @Test
+  void testCommunicationRequestConversion40To30() throws IOException {
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/communication_request_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_40_converted_to_30.json");
+
+    org.hl7.fhir.r4.model.CommunicationRequest r4Actual = (org.hl7.fhir.r4.model.CommunicationRequest) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4Actual);
+
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3Expected = dstu3Parser.parse(dstu3ExpectedOutputJson);
+
+    Assertions.assertTrue(dstu3Expected.equalsDeep(dstu3Converted),
+      "Failed comparing\n" + dstu3Parser.composeString(dstu3Expected) + "\nand\n" + dstu3Parser.composeString(dstu3Converted));
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_30.json
@@ -1,0 +1,184 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "medrx0302",
+  "text": {
+    "status": "generated"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0320",
+      "code": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "324252006",
+            "display": "Azithromycin 250mg capsule (product)"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/prescriptions",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "#med0320"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "authoredOn": "2015-01-15",
+  "requester": {
+    "agent": {
+      "reference": "Practitioner/f007",
+      "display": "Patrick Pump"
+    },
+    "onBehalfOf": {
+      "reference": "Organization/f002"
+    }
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "11840006",
+          "display": "Traveller's Diarrhea (disorder)"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient told to take with food"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "Two tablets at once",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "421521009",
+            "display": "Swallow - dosing instruction imperative (qualifier value)"
+          }
+        ]
+      },
+      "doseQuantity": {
+        "value": 2,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      }
+    },
+    {
+      "sequence": 2,
+      "text": "One tablet daily for 4 days",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 4,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "validityPeriod": {
+      "start": "2015-01-15",
+      "end": "2016-01-15"
+    },
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 6,
+      "unit": "TAB",
+      "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 5,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  },
+  "substitution": {
+    "allowed": true,
+    "reason": {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/v3/ActReason",
+          "code": "FP",
+          "display": "formulary policy"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_30_converted_to_40.json
@@ -1,0 +1,211 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "medrx0302",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medrx0302</p><p><b>contained</b>: </p><p><b>identifier</b>: 12345689 (OFFICIAL)</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: id: med0320; Azithromycin 250mg capsule (product) <span>(Details : {SNOMED CT code '324252006' = 'Azithromycin 250mg capsule', given as 'Azithromycin 250mg capsule (product)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>encounter</b>: <a>encounter who leads to this prescription</a></p><p><b>supportingInformation</b>: <a>Coverage/SP1234</a></p><p><b>authoredOn</b>: 15/01/2015</p><p><b>requester</b>: <a>Patrick Pump</a></p><p><b>reasonCode</b>: Traveller's Diarrhea (disorder) <span>(Details : {SNOMED CT code '11840006' = 'Traveler's diarrhea', given as 'Traveller's Diarrhea (disorder)'})</span></p><p><b>note</b>: Patient told to take with food</p><p><b>dosageInstruction</b>: , </p><h3>DispenseRequests</h3><table><tr><td>-</td><td><b>ValidityPeriod</b></td><td><b>NumberOfRepeatsAllowed</b></td><td><b>Quantity</b></td><td><b>ExpectedSupplyDuration</b></td></tr><tr><td>*</td><td>15/01/2015 --&gt; 15/01/2016</td><td>1</td><td>6 TAB<span> (Details: http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm code TAB = 'Tablet')</span></td><td>5 days<span> (Details: UCUM code d = 'd')</span></td></tr></table><h3>Substitutions</h3><table><tr><td>-</td><td><b>Allowed[x]</b></td><td><b>Reason</b></td></tr><tr><td>*</td><td>true</td><td>formulary policy <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-ActReason code 'FP' = 'formulary policy', given as 'formulary policy'})</span></td></tr></table></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0320",
+      "code": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "324252006",
+            "display": "Azithromycin 250mg capsule (product)"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/prescriptions",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "#med0320"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "encounter": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "supportingInformation": [
+    {
+      "reference": "Coverage/SP1234"
+    }
+  ],
+  "authoredOn": "2015-01-15",
+  "requester": {
+    "reference": "Practitioner/f007",
+    "display": "Patrick Pump"
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "11840006",
+          "display": "Traveller's Diarrhea (disorder)"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient told to take with food"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "Two tablets at once",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "421521009",
+            "display": "Swallow - dosing instruction imperative (qualifier value)"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 2,
+            "unit": "TAB",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "code": "TAB"
+          }
+        }
+      ]
+    },
+    {
+      "sequence": 2,
+      "text": "One tablet daily for 4 days",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 4,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "TAB",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "code": "TAB"
+          }
+        }
+      ]
+    }
+  ],
+  "dispenseRequest": {
+    "validityPeriod": {
+      "start": "2015-01-15",
+      "end": "2016-01-15"
+    },
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 6,
+      "unit": "TAB",
+      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 5,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  },
+  "substitution": {
+    "allowedBoolean": true,
+    "reason": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+          "code": "FP",
+          "display": "formulary policy"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_30_converted_to_40.json
@@ -2,8 +2,19 @@
   "resourceType": "MedicationRequest",
   "id": "medrx0302",
   "text": {
-    "status": "generated",
-    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medrx0302</p><p><b>contained</b>: </p><p><b>identifier</b>: 12345689 (OFFICIAL)</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: id: med0320; Azithromycin 250mg capsule (product) <span>(Details : {SNOMED CT code '324252006' = 'Azithromycin 250mg capsule', given as 'Azithromycin 250mg capsule (product)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>encounter</b>: <a>encounter who leads to this prescription</a></p><p><b>supportingInformation</b>: <a>Coverage/SP1234</a></p><p><b>authoredOn</b>: 15/01/2015</p><p><b>requester</b>: <a>Patrick Pump</a></p><p><b>reasonCode</b>: Traveller's Diarrhea (disorder) <span>(Details : {SNOMED CT code '11840006' = 'Traveler's diarrhea', given as 'Traveller's Diarrhea (disorder)'})</span></p><p><b>note</b>: Patient told to take with food</p><p><b>dosageInstruction</b>: , </p><h3>DispenseRequests</h3><table><tr><td>-</td><td><b>ValidityPeriod</b></td><td><b>NumberOfRepeatsAllowed</b></td><td><b>Quantity</b></td><td><b>ExpectedSupplyDuration</b></td></tr><tr><td>*</td><td>15/01/2015 --&gt; 15/01/2016</td><td>1</td><td>6 TAB<span> (Details: http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm code TAB = 'Tablet')</span></td><td>5 days<span> (Details: UCUM code d = 'd')</span></td></tr></table><h3>Substitutions</h3><table><tr><td>-</td><td><b>Allowed[x]</b></td><td><b>Reason</b></td></tr><tr><td>*</td><td>true</td><td>formulary policy <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-ActReason code 'FP' = 'formulary policy', given as 'formulary policy'})</span></td></tr></table></div>"
+    "status": "generated"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationRequest.requester.onBehalfOf",
+      "valueReference": {
+        "reference": "Organization/f002"
+      }
+    }
+  ],
+  "requester": {
+    "reference": "Practitioner/f007",
+    "display": "Patrick Pump"
   },
   "contained": [
     {
@@ -40,16 +51,7 @@
     "reference": "Encounter/f001",
     "display": "encounter who leads to this prescription"
   },
-  "supportingInformation": [
-    {
-      "reference": "Coverage/SP1234"
-    }
-  ],
   "authoredOn": "2015-01-15",
-  "requester": {
-    "reference": "Practitioner/f007",
-    "display": "Patrick Pump"
-  },
   "reasonCode": [
     {
       "coding": [
@@ -106,21 +108,18 @@
           }
         ]
       },
+      "doseQuantity": {
+        "value": 2,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      },
       "doseAndRate": [
         {
-          "type": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
-                "code": "ordered",
-                "display": "Ordered"
-              }
-            ]
-          },
           "doseQuantity": {
             "value": 2,
             "unit": "TAB",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "system": "http://hl7.org/fhir/v3/orderableDrugForm",
             "code": "TAB"
           }
         }
@@ -156,21 +155,18 @@
           }
         ]
       },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      },
       "doseAndRate": [
         {
-          "type": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
-                "code": "ordered",
-                "display": "Ordered"
-              }
-            ]
-          },
           "doseQuantity": {
             "value": 1,
             "unit": "TAB",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "system": "http://hl7.org/fhir/v3/orderableDrugForm",
             "code": "TAB"
           }
         }
@@ -186,7 +182,7 @@
     "quantity": {
       "value": 6,
       "unit": "TAB",
-      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+      "system": "http://hl7.org/fhir/v3/orderableDrugForm",
       "code": "TAB"
     },
     "expectedSupplyDuration": {
@@ -201,7 +197,7 @@
     "reason": {
       "coding": [
         {
-          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+          "system": "http://hl7.org/fhir/v3/ActReason",
           "code": "FP",
           "display": "formulary policy"
         }

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_40.json
@@ -1,0 +1,218 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "medrx0302",
+  "text": {
+    "status": "generated"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationRequest.requester.onBehalfOf",
+      "valueReference": {
+        "reference": "Organization/f002"
+      }
+    }
+  ],
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0320",
+      "code": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "324252006",
+            "display": "Azithromycin 250mg capsule (product)"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/prescriptions",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "#med0320"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "supportingInformation": [
+    {
+      "reference": "Coverage/SP1234"
+    }
+  ],
+  "authoredOn": "2015-01-15",
+  "requester": {
+    "reference": "Practitioner/f007",
+    "display": "Patrick Pump"
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "11840006",
+          "display": "Traveller's Diarrhea (disorder)"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient told to take with food"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "Two tablets at once",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "421521009",
+            "display": "Swallow - dosing instruction imperative (qualifier value)"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 2,
+            "unit": "TAB",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "code": "TAB"
+          }
+        }
+      ]
+    },
+    {
+      "sequence": 2,
+      "text": "One tablet daily for 4 days",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 4,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "TAB",
+            "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+            "code": "TAB"
+          }
+        }
+      ]
+    }
+  ],
+  "dispenseRequest": {
+    "validityPeriod": {
+      "start": "2015-01-15",
+      "end": "2016-01-15"
+    },
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 6,
+      "unit": "TAB",
+      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 5,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  },
+  "substitution": {
+    "allowedBoolean": true,
+    "reason": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+          "code": "FP",
+          "display": "formulary policy"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_40_converted_to_30.json
@@ -1,0 +1,185 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "medrx0302",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medrx0302</p><p><b>contained</b>: </p><p><b>identifier</b>: 12345689 (OFFICIAL)</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: id: med0320; Azithromycin 250mg capsule (product) <span>(Details : {SNOMED CT code '324252006' = 'Azithromycin 250mg capsule', given as 'Azithromycin 250mg capsule (product)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>context</b>: <a>encounter who leads to this prescription</a></p><p><b>authoredOn</b>: 15/01/2015</p><h3>Requesters</h3><table><tr><td>-</td><td><b>Agent</b></td><td><b>OnBehalfOf</b></td></tr><tr><td>*</td><td><a>Patrick Pump</a></td><td><a>Organization/f002</a></td></tr></table><p><b>reasonCode</b>: Traveller's Diarrhea (disorder) <span>(Details : {SNOMED CT code '11840006' = 'Traveler's diarrhea', given as 'Traveller's Diarrhea (disorder)'})</span></p><p><b>note</b>: Patient told to take with food</p><p><b>dosageInstruction</b>: , </p><h3>DispenseRequests</h3><table><tr><td>-</td><td><b>ValidityPeriod</b></td><td><b>NumberOfRepeatsAllowed</b></td><td><b>Quantity</b></td><td><b>ExpectedSupplyDuration</b></td></tr><tr><td>*</td><td>15/01/2015 --&gt; 15/01/2016</td><td>1</td><td>6 TAB<span> (Details: http://hl7.org/fhir/v3/orderableDrugForm code TAB = 'Tablet')</span></td><td>5 days<span> (Details: UCUM code d = 'd')</span></td></tr></table><h3>Substitutions</h3><table><tr><td>-</td><td><b>Allowed</b></td><td><b>Reason</b></td></tr><tr><td>*</td><td>true</td><td>formulary policy <span>(Details : {http://hl7.org/fhir/v3/ActReason code 'FP' = 'formulary policy', given as 'formulary policy'})</span></td></tr></table></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "med0320",
+      "code": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "324252006",
+            "display": "Azithromycin 250mg capsule (product)"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/prescriptions",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "#med0320"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "context": {
+    "reference": "Encounter/f001",
+    "display": "encounter who leads to this prescription"
+  },
+  "authoredOn": "2015-01-15",
+  "requester": {
+    "agent": {
+      "reference": "Practitioner/f007",
+      "display": "Patrick Pump"
+    },
+    "onBehalfOf": {
+      "reference": "Organization/f002"
+    }
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "11840006",
+          "display": "Traveller's Diarrhea (disorder)"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient told to take with food"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "Two tablets at once",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "421521009",
+            "display": "Swallow - dosing instruction imperative (qualifier value)"
+          }
+        ]
+      },
+      "doseQuantity": {
+        "value": 2,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      }
+    },
+    {
+      "sequence": 2,
+      "text": "One tablet daily for 4 days",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "311504000",
+              "display": "With or after food"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 4,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseQuantity": {
+        "value": 1,
+        "unit": "TAB",
+        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "code": "TAB"
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "validityPeriod": {
+      "start": "2015-01-15",
+      "end": "2016-01-15"
+    },
+    "numberOfRepeatsAllowed": 1,
+    "quantity": {
+      "value": 6,
+      "unit": "TAB",
+      "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 5,
+      "unit": "days",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  },
+  "substitution": {
+    "allowed": true,
+    "reason": {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/v3/ActReason",
+          "code": "FP",
+          "display": "formulary policy"
+        }
+      ]
+    }
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_request_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_request_40_converted_to_30.json
@@ -2,8 +2,7 @@
   "resourceType": "MedicationRequest",
   "id": "medrx0302",
   "text": {
-    "status": "generated",
-    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: medrx0302</p><p><b>contained</b>: </p><p><b>identifier</b>: 12345689 (OFFICIAL)</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: id: med0320; Azithromycin 250mg capsule (product) <span>(Details : {SNOMED CT code '324252006' = 'Azithromycin 250mg capsule', given as 'Azithromycin 250mg capsule (product)'})</span></p><p><b>subject</b>: <a>Donald Duck</a></p><p><b>context</b>: <a>encounter who leads to this prescription</a></p><p><b>authoredOn</b>: 15/01/2015</p><h3>Requesters</h3><table><tr><td>-</td><td><b>Agent</b></td><td><b>OnBehalfOf</b></td></tr><tr><td>*</td><td><a>Patrick Pump</a></td><td><a>Organization/f002</a></td></tr></table><p><b>reasonCode</b>: Traveller's Diarrhea (disorder) <span>(Details : {SNOMED CT code '11840006' = 'Traveler's diarrhea', given as 'Traveller's Diarrhea (disorder)'})</span></p><p><b>note</b>: Patient told to take with food</p><p><b>dosageInstruction</b>: , </p><h3>DispenseRequests</h3><table><tr><td>-</td><td><b>ValidityPeriod</b></td><td><b>NumberOfRepeatsAllowed</b></td><td><b>Quantity</b></td><td><b>ExpectedSupplyDuration</b></td></tr><tr><td>*</td><td>15/01/2015 --&gt; 15/01/2016</td><td>1</td><td>6 TAB<span> (Details: http://hl7.org/fhir/v3/orderableDrugForm code TAB = 'Tablet')</span></td><td>5 days<span> (Details: UCUM code d = 'd')</span></td></tr></table><h3>Substitutions</h3><table><tr><td>-</td><td><b>Allowed</b></td><td><b>Reason</b></td></tr><tr><td>*</td><td>true</td><td>formulary policy <span>(Details : {http://hl7.org/fhir/v3/ActReason code 'FP' = 'formulary policy', given as 'formulary policy'})</span></td></tr></table></div>"
+    "status": "generated"
   },
   "contained": [
     {
@@ -36,10 +35,15 @@
     "reference": "Patient/pat1",
     "display": "Donald Duck"
   },
-  "context": {
+  "encounter": {
     "reference": "Encounter/f001",
     "display": "encounter who leads to this prescription"
   },
+  "supportingInformation": [
+    {
+      "reference": "Coverage/SP1234"
+    }
+  ],
   "authoredOn": "2015-01-15",
   "requester": {
     "agent": {
@@ -106,10 +110,10 @@
           }
         ]
       },
-      "doseQuantity": {
+      "doseSimpleQuantity": {
         "value": 2,
         "unit": "TAB",
-        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
         "code": "TAB"
       }
     },
@@ -143,10 +147,10 @@
           }
         ]
       },
-      "doseQuantity": {
+      "doseSimpleQuantity": {
         "value": 1,
         "unit": "TAB",
-        "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
         "code": "TAB"
       }
     }
@@ -160,7 +164,7 @@
     "quantity": {
       "value": 6,
       "unit": "TAB",
-      "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
       "code": "TAB"
     },
     "expectedSupplyDuration": {
@@ -175,7 +179,7 @@
     "reason": {
       "coding": [
         {
-          "system": "http://hl7.org/fhir/v3/ActReason",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
           "code": "FP",
           "display": "formulary policy"
         }


### PR DESCRIPTION
- Support mapping src.instantiatesCanonical <-> tgt.definition;
- Support mapping src.basedOn <-> tgt.basedOn
- Support mapping src.category <-> tgt.category;
- Support mapping of requester with behalfof extension v4 to v3
- Moved the medication request conversion from v3 to v4 to the corresponding file.
- Added tests for MedicationRequest mapping
  -  Tests files are based on example json from https://hl7.org/fhir/R4/medicationrequest0302.json.html + manually added extension requester info to make sure these are mapped correctly
