### PR TITLE
Update rendering-phrases-fr.po

### DIFF
--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
@@ -5496,7 +5496,7 @@ msgstr "Système"
 # VALUE_SET_THESE_CODES_DEF
 #: VALUE_SET_THESE_CODES_DEF
 msgid "these codes as defined in"
-msgstr "ce•s code•s tel qu'il•s est/sont défini•s dans"
+msgstr "ce(s) code(s) tel qu'il(s) est (sont) défini(s) dans"
 
 # VALUE_SET_TOO_COSTLY
 #: VALUE_SET_TOO_COSTLY

--- a/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
+++ b/org.hl7.fhir.utilities/src/main/resources/source/rendering-phrases-fr.po
@@ -5496,7 +5496,7 @@ msgstr "Système"
 # VALUE_SET_THESE_CODES_DEF
 #: VALUE_SET_THESE_CODES_DEF
 msgid "these codes as defined in"
-msgstr "les codes sont définis dans"
+msgstr "ce•s code•s tel qu'il•s est/sont défini•s dans"
 
 # VALUE_SET_TOO_COSTLY
 #: VALUE_SET_TOO_COSTLY


### PR DESCRIPTION
Change:
<img width="704" height="175" alt="image" src="https://github.com/user-attachments/assets/65dc1998-53d3-4672-99df-45949c397e2e" />

Include les codes sont définis dans

To : Inclut le•s code•s tel qu'il est/sont défini•s dans {xxx}