### PR TITLE
Setter/getter for validation progress logging

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
@@ -43,6 +43,7 @@ public class HTTPServerTask extends ValidationEngineTask {
 
   @Override
   public void executeTask(ValidationService validationService, ValidationEngine validationEngine, ValidationContext validationContext, String[] args, TimeTracker tt, TimeTracker.Session tts) throws Exception {
+    validationEngine.setLogProgress(false);
     FhirValidatorHttpService service = new FhirValidatorHttpService(validationEngine, Integer.parseInt(Params.getParam(args, Params.SERVER)));
     service.startServer();
     log.info("Press any key to stop the server...");

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
@@ -1,11 +1,7 @@
 package org.hl7.fhir.validation.cli.tasks;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hl7.fhir.r5.model.Constants;
-import org.hl7.fhir.r5.model.ImplementationGuide;
-import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.utilities.TimeTracker;
-import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.validation.FhirValidatorHttpService;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.cli.Display;
@@ -43,7 +39,7 @@ public class HTTPServerTask extends ValidationEngineTask {
 
   @Override
   public void executeTask(ValidationService validationService, ValidationEngine validationEngine, ValidationContext validationContext, String[] args, TimeTracker tt, TimeTracker.Session tts) throws Exception {
-    validationEngine.setLogProgress(false);
+    validationEngine.setLogValidationProgress(false);
     FhirValidatorHttpService service = new FhirValidatorHttpService(validationEngine, Integer.parseInt(Params.getParam(args, Params.SERVER)));
     service.startServer();
     log.info("Press any key to stop the server...");

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -70,7 +70,6 @@ import org.hl7.fhir.r5.renderers.RendererFactory;
 import org.hl7.fhir.r5.renderers.utils.RenderingContext;
 import org.hl7.fhir.r5.renderers.utils.RenderingContext.GenerationRules;
 import org.hl7.fhir.r5.renderers.utils.RenderingContext.ResourceRendererMode;
-import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.r5.renderers.utils.ResourceWrapper;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
 import org.hl7.fhir.r5.utils.ToolingExtensions;
@@ -216,7 +215,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
   @Getter @Setter private boolean doNative;
   @Getter @Setter private boolean noInvariantChecks;
   @Getter @Setter private boolean displayWarnings;
-  @Getter @Setter private boolean logProgress;
+  @Getter @Setter private boolean logValidationProgress;
   @Getter @Setter private boolean wantInvariantInMessage;
   @Getter @Setter private boolean hintAboutNonMustSupport;
   @Getter @Setter private boolean anyExtensionsAllowed = false;
@@ -286,7 +285,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     pcm = other.pcm;
     mapLog = other.mapLog;
     debug = other.debug;
-    logProgress = other.logProgress;
+    logValidationProgress = other.logValidationProgress;
     fetcher = other.fetcher;
     policyAdvisor = other.policyAdvisor;
     locator = other.locator;
@@ -977,7 +976,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
       igLoader.loadIg(getIgs(), getBinaries(), SHCParser.CURRENT_PACKAGE, true);      
     }
     validator.setJurisdiction(jurisdiction);
-    validator.setLogProgress(logProgress);
+    validator.setLogProgress(logValidationProgress);
     if (policyAdvisor != null) {
       validator.setPolicyAdvisor(policyAdvisor);
     }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -216,6 +216,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
   @Getter @Setter private boolean doNative;
   @Getter @Setter private boolean noInvariantChecks;
   @Getter @Setter private boolean displayWarnings;
+  @Getter @Setter private boolean logProgress;
   @Getter @Setter private boolean wantInvariantInMessage;
   @Getter @Setter private boolean hintAboutNonMustSupport;
   @Getter @Setter private boolean anyExtensionsAllowed = false;
@@ -285,6 +286,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     pcm = other.pcm;
     mapLog = other.mapLog;
     debug = other.debug;
+    logProgress = other.logProgress;
     fetcher = other.fetcher;
     policyAdvisor = other.policyAdvisor;
     locator = other.locator;
@@ -975,7 +977,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
       igLoader.loadIg(getIgs(), getBinaries(), SHCParser.CURRENT_PACKAGE, true);      
     }
     validator.setJurisdiction(jurisdiction);
-    validator.setLogProgress(true);
+    validator.setLogProgress(logProgress);
     if (policyAdvisor != null) {
       validator.setPolicyAdvisor(policyAdvisor);
     }


### PR DESCRIPTION
This field allows a caller of ValidationEngine to enable or disable validation progress logging when the InstanceValidator is used.