### PR TITLE
Improve validator search url detection

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -1322,7 +1322,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
       rule(errors, NO_RULE_DATE, IssueType.REQUIRED, -1, -1, path, Utilities.existsInList(type, "batch-response", "transaction-response") || path.startsWith("Bundle.signature"), I18nConstants.BUNDLE_BUNDLE_FULLURL_MISSING);
       return null;
 
-    } else if (StringUtils.countMatches(ref, '/') != 2 && StringUtils.countMatches(ref, '/') != 4) {
+    } else if (StringUtils.countMatches(ref, '/') != 1 && StringUtils.countMatches(ref, '/') != 3) {
       if (isTransaction) {
         rule(errors, NO_RULE_DATE, IssueType.INVALID, -1, -1, path, isSearchUrl(context, ref), I18nConstants.REFERENCE_REF_FORMAT1, ref);
       } else {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -94,6 +94,12 @@ import org.hl7.fhir.validation.instance.utils.NodeStack;
 
 public class BaseValidator implements IValidationContextResourceLoader, IMessagingServices {
 
+  /**
+   * This regex tests FHIR search parameters. It expects the formats:
+   * [paramName]=[paramValue]
+   * [paramName]=[paramValue]&[paramName]=[paramValue]
+   * etc..
+   */
   private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
 
   public static class BooleanHolder {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 
@@ -92,6 +93,8 @@ import org.hl7.fhir.validation.instance.utils.IndexedElement;
 import org.hl7.fhir.validation.instance.utils.NodeStack;
 
 public class BaseValidator implements IValidationContextResourceLoader, IMessagingServices {
+
+  private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
 
   public static class BooleanHolder {
     private boolean value = true;
@@ -1441,7 +1444,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
     if (!context.getResourceNamesAsSet().contains(resourceType)) {
       return false;
     } else {
-      return query.matches("([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
+      return SEARCH_URL_PARAMS.matcher(query).matches();
     }
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -100,7 +100,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
    * [paramName]=[paramValue]&[paramName]=[paramValue]
    * etc..
    */
-  private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("([_a-zA-Z][_a-zA-Z0-9.:-]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
+  private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("[_a-zA-Z][_a-zA-Z0-9.:-]*=[^=&]*(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
 
   public static class BooleanHolder {
     private boolean value = true;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -100,7 +100,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
    * [paramName]=[paramValue]&[paramName]=[paramValue]
    * etc..
    */
-  private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
+  private static final Pattern SEARCH_URL_PARAMS = Pattern.compile("([_a-zA-Z][_a-zA-Z0-9.:-]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9.:]*=[^=&]*))*");
 
   public static class BooleanHolder {
     private boolean value = true;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -1302,7 +1302,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
   }
 
   protected IndexedElement getFromBundle(Element bundle, String ref, String fullUrl, List<ValidationMessage> errors, String path, String type, boolean isTransaction, BooleanHolder bh) {
-    String targetUrl = null;
+    String targetUrl;
     String version = "";
     String resourceType = null;
     if (ref.startsWith("http:") || ref.startsWith("urn:") || Utilities.isAbsoluteUrl(ref)) {
@@ -1319,7 +1319,7 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
       rule(errors, NO_RULE_DATE, IssueType.REQUIRED, -1, -1, path, Utilities.existsInList(type, "batch-response", "transaction-response") || path.startsWith("Bundle.signature"), I18nConstants.BUNDLE_BUNDLE_FULLURL_MISSING);
       return null;
 
-    } else if (ref.split("/").length != 2 && ref.split("/").length != 4) {
+    } else if (StringUtils.countMatches(ref, '/') != 2 && StringUtils.countMatches(ref, '/') != 4) {
       if (isTransaction) {
         rule(errors, NO_RULE_DATE, IssueType.INVALID, -1, -1, path, isSearchUrl(context, ref), I18nConstants.REFERENCE_REF_FORMAT1, ref);
       } else {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/InstanceValidator.java
@@ -4594,8 +4594,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     }
 
     if (conditional) {
-      String query = ref.substring(ref.indexOf("?"));
-      boolean test = !Utilities.noString(query) && query.matches("\\?([_a-zA-Z][_a-zA-Z0-9]*=[^=&]*)(&([_a-zA-Z][_a-zA-Z0-9]*=[^=&]*))*");
+      boolean test = isSearchUrl(context, ref);
           //("^\\?([\\w-]+(=[\\w-]*)?(&[\\w-]+(=[\\w-]*)?)*)?$"),
       ok = rule(errors, "2023-02-20", IssueType.INVALID, element.line(), element.col(), path, test, I18nConstants.REFERENCE_REF_QUERY_INVALID, ref) && ok;
     } else if (stop.ok()) {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/InstanceValidatorTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/InstanceValidatorTests.java
@@ -7,39 +7,50 @@ import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.ValidatorSettings;
 import org.hl7.fhir.validation.instance.utils.NodeStack;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static org.apache.commons.lang3.StringUtils.trim;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class InstanceValidatorTests {
+
+  @Mock
+  private IWorkerContext context;
 
   @Test
   public void testCheckCodeOnServerNoStackLocale() throws InstanceValidator.CheckCodeOnServerException {
-      NodeStack stack =mock(NodeStack.class);
-      testCheckCodeOnServer(stack, "ko-KR");
+    when(context.getLocale()).thenReturn(Locale.KOREA);
+    NodeStack stack =mock(NodeStack.class);
+    testCheckCodeOnServer(stack, "ko-KR");
   }
 
   @Test
   public void testCheckCodeOnServerStackLocale() throws InstanceValidator.CheckCodeOnServerException {
-      NodeStack stack =mock(NodeStack.class);
-      when(stack.getWorkingLang()).thenReturn("fr-CA");
-      testCheckCodeOnServer(stack, "fr-CA");
+    NodeStack stack =mock(NodeStack.class);
+    when(stack.getWorkingLang()).thenReturn("fr-CA");
+    testCheckCodeOnServer(stack, "fr-CA");
   }
 
   private void testCheckCodeOnServer(NodeStack stack, String expectedLocale) throws InstanceValidator.CheckCodeOnServerException {
-    IWorkerContext context = mock(IWorkerContext.class);
-    when(context.getLocale()).thenReturn(Locale.KOREA);
     when(context.getVersion()).thenReturn("5.0.1");
     InstanceValidator instanceValidator = new InstanceValidator(context, null, null, null, new ValidatorSettings());
 
@@ -55,13 +66,11 @@ class InstanceValidatorTests {
 
     ValidationOptions options = validationOptionsArgumentCaptor.getValue();
 
-    Assertions.assertEquals(expectedLocale, options.getLanguages().getSource());
+    assertEquals(expectedLocale, options.getLanguages().getSource());
   }
 
   @Test
   void testElementDebug() throws IOException {
-    IWorkerContext context = mock(IWorkerContext.class);
-    when(context.getLocale()).thenReturn(Locale.KOREA);
     when(context.getVersion()).thenReturn("5.0.1");
     InstanceValidator instanceValidator = new InstanceValidator(context, null, null, null, new ValidatorSettings());
 
@@ -71,5 +80,36 @@ class InstanceValidatorTests {
     instanceValidator.debugElement(element, mockLogger);
     verify(mockLogger, times(1)).debug("dummyName" + System.lineSeparator());
   }
+
+  @ParameterizedTest
+  @CsvSource({
+    // Good URLs
+    "Patient?name=simpson                              , true",
+    "Patient?name:exact=simpson                        , true",
+    "Patient?name.chain=simpson                        , true",
+    "Patient?family=simpson&given=homer                , true",
+    "Patient?family=                                   , true",
+    "Patient?family=&given=                            , true",
+    // Bad URLs
+    "?                                                 , false",
+    "name=simpson                                      , false",
+    "?name=simpson                                     , false",
+    "Hello?name=simpson                                , false",
+    "Patient?                                          , false",
+    "Patient?=simpson                                  , false",
+    "Patient?==simpson                                 , false",
+    "Patient?==                                        , false",
+    "Patient?family==simpson                           , false",
+    "Patient?f&mily=simpson                            , false",
+  })
+  void testIsSearchUrl(String theInput, boolean theExpected) {
+    if (theInput.contains("?")) {
+      when(context.getResourceNamesAsSet()).thenReturn(Set.of("Patient"));
+    }
+
+    boolean actual = BaseValidator.isSearchUrl(context, trim(theInput));
+    assertEquals(theExpected, actual);
+  }
+
 
 }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/InstanceValidatorTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/InstanceValidatorTests.java
@@ -89,6 +89,9 @@ class InstanceValidatorTests {
     "Patient?name.chain=simpson                        , true",
     "Patient?family=simpson&given=homer                , true",
     "Patient?family=                                   , true",
+    "Patient?param-name=param-value                    , true",
+    "Patient?param=param+value                         , true",
+    "Patient?param=param%20value                       , true",
     "Patient?family=&given=                            , true",
     // Bad URLs
     "?                                                 , false",


### PR DESCRIPTION
InstanceValidator has two separate code paths for validating search URLs within resources.  This PR collapses these into a single method. In addition:

* The regex has been modified to allow `.` and `:` within parameter names
* The regex is now pre-compiled for better evaluation performance
* Two calls to `String#split` have been replaced with `StringUtil.countMatches` for better performance