### PR TITLE
FHIRPATH buig fixes

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -2754,6 +2754,9 @@ public class FHIRPathEngine {
     if (right.size() == 0) { 
       return makeBoolean(false);
     }
+    if (left.size() > 1) {
+      throw makeExceptionPlural(left.size(), expr, I18nConstants.FHIRPATH_LEFT_VALUE, "in");
+    }
     boolean ans = true;
     for (Base l : left) {
       boolean f = false;
@@ -2773,8 +2776,11 @@ public class FHIRPathEngine {
   }
 
   private List<Base> opContains(List<Base> left, List<Base> right, ExpressionNode expr) {
-    if (left.size() == 0 || right.size() == 0) { 
+    if (right.size() == 0) { 
       return new ArrayList<Base>();
+    }
+    if (left.size() == 0) { 
+      return makeBoolean(false);
     }
     boolean ans = true;
     for (Base r : right) {
@@ -4211,6 +4217,9 @@ public class FHIRPathEngine {
   }
   
   private List<Base> funcSqrt(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "sqrt", focus.size());
     }
@@ -4231,6 +4240,9 @@ public class FHIRPathEngine {
 
 
   private List<Base> funcAbs(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "abs", focus.size());
     }
@@ -4254,6 +4266,9 @@ public class FHIRPathEngine {
 
 
   private List<Base> funcCeiling(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "ceiling", focus.size());
     }
@@ -4272,6 +4287,9 @@ public class FHIRPathEngine {
   }
 
   private List<Base> funcFloor(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "floor", focus.size());
     }
@@ -4316,6 +4334,9 @@ public class FHIRPathEngine {
 
 
   private List<Base> funcLn(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "ln", focus.size());
     }
@@ -4336,6 +4357,9 @@ public class FHIRPathEngine {
 
 
   private List<Base> funcLog(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "log", focus.size());
     }
@@ -4364,6 +4388,9 @@ public class FHIRPathEngine {
   }
 
   private List<Base> funcPower(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "power", focus.size());
     }
@@ -4388,6 +4415,9 @@ public class FHIRPathEngine {
   }
 
   private List<Base> funcTruncate(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "truncate", focus.size());
     }
@@ -4494,6 +4524,9 @@ public class FHIRPathEngine {
   }
   
   private List<Base> funcPrecision(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "highBoundary", focus.size());
     }
@@ -4512,6 +4545,9 @@ public class FHIRPathEngine {
   }
 
   private List<Base> funcRound(ExecutionContext context, List<Base> focus, ExpressionNode expr) {
+    if (focus.size() == 0) {
+      return new ArrayList<Base>();
+    }
     if (focus.size() != 1) {
       throw makeExceptionPlural(focus.size(), expr, I18nConstants.FHIRPATH_FOCUS, "round", focus.size());
     }
@@ -5930,12 +5966,14 @@ public class FHIRPathEngine {
 
   private List<Base> funcIndexOf(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
     List<Base> result = new ArrayList<Base>();
+    if (focus.size() == 0) { 
+      // no result, and don't need to do anything (including evaluate the parameter)
+      return result;
+    }
 
     List<Base> swb = execute(context, focus, exp.getParameters().get(0), true);
     String sw = convertToString(swb);
-    if (focus.size() == 0) {
-      // no result
-    } else if (swb.size() == 0) {
+    if (swb.size() == 0) {
       // no result
     } else if (Utilities.noString(sw)) {
       result.add(new IntegerType(0).noExtensions());
@@ -5952,7 +5990,16 @@ public class FHIRPathEngine {
 
   private List<Base> funcSubstring(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
     List<Base> result = new ArrayList<Base>();
+    if (focus.size() == 0) {
+      // if there is no focus, then we don't need to do anything (including evaluate the parameter(s))
+      return result;
+    }
+
     List<Base> n1 = execute(context, focus, exp.getParameters().get(0), true);
+    if (n1.size() == 0) {
+      // the start parameter is not present, so return an empty list)
+      return result;
+    }
     int i1 = Integer.parseInt(n1.get(0).primitiveValue());
     int i2 = -1;
     if (exp.parameterCount() == 2) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -3437,11 +3437,11 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
   private void evaluateParameters(ExecutionTypeContext context, TypeDetails focus, ExpressionNode exp, Set<ElementDefinition> elementDependencies, List<TypeDetails> paramTypes, boolean canBeNone) {
     int i = 0;
-    for (ExpressionNode expr : exp.getParameters()) {
+    for (ExpressionNode exprParam : exp.getParameters()) {
       if (isExpressionParameter(exp, i)) {
-        paramTypes.add(executeType(changeThis(context, focus), focus, expr, elementDependencies, true, canBeNone, expr));
+        paramTypes.add(executeType(changeThis(context, focus), focus, exprParam, elementDependencies, true, canBeNone, exp));
       } else {
-        paramTypes.add(executeType(context, context.thisItem, expr, elementDependencies, true, canBeNone, expr));
+        paramTypes.add(executeType(context, focus, exprParam, elementDependencies, true, canBeNone, exp));
       }
       i++;
     }
@@ -5246,7 +5246,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         result.add(item);
       }
     }
-    for (Base item : execute(context, baseToList(context.thisItem), exp.getParameters().get(0), true)) {
+    for (Base item : execute(context, focus, exp.getParameters().get(0), true)) {
       if (!doContains(result, item)) {
         result.add(item);
       }
@@ -5259,7 +5259,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     for (Base item : focus) {
       result.add(item);
     }
-    for (Base item : execute(context, baseToList(context.thisItem), exp.getParameters().get(0), true)) {
+    for (Base item : execute(context, focus, exp.getParameters().get(0), true)) {
       result.add(item);
     }
     return result;
@@ -5267,7 +5267,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
   private List<Base> funcIntersect(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
     List<Base> result = new ArrayList<Base>();
-    List<Base> other = execute(context, baseToList(context.thisItem), exp.getParameters().get(0), true);
+    List<Base> other = execute(context, focus, exp.getParameters().get(0), true);
 
     for (Base item : focus) {
       if (!doContains(result, item) && doContains(other, item)) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -4367,6 +4367,10 @@ public class FHIRPathEngine {
     List<Base> result = new ArrayList<Base>();
     if (base.hasType("integer", "decimal", "unsignedInt", "positiveInt")) {
       List<Base> n1 = execute(context, focus, expr.getParameters().get(0), true);
+      if (n1.size() == 0) {
+        // no base, so we just return nothing (as per the spec)
+        return new ArrayList<Base>();
+      }
       if (n1.size() != 1) {
         throw makeException(expr, I18nConstants.FHIRPATH_WRONG_PARAM_TYPE, "log", "0", "Multiple Values", "integer or decimal");
       }
@@ -4398,6 +4402,10 @@ public class FHIRPathEngine {
     List<Base> result = new ArrayList<Base>();
     if (base.hasType("integer", "decimal", "unsignedInt", "positiveInt")) {
       List<Base> n1 = execute(context, focus, expr.getParameters().get(0), true);
+      if (n1.size() == 0) {
+        // no base, so we just return nothing (as per the spec)
+        return new ArrayList<Base>();
+      }
       if (n1.size() != 1) {
         throw makeException(expr, I18nConstants.FHIRPATH_WRONG_PARAM_TYPE, "power", "0", "Multiple Values", "integer or decimal");
       }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `FHIRPathEngine.java` file, focusing on improving FHIRPath function behavior, handling edge cases, and adding support for new operations.
Additionally, minor updates are made to the `TimeType.java` file to support new functionality. Below is a categorized summary of the most important changes:

### Enhancements to FHIRPath Functions

* Added handling for empty focus lists in mathematical functions like `funcSqrt`, `funcAbs`, `funcCeiling`, `funcFloor`, `funcLn`, `funcLog`, `funcPower`, and `funcRound`. These functions now return an empty list when the focus is empty, ensuring compliance with the specification. [[1]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4271-R4273) [[2]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4294-R4296) [[3]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4320-R4322) [[4]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4341-R4343) [[5]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4388-R4390) [[6]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4411-R4424) [[7]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4446-R4459) [[8]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR4477-R4479)
* Improved handling of empty focus lists in string-related functions like `funcIndexOf` and `funcSubstring`. These functions now skip parameter evaluation and return an empty list when the focus is empty. [[1]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR6028-R6035) [[2]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR6052-R6061)

### Arithmetic Operations Enhancements

* Extended support for `time` type in arithmetic operations (`opPlus` and `opMinus`) with `Quantity`. Added logic to handle milliseconds and introduced a new `timeAdd` method for precise time arithmetic. [[1]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceL2810-R2816) [[2]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR2835-R2838) [[3]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceL3073-R3126) [[4]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR3150-R3153) [[5]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceR2886-R2928)
* Enhanced the `dateAdd` method to handle fractional seconds and milliseconds more accurately.

### Code Refinements

* Updated parameter names in `evaluateParameters` for clarity and consistency.
* Fixed logic in `funcUnion`, `funcCombine`, and `funcIntersect` to ensure operations use the correct focus list instead of `context.thisItem`. [[1]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceL5154-R5249) [[2]](diffhunk://#diff-586a33c07b08c6833676c95a3df54b89819616d21fe9dd233ad56ee5b68e1bceL5167-R5270)

### Updates to `TimeType.java`

* Added imports for `Calendar` and `DataFormatException` to support new time arithmetic functionality. [[1]](diffhunk://#diff-45f531037e2bda18e43cabc028cd25a4e5b852500c46d4ffa4256f54708580ddR3-R4) [[2]](diffhunk://#diff-45f531037e2bda18e43cabc028cd25a4e5b852500c46d4ffa4256f54708580ddR41)

These changes collectively improve the robustness, accuracy, and compliance of the FHIRPath engine and related functionality.