### PR TITLE
Don't keep Extension EXT_IG_CONFORMANCE_MESSAGE_EVENT with CapabilityStatement conversion part of #2021

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
@@ -252,7 +252,7 @@ public class CapabilityStatement30_40 {
     if (src == null)
       return null;
     org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent tgt = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src,tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyBackboneElement(src, tgt, VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
     for (org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingEndpointComponent t : src.getEndpoint())
       tgt.addEndpoint(convertCapabilityStatementMessagingEndpointComponent(t));
     if (src.hasReliableCache())

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
@@ -273,11 +273,6 @@ public class CapabilityStatement30_40 {
     if (extension.hasExtension("category"))
       event.setCategory(CapabilityStatement.MessageSignificanceCategory.fromCode(extension.getExtensionByUrl("category").getValue().toString()));
     event.setMode(CapabilityStatement.EventCapabilityMode.fromCode(extension.getExtensionByUrl("mode").getValue().toString()));
-    //TODO this seems to be duplicate code
-    event.setCode(Coding30_40.convertCoding((org.hl7.fhir.r4.model.Coding) extension.getExtensionByUrl("code").getValue()));
-    if (extension.hasExtension("category"))
-      event.setCategory(CapabilityStatement.MessageSignificanceCategory.fromCode(extension.getExtensionByUrl("category").getValue().toString()));
-    event.setMode(CapabilityStatement.EventCapabilityMode.fromCode(extension.getExtensionByUrl("mode").getValue().toString()));
 
     event.setFocusElement(convertFocusExtensionR4ToMessageEventDstu3(extension.getExtensionByUrl("focus")));
     event.setRequest(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) extension.getExtensionByUrl("request").getValue()));

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
@@ -1,7 +1,5 @@
 package org.hl7.fhir.convertors.conv30_40.resources30_40;
 
-import java.util.stream.Collectors;
-
 import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.ContactDetail30_40;
@@ -9,16 +7,13 @@ import org.hl7.fhir.convertors.conv30_40.datatypes30_40.Reference30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.CodeableConcept30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Coding30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Timing30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Boolean30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Code30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.DateTime30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.MarkDown30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.UnsignedInt30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Uri30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.*;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.hl7.fhir.dstu3.model.Enumeration;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.Extension;
+
+import java.util.stream.Collectors;
 
 public class CapabilityStatement30_40 {
 
@@ -267,29 +262,40 @@ public class CapabilityStatement30_40 {
     for (org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingSupportedMessageComponent t : src.getSupportedMessage())
       tgt.addSupportedMessage(convertCapabilityStatementMessagingSupportedMessageComponent(t));
     for (org.hl7.fhir.r4.model.Extension e : src.getExtensionsByUrl(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT)) {
-      org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent event = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent();
-      tgt.addEvent(event);
-      event.setCode(Coding30_40.convertCoding((org.hl7.fhir.r4.model.Coding) e.getExtensionByUrl("code").getValue()));
-      if (e.hasExtension("category"))
-        event.setCategory(org.hl7.fhir.dstu3.model.CapabilityStatement.MessageSignificanceCategory.fromCode(e.getExtensionByUrl("category").getValue().toString()));
-      event.setMode(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.fromCode(e.getExtensionByUrl("mode").getValue().toString()));
-      event.setCode(Coding30_40.convertCoding((org.hl7.fhir.r4.model.Coding) e.getExtensionByUrl("code").getValue()));
-      if (e.hasExtension("category"))
-        event.setCategory(org.hl7.fhir.dstu3.model.CapabilityStatement.MessageSignificanceCategory.fromCode(e.getExtensionByUrl("category").getValue().toString()));
-      event.setMode(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.fromCode(e.getExtensionByUrl("mode").getValue().toString()));
-      org.hl7.fhir.r4.model.Extension focusE = e.getExtensionByUrl("focus");
-      if (focusE.getValue().hasPrimitiveValue())
-        event.setFocus(focusE.getValue().toString());
-      else {
-        event.setFocusElement(new org.hl7.fhir.dstu3.model.CodeType());
-        ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(focusE.getValue(), event.getFocusElement());
-      }
-      event.setRequest(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) e.getExtensionByUrl("request").getValue()));
-      event.setResponse(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) e.getExtensionByUrl("response").getValue()));
-      if (e.hasExtension("documentation"))
-        event.setDocumentation(e.getExtensionByUrl("documentation").getValue().toString());
+      tgt.addEvent(convertMessageExtensionToMessageEvent(e));
     }
     return tgt;
+  }
+
+  public static CapabilityStatement.CapabilityStatementMessagingEventComponent convertMessageExtensionToMessageEvent(Extension extension) {
+    CapabilityStatement.CapabilityStatementMessagingEventComponent event = new CapabilityStatement.CapabilityStatementMessagingEventComponent();
+    event.setCode(Coding30_40.convertCoding((org.hl7.fhir.r4.model.Coding) extension.getExtensionByUrl("code").getValue()));
+    if (extension.hasExtension("category"))
+      event.setCategory(CapabilityStatement.MessageSignificanceCategory.fromCode(extension.getExtensionByUrl("category").getValue().toString()));
+    event.setMode(CapabilityStatement.EventCapabilityMode.fromCode(extension.getExtensionByUrl("mode").getValue().toString()));
+    //TODO this seems to be duplicate code
+    event.setCode(Coding30_40.convertCoding((org.hl7.fhir.r4.model.Coding) extension.getExtensionByUrl("code").getValue()));
+    if (extension.hasExtension("category"))
+      event.setCategory(CapabilityStatement.MessageSignificanceCategory.fromCode(extension.getExtensionByUrl("category").getValue().toString()));
+    event.setMode(CapabilityStatement.EventCapabilityMode.fromCode(extension.getExtensionByUrl("mode").getValue().toString()));
+
+    event.setFocusElement(convertFocusExtensionR4ToMessageEventDstu3(extension.getExtensionByUrl("focus")));
+    event.setRequest(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) extension.getExtensionByUrl("request").getValue()));
+    event.setResponse(Reference30_40.convertReference((org.hl7.fhir.r4.model.Reference) extension.getExtensionByUrl("response").getValue()));
+    if (extension.hasExtension("documentation"))
+      event.setDocumentation(extension.getExtensionByUrl("documentation").getValue().toString());
+
+    return event;
+  }
+
+  public static org.hl7.fhir.dstu3.model.CodeType convertFocusExtensionR4ToMessageEventDstu3(Extension focusE) {
+    org.hl7.fhir.dstu3.model.CodeType result = new org.hl7.fhir.dstu3.model.CodeType();
+    if (focusE.getValue().hasPrimitiveValue()) {
+      result.setValue(focusE.getValue().toString());
+    } else {
+      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(focusE.getValue(), result);
+    }
+    return result;
   }
 
   public static org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingComponent convertCapabilityStatementMessagingComponent(org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent src) throws FHIRException {

--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/resources30_40/CapabilityStatement30_40.java
@@ -307,26 +307,40 @@ public class CapabilityStatement30_40 {
     for (org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingSupportedMessageComponent t : src.getSupportedMessage())
       tgt.addSupportedMessage(convertCapabilityStatementMessagingSupportedMessageComponent(t));
     for (org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent t : src.getEvent()) {
-      org.hl7.fhir.r4.model.Extension e = new org.hl7.fhir.r4.model.Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
-      e.addExtension(new org.hl7.fhir.r4.model.Extension("code", Coding30_40.convertCoding(t.getCode())));
-      if (t.hasCategory())
-        e.addExtension(new org.hl7.fhir.r4.model.Extension("category", new org.hl7.fhir.r4.model.CodeType(t.getCategory().toCode())));
-      e.addExtension(new org.hl7.fhir.r4.model.Extension("mode", new org.hl7.fhir.r4.model.CodeType(t.getMode().toCode())));
-      if (t.getFocusElement().hasValue())
-        e.addExtension(new org.hl7.fhir.r4.model.Extension("focus", new org.hl7.fhir.r4.model.StringType(t.getFocus())));
-      else {
-        org.hl7.fhir.r4.model.CodeType focus = new org.hl7.fhir.r4.model.CodeType();
-        org.hl7.fhir.r4.model.Extension focusE = new org.hl7.fhir.r4.model.Extension("focus", focus);
-        ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(t.getFocusElement(), focus);
-        e.addExtension(focusE);
-      }
-      e.addExtension(new org.hl7.fhir.r4.model.Extension("request", Reference30_40.convertReference(t.getRequest())));
-      e.addExtension(new org.hl7.fhir.r4.model.Extension("response", Reference30_40.convertReference(t.getResponse())));
-      if (t.hasDocumentation())
-        e.addExtension(new org.hl7.fhir.r4.model.Extension("documentation", new org.hl7.fhir.r4.model.StringType(t.getDocumentation())));
+      Extension e = convertCapabilityStatementMessageEvent(t);
       tgt.addExtension(e);
     }
     return tgt;
+  }
+
+  public static Extension convertCapabilityStatementMessageEvent(CapabilityStatement.CapabilityStatementMessagingEventComponent t) {
+    Extension e = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
+    e.addExtension(new Extension("code", Coding30_40.convertCoding(t.getCode())));
+    if (t.hasCategory()) {
+      e.addExtension(new Extension("category", new org.hl7.fhir.r4.model.CodeType(t.getCategory().toCode())));
+    }
+    e.addExtension(new Extension("mode", new org.hl7.fhir.r4.model.CodeType(t.getMode().toCode())));
+    if (t.hasFocusElement()) {
+      e.addExtension(convertFocusMessagingEventComponent(t.getFocusElement()));
+    }
+    e.addExtension(new Extension("request", Reference30_40.convertReference(t.getRequest())));
+    e.addExtension(new Extension("response", Reference30_40.convertReference(t.getResponse())));
+    if (t.hasDocumentation()) {
+      e.addExtension(new Extension("documentation", new org.hl7.fhir.r4.model.StringType(t.getDocumentation())));
+    }
+    return e;
+  }
+
+  public static Extension convertFocusMessagingEventComponent(org.hl7.fhir.dstu3.model.CodeType t) {
+    Extension result = new Extension("focus");
+    if (t.hasValue()) {
+      result.setValue(new org.hl7.fhir.r4.model.StringType(t.getValue()));
+    } else {
+      org.hl7.fhir.r4.model.CodeType focus = new org.hl7.fhir.r4.model.CodeType();
+      ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(t, focus);
+      result.setValue(focus);
+    }
+    return result;
   }
 
   public static org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEndpointComponent convertCapabilityStatementMessagingEndpointComponent(org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingEndpointComponent src) throws FHIRException {

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
@@ -1,13 +1,21 @@
 package org.hl7.fhir.convertors.conv30_40;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.hl7.fhir.convertors.VersionConvertorConstants;
+import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_30_40;
+import org.hl7.fhir.convertors.context.ConversionContext30_40;
+import org.hl7.fhir.convertors.conv30_40.resources30_40.CapabilityStatement30_40;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.hl7.fhir.dstu3.model.CapabilityStatement;
+import org.hl7.fhir.dstu3.model.CodeType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CapabilityStatement30_40Test {
   @Test
@@ -15,8 +23,8 @@ public class CapabilityStatement30_40Test {
   public void testR4_Dstu3() throws IOException {
     InputStream r4_input = this.getClass().getResourceAsStream("/capability_statement_40_with_30_extensions.json");
 
-    org.hl7.fhir.r4.model.CapabilityStatement r5_actual = (org.hl7.fhir.r4.model.CapabilityStatement) new org.hl7.fhir.r4.formats.JsonParser().parse(r4_input);
-    org.hl7.fhir.dstu3.model.Resource dstu3_conv = VersionConvertorFactory_30_40.convertResource(r5_actual);
+    org.hl7.fhir.r4.model.CapabilityStatement r4_actual = (org.hl7.fhir.r4.model.CapabilityStatement) new org.hl7.fhir.r4.formats.JsonParser().parse(r4_input);
+    org.hl7.fhir.dstu3.model.Resource dstu3_conv = VersionConvertorFactory_30_40.convertResource(r4_actual);
 
     org.hl7.fhir.dstu3.formats.JsonParser dstu3_parser = new org.hl7.fhir.dstu3.formats.JsonParser();
 
@@ -25,4 +33,93 @@ public class CapabilityStatement30_40Test {
 
     assertTrue(dstu3_actual.equalsDeep(dstu3_conv), "should be the same");
   }
+
+  @Test
+  public void convertCapabilityStatementMessagingComponentR4toDstu3() {
+    org.hl7.fhir.r4.model.CapabilityStatement capabilityStatementR4 = new org.hl7.fhir.r4.model.CapabilityStatement();
+    org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingComponent input = new org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingComponent();
+    input.addEndpoint(new org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingEndpointComponent(
+      new org.hl7.fhir.r4.model.Coding("system", "code", "display"), new org.hl7.fhir.r4.model.UrlType("My Address")));
+    input.setReliableCache(1234);
+    input.setDocumentation("Some documentation");
+
+    org.hl7.fhir.r4.model.Enumeration<org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode> enumeration =
+      new org.hl7.fhir.r4.model.Enumeration<>(new org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    enumeration.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
+    input.addSupportedMessage(new org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingSupportedMessageComponent(enumeration, new org.hl7.fhir.r4.model.CanonicalType("xyz")));
+
+    Extension message = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
+    message.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+    message.addExtension(new Extension("mode", new StringType("receiver")));
+    message.addExtension(new Extension("focus", new StringType("focus")));
+    message.addExtension(new Extension("request", new org.hl7.fhir.r4.model.Reference("requestRef")));
+    message.addExtension(new Extension("response", new org.hl7.fhir.r4.model.Reference("responseRef")));
+    input.addExtension(message);
+
+    capabilityStatementR4.addMessaging(input);
+
+    //conversion
+    org.hl7.fhir.dstu3.model.CapabilityStatement capabilityStatementDstu3 = (org.hl7.fhir.dstu3.model.CapabilityStatement) VersionConvertorFactory_30_40.convertResource(capabilityStatementR4);
+    org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent result = capabilityStatementDstu3.getMessagingFirstRep();
+
+
+    assertEquals(input.getReliableCache(), result.getReliableCache());
+    assertEquals(input.getDocumentation(), result.getDocumentation());
+
+    //Verify endpoint
+    assertEquals("My Address", result.getEndpointFirstRep().getAddress());
+    assertTrue(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display").equalsDeep(result.getEndpointFirstRep().getProtocol()));
+
+    //Verify support message
+    assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.SENDER, result.getSupportedMessageFirstRep().getMode());
+    assertTrue(new org.hl7.fhir.dstu3.model.Reference("xyz").equalsDeep(result.getSupportedMessageFirstRep().getDefinition()));
+
+    //Verify message events
+    assertTrue(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display").equalsDeep(result.getEventFirstRep().getCode()));
+    assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER, result.getEventFirstRep().getMode());
+    assertEquals("focus", result.getEventFirstRep().getFocus());
+    assertTrue(new org.hl7.fhir.dstu3.model.Reference("requestRef").equalsDeep(result.getEventFirstRep().getRequest()));
+    assertTrue(new org.hl7.fhir.dstu3.model.Reference("responseRef").equalsDeep(result.getEventFirstRep().getResponse()));
+
+    // verify extension is not converted back
+    assertFalse(result.hasExtension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT));
+  }
+
+  @Test
+  public void convertMessageExtensionToMessageEvent() {
+    Extension input = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
+    input.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+    input.addExtension(new Extension("category", new StringType("Currency")));
+    input.addExtension(new Extension("mode", new StringType("receiver")));
+    input.addExtension(new Extension("focus", new StringType("focus")));
+    input.addExtension(new Extension("request", new org.hl7.fhir.r4.model.Reference("requestRef")));
+    input.addExtension(new Extension("response", new org.hl7.fhir.r4.model.Reference("responseRef")));
+    input.addExtension(new Extension("documentation", new StringType("some documentation")));
+
+    ConversionContext30_40.INSTANCE.init(new VersionConvertor_30_40(new BaseAdvisor_30_40()), input.fhirType());
+    CapabilityStatement.CapabilityStatementMessagingEventComponent result = CapabilityStatement30_40.convertMessageExtensionToMessageEvent(input);
+
+    assertNotNull(result);
+    //verify extension does not get mapped
+    assertTrue(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display").equalsDeep(result.getCode()));
+    assertEquals(CapabilityStatement.MessageSignificanceCategory.CURRENCY, result.getCategory());
+    assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER, result.getMode());
+    assertEquals("focus", result.getFocus());
+    assertTrue(new org.hl7.fhir.dstu3.model.Reference("requestRef").equalsDeep(result.getRequest()));
+    assertTrue(new org.hl7.fhir.dstu3.model.Reference("responseRef").equalsDeep(result.getResponse()));
+    assertEquals("some documentation", result.getDocumentation());
+  }
+
+  @Test
+  public void convertFocusExtensionR4ToMessageEventDstu3() {
+    Extension inputString = new Extension("", new StringType("stringInput"));
+    Extension inputCode = new Extension("", new org.hl7.fhir.r4.model.CodeType("codeInput"));
+
+    ConversionContext30_40.INSTANCE.init(new VersionConvertor_30_40(new BaseAdvisor_30_40()), inputString.fhirType());
+    CodeType resultString = CapabilityStatement30_40.convertFocusExtensionR4ToMessageEventDstu3(inputString);
+    assertEquals("stringInput", resultString.getValue());
+    CodeType resultCode = CapabilityStatement30_40.convertFocusExtensionR4ToMessageEventDstu3(inputCode);
+    assertEquals("codeInput", resultCode.getValue());
+  }
+
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
@@ -100,7 +100,6 @@ public class CapabilityStatement30_40Test {
     CapabilityStatement.CapabilityStatementMessagingEventComponent result = CapabilityStatement30_40.convertMessageExtensionToMessageEvent(input);
 
     assertNotNull(result);
-    //verify extension does not get mapped
     assertTrue(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display").equalsDeep(result.getCode()));
     assertEquals(CapabilityStatement.MessageSignificanceCategory.CURRENCY, result.getCategory());
     assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER, result.getMode());

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/CapabilityStatement30_40Test.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.convertors.conv30_40.resources30_40.CapabilityStatement30_40
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.hl7.fhir.dstu3.model.CodeType;
+import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.DisplayName;
@@ -48,13 +49,21 @@ public class CapabilityStatement30_40Test {
     enumeration.setValue(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER);
     input.addSupportedMessage(new org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingSupportedMessageComponent(enumeration, new org.hl7.fhir.r4.model.CanonicalType("xyz")));
 
-    Extension message = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
-    message.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
-    message.addExtension(new Extension("mode", new StringType("receiver")));
-    message.addExtension(new Extension("focus", new StringType("focus")));
-    message.addExtension(new Extension("request", new org.hl7.fhir.r4.model.Reference("requestRef")));
-    message.addExtension(new Extension("response", new org.hl7.fhir.r4.model.Reference("responseRef")));
-    input.addExtension(message);
+    Extension message1 = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
+    message1.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+    message1.addExtension(new Extension("mode", new StringType("receiver")));
+    message1.addExtension(new Extension("focus", new StringType("focus")));
+    message1.addExtension(new Extension("request", new org.hl7.fhir.r4.model.Reference("requestRef")));
+    message1.addExtension(new Extension("response", new org.hl7.fhir.r4.model.Reference("responseRef")));
+    input.addExtension(message1);
+
+    Extension message2 = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
+    message2.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
+    message2.addExtension(new Extension("mode", new StringType("receiver")));
+    message2.addExtension(new Extension("focus", new StringType("focus")));
+    message2.addExtension(new Extension("request", new org.hl7.fhir.r4.model.Reference("requestRef")));
+    message2.addExtension(new Extension("response", new org.hl7.fhir.r4.model.Reference("responseRef")));
+    input.addExtension(message2);
 
     capabilityStatementR4.addMessaging(input);
 
@@ -74,6 +83,7 @@ public class CapabilityStatement30_40Test {
     assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.SENDER, result.getSupportedMessageFirstRep().getMode());
     assertTrue(new org.hl7.fhir.dstu3.model.Reference("xyz").equalsDeep(result.getSupportedMessageFirstRep().getDefinition()));
 
+    assertEquals(2, result.getEvent().size());
     //Verify message events
     assertTrue(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display").equalsDeep(result.getEventFirstRep().getCode()));
     assertEquals(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER, result.getEventFirstRep().getMode());
@@ -86,7 +96,7 @@ public class CapabilityStatement30_40Test {
   }
 
   @Test
-  public void convertMessageExtensionToMessageEvent() {
+  public void convertMessageExtensionR4ToMessageEventDstu3() {
     Extension input = new Extension(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT);
     input.addExtension(new Extension("code", new org.hl7.fhir.r4.model.Coding("system", "code", "display")));
     input.addExtension(new Extension("category", new StringType("Currency")));
@@ -121,4 +131,113 @@ public class CapabilityStatement30_40Test {
     assertEquals("codeInput", resultCode.getValue());
   }
 
+  @Test
+  public void convertCapabilityStatementMessagingComponentDstu3toR4() {
+    org.hl7.fhir.dstu3.model.CapabilityStatement capabilityStatementR4 = new org.hl7.fhir.dstu3.model.CapabilityStatement();
+    org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent input = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingComponent();
+
+    input.addEndpoint(new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEndpointComponent(
+      new org.hl7.fhir.dstu3.model.Coding("system", "code", "display"), new org.hl7.fhir.dstu3.model.UriType("My Address")));
+    input.setReliableCache(1234);
+    input.setDocumentation("Some documentation");
+
+    org.hl7.fhir.dstu3.model.Enumeration<org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode> enumeration =
+      new org.hl7.fhir.dstu3.model.Enumeration<>(new org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityModeEnumFactory());
+    enumeration.setValue(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.SENDER);
+    input.addSupportedMessage(new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingSupportedMessageComponent(enumeration, new org.hl7.fhir.dstu3.model.Reference("xyz")));
+
+    org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent message1 = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent();
+    message1.setCode(new Coding("system", "code", "display"));
+    message1.setMode(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+    message1.setRequest(new org.hl7.fhir.dstu3.model.Reference("request"));
+    message1.setResponse(new org.hl7.fhir.dstu3.model.Reference("response"));
+    input.addEvent(message1);
+
+    org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent message2 = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent();
+    message2.setCode(new Coding("system", "code", "display"));
+    message2.setMode(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.RECEIVER);
+    message2.setRequest(new org.hl7.fhir.dstu3.model.Reference("request"));
+    message2.setResponse(new org.hl7.fhir.dstu3.model.Reference("response"));
+    input.addEvent(message2);
+
+    capabilityStatementR4.addMessaging(input);
+
+    //conversion
+    org.hl7.fhir.r4.model.CapabilityStatement capabilityStatementDstu3 = (org.hl7.fhir.r4.model.CapabilityStatement) VersionConvertorFactory_30_40.convertResource(capabilityStatementR4);
+    org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementMessagingComponent result = capabilityStatementDstu3.getMessagingFirstRep();
+
+
+    assertEquals(input.getReliableCache(), result.getReliableCache());
+    assertEquals(input.getDocumentation(), result.getDocumentation());
+
+    //Verify endpoint
+    assertEquals("My Address", result.getEndpointFirstRep().getAddress());
+    assertTrue(new org.hl7.fhir.r4.model.Coding("system", "code", "display").equalsDeep(result.getEndpointFirstRep().getProtocol()));
+
+    //Verify support message
+    assertEquals(org.hl7.fhir.r4.model.CapabilityStatement.EventCapabilityMode.SENDER, result.getSupportedMessageFirstRep().getMode());
+    assertEquals("xyz", result.getSupportedMessageFirstRep().getDefinition());
+
+    assertEquals(2, result.getExtensionsByUrl(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT).size());
+  }
+
+  @Test
+  public void convertCapabilityStatementMessageEventDstu3ToExtensionR4() {
+    org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent input = new org.hl7.fhir.dstu3.model.CapabilityStatement.CapabilityStatementMessagingEventComponent();
+    input.setCode(new org.hl7.fhir.dstu3.model.Coding("system", "code", "display"));
+    input.setCategory(CapabilityStatement.MessageSignificanceCategory.NOTIFICATION);
+    input.setMode(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.SENDER);
+    input.setFocus("abc");
+    input.setRequest(new org.hl7.fhir.dstu3.model.Reference("request ref"));
+    input.setResponse(new org.hl7.fhir.dstu3.model.Reference("response ref"));
+    input.setDocumentation("Some documentation");
+
+    ConversionContext30_40.INSTANCE.init(new VersionConvertor_30_40(new BaseAdvisor_30_40()), input.fhirType());
+    org.hl7.fhir.r4.model.Extension result = CapabilityStatement30_40.convertCapabilityStatementMessageEvent(input);
+
+    assertEquals(VersionConvertorConstants.EXT_IG_CONFORMANCE_MESSAGE_EVENT, result.getUrl());
+
+    org.hl7.fhir.r4.model.Extension codeExtension = result.getExtensionByUrl("code");
+    assertNotNull(codeExtension);
+    assertTrue(new org.hl7.fhir.r4.model.Coding("system", "code", "display").equalsDeep(codeExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension categoryExtension = result.getExtensionByUrl("category");
+    assertNotNull(categoryExtension);
+    assertTrue(new org.hl7.fhir.r4.model.CodeType(CapabilityStatement.MessageSignificanceCategory.NOTIFICATION.toCode()).equalsDeep(categoryExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension modeExtension = result.getExtensionByUrl("mode");
+    assertNotNull(modeExtension);
+    assertTrue(new org.hl7.fhir.r4.model.CodeType(org.hl7.fhir.dstu3.model.CapabilityStatement.EventCapabilityMode.SENDER.toCode()).equalsDeep(modeExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension focusExtension = result.getExtensionByUrl("focus");
+    assertNotNull(focusExtension);
+    assertTrue(new org.hl7.fhir.r4.model.StringType("abc").equalsDeep(focusExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension requestExtension = result.getExtensionByUrl("request");
+    assertNotNull(requestExtension);
+    assertTrue(new org.hl7.fhir.r4.model.Reference("request ref").equalsDeep(requestExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension responseExtension = result.getExtensionByUrl("response");
+    assertNotNull(responseExtension);
+    assertTrue(new org.hl7.fhir.r4.model.Reference("response ref").equalsDeep(responseExtension.getValue()));
+
+    org.hl7.fhir.r4.model.Extension documentationExtension = result.getExtensionByUrl("documentation");
+    assertNotNull(documentationExtension);
+    assertTrue(new org.hl7.fhir.r4.model.StringType("Some documentation").equalsDeep(documentationExtension.getValue()));
+  }
+
+  @Test
+  public void convertFocusMessagingEventComponentDstu3ToExtensionR4() {
+    ConversionContext30_40.INSTANCE.init(new VersionConvertor_30_40(new BaseAdvisor_30_40()), "");
+
+    org.hl7.fhir.r4.model.Extension result1 = CapabilityStatement30_40.convertFocusMessagingEventComponent(new org.hl7.fhir.dstu3.model.CodeType("someCode"));
+    assertNotNull(result1);
+    assertEquals("focus", result1.getUrl());
+    assertTrue(new org.hl7.fhir.r4.model.StringType("someCode").equalsDeep(result1.getValue()));
+
+    org.hl7.fhir.r4.model.Extension result2 = CapabilityStatement30_40.convertFocusMessagingEventComponent(new org.hl7.fhir.dstu3.model.CodeType());
+    assertNotNull(result2);
+    assertEquals("focus", result2.getUrl());
+    assertTrue(new org.hl7.fhir.r4.model.CodeType().equalsDeep(result2.getValue()));
+  }
 }


### PR DESCRIPTION
Part of #2021

With this change we no longer keep the `EXT_IG_CONFORMANCE_MESSAGE_EVENT ` extension when converting back from R4 to dstu3.

PR contains mostly tests for CapabilityStatement conversion between R4 and dstu3
Next to that some small refactoring where I split up some methods
And removed some duplicate code

