### PR TITLE
Implement Converage.class/grouping conversion between dstu3 and r4

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Coverage30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Coverage30_40.java
@@ -11,6 +11,8 @@ import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Stri
 import org.hl7.fhir.dstu3.model.Coverage;
 import org.hl7.fhir.dstu3.model.Enumeration;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.codesystems.CoverageClass;
 
 /*
   Copyright (c) 2011+, HL7, Inc.
@@ -41,6 +43,7 @@ import org.hl7.fhir.exceptions.FHIRException;
   
 */
 // Generated on Sun, Feb 24, 2019 11:37+1100 for FHIR v4.0.0
+// mapping based on https://hl7.org/fhir/R4/coverage-version-maps.html
 public class Coverage30_40 {
 
   public static org.hl7.fhir.dstu3.model.Coverage convertCoverage(org.hl7.fhir.r4.model.Coverage src) throws FHIRException {
@@ -68,14 +71,25 @@ public class Coverage30_40 {
       tgt.setRelationship(CodeableConcept30_40.convertCodeableConcept(src.getRelationship()));
     if (src.hasPeriod())
       tgt.setPeriod(Period30_40.convertPeriod(src.getPeriod()));
-    for (org.hl7.fhir.r4.model.Reference t : src.getPayor()) tgt.addPayor(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.r4.model.Reference t : src.getPayor())
+      tgt.addPayor(Reference30_40.convertReference(t));
     if (src.hasOrder())
       tgt.setOrderElement(PositiveInt30_40.convertPositiveInt(src.getOrderElement()));
     if (src.hasNetwork())
       tgt.setNetworkElement(String30_40.convertString(src.getNetworkElement()));
-    for (org.hl7.fhir.r4.model.Reference t : src.getContract()) tgt.addContract(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.r4.model.Reference t : src.getContract())
+      tgt.addContract(Reference30_40.convertReference(t));
+
+    if (src.hasClass_()) {
+      tgt.setGrouping(new Coverage.GroupComponent());
+      for (org.hl7.fhir.r4.model.Coverage.ClassComponent t : src.getClass_()) {
+        mapClassToGroup(tgt, t);
+      }
+    }
+
     return tgt;
   }
+
 
   public static org.hl7.fhir.r4.model.Coverage convertCoverage(org.hl7.fhir.dstu3.model.Coverage src) throws FHIRException {
     if (src == null)
@@ -102,14 +116,99 @@ public class Coverage30_40 {
       tgt.setRelationship(CodeableConcept30_40.convertCodeableConcept(src.getRelationship()));
     if (src.hasPeriod())
       tgt.setPeriod(Period30_40.convertPeriod(src.getPeriod()));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getPayor()) tgt.addPayor(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getPayor())
+      tgt.addPayor(Reference30_40.convertReference(t));
     if (src.hasOrder())
       tgt.setOrderElement(PositiveInt30_40.convertPositiveInt(src.getOrderElement()));
     if (src.hasNetwork())
       tgt.setNetworkElement(String30_40.convertString(src.getNetworkElement()));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getContract()) tgt.addContract(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getContract())
+      tgt.addContract(Reference30_40.convertReference(t));
+
+
+    if (src.hasGrouping()) {
+      org.hl7.fhir.dstu3.model.Coverage.GroupComponent group = src.getGrouping();
+      if (group.hasGroup()) {
+        tgt.addClass_(convertCoverageGrouping("group", group.getGroup(), group.getGroupDisplay()));
+      }
+      if (group.hasSubGroup()) {
+        tgt.addClass_(convertCoverageGrouping("subGroup", group.getSubGroup(), group.getSubGroupDisplay()));
+      }
+      if (group.hasPlan()) {
+        tgt.addClass_(convertCoverageGrouping("plan", group.getPlan(), group.getPlanDisplay()));
+      }
+      if (group.hasSubPlan()) {
+        tgt.addClass_(convertCoverageGrouping("subPlan", group.getSubPlan(), group.getSubPlanDisplay()));
+      }
+      if (group.hasClass_()) {
+        tgt.addClass_(convertCoverageGrouping("class", group.getClass_(), group.getClassDisplay()));
+      }
+      if (group.hasSubClass()) {
+        tgt.addClass_(convertCoverageGrouping("subClass", group.getSubClass(), group.getSubClassDisplay()));
+      }
+    }
+    //note mapping of sequence from dstu3 to r4 is not described in mapping
+    if (src.hasSequence()) {
+      tgt.addClass_(convertCoverageGrouping("sequence", src.getSequence(), null));
+    }
+
     return tgt;
   }
+
+
+  private static org.hl7.fhir.r4.model.Coverage.ClassComponent convertCoverageGrouping(String code, String value, String name) {
+    org.hl7.fhir.r4.model.Coverage.ClassComponent tgt = new org.hl7.fhir.r4.model.Coverage.ClassComponent();
+
+    org.hl7.fhir.r4.model.Coding coding = new org.hl7.fhir.r4.model.Coding();
+    coding.setSystem(CoverageClass.CLASS.getSystem());
+    coding.setCode(code);
+    CodeableConcept codeableConcept = new CodeableConcept(coding);
+    tgt.setType(codeableConcept);
+    tgt.setValue(value);
+    tgt.setName(name);
+    return tgt;
+  }
+
+  private static void mapClassToGroup(Coverage tgt, org.hl7.fhir.r4.model.Coverage.ClassComponent classComponent) {
+    if (classComponent == null || tgt == null)
+      return;
+
+
+    if (!classComponent.hasType())
+      return;
+
+    Coverage.GroupComponent grouping = tgt.getGrouping();
+    switch (classComponent.getType().getCodingFirstRep().getCode()) {
+      case "group":
+        grouping.setGroup(classComponent.getValue());
+        grouping.setGroupDisplay(classComponent.getName());
+        break;
+      case "subGroup":
+        grouping.setSubGroup(classComponent.getValue());
+        grouping.setSubGroupDisplay(classComponent.getName());
+        break;
+      case "plan":
+        grouping.setPlan(classComponent.getValue());
+        grouping.setPlanDisplay(classComponent.getName());
+        break;
+      case "subPlan":
+        grouping.setSubPlan(classComponent.getValue());
+        grouping.setSubPlanDisplay(classComponent.getName());
+        break;
+      case "class":
+        grouping.setClass_(classComponent.getValue());
+        grouping.setClassDisplay(classComponent.getName());
+        break;
+      case "subClass":
+        grouping.setSubClass(classComponent.getValue());
+        grouping.setSubClassDisplay(classComponent.getName());
+        break;
+      case "sequence":
+        tgt.setSequence(classComponent.getValue());
+        break;
+    }
+  }
+
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Coverage.CoverageStatus> convertCoverageStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Coverage.CoverageStatus> src) throws FHIRException {
       if (src == null || src.isEmpty())

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Coverage30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Coverage30_40Test.java
@@ -1,0 +1,43 @@
+package org.hl7.fhir.convertors.conv30_40;
+
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Coverage30_40Test {
+
+  @Test
+  public void testConvertCoverage30to40() throws IOException {
+
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/coverage_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/coverage_30_converted_to_40.json");
+
+    org.hl7.fhir.dstu3.model.Coverage dstu3Actual = (org.hl7.fhir.dstu3.model.Coverage) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
+
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
+  }
+
+  @Test
+  void testConvertCoverage40To30() throws IOException {
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/coverage_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/coverage_40_converted_to_30.json");
+
+    org.hl7.fhir.r4.model.Coverage r4Actual = (org.hl7.fhir.r4.model.Coverage) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4Actual);
+
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3Expected = dstu3Parser.parse(dstu3ExpectedOutputJson);
+
+    Assertions.assertTrue(dstu3Expected.equalsDeep(dstu3Converted),
+      "Failed comparing\n" + dstu3Parser.composeString(dstu3Expected) + "\nand\n" + dstu3Parser.composeString(dstu3Converted));
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/coverage_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/coverage_30.json
@@ -1,0 +1,65 @@
+{
+  "resourceType": "Coverage",
+  "id": "9876B1",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://benefitsinc.com/certificate",
+      "value": "12345"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActCode",
+        "code": "EHCPOL",
+        "display": "extended healthcare"
+      }
+    ]
+  },
+  "policyHolder": {
+    "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+  },
+  "subscriber": {
+    "reference": "Patient/4"
+  },
+  "beneficiary": {
+    "reference": "Patient/4"
+  },
+  "relationship": {
+    "coding": [
+      {
+        "code": "self"
+      }
+    ]
+  },
+  "period": {
+    "start": "2011-05-23",
+    "end": "2012-05-23"
+  },
+  "payor": [
+    {
+      "reference": "Organization/2"
+    }
+  ],
+  "grouping": {
+    "group": "CBI35",
+    "groupDisplay": "Corporate Baker's Inc. Local #35",
+    "subGroup": "123",
+    "subGroupDisplay": "Trainee Part-time Benefits",
+    "plan": "B37FC",
+    "planDisplay": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC",
+    "subPlan": "P7",
+    "subPlanDisplay": "Includes afterlife benefits",
+    "class": "SILVER",
+    "classDisplay": "Silver: Family Plan spouse only",
+    "subClass": "Tier2",
+    "subClassDisplay": "Low deductable, max $20 copay"
+  },
+  "dependent": "0",
+  "sequence": "9"
+}

--- a/org.hl7.fhir.convertors/src/test/resources/coverage_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/coverage_30_converted_to_40.json
@@ -1,0 +1,135 @@
+{
+  "resourceType": "Coverage",
+  "id": "9876B1",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://benefitsinc.com/certificate",
+      "value": "12345"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActCode",
+        "code": "EHCPOL",
+        "display": "extended healthcare"
+      }
+    ]
+  },
+  "policyHolder": {
+    "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+  },
+  "subscriber": {
+    "reference": "Patient/4"
+  },
+  "beneficiary": {
+    "reference": "Patient/4"
+  },
+  "relationship": {
+    "coding": [
+      {
+        "code": "self"
+      }
+    ]
+  },
+  "period": {
+    "start": "2011-05-23",
+    "end": "2012-05-23"
+  },
+  "payor": [
+    {
+      "reference": "Organization/2"
+    }
+  ],
+  "class": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "group"
+          }
+        ]
+      },
+      "value": "CBI35",
+      "name": "Corporate Baker's Inc. Local #35"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subGroup"
+          }
+        ]
+      },
+      "value": "123",
+      "name": "Trainee Part-time Benefits"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "plan"
+          }
+        ]
+      },
+      "value": "B37FC",
+      "name": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subPlan"
+          }
+        ]
+      },
+      "value": "P7",
+      "name": "Includes afterlife benefits"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "class"
+          }
+        ]
+      },
+      "value": "SILVER",
+      "name": "Silver: Family Plan spouse only"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subClass"
+          }
+        ]
+      },
+      "value": "Tier2",
+      "name": "Low deductable, max $20 copay"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "sequence"
+          }
+        ]
+      },
+      "value": "9"
+    }
+  ],
+  "dependent": "0"
+}

--- a/org.hl7.fhir.convertors/src/test/resources/coverage_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/coverage_40.json
@@ -1,0 +1,190 @@
+{
+  "resourceType": "Coverage",
+  "id": "9876B1",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://benefitsinc.com/certificate",
+      "value": "12345"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "EHCPOL",
+        "display": "extended healthcare"
+      }
+    ]
+  },
+  "policyHolder": {
+    "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+  },
+  "subscriber": {
+    "reference": "Patient/4"
+  },
+  "beneficiary": {
+    "reference": "Patient/4"
+  },
+  "dependent": "0",
+  "relationship": {
+    "coding": [
+      {
+        "code": "self"
+      }
+    ]
+  },
+  "period": {
+    "start": "2011-05-23",
+    "end": "2012-05-23"
+  },
+  "payor": [
+    {
+      "reference": "Organization/2"
+    }
+  ],
+  "class": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "group"
+          }
+        ]
+      },
+      "value": "CB135",
+      "name": "Corporate Baker's Inc. Local #35"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subgroup"
+          }
+        ]
+      },
+      "value": "123",
+      "name": "Trainee Part-time Benefits"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "plan"
+          }
+        ]
+      },
+      "value": "B37FC",
+      "name": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subplan"
+          }
+        ]
+      },
+      "value": "P7",
+      "name": "Includes afterlife benefits"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "class"
+          }
+        ]
+      },
+      "value": "SILVER",
+      "name": "Silver: Family Plan spouse only"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "subclass"
+          }
+        ]
+      },
+      "value": "Tier2",
+      "name": "Low deductable, max $20 copay"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "sequence"
+          }
+        ]
+      },
+      "value": "9"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "rxid"
+          }
+        ]
+      },
+      "value": "MDF12345"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "rxbin"
+          }
+        ]
+      },
+      "value": "987654"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "rxgroup"
+          }
+        ]
+      },
+      "value": "M35PT"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "rxpcn"
+          }
+        ]
+      },
+      "value": "234516"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+            "code": "sequence"
+          }
+        ]
+      },
+      "value": "9"
+    }
+  ]
+}

--- a/org.hl7.fhir.convertors/src/test/resources/coverage_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/coverage_40_converted_to_30.json
@@ -1,0 +1,59 @@
+{
+  "resourceType": "Coverage",
+  "id": "9876B1",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+  },
+  "identifier": [
+    {
+      "system": "http://benefitsinc.com/certificate",
+      "value": "12345"
+    }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "EHCPOL",
+        "display": "extended healthcare"
+      }
+    ]
+  },
+  "policyHolder": {
+    "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+  },
+  "subscriber": {
+    "reference": "Patient/4"
+  },
+  "beneficiary": {
+    "reference": "Patient/4"
+  },
+  "dependent": "0",
+  "relationship": {
+    "coding": [
+      {
+        "code": "self"
+      }
+    ]
+  },
+  "period": {
+    "start": "2011-05-23",
+    "end": "2012-05-23"
+  },
+  "payor": [
+    {
+      "reference": "Organization/2"
+    }
+  ],
+  "grouping": {
+    "group": "CB135",
+    "groupDisplay": "Corporate Baker's Inc. Local #35",
+    "plan": "B37FC",
+    "planDisplay": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC",
+    "class": "SILVER",
+    "classDisplay": "Silver: Family Plan spouse only"
+  },
+  "sequence": "9"
+}


### PR DESCRIPTION
Implemented conversion support for class and grouping elements of Coverage resource between DSTU3 and R4 versions.
Implementation is based on mapping description from https://hl7.org/fhir/R4/coverage-version-maps.html

Test resources are based on example files at https://hl7.org/fhir/R4/coverage-example.json.html

Note that the mapping definition does not define the mapping of the sequence element between DSTU3 and R4 versions.
I think this is an error in the mapping definition, so I still implemented it based on the conversion from R4 to DSTU3
```
    //note mapping of sequence from dstu3 to r4 is not described in mapping
    if (src.hasSequence()) {
      tgt.addClass_(convertCoverageGrouping("sequence", src.getSequence(), null));
    }
```