### PR TITLE
Expiring terminology capabilities in terminology cache

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/CommonsTerminologyCapabilitiesCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/CommonsTerminologyCapabilitiesCache.java
@@ -1,0 +1,30 @@
+package org.hl7.fhir.r5.terminologies.utilities;
+
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+
+import java.util.concurrent.TimeUnit;
+
+
+public class CommonsTerminologyCapabilitiesCache<V> implements TerminologyCapabilitiesCache<V>{
+
+  PassiveExpiringMap<String, V> cache;
+
+  public CommonsTerminologyCapabilitiesCache(long timeToLive, TimeUnit timeUnit) {
+    cache = new PassiveExpiringMap<>(timeToLive, timeUnit);
+  }
+
+  @Override
+  public boolean containsKey(String key) {
+    return cache.containsKey(key);
+  }
+
+  @Override
+  public V get(String key) {
+    return cache.get(key);
+  }
+
+  @Override
+  public V put(String key, V value) {
+    return cache.put(key, value);
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -36,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -284,21 +285,26 @@ public class TerminologyCache {
   @Getter private int requestCount;
   @Getter private int hitCount;
   @Getter private int networkCount;
-  private Map<String, CapabilityStatement> capabilityStatementCache = new HashMap<>();
-  private Map<String, TerminologyCapabilities> terminologyCapabilitiesCache = new HashMap<>();
+
+  private final static long CAPABILITY_CACHE_EXPIRATION_HOURS = 24;
+  private final static long CAPABILITY_CACHE_EXPIRATION_MILLISECONDS = CAPABILITY_CACHE_EXPIRATION_HOURS * 60 * 60 * 1000;
+  private final long capabilityCacheExpirationMilliseconds;
+  private final TerminologyCapabilitiesCache<CapabilityStatement> capabilityStatementCache;
+  private final TerminologyCapabilitiesCache<TerminologyCapabilities> terminologyCapabilitiesCache;
   private Map<String, NamedCache> caches = new HashMap<String, NamedCache>();
   private Map<String, SourcedValueSetEntry> vsCache = new HashMap<>();
   private Map<String, SourcedCodeSystemEntry> csCache = new HashMap<>();
   private Map<String, String> serverMap = new HashMap<>();
-  @Getter @Setter private static boolean noCaching;
 
+  @Getter @Setter private static boolean noCaching;
   @Getter @Setter private static boolean cacheErrors;
 
-
-  // use lock from the context
-  public TerminologyCache(Object lock, String folder) throws FileNotFoundException, IOException, FHIRException {
+  protected TerminologyCache(Object lock, String folder, Long capabilityCacheExpirationMilliseconds) throws FileNotFoundException, IOException, FHIRException {
     super();
-    this.lock = lock;
+   this.lock = lock;
+   this.capabilityCacheExpirationMilliseconds = capabilityCacheExpirationMilliseconds;
+   capabilityStatementCache = new CommonsTerminologyCapabilitiesCache<>(capabilityCacheExpirationMilliseconds, TimeUnit.MILLISECONDS);
+   terminologyCapabilitiesCache = new CommonsTerminologyCapabilitiesCache<>(capabilityCacheExpirationMilliseconds, TimeUnit.MILLISECONDS);
     if (folder == null) {
       folder = Utilities.path("[tmp]", "default-tx-cache");
     } else if ("n/a".equals(folder)) {
@@ -318,9 +324,14 @@ public class TerminologyCache {
       if (!f.exists()) {
         throw new IOException("Unable to create terminology cache at "+folder);
       }
-      checkVersion();      
+      checkVersion();
       load();
     }
+  }
+
+  // use lock from the context
+  public TerminologyCache(Object lock, String folder) throws IOException, FHIRException {
+    this(lock, folder, CAPABILITY_CACHE_EXPIRATION_MILLISECONDS);
   }
 
   private void checkVersion() throws IOException {
@@ -786,7 +797,10 @@ public class TerminologyCache {
     return fn.startsWith(CAPABILITY_STATEMENT_TITLE) || fn.startsWith(TERMINOLOGY_CAPABILITIES_TITLE);
   }
 
-  private void loadCapabilityCache(String fn) {
+  private void loadCapabilityCache(String fn) throws IOException {
+    if (TerminologyCapabilitiesCache.cacheFileHasExpired(Utilities.path(folder, fn), capabilityCacheExpirationMilliseconds)) {
+      return;
+    }
     try {
       String src = FileUtilities.fileToString(Utilities.path(folder, fn));
       String serverId = Utilities.getFileNameForName(fn).replace(CACHE_FILE_EXTENSION, "");
@@ -867,7 +881,7 @@ public class TerminologyCache {
     return ce;
   }
 
-  private void loadNamedCache(String fn) {
+  private void loadNamedCache(String fn) throws IOException {
     int c = 0;
     try {
       String src = FileUtilities.fileToString(Utilities.path(folder, fn));

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCapabilitiesCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCapabilitiesCache.java
@@ -1,0 +1,25 @@
+package org.hl7.fhir.r5.terminologies.utilities;
+
+import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface TerminologyCapabilitiesCache<V> {
+  boolean containsKey(String key);
+
+  V get(String key);
+
+  V put(String key, V value);
+
+  static boolean cacheFileHasExpired(String fn, long expirationTimeMillis) throws IOException {
+    File cacheFile = ManagedFileAccess.csfile(fn);
+    if (!cacheFile.exists()) {
+      return true;
+    }
+    final long lastModified = cacheFile.lastModified();
+    final long currentTime = System.currentTimeMillis();
+
+    return (currentTime - lastModified) > expirationTimeMillis;
+  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/TerminologyCacheManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/TerminologyCacheManagerTests.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/utilities/CommonsTerminologyCapabilitiesCacheTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/utilities/CommonsTerminologyCapabilitiesCacheTest.java
@@ -1,0 +1,62 @@
+package org.hl7.fhir.r5.terminologies.utilities;
+
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CommonsTerminologyCapabilitiesCacheTest {
+
+  public static final String TEST_KEY = "testKey";
+
+  @Test
+  public void testFileExpiry() throws IOException, InterruptedException {
+    String expiringFilePath = TestingUtilities.tempFile("capabilitiesCache", "fileToExpire");
+
+    File file = ManagedFileAccess.file(expiringFilePath);
+    if (file.exists()) {
+      file.delete();
+    }
+    file.createNewFile();
+    Assertions.assertFalse(TerminologyCapabilitiesCache.cacheFileHasExpired(expiringFilePath, 100L));
+    Thread.sleep(200L);
+    Assertions.assertTrue(TerminologyCapabilitiesCache.cacheFileHasExpired(expiringFilePath, 100L));
+
+  }
+
+  @Test
+  public void testEmptyCache() {
+    CommonsTerminologyCapabilitiesCache<String> cache = new CommonsTerminologyCapabilitiesCache<>(100L, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+    Assertions.assertFalse(cache.containsKey(TEST_KEY));
+    Assertions.assertNull(cache.get(TEST_KEY));
+  }
+
+  @Test
+  public void testEntry() {
+    CommonsTerminologyCapabilitiesCache<String> cache = new CommonsTerminologyCapabilitiesCache<>(100L, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+    cache.put(TEST_KEY, "testValue");
+    assertTrue(cache.containsKey(TEST_KEY));
+    assertTrue(cache.get(TEST_KEY).equals("testValue"));
+  }
+
+  @Test
+  public void testExpiredEntry() throws InterruptedException {
+    CommonsTerminologyCapabilitiesCache<String> cache = new CommonsTerminologyCapabilitiesCache<>(100L, java.util.concurrent.TimeUnit.MILLISECONDS);
+    cache.put(TEST_KEY, "testValue");
+
+    Thread.sleep(200L);
+
+    assertFalse(cache.containsKey(TEST_KEY));
+    assertThat(cache.get(TEST_KEY)).isNull();
+
+  }
+}


### PR DESCRIPTION
Since terminology server capabilities may change, the cached capabilities should expire after 24 hours.

This adds an interface for caching these capabilities and an implementation based on the apache commons expiring map, which is already available in our dependencies.