### PR TITLE
Improve Medication Conversion dstu3 <-> r4

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
@@ -54,10 +54,12 @@ public class VersionConvertorConstants {
   public static final String EXT_IG_DEFINITION_PARAM_URL_EXT = "http://hl7.org/fhir/tools/CodeSystem/ig-parameters";
   public static final String EXT_IG_DEFINITION_RESOURCE_PROFILE = "http://hl7.org/fhir/5.0/StructureDefinition/extension-ImplementationGuide.definition.resource.profile";
   public static final String EXT_IG_DEPENDSON_REASON = "http://hl7.org/fhir/5.0/StructureDefinition/extension-ImplementationGuide.dependsOn.reason";
-  public static final String EXT_MED_CONT = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.container";
   public static final String EXT_MED_ISBRAND = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.isBrand";
+  public static final String EXT_MED_OTC = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationOTC";
+  public static final String EXT_MED_IMAGE = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationImage";
+  public static final String EXT_MED_PACK_CONTAINER = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.container";
   public static final String EXT_MED_PACK_AMOUNT = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content.amount";
-  public static final String EXT_MED_PACK_CONT = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content";
+  public static final String EXT_MED_PACK_CONTENT = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content";
   public static final String EXT_MUST_VALUE = "http://hl7.org/fhir/5.0/StructureDefinition/extension-ElementDefinition.mustHaveValue";
   public static final String EXT_NAMINGSYSTEM_TITLE = "http://hl7.org/fhir/5.0/StructureDefinition/extension-NamingSystem.title";
   public static final String EXT_NAMINGSYSTEM_URL = "http://hl7.org/fhir/5.0/StructureDefinition/extension-NamingSystem.url";

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/resources10_40/Medication10_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv10_40/resources10_40/Medication10_40.java
@@ -7,10 +7,7 @@ import org.hl7.fhir.convertors.conv10_40.datatypes10_40.complextypes10_40.Codeab
 import org.hl7.fhir.convertors.conv10_40.datatypes10_40.complextypes10_40.Ratio10_40;
 import org.hl7.fhir.convertors.conv10_40.datatypes10_40.complextypes10_40.SimpleQuantity10_40;
 import org.hl7.fhir.convertors.conv10_40.datatypes10_40.primitivetypes10_40.Boolean10_40;
-import org.hl7.fhir.dstu2.model.Medication;
-import org.hl7.fhir.dstu2.model.Medication.MedicationPackageContentComponent;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r4.model.Extension;
 
 public class Medication10_40 {
 
@@ -40,12 +37,12 @@ public class Medication10_40 {
       org.hl7.fhir.dstu2.model.Medication.MedicationPackageComponent package_ = src.getPackage();
       if (package_.hasContainer())
         tgt.addExtension(
-          VersionConvertorConstants.EXT_MED_CONT,
+          VersionConvertorConstants.EXT_MED_PACK_CONTAINER,
           CodeableConcept10_40.convertCodeableConcept(package_.getContainer())
         );
       for (org.hl7.fhir.dstu2.model.Medication.MedicationPackageContentComponent c : package_.getContent())
         tgt.addExtension(
-          VersionConvertorConstants.EXT_MED_PACK_CONT,
+          VersionConvertorConstants.EXT_MED_PACK_CONTENT,
           Medication10_40.content(c)
         );
     }
@@ -83,7 +80,7 @@ public class Medication10_40 {
     ConversionContext10_40.INSTANCE.getVersionConvertor_10_40().copyElement(src, tgt);
     if (src.hasItem())
       tgt.addExtension(
-        VersionConvertorConstants.EXT_MED_PACK_CONT,
+        VersionConvertorConstants.EXT_MED_PACK_CONTENT,
         Reference10_40.convertReference(src.getItem())
       );
     if (src.hasAmount())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Medication30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/Medication30_40.java
@@ -1,17 +1,33 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
+import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Attachment30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.CodeableConcept30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Ratio30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.SimpleQuantity30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Boolean30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
-import org.hl7.fhir.dstu3.model.Enumeration;
-import org.hl7.fhir.dstu3.model.Medication;
 import org.hl7.fhir.exceptions.FHIRException;
 
+import java.util.List;
+
+
+/**
+ * Conversion is based on mapping defined at https://hl7.org/fhir/R4/medication-version-maps.html
+ * Only deviation is the status mapping, which seems incorrect in the definition.
+ * Because they define an extension based mapping, but both dstu3 and r4 have a corresponding status field,
+ * so it seems incorrect to not just map the status fields
+ */
+
 public class Medication30_40 {
+  private static final String[] IGNORED_EXTENSION_URLS = new String[]{
+    VersionConvertorConstants.EXT_MED_ISBRAND, VersionConvertorConstants.EXT_MED_OTC,
+    VersionConvertorConstants.EXT_MED_PACK_CONTAINER, VersionConvertorConstants.EXT_MED_PACK_CONTENT,
+    VersionConvertorConstants.EXT_MED_IMAGE
+  };
 
   public static org.hl7.fhir.r4.model.Medication convertMedication(org.hl7.fhir.dstu3.model.Medication src) throws FHIRException {
     if (src == null)
@@ -22,34 +38,146 @@ public class Medication30_40 {
       tgt.setCode(CodeableConcept30_40.convertCodeableConcept(src.getCode()));
     if (src.hasStatus())
       tgt.setStatusElement(convertMedicationStatus(src.getStatusElement()));
+    if (src.hasIsBrand())
+      tgt.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_ISBRAND, new org.hl7.fhir.r4.model.BooleanType(src.getIsBrand())));
+    if (src.hasIsOverTheCounter())
+      tgt.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_OTC, new org.hl7.fhir.r4.model.BooleanType(src.getIsOverTheCounter())));
     if (src.hasManufacturer())
       tgt.setManufacturer(Reference30_40.convertReference(src.getManufacturer()));
     if (src.hasForm())
       tgt.setForm(CodeableConcept30_40.convertCodeableConcept(src.getForm()));
     for (org.hl7.fhir.dstu3.model.Medication.MedicationIngredientComponent t : src.getIngredient())
       tgt.addIngredient(convertMedicationIngredientComponent(t));
-    if (src.hasPackage())
+
+    if (src.hasPackage()) {
+      if (src.getPackage().hasContainer())
+        tgt.addExtension(
+          VersionConvertorConstants.EXT_MED_PACK_CONTAINER,
+          CodeableConcept30_40.convertCodeableConcept(src.getPackage().getContainer())
+        );
+      for (org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent c : src.getPackage().getContent())
+        tgt.addExtension(
+          VersionConvertorConstants.EXT_MED_PACK_CONTENT,
+          Medication30_40.convertMedicationPackageContentComponent(c)
+        );
       tgt.setBatch(convertMedicationPackageBatchComponent(src.getPackage().getBatchFirstRep()));
+    }
+
+    for (org.hl7.fhir.dstu3.model.Attachment attachment : src.getImage()) {
+      tgt.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_IMAGE, Attachment30_40.convertAttachment(attachment)));
+    }
     return tgt;
   }
 
   public static org.hl7.fhir.dstu3.model.Medication convertMedication(org.hl7.fhir.r4.model.Medication src) throws FHIRException {
     if (src == null)
       return null;
+
     org.hl7.fhir.dstu3.model.Medication tgt = new org.hl7.fhir.dstu3.model.Medication();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt, IGNORED_EXTENSION_URLS);
     if (src.hasCode())
       tgt.setCode(CodeableConcept30_40.convertCodeableConcept(src.getCode()));
     if (src.hasStatus())
       tgt.setStatusElement(convertMedicationStatus(src.getStatusElement()));
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_ISBRAND)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_ISBRAND);
+      if (ext.hasValue() && ext.getValue() instanceof org.hl7.fhir.r4.model.BooleanType) {
+        tgt.setIsBrandElement(Boolean30_40.convertBoolean((org.hl7.fhir.r4.model.BooleanType) ext.getValue()));
+      }
+    }
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_OTC)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_OTC);
+      if (ext.hasValue() && ext.getValue() instanceof org.hl7.fhir.r4.model.BooleanType) {
+        tgt.setIsOverTheCounterElement(Boolean30_40.convertBoolean((org.hl7.fhir.r4.model.BooleanType) ext.getValue()));
+      }
+    }
     if (src.hasManufacturer())
       tgt.setManufacturer(Reference30_40.convertReference(src.getManufacturer()));
     if (src.hasForm())
       tgt.setForm(CodeableConcept30_40.convertCodeableConcept(src.getForm()));
     for (org.hl7.fhir.r4.model.Medication.MedicationIngredientComponent t : src.getIngredient())
       tgt.addIngredient(convertMedicationIngredientComponent(t));
+
+    if (src.hasBatch() || src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_CONTAINER) || src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_CONTENT)) {
+      tgt.setPackage(convertMedicationPackageComponent(src));
+    }
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_IMAGE)) {
+      List<org.hl7.fhir.r4.model.Extension> extensions = src.getExtensionsByUrl(VersionConvertorConstants.EXT_MED_IMAGE);
+      for (org.hl7.fhir.r4.model.Extension ext : extensions) {
+        if (ext.getValue() instanceof org.hl7.fhir.r4.model.Attachment) {
+          tgt.addImage(Attachment30_40.convertAttachment((org.hl7.fhir.r4.model.Attachment) ext.getValue()));
+        }
+      }
+    }
+
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Medication.MedicationPackageComponent convertMedicationPackageComponent(org.hl7.fhir.r4.model.Medication src) throws FHIRException {
+    if (src == null)
+      return null;
+    org.hl7.fhir.dstu3.model.Medication.MedicationPackageComponent tgt = new org.hl7.fhir.dstu3.model.Medication.MedicationPackageComponent();
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_CONTAINER)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_PACK_CONTAINER);
+      if (ext.hasValue() && ext.getValue() instanceof org.hl7.fhir.r4.model.CodeableConcept) {
+        tgt.setContainer(CodeableConcept30_40.convertCodeableConcept((org.hl7.fhir.r4.model.CodeableConcept) ext.getValue()));
+      }
+    }
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_CONTENT)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_PACK_CONTENT);
+      if (ext.hasValue() && ext.getValue() instanceof org.hl7.fhir.r4.model.Extension) {
+        tgt.addContent(convertMedicationPackageContentComponent((org.hl7.fhir.r4.model.Extension) ext.getValue()));
+      }
+    }
+
     if (src.hasBatch())
-      tgt.getPackage().addBatch(convertMedicationPackageBatchComponent(src.getBatch()));
+      tgt.addBatch(convertMedicationPackageBatchComponent(src.getBatch()));
+
+    return tgt;
+  }
+
+  public static org.hl7.fhir.r4.model.Extension convertMedicationPackageContentComponent(org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent src) {
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Extension tgt = new org.hl7.fhir.r4.model.Extension();
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+
+    if (src.hasItem())
+      tgt.addExtension(
+        VersionConvertorConstants.EXT_MED_PACK_CONTENT,
+        ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(src.getItem())
+      );
+    if (src.hasAmount())
+      tgt.addExtension(
+        VersionConvertorConstants.EXT_MED_PACK_AMOUNT,
+        SimpleQuantity30_40.convertSimpleQuantity(src.getAmount())
+      );
+    return tgt;
+  }
+
+  public static org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent convertMedicationPackageContentComponent(org.hl7.fhir.r4.model.Extension src) {
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent tgt = new org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent();
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt, VersionConvertorConstants.EXT_MED_PACK_CONTENT, VersionConvertorConstants.EXT_MED_PACK_AMOUNT);
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_CONTENT)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_PACK_CONTENT);
+      if (ext.hasValue() && (ext.getValue() instanceof org.hl7.fhir.r4.model.CodeableConcept || ext.getValue() instanceof org.hl7.fhir.r4.model.Reference)) {
+        tgt.setItem(ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(ext.getValue()));
+      }
+    }
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_PACK_AMOUNT)) {
+      org.hl7.fhir.r4.model.Extension ext = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_PACK_AMOUNT);
+      if (ext.hasValue() && ext.getValue() instanceof org.hl7.fhir.r4.model.Quantity) {
+        tgt.setAmount(SimpleQuantity30_40.convertSimpleQuantity((org.hl7.fhir.r4.model.Quantity) ext.getValue()));
+      }
+    }
+
     return tgt;
   }
 
@@ -57,7 +185,7 @@ public class Medication30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.Medication.MedicationIngredientComponent tgt = new org.hl7.fhir.dstu3.model.Medication.MedicationIngredientComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasItem())
       tgt.setItem(ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(src.getItem()));
     if (src.hasIsActive())
@@ -71,7 +199,7 @@ public class Medication30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.Medication.MedicationIngredientComponent tgt = new org.hl7.fhir.r4.model.Medication.MedicationIngredientComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasItem())
       tgt.setItem(ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().convertType(src.getItem()));
     if (src.hasIsActive())
@@ -85,7 +213,7 @@ public class Medication30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.Medication.MedicationPackageBatchComponent tgt = new org.hl7.fhir.dstu3.model.Medication.MedicationPackageBatchComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasLotNumber())
       tgt.setLotNumberElement(String30_40.convertString(src.getLotNumberElement()));
     if (src.hasExpirationDate())
@@ -97,7 +225,7 @@ public class Medication30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.r4.model.Medication.MedicationBatchComponent tgt = new org.hl7.fhir.r4.model.Medication.MedicationBatchComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt);
     if (src.hasLotNumber())
       tgt.setLotNumberElement(String30_40.convertString(src.getLotNumberElement()));
     if (src.hasExpirationDate())
@@ -106,54 +234,54 @@ public class Medication30_40 {
   }
 
   static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Medication.MedicationStatus> convertMedicationStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Medication.MedicationStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      Enumeration<Medication.MedicationStatus> tgt = new Enumeration<>(new Medication.MedicationStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(Medication.MedicationStatus.ACTIVE);
-                  break;
-              case INACTIVE:
-                  tgt.setValue(Medication.MedicationStatus.INACTIVE);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(Medication.MedicationStatus.ENTEREDINERROR);
-                  break;
-              default:
-                  tgt.setValue(Medication.MedicationStatus.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Medication.MedicationStatus> tgt = new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.Medication.MedicationStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Medication.MedicationStatus.ACTIVE);
+          break;
+        case INACTIVE:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Medication.MedicationStatus.INACTIVE);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Medication.MedicationStatus.ENTEREDINERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.dstu3.model.Medication.MedicationStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Medication.MedicationStatus> convertMedicationStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.Medication.MedicationStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Medication.MedicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Medication.MedicationStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.ACTIVE);
-                  break;
-              case INACTIVE:
-                  tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.INACTIVE);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.ENTEREDINERROR);
-                  break;
-              default:
-                  tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.Medication.MedicationStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.Medication.MedicationStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.ACTIVE);
+          break;
+        case INACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.INACTIVE);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.ENTEREDINERROR);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.Medication.MedicationStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Medication30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/Medication30_40Test.java
@@ -1,0 +1,43 @@
+package org.hl7.fhir.convertors.conv30_40;
+
+
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Medication30_40Test {
+
+  @Test
+  public void convertMedication30to40() throws IOException {
+
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/medication_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_30_converted_to_40.json");
+
+    org.hl7.fhir.dstu3.model.Medication dstu3Actual = (org.hl7.fhir.dstu3.model.Medication) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
+
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
+  }
+
+  @Test
+  public void convertMedication40To30() throws IOException {
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/medication_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_40_converted_to_30.json");
+
+    org.hl7.fhir.r4.model.Medication r4Actual = (org.hl7.fhir.r4.model.Medication) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4Actual);
+
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3Expected = dstu3Parser.parse(dstu3ExpectedOutputJson);
+
+    Assertions.assertTrue(dstu3Expected.equalsDeep(dstu3Converted),
+      "Failed comparing\n" + dstu3Parser.composeString(dstu3Expected) + "\nand\n" + dstu3Parser.composeString(dstu3Converted));
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_30.json
@@ -1,0 +1,103 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4",
+      "name": "Pfizer Laboratories Div Pfizer Inc"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "isBrand": true,
+  "isOverTheCounter": false,
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "amount": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "package": {
+    "container": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "415818006",
+          "display": "Vial"
+        }
+      ]
+    },
+    "content": [
+      {
+        "itemCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "324337001",
+              "display": "Vancomycin 500mg powder for infusion solution vial (product)"
+            }
+          ]
+        },
+        "amount": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    ],
+    "batch": [
+      {
+        "lotNumber": "9494788",
+        "expirationDate": "2017-05-22"
+      }
+    ]
+  },
+  "image": [
+    {
+      "contentType": "application/pdf",
+      "url": "https://www.drugs.com/images/pills/fio/AKN07410.JPG",
+      "title": "Vancomycin Image"
+    }
+  ]
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_30_converted_to_40.json
@@ -1,0 +1,120 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.isBrand",
+      "valueBoolean": true
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationOTC",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.container",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "415818006",
+            "display": "Vial"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content",
+      "valueExtension": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "324337001",
+                  "display": "Vancomycin 500mg powder for infusion solution vial (product)"
+                }
+              ]
+            }
+          },
+          {
+            "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content.amount",
+            "valueQuantity": {
+              "value": 10,
+              "system": "http://unitsofmeasure.org",
+              "code": "mL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationImage",
+      "valueAttachment": {
+        "contentType": "application/pdf",
+        "url": "https://www.drugs.com/images/pills/fio/AKN07410.JPG",
+        "title": "Vancomycin Image"
+      }
+    }
+  ],
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4",
+      "name": "Pfizer Laboratories Div Pfizer Inc"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "batch": {
+    "lotNumber": "9494788",
+    "expirationDate": "2017-05-22"
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_40.json
@@ -1,0 +1,120 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.isBrand",
+      "valueBoolean": true
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationOTC",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.container",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "415818006",
+            "display": "Vial"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content",
+      "valueExtension": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "324337001",
+                  "display": "Vancomycin 500mg powder for infusion solution vial (product)"
+                }
+              ]
+            }
+          },
+          {
+            "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-Medication.package.content.amount",
+            "valueQuantity": {
+              "value": 10,
+              "system": "http://unitsofmeasure.org",
+              "code": "mL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationImage",
+      "valueAttachment": {
+        "contentType": "application/pdf",
+        "url": "https://www.drugs.com/images/pills/fio/AKN07410.JPG",
+        "title": "Vancomycin Image"
+      }
+    }
+  ],
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4",
+      "name": "Pfizer Laboratories Div Pfizer Inc"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "batch": {
+    "lotNumber": "9494788",
+    "expirationDate": "2017-05-22"
+  }
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_40_converted_to_30.json
@@ -1,0 +1,103 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4",
+      "name": "Pfizer Laboratories Div Pfizer Inc"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "isBrand": true,
+  "isOverTheCounter": false,
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "amount": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "package": {
+    "container": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "415818006",
+          "display": "Vial"
+        }
+      ]
+    },
+    "content": [
+      {
+        "itemCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "324337001",
+              "display": "Vancomycin 500mg powder for infusion solution vial (product)"
+            }
+          ]
+        },
+        "amount": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    ],
+    "batch": [
+      {
+        "lotNumber": "9494788",
+        "expirationDate": "2017-05-22"
+      }
+    ]
+  },
+  "image": [
+    {
+      "contentType": "application/pdf",
+      "url": "https://www.drugs.com/images/pills/fio/AKN07410.JPG",
+      "title": "Vancomycin Image"
+    }
+  ]
+}


### PR DESCRIPTION
- Implemented conversion of`IsBrand`, `IsOverTheCounter` and `Image` properties
- Improved `Package` conversion to also support package container and content.

Implementation is based on conversion maps at https://hl7.org/fhir/R4/medication-version-maps.html

Test resources are based on the example files, with some manual changes to make sure we test the complex parts
https://hl7.org/fhir/R4/medicationexample0301.json.html
http://hl7.org/fhir/STU3/medicationexample0301.json.html