### PR TITLE
Improve Medicationstatement conversion between dstu3 and r4

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
@@ -72,6 +72,8 @@ public class VersionConvertorConstants {
   public static final String EXT_NOT_GIVEN_EXTENSION_URL = "http://hl7.org/fhir/3.0/StructureDefinition/extension-Immunization.notGiven";
   public static final String EXT_IG_DEPENDSON_PACKAGE_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ImplementationGuide.dependsOn.packageId";
   public static final String EXT_MED_REQ_ONBEHALF = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationRequest.requester.onBehalfOf";
+  public static final String EXT_MED_STAT_STATUS = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.status";
+  public static final String EXT_MED_STAT_TAKEN = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.takem";
   public static final String EXT_COM_REQ_ONBEHALF = "http://hl7.org/fhir/3.0/StructureDefinition/extension-CommunicationRequest.requester.onBehalfOf";
   public static final String EXT_DOC_REF_CREATED = "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created";
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/VersionConvertorConstants.java
@@ -39,7 +39,6 @@ public class VersionConvertorConstants {
   public final static String EXT_IG_DEPENDSON_VERSION_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ImplementationGuide.dependsOn.version";
   public final static String EXT_MODIFIER_REASON_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ElementDefinition.isModifierReason";
   public final static String EXT_MODIFIER_REASON_LEGACY = "No Modifier Reason provideed in previous versions of FHIR";
-  public final static String EXT_MODIFIER_TAKEN = "http://hl7.org/fhir/4.0/StructureDefinition/extension-MedicationStatment.taken";
   public final static String EXT_PROFILE_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ElementDefinition.type.profile";
   public static final String EXT_ACCEPT_UNKNOWN_EXTENSION_URL = "http://hl7.org/fhir/3.0/StructureDefinition/extension-CapabilityStatement.acceptUnknown";
   public static final String EXT_CarePlanActivityDetailComponentExtension = "http://hl7.org/fhir/3.0/StructureDefinition/extension-CarePlan.activity.detail.category";
@@ -73,7 +72,7 @@ public class VersionConvertorConstants {
   public static final String EXT_IG_DEPENDSON_PACKAGE_EXTENSION = "http://hl7.org/fhir/4.0/StructureDefinition/extension-ImplementationGuide.dependsOn.packageId";
   public static final String EXT_MED_REQ_ONBEHALF = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationRequest.requester.onBehalfOf";
   public static final String EXT_MED_STAT_STATUS = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.status";
-  public static final String EXT_MED_STAT_TAKEN = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.takem";
+  public static final String EXT_MED_STAT_TAKEN = "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.taken";
   public static final String EXT_COM_REQ_ONBEHALF = "http://hl7.org/fhir/3.0/StructureDefinition/extension-CommunicationRequest.requester.onBehalfOf";
   public static final String EXT_DOC_REF_CREATED = "http://hl7.org/fhir/3.0/StructureDefinition/extension-DocumentReference.created";
 

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
@@ -18,7 +18,7 @@ public class MedicationStatement30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.MedicationStatement tgt = new org.hl7.fhir.dstu3.model.MedicationStatement();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt, VersionConvertorConstants.EXT_MED_STAT_STATUS, VersionConvertorConstants.EXT_MED_STAT_TAKEN);
 
     for (org.hl7.fhir.r4.model.Identifier t : src.getIdentifier())
       tgt.addIdentifier(Identifier30_40.convertIdentifier(t));

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
+import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Dosage30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
@@ -18,14 +19,31 @@ public class MedicationStatement30_40 {
       return null;
     org.hl7.fhir.dstu3.model.MedicationStatement tgt = new org.hl7.fhir.dstu3.model.MedicationStatement();
     ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+
     for (org.hl7.fhir.r4.model.Identifier t : src.getIdentifier())
       tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
-    for (org.hl7.fhir.r4.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.r4.model.Reference t : src.getPartOf()) tgt.addPartOf(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.r4.model.Reference t : src.getBasedOn())
+      tgt.addBasedOn(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.r4.model.Reference t : src.getPartOf())
+      tgt.addPartOf(Reference30_40.convertReference(t));
     if (src.hasContext())
       tgt.setContext(Reference30_40.convertReference(src.getContext()));
-    if (src.hasStatus())
-      tgt.setStatusElement(convertMedicationStatementStatus(src.getStatusElement()));
+
+    if (src.hasExtension(VersionConvertorConstants.EXT_MED_STAT_STATUS)) {
+      org.hl7.fhir.r4.model.Extension statusExtension = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_STAT_STATUS);
+      if (statusExtension.getValue() instanceof org.hl7.fhir.r4.model.StringType) {
+        tgt.setStatus(MedicationStatement.MedicationStatementStatus.fromCode(((org.hl7.fhir.r4.model.StringType) statusExtension.getValue()).getValue()));
+      }
+      if (src.hasExtension(VersionConvertorConstants.EXT_MED_STAT_TAKEN)) {
+        org.hl7.fhir.r4.model.Extension takenExtension = src.getExtensionByUrl(VersionConvertorConstants.EXT_MED_STAT_TAKEN);
+        if (takenExtension.getValue() instanceof org.hl7.fhir.r4.model.StringType) {
+          tgt.setTaken(MedicationStatement.MedicationStatementTaken.fromCode(((org.hl7.fhir.r4.model.StringType) takenExtension.getValue()).getValue()));
+        }
+      }
+    } else if (src.hasStatus()) {
+      tgt.setStatusElement(convertMedicationStatementStatus(src.getStatusElement(), tgt));
+    }
+
     if (src.hasCategory())
       tgt.setCategory(CodeableConcept30_40.convertCodeableConcept(src.getCategory()));
     if (src.hasMedication())
@@ -40,12 +58,21 @@ public class MedicationStatement30_40 {
       tgt.setSubject(Reference30_40.convertReference(src.getSubject()));
     for (org.hl7.fhir.r4.model.Reference t : src.getDerivedFrom())
       tgt.addDerivedFrom(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.r4.model.CodeableConcept t : src.getReasonCode())
-      tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
+
+    if (src.getStatus() == org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.NOTTAKEN) {
+      for (org.hl7.fhir.r4.model.CodeableConcept t : src.getReasonCode())
+        tgt.addReasonNotTaken(CodeableConcept30_40.convertCodeableConcept(t));
+    } else {
+      for (org.hl7.fhir.r4.model.CodeableConcept t : src.getReasonCode())
+        tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
+    }
+
     for (org.hl7.fhir.r4.model.Reference t : src.getReasonReference())
       tgt.addReasonReference(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.r4.model.Annotation t : src.getNote()) tgt.addNote(Annotation30_40.convertAnnotation(t));
-    for (org.hl7.fhir.r4.model.Dosage t : src.getDosage()) tgt.addDosage(Dosage30_40.convertDosage(t));
+    for (org.hl7.fhir.r4.model.Annotation t : src.getNote())
+      tgt.addNote(Annotation30_40.convertAnnotation(t));
+    for (org.hl7.fhir.r4.model.Dosage t : src.getDosage())
+      tgt.addDosage(Dosage30_40.convertDosage(t));
     return tgt;
   }
 
@@ -85,73 +112,81 @@ public class MedicationStatement30_40 {
     return tgt;
   }
 
-  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus> convertMedicationStatementStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      Enumeration<MedicationStatement.MedicationStatementStatus> tgt = new Enumeration<>(new MedicationStatement.MedicationStatementStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.ACTIVE);
-                  break;
-              case COMPLETED:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.COMPLETED);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.ENTEREDINERROR);
-                  break;
-              case INTENDED:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.INTENDED);
-                  break;
-              case STOPPED:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.STOPPED);
-                  break;
-              case ONHOLD:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.ONHOLD);
-                  break;
-              default:
-                  tgt.setValue(MedicationStatement.MedicationStatementStatus.NULL);
-                  break;
-          }
+  static public org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus> convertMedicationStatementStatus(org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus> src, org.hl7.fhir.dstu3.model.MedicationStatement medicationStatementTarget) throws FHIRException {
+    if (src == null || src.isEmpty())
+      return null;
+    Enumeration<MedicationStatement.MedicationStatementStatus> tgt = new Enumeration<>(new MedicationStatement.MedicationStatementStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.ACTIVE);
+          break;
+        case COMPLETED:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.COMPLETED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.ENTEREDINERROR);
+          break;
+        case INTENDED:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.INTENDED);
+          break;
+        case STOPPED:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.STOPPED);
+          break;
+        case ONHOLD:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.ONHOLD);
+          break;
+        case UNKNOWN:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.COMPLETED);
+          medicationStatementTarget.setTaken(MedicationStatement.MedicationStatementTaken.UNK);
+          break;
+        case NOTTAKEN:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.COMPLETED);
+          medicationStatementTarget.setTaken(MedicationStatement.MedicationStatementTaken.N);
+          break;
+        default:
+          tgt.setValue(MedicationStatement.MedicationStatementStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 
   static public org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus> convertMedicationStatementStatus(org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus> src) throws FHIRException {
-      if (src == null || src.isEmpty())
-          return null;
-      org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatusEnumFactory());
-      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
-      if (src.getValue() == null) {
-          tgt.setValue(null);
-      } else {
-          switch (src.getValue()) {
-              case ACTIVE:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ACTIVE);
-                  break;
-              case COMPLETED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.COMPLETED);
-                  break;
-              case ENTEREDINERROR:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ENTEREDINERROR);
-                  break;
-              case INTENDED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.INTENDED);
-                  break;
-              case STOPPED:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.STOPPED);
-                  break;
-              case ONHOLD:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ONHOLD);
-                  break;
-              default:
-                  tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.NULL);
-                  break;
-          }
+    if (src == null || src.isEmpty())
+      return null;
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus> tgt = new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatusEnumFactory());
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    if (src.getValue() == null) {
+      tgt.setValue(null);
+    } else {
+      switch (src.getValue()) {
+        case ACTIVE:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ACTIVE);
+          break;
+        case COMPLETED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.COMPLETED);
+          break;
+        case ENTEREDINERROR:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ENTEREDINERROR);
+          break;
+        case INTENDED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.INTENDED);
+          break;
+        case STOPPED:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.STOPPED);
+          break;
+        case ONHOLD:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ONHOLD);
+          break;
+        default:
+          tgt.setValue(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.NULL);
+          break;
       }
-      return tgt;
+    }
+    return tgt;
   }
 }

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/MedicationStatement30_40.java
@@ -81,14 +81,27 @@ public class MedicationStatement30_40 {
       return null;
     org.hl7.fhir.r4.model.MedicationStatement tgt = new org.hl7.fhir.r4.model.MedicationStatement();
     ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyDomainResource(src, tgt);
+
     for (org.hl7.fhir.dstu3.model.Identifier t : src.getIdentifier())
       tgt.addIdentifier(Identifier30_40.convertIdentifier(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn()) tgt.addBasedOn(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.dstu3.model.Reference t : src.getPartOf()) tgt.addPartOf(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn())
+      tgt.addBasedOn(Reference30_40.convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getPartOf())
+      tgt.addPartOf(Reference30_40.convertReference(t));
     if (src.hasContext())
       tgt.setContext(Reference30_40.convertReference(src.getContext()));
-    if (src.hasStatus())
+    if (src.hasStatus()) {
+      tgt.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_STAT_STATUS, new org.hl7.fhir.r4.model.StringType(src.getStatus().toCode())));
       tgt.setStatusElement(convertMedicationStatementStatus(src.getStatusElement()));
+    }
+    if (src.hasTaken()) {
+      tgt.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_STAT_TAKEN, new org.hl7.fhir.r4.model.StringType(src.getTaken().toCode())));
+      if (src.getTaken() == org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.N) {
+        tgt.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.NOTTAKEN);
+      } else if (src.getTaken() == org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.UNK) {
+        tgt.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.UNKNOWN);
+      }
+    }
     if (src.hasCategory())
       tgt.setCategory(CodeableConcept30_40.convertCodeableConcept(src.getCategory()));
     if (src.hasMedication())
@@ -105,10 +118,14 @@ public class MedicationStatement30_40 {
       tgt.addDerivedFrom(Reference30_40.convertReference(t));
     for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getReasonCode())
       tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
+    for (org.hl7.fhir.dstu3.model.CodeableConcept t : src.getReasonNotTaken())
+      tgt.addReasonCode(CodeableConcept30_40.convertCodeableConcept(t));
     for (org.hl7.fhir.dstu3.model.Reference t : src.getReasonReference())
       tgt.addReasonReference(Reference30_40.convertReference(t));
-    for (org.hl7.fhir.dstu3.model.Annotation t : src.getNote()) tgt.addNote(Annotation30_40.convertAnnotation(t));
-    for (org.hl7.fhir.dstu3.model.Dosage t : src.getDosage()) tgt.addDosage(Dosage30_40.convertDosage(t));
+    for (org.hl7.fhir.dstu3.model.Annotation t : src.getNote())
+      tgt.addNote(Annotation30_40.convertAnnotation(t));
+    for (org.hl7.fhir.dstu3.model.Dosage t : src.getDosage())
+      tgt.addDosage(Dosage30_40.convertDosage(t));
     return tgt;
   }
 

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationStatement30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationStatement30_40Test.java
@@ -1,0 +1,110 @@
+package org.hl7.fhir.convertors.conv30_40;
+
+
+import org.hl7.fhir.convertors.VersionConvertorConstants;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class MedicationStatement30_40Test {
+
+  @Test
+  public void convertMedicationStatement30to40() throws IOException {
+
+    InputStream dstu3InputJson = this.getClass().getResourceAsStream("/medication_statement_30.json");
+    InputStream r4ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_statement_30_converted_to_40.json");
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Actual = (org.hl7.fhir.dstu3.model.MedicationStatement) new org.hl7.fhir.dstu3.formats.JsonParser().parse(dstu3InputJson);
+    org.hl7.fhir.r4.model.Resource r4Converted = VersionConvertorFactory_30_40.convertResource(dstu3Actual);
+
+    org.hl7.fhir.r4.formats.JsonParser r4Parser = new org.hl7.fhir.r4.formats.JsonParser();
+    org.hl7.fhir.r4.model.Resource r4Expected = r4Parser.parse(r4ExpectedOutputJson);
+
+    Assertions.assertTrue(r4Expected.equalsDeep(r4Converted),
+      "Failed comparing\n" + r4Parser.composeString(r4Expected) + "\nand\n" + r4Parser.composeString(r4Converted));
+  }
+
+  @Test
+  public void convertMedicationStatement40to30() throws IOException {
+    InputStream r4InputJson = this.getClass().getResourceAsStream("/medication_statement_40.json");
+    InputStream dstu3ExpectedOutputJson = this.getClass().getResourceAsStream("/medication_statement_40_converted_to_30.json");
+
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = (org.hl7.fhir.r4.model.MedicationStatement) new org.hl7.fhir.r4.formats.JsonParser().parse(r4InputJson);
+    org.hl7.fhir.dstu3.model.Resource dstu3Converted = VersionConvertorFactory_30_40.convertResource(r4Actual);
+
+    org.hl7.fhir.dstu3.formats.JsonParser dstu3Parser = new org.hl7.fhir.dstu3.formats.JsonParser();
+    org.hl7.fhir.dstu3.model.Resource dstu3Expected = dstu3Parser.parse(dstu3ExpectedOutputJson);
+
+    Assertions.assertTrue(dstu3Expected.equalsDeep(dstu3Converted),
+      "Failed comparing\n" + dstu3Parser.composeString(dstu3Expected) + "\nand\n" + dstu3Parser.composeString(dstu3Converted));
+  }
+
+
+  @Test
+  public void testStatusConversion40To30() {
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = new org.hl7.fhir.r4.model.MedicationStatement();
+    r4Actual.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ACTIVE);
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
+    Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus.ACTIVE, dstu3Converted.getStatus());
+    Assertions.assertNull(dstu3Converted.getTaken());
+  }
+
+  @Test
+  public void testStatusConversionWithExtensions40To30() {
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = new org.hl7.fhir.r4.model.MedicationStatement();
+    r4Actual.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_STAT_STATUS,
+      new org.hl7.fhir.r4.model.StringType(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus.INTENDED.toCode())));
+    r4Actual.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_STAT_TAKEN,
+      new org.hl7.fhir.r4.model.StringType(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.UNK.toCode())));
+    //Also set status to a different value, to test the extension gets priority in conversion
+    r4Actual.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.ACTIVE);
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
+    Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus.INTENDED, dstu3Converted.getStatus());
+    Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.UNK, dstu3Converted.getTaken());
+  }
+
+  @Test
+  public void testTakenConversionWithoutStatusExtensions40To30() {
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = new org.hl7.fhir.r4.model.MedicationStatement();
+    r4Actual.addExtension(new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_MED_STAT_TAKEN,
+      new org.hl7.fhir.r4.model.StringType(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.UNK.toCode())));
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
+    Assertions.assertNull(dstu3Converted.getStatus());
+    Assertions.assertNull(dstu3Converted.getTaken());
+  }
+
+  @Test
+  public void testReasonCode40To30() {
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = new org.hl7.fhir.r4.model.MedicationStatement();
+    r4Actual.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.COMPLETED);
+    r4Actual.addReasonCode(new org.hl7.fhir.r4.model.CodeableConcept(new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
+    Assertions.assertNull(dstu3Converted.getTaken());
+    assertThat(dstu3Converted.getReasonNotTaken(), is(empty()));
+    assertThat(dstu3Converted.getReasonCode(), hasSize(1));
+  }
+
+  @Test
+  public void testReasonCodeNotTaken40To30() {
+    org.hl7.fhir.r4.model.MedicationStatement r4Actual = new org.hl7.fhir.r4.model.MedicationStatement();
+    r4Actual.setStatus(org.hl7.fhir.r4.model.MedicationStatement.MedicationStatementStatus.NOTTAKEN);
+    r4Actual.addReasonCode(new org.hl7.fhir.r4.model.CodeableConcept(new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+
+    org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
+    Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.N, dstu3Converted.getTaken());
+    assertThat(dstu3Converted.getReasonNotTaken(), hasSize(1));
+    assertThat(dstu3Converted.getReasonCode(), is(empty()));
+  }
+
+
+}

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationStatement30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/MedicationStatement30_40Test.java
@@ -69,6 +69,8 @@ public class MedicationStatement30_40Test {
     org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
     Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementStatus.INTENDED, dstu3Converted.getStatus());
     Assertions.assertEquals(org.hl7.fhir.dstu3.model.MedicationStatement.MedicationStatementTaken.UNK, dstu3Converted.getTaken());
+    Assertions.assertFalse(dstu3Converted.hasExtension(VersionConvertorConstants.EXT_MED_STAT_STATUS));
+    Assertions.assertFalse(dstu3Converted.hasExtension(VersionConvertorConstants.EXT_MED_STAT_TAKEN));
   }
 
   @Test
@@ -80,6 +82,8 @@ public class MedicationStatement30_40Test {
     org.hl7.fhir.dstu3.model.MedicationStatement dstu3Converted = (org.hl7.fhir.dstu3.model.MedicationStatement) VersionConvertorFactory_30_40.convertResource(r4Actual);
     Assertions.assertNull(dstu3Converted.getStatus());
     Assertions.assertNull(dstu3Converted.getTaken());
+    Assertions.assertFalse(dstu3Converted.hasExtension(VersionConvertorConstants.EXT_MED_STAT_STATUS));
+    Assertions.assertFalse(dstu3Converted.hasExtension(VersionConvertorConstants.EXT_MED_STAT_TAKEN));
   }
 
   @Test

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_30.json
@@ -1,0 +1,106 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example001",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/medstatements",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "category": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/medication-statement-category",
+        "code": "inpatient",
+        "display": "Inpatient"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#med0309"
+  },
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "derivedFrom": [
+    {
+      "reference": "MedicationRequest/medrx002"
+    }
+  ],
+  "taken": "n",
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914008",
+          "display": "Restless Legs"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient indicates they miss the occasional dose"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1-2 tablets once daily at bedtime as needed for restless legs",
+      "additionalInstruction": [
+        {
+          "text": "Taking at bedtime"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "32914008",
+            "display": "Restless Legs"
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseRange": {
+        "low": {
+          "value": 1,
+          "unit": "TAB",
+          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+          "code": "TAB"
+        },
+        "high": {
+          "value": 2,
+          "unit": "TAB",
+          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+          "code": "TAB"
+        }
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_30.json
@@ -48,6 +48,17 @@
       ]
     }
   ],
+  "reasonNotTaken": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914009",
+          "display": "this should be merged with reasonCode in 40"
+        }
+      ]
+    }
+  ],
   "note": [
     {
       "text": "Patient indicates they miss the occasional dose"

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_30_converted_to_40.json
@@ -1,0 +1,106 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example001",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/medstatements",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "category": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/medication-statement-category",
+        "code": "inpatient",
+        "display": "Inpatient"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#med0309"
+  },
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "derivedFrom": [
+    {
+      "reference": "MedicationRequest/medrx002"
+    }
+  ],
+  "taken": "n",
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914008",
+          "display": "Restless Legs"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient indicates they miss the occasional dose"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1-2 tablets once daily at bedtime as needed for restless legs",
+      "additionalInstruction": [
+        {
+          "text": "Taking at bedtime"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "32914008",
+            "display": "Restless Legs"
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseRange": {
+        "low": {
+          "value": 1,
+          "unit": "TAB",
+          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+          "code": "TAB"
+        },
+        "high": {
+          "value": 2,
+          "unit": "TAB",
+          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+          "code": "TAB"
+        }
+      }
+    }
+  ]
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_30_converted_to_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_30_converted_to_40.json
@@ -1,6 +1,16 @@
 {
   "resourceType": "MedicationStatement",
   "id": "example001",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.status",
+      "valueString": "active"
+    },
+    {
+      "url": "http://hl7.org/fhir/3.0/StructureDefinition/extension-MedicationStatement.taken",
+      "valueString": "n"
+    }
+  ],
   "identifier": [
     {
       "use": "official",
@@ -8,7 +18,7 @@
       "value": "12345689"
     }
   ],
-  "status": "active",
+  "status": "not-taken",
   "category": {
     "coding": [
       {
@@ -21,13 +31,13 @@
   "medicationReference": {
     "reference": "#med0309"
   },
-  "effectiveDateTime": "2015-01-23",
-  "dateAsserted": "2015-02-22",
-  "informationSource": {
+  "subject": {
     "reference": "Patient/pat1",
     "display": "Donald Duck"
   },
-  "subject": {
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
     "reference": "Patient/pat1",
     "display": "Donald Duck"
   },
@@ -36,7 +46,6 @@
       "reference": "MedicationRequest/medrx002"
     }
   ],
-  "taken": "n",
   "reasonCode": [
     {
       "coding": [
@@ -44,6 +53,15 @@
           "system": "http://snomed.info/sct",
           "code": "32914008",
           "display": "Restless Legs"
+        }
+      ]
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914009",
+          "display": "this should be merged with reasonCode in 40"
         }
       ]
     }
@@ -87,20 +105,24 @@
           }
         ]
       },
-      "doseRange": {
-        "low": {
-          "value": 1,
-          "unit": "TAB",
-          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
-          "code": "TAB"
-        },
-        "high": {
-          "value": 2,
-          "unit": "TAB",
-          "system": "http://hl7.org/fhir/v3/orderableDrugForm",
-          "code": "TAB"
+      "doseAndRate": [
+        {
+          "doseRange": {
+            "low": {
+              "value": 1,
+              "unit": "TAB",
+              "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+              "code": "TAB"
+            },
+            "high": {
+              "value": 2,
+              "unit": "TAB",
+              "system": "http://hl7.org/fhir/v3/orderableDrugForm",
+              "code": "TAB"
+            }
+          }
         }
-      }
+      ]
     }
   ]
 }

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_40.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_40.json
@@ -1,0 +1,118 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example001",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/medstatements",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "category": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/medication-statement-category",
+        "code": "inpatient",
+        "display": "Inpatient"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#med0309"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "derivedFrom": [
+    {
+      "reference": "MedicationRequest/medrx002"
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914008",
+          "display": "Restless Legs"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient indicates they miss the occasional dose"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1-2 tablets once daily at bedtime as needed for restless legs",
+      "additionalInstruction": [
+        {
+          "text": "Taking at bedtime"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "32914008",
+            "display": "Restless Legs"
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseRange": {
+            "low": {
+              "value": 1,
+              "unit": "TAB",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "TAB"
+            },
+            "high": {
+              "value": 2,
+              "unit": "TAB",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+              "code": "TAB"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.convertors/src/test/resources/medication_statement_40_converted_to_30.json
+++ b/org.hl7.fhir.convertors/src/test/resources/medication_statement_40_converted_to_30.json
@@ -1,0 +1,105 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example001",
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://www.bmc.nl/portal/medstatements",
+      "value": "12345689"
+    }
+  ],
+  "status": "active",
+  "category": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/medication-statement-category",
+        "code": "inpatient",
+        "display": "Inpatient"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#med0309"
+  },
+  "subject": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "effectiveDateTime": "2015-01-23",
+  "dateAsserted": "2015-02-22",
+  "informationSource": {
+    "reference": "Patient/pat1",
+    "display": "Donald Duck"
+  },
+  "derivedFrom": [
+    {
+      "reference": "MedicationRequest/medrx002"
+    }
+  ],
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "32914008",
+          "display": "Restless Legs"
+        }
+      ]
+    }
+  ],
+  "note": [
+    {
+      "text": "Patient indicates they miss the occasional dose"
+    }
+  ],
+  "dosage": [
+    {
+      "sequence": 1,
+      "text": "1-2 tablets once daily at bedtime as needed for restless legs",
+      "additionalInstruction": [
+        {
+          "text": "Taking at bedtime"
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "32914008",
+            "display": "Restless Legs"
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral Route"
+          }
+        ]
+      },
+      "doseRange": {
+        "low": {
+          "value": 1,
+          "unit": "TAB",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+          "code": "TAB"
+        },
+        "high": {
+          "value": 2,
+          "unit": "TAB",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+          "code": "TAB"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Implemented conversion of `taken` and `reasonNotTaken`
- Include Extensions for status and taken mapping, if available, for safe conversion

Conversion is based on mapping at https://hl7.org/fhir/R4/medicationstatement-version-maps.html


Test resources are based on example files at https://hl7.org/fhir/R4/medicationstatement-examples.html, with some manual changes to test some edge cases, like the mergin of reasonCode and reasonNotTaken