### PR TITLE
Add tests for CommunicationRequests conversion r4 <-> r5

### DIFF
--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/CommunicationRequest40_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv40_50/CommunicationRequest40_50Test.java
@@ -1,0 +1,43 @@
+package org.hl7.fhir.convertors.conv40_50;
+
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CommunicationRequest40_50Test {
+
+  @Test
+  public void convertCommunicationRequest40to50() throws IOException {
+
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/communication_request_40.json");
+    InputStream r5ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_40_converted_to_50.json");
+
+    org.hl7.fhir.r4.model.CommunicationRequest r4Actual = (org.hl7.fhir.r4.model.CommunicationRequest) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.r5.model.Resource r5Converted = VersionConvertorFactory_40_50.convertResource(r4Actual);
+
+    org.hl7.fhir.r5.formats.JsonParser r5Parser = new org.hl7.fhir.r5.formats.JsonParser();
+    org.hl7.fhir.r5.model.Resource r5Expected = r5Parser.parse(r5ExpectedOutputJson);
+
+    Assertions.assertTrue(r5Expected.equalsDeep(r5Converted),
+      "Failed comparing\n" + r5Parser.composeString(r5Expected) + "\nand\n" + r5Parser.composeString(r5Converted));
+  }
+
+  @Test
+  public void convertCommunicationRequest50to40() throws IOException {
+    InputStream r5InputJson = this.getClass().getResourceAsStream("/communication_request_50.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/communication_request_50_converted_to_40.json");
+
+    org.hl7.fhir.r5.model.CommunicationRequest r5Actual = (org.hl7.fhir.r5.model.CommunicationRequest) new org.hl7.fhir.r5.formats.JsonParser().parse(r5InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_40_50.convertResource(r5Actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
+
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/communication_request_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/communication_request_40.json
@@ -85,6 +85,17 @@
   "payload": [
     {
       "contentString": "Please provide the accident report and any associated pictures to support your Claim# DEF5647."
+    },
+    {
+      "contentString": "this contentString is ignored in conversion to r5",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-CommunicationRequest.payload.content",
+          "valueReference": {
+            "reference": "#payload-extension-reference"
+          }
+        }
+      ]
     }
   ],
   "occurrenceDateTime": "2016-06-10T11:01:10-08:00",

--- a/org.hl7.fhir.convertors/src/test/resources/communication_request_40_converted_to_50.json
+++ b/org.hl7.fhir.convertors/src/test/resources/communication_request_40_converted_to_50.json
@@ -79,41 +79,42 @@
       "text": "written"
     }
   ],
-  "context": {
+  "encounter": {
     "reference": "Encounter/example"
   },
   "payload": [
     {
-      "contentString": "Please provide the accident report and any associated pictures to support your Claim# DEF5647."
+      "contentCodeableConcept": {
+        "text": "Please provide the accident report and any associated pictures to support your Claim# DEF5647."
+      }
     },
     {
-      "contentString": "this contentString is ignored in conversion to r5",
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-CommunicationRequest.payload.content",
-          "valueReference": {
-            "reference": "#payload-extension-reference"
-          }
-        }
-      ]
+      "contentReference": {
+        "reference": "#payload-extension-reference"
+      }
     }
   ],
   "occurrenceDateTime": "2016-06-10T11:01:10-08:00",
   "authoredOn": "2016-06-10T11:01:10-08:00",
   "requester": {
-    "agent": {
-      "reference": "#requester"
-    },
-    "onBehalfOf": {
-      "reference": "#requester2"
-    }
+    "reference": "#requester"
   },
   "recipient": [
     {
       "reference": "#provider"
     }
   ],
-  "sender": {
-    "reference": "#payor"
-  }
+  "informationProvider": [
+    {
+      "reference": "#payor"
+    }
+  ],
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-CommunicationRequest.requester.onBehalfOf",
+      "valueReference": {
+        "reference": "#requester2"
+      }
+    }
+  ]
 }

--- a/org.hl7.fhir.convertors/src/test/resources/communication_request_50.json
+++ b/org.hl7.fhir.convertors/src/test/resources/communication_request_50.json
@@ -56,6 +56,7 @@
     "value": "12345"
   },
   "status": "active",
+  "intent": "proposal",
   "category": [
     {
       "coding": [
@@ -79,41 +80,38 @@
       "text": "written"
     }
   ],
-  "context": {
+  "encounter": {
     "reference": "Encounter/example"
   },
   "payload": [
     {
-      "contentString": "Please provide the accident report and any associated pictures to support your Claim# DEF5647."
+      "contentCodeableConcept": {
+        "text": "This should be converted to a contentString in R4"
+      }
     },
     {
-      "contentString": "this contentString is ignored in conversion to r5",
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-CommunicationRequest.payload.content",
-          "valueReference": {
-            "reference": "#payload-extension-reference"
+      "contentCodeableConcept": {
+        "coding": [
+          {
+            "code": "This should be converted to an extension in R4"
           }
-        }
-      ]
+        ]
+      }
     }
   ],
   "occurrenceDateTime": "2016-06-10T11:01:10-08:00",
   "authoredOn": "2016-06-10T11:01:10-08:00",
   "requester": {
-    "agent": {
-      "reference": "#requester"
-    },
-    "onBehalfOf": {
-      "reference": "#requester2"
-    }
+    "reference": "#requester"
   },
   "recipient": [
     {
       "reference": "#provider"
     }
   ],
-  "sender": {
-    "reference": "#payor"
-  }
+  "informationProvider": [
+    {
+      "reference": "#payor"
+    }
+  ]
 }

--- a/org.hl7.fhir.convertors/src/test/resources/communication_request_50_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/communication_request_50_converted_to_40.json
@@ -56,6 +56,7 @@
     "value": "12345"
   },
   "status": "active",
+  "intent": "proposal",
   "category": [
     {
       "coding": [
@@ -79,20 +80,23 @@
       "text": "written"
     }
   ],
-  "context": {
+  "encounter": {
     "reference": "Encounter/example"
   },
   "payload": [
     {
-      "contentString": "Please provide the accident report and any associated pictures to support your Claim# DEF5647."
+      "contentString": "This should be converted to a contentString in R4"
     },
     {
-      "contentString": "this contentString is ignored in conversion to r5",
       "extension": [
         {
           "url": "http://hl7.org/fhir/4.0/StructureDefinition/extension-CommunicationRequest.payload.content",
-          "valueReference": {
-            "reference": "#payload-extension-reference"
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "code": "This should be converted to an extension in R4"
+              }
+            ]
           }
         }
       ]
@@ -101,12 +105,7 @@
   "occurrenceDateTime": "2016-06-10T11:01:10-08:00",
   "authoredOn": "2016-06-10T11:01:10-08:00",
   "requester": {
-    "agent": {
-      "reference": "#requester"
-    },
-    "onBehalfOf": {
-      "reference": "#requester2"
-    }
+    "reference": "#requester"
   },
   "recipient": [
     {


### PR DESCRIPTION
Added basic tests for current conversion logic between r4 and r5.

Test resources are based on example file at http://hl7.org/fhir/R5/communicationrequest-example-fm-solicit-attachment.json.html
With some additions to make sure the payload is converted correclty in different scenarios