### PR TITLE
HTTPService: warn about ignored args + remove IG endpoint

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
@@ -84,7 +84,7 @@ public class Params {
   public static final String LOG = "-log";
   public static final String LANGUAGE = "-language";
   public static final String IMPLEMENTATION_GUIDE = "-ig";
-  public static final String DEFINITION = "defn";
+  public static final String DEFINITION = "-defn";
   public static final String MAP = "-map";
   public static final String X = "-x";
   public static final String CONVERT = "-convert";
@@ -143,9 +143,9 @@ public class Params {
   public static final String EXTERNALS = "-externals";
   public static final String MODE = "-mode";
   private static final String FHIR_SETTINGS_PARAM = "-fhir-settings";
-  private static final String WATCH_MODE_PARAM = "-watch-mode";
-  private static final String WATCH_SCAN_DELAY = "-watch-scan-delay";
-  private static final String WATCH_SETTLE_TIME = "-watch-settle-time";
+  public static final String WATCH_MODE_PARAM = "-watch-mode";
+  public static final String WATCH_SCAN_DELAY = "-watch-scan-delay";
+  public static final String WATCH_SETTLE_TIME = "-watch-settle-time";
   public static final String NO_HTTP_ACCESS = "-no-http-access";
   public static final String AUTH_NONCONFORMANT_SERVERS = "-authorise-non-conformant-tx-servers";
   public static final String R5_REF_POLICY = "r5-bundle-relative-reference-policy";

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/tasks/HTTPServerTask.java
@@ -39,11 +39,26 @@ public class HTTPServerTask extends ValidationEngineTask {
 
   @Override
   public void executeTask(ValidationService validationService, ValidationEngine validationEngine, ValidationContext validationContext, String[] args, TimeTracker tt, TimeTracker.Session tts) throws Exception {
+    checkForInvalidArgs(args);
     validationEngine.setLogValidationProgress(false);
     FhirValidatorHttpService service = new FhirValidatorHttpService(validationEngine, Integer.parseInt(Params.getParam(args, Params.SERVER)));
     service.startServer();
     log.info("Press any key to stop the server...");
     System.in.read();
     service.stop();
+  }
+
+  private void checkForInvalidArgs(String[] args) {
+    final String[] invalidParams = {
+      Params.WATCH_MODE_PARAM,
+      Params.WATCH_SCAN_DELAY,
+      Params.WATCH_SETTLE_TIME
+    };
+    final String warningText = " is not supported in server mode and will be ignored.";
+    for (String invalidParam : invalidParams) {
+      if (Params.hasParam(args, invalidParam)) {
+        log.warn(invalidParam + warningText);
+      }
+    }
   }
 }


### PR DESCRIPTION
This warns when watch-mode is used in server mode and removes the IG loading endpoint.

The IG endpoint was a source of mutation for the state of the ValidationEngine, which increased the possibility of misuse.