### PR TITLE
Update Java versions used for testing

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -57,10 +57,10 @@ jobs:
   - template: test-unit-jobs-template.yml
     parameters:
       testUnits:
-        - name: ubuntu_java_11
+        - name: ubuntu_java_17
           vmImage: "ubuntu-latest"
           javaToolOptions:
-          jdkVersion: 1.11
+          jdkVersion: 1.17
           skipJaCoCo: true
           modules:
             ${{ parameters.modulesToTest.modules }}
@@ -68,7 +68,7 @@ jobs:
   - job: deploy_to_sonatype
     dependsOn:
       - ${{ each module in parameters.modulesToTest.modules }}:
-          - ubuntu_java_11_${{ module }}
+          - ubuntu_java_17_${{ module }}
     pool:
       vmImage: "ubuntu-latest"
     steps:
@@ -92,7 +92,7 @@ jobs:
           mavenPomFile: '$(System.DefaultWorkingDirectory)/pom.xml'
           goals: jar:jar jar:test-jar deploy
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.11'
+          jdkVersionOption: '17'
           jdkArchitectureOption: 'x64'
           options: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) --settings $(Agent.TempDirectory)/settings.xml -pl "!org.hl7.fhir.report" -DskipTests -DdeployToMavenCentral'
           mavenOptions: '-Xmx768m -Dmaven.resolver.transport=wagon'
@@ -101,7 +101,7 @@ jobs:
   - job: deploy_to_github
     dependsOn:
       - ${{ each module in parameters.modulesToTest.modules }}:
-          - ubuntu_java_11_${{ module }}
+          - ubuntu_java_17_${{ module }}
     pool:
       vmImage: "ubuntu-latest"
     steps:
@@ -135,7 +135,7 @@ jobs:
   - job: generate_i8n_csv_png_and_commit
     dependsOn: setup
       #- ${{ each module in parameters.modulesToTest.modules }}:
-      #    - ubuntu_java_11_${{ module }}
+      #    - ubuntu_java_17_${{ module }}
     variables:
       # Normally this test outputs to console. This variable appears as env param
       # I18N_COVERAGE_FILE, which tells the test to write the output to a file

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -130,7 +130,7 @@ jobs:
   - job: publish_codecov
     dependsOn:
       - ${{ each module in parameters.modulesToTest.modules }}:
-          - ubuntu_java_11_${{ module }}
+          - ubuntu_java_17_${{ module }}
     displayName: Publish Test Results and Coverage
 
     pool:

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -109,7 +109,7 @@ jobs:
               vmImage: ${{ configuration.image }}
               javaToolOptions:  ${{ configuration.javaToolOptions }}
               jdkVersion: ${{ configuration.jdk }}
-              ${{ if eq(configuration.name, 'ubuntu_java_11') }}:
+              ${{ if eq(configuration.name, 'ubuntu_java_17') }}:
                 skipJaCoCo: false
                 modules:
                   ${{ parameters.modulesToTest.modules }}


### PR DESCRIPTION
This will switch the Java version we use for pipeline testing to 17 from 11, and also add support for testing Java 21 LTS for execution and for utlities tests.