### PR TITLE
Only report missing lcoalization messages the first time

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
@@ -19,7 +19,7 @@ public abstract class I18nBase {
 
   public static final String KEY_DELIMITER = "_";
 
-  public static Map<Locale, Set<String>> uncontainedKeys = new HashMap<>();
+  public static final Map<Locale, Set<String>> uncontainedKeys = new HashMap<>();
 
   private Locale locale = null;
   private ResourceBundle messages = null;

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
@@ -62,7 +62,7 @@ public abstract class I18nBase {
           warnedLocales = new HashSet<String>();
         }
         if (!warnedLocales.contains(locale.toLanguageTag())) {
-          log.warn("The locale " + locale.toLanguageTag() + " is not supported. Messages will default to en-US.");
+          logUncontainedMessage("The locale " + locale.toLanguageTag() + " is not supported. Messages will default to en-US.");
           warnedLocales.add(locale.toLanguageTag());
         }
       }
@@ -99,7 +99,7 @@ public abstract class I18nBase {
         if (warnAboutMissingMessages && (hasArgs || !message.contains(" "))) {
           Set<String> uncontainedKeys = I18nBase.uncontainedKeys.computeIfAbsent(getLocale(), k -> new HashSet<>());
           if (!uncontainedKeys.contains(message)) {
-            log.warn("Attempting to localize " + typeOfString() + " " + message + ", but no such equivalent message exists for" +
+            logUncontainedMessage("Attempting to localize " + typeOfString() + " " + message + ", but no such equivalent message exists for" +
               " the locale " + getLocale());
             uncontainedKeys.add(message);
           }
@@ -107,6 +107,10 @@ public abstract class I18nBase {
       }
     }
     return messageKeyExistsForLocale(message);
+  }
+
+  protected void logUncontainedMessage(String message) {
+    log.warn(message);
   }
 
   protected String typeOfString() {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nBase.java
@@ -1,12 +1,7 @@
 package org.hl7.fhir.utilities.i18n;
 
 import java.text.MessageFormat;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.ResourceBundle;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -23,6 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class I18nBase {
 
   public static final String KEY_DELIMITER = "_";
+
+  public static Map<Locale, Set<String>> uncontainedKeys = new HashMap<>();
+
   private Locale locale = null;
   private ResourceBundle messages = null;
   private PluralRules pluralRules = null;
@@ -99,8 +97,12 @@ public abstract class I18nBase {
     if (!messageKeyExistsForLocale(message)) {
       if (!message.contains(" ")) {
         if (warnAboutMissingMessages && (hasArgs || !message.contains(" "))) {
-          log.warn("Attempting to localize "+typeOfString()+" " + message + ", but no such equivalent message exists for" +
+          Set<String> uncontainedKeys = I18nBase.uncontainedKeys.computeIfAbsent(getLocale(), k -> new HashSet<>());
+          if (!uncontainedKeys.contains(message)) {
+            log.warn("Attempting to localize " + typeOfString() + " " + message + ", but no such equivalent message exists for" +
               " the locale " + getLocale());
+            uncontainedKeys.add(message);
+          }
         }
       }
     }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/i18n/I18nBaseTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/i18n/I18nBaseTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -18,6 +20,7 @@ import java.util.ResourceBundle;
 import com.ibm.icu.text.PluralRules;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class I18nBaseTest {
 
@@ -138,6 +141,20 @@ class I18nBaseTest {
   void testFormatMessageForNonExistentMessage() {
     I18nTestClass testClass = new I18nTestClass();
     assertEquals(BAD_STRING_ARG, testClass.formatMessage(BAD_STRING_ARG, ARG_1));
+  }
+
+  @Test
+  @DisplayName("Assert that a warning is only logged once for a non-existent message.")
+  void testOnlyOneLogForNonExistentMessages() {
+    I18nTestClass testClass = Mockito.spy(new I18nTestClass());
+
+    assertEquals(BAD_STRING_ARG, testClass.formatMessage(BAD_STRING_ARG, ARG_1));
+
+    verify(testClass).logUncontainedMessage(anyString());
+
+    assertEquals(BAD_STRING_ARG, testClass.formatMessage(BAD_STRING_ARG, ARG_1));
+
+    verify(testClass).logUncontainedMessage(anyString());
   }
 
   @Test


### PR DESCRIPTION
Only logs missing localization messages once. This also tracks by locale, in case multiple localizations are used in a single run.