### PR TITLE
Don't keep MODIFIER_REASON extension when converting ElementDefintion from dstu3 to r4 (part of #2021)

### DIFF
--- a/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/datatypes30_40/ElementDefinition30_40.java
+++ b/org.hl7.fhir.convertors/src/main/java/org/hl7/fhir/convertors/conv30_40/datatypes30_40/ElementDefinition30_40.java
@@ -1,20 +1,10 @@
 package org.hl7.fhir.convertors.conv30_40.datatypes30_40;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.hl7.fhir.convertors.VersionConvertorConstants;
 import org.hl7.fhir.convertors.context.ConversionContext30_40;
 import org.hl7.fhir.convertors.conv30_40.VersionConvertor_30_40;
 import org.hl7.fhir.convertors.conv30_40.datatypes30_40.complextypes30_40.Coding30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Boolean30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Code30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Id30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Integer30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.MarkDown30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.String30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.UnsignedInt30_40;
-import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.Uri30_40;
+import org.hl7.fhir.convertors.conv30_40.datatypes30_40.primitivetypes30_40.*;
 import org.hl7.fhir.convertors.conv30_40.resources30_40.Enumerations30_40;
 import org.hl7.fhir.dstu3.utils.ExtensionUtilities;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -22,11 +12,14 @@ import org.hl7.fhir.r4.model.ElementDefinition;
 import org.hl7.fhir.r4.model.Type;
 import org.hl7.fhir.utilities.Utilities;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ElementDefinition30_40 {
   public static org.hl7.fhir.r4.model.ElementDefinition convertElementDefinition(org.hl7.fhir.dstu3.model.ElementDefinition src) throws FHIRException {
     if (src == null) return null;
     org.hl7.fhir.r4.model.ElementDefinition tgt = new org.hl7.fhir.r4.model.ElementDefinition();
-    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt);
+    ConversionContext30_40.INSTANCE.getVersionConvertor_30_40().copyElement(src, tgt, VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION);
     if (src.hasPath()) tgt.setPathElement(String30_40.convertString(src.getPathElement()));
     tgt.setRepresentation(src.getRepresentation().stream().map(ElementDefinition30_40::convertPropertyRepresentation).collect(Collectors.toList()));
     if (src.hasSliceName()) tgt.setSliceNameElement(String30_40.convertString(src.getSliceNameElement()));

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/ElementDefinition30_40Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv30_40/ElementDefinition30_40Test.java
@@ -1,0 +1,104 @@
+package org.hl7.fhir.convertors.conv30_40;
+
+import org.hl7.fhir.convertors.VersionConvertorConstants;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ElementDefinition30_40Test {
+
+  @Test
+  public void convertR4toDstu3Empty() {
+    org.hl7.fhir.r4.model.ElementDefinition input = new org.hl7.fhir.r4.model.ElementDefinition();
+    org.hl7.fhir.dstu3.model.ElementDefinition result = (org.hl7.fhir.dstu3.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void convertR4toDstu3ModifierReason() {
+    org.hl7.fhir.r4.model.ElementDefinition input = new org.hl7.fhir.r4.model.ElementDefinition();
+    input.setIsModifierReason("My Modifier");
+    org.hl7.fhir.dstu3.model.ElementDefinition result = (org.hl7.fhir.dstu3.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNotNull(result);
+    assertTrue(result.hasExtension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION));
+    assertThat(result.getExtensionString(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION), is("My Modifier"));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  @ValueSource(strings = VersionConvertorConstants.EXT_MODIFIER_REASON_LEGACY)
+  public void convertR4toDstu3InvalidModifierReason(String modifierReason) {
+    org.hl7.fhir.r4.model.ElementDefinition input = new org.hl7.fhir.r4.model.ElementDefinition();
+    input.setId("id");//set id to prevent complete null result
+    input.setIsModifierReason(modifierReason);
+    org.hl7.fhir.dstu3.model.ElementDefinition result = (org.hl7.fhir.dstu3.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNotNull(result);
+    assertThat(result.getId(), is("id"));
+    assertFalse(result.hasExtension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION));
+  }
+
+  @Test
+  public void convertDstu3oR4Empty() {
+    org.hl7.fhir.dstu3.model.ElementDefinition input = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    org.hl7.fhir.r4.model.ElementDefinition result = (org.hl7.fhir.r4.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNull(result);
+  }
+
+
+  @Test
+  public void convertDstu3oR4ModifierReason() {
+    org.hl7.fhir.dstu3.model.ElementDefinition input = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    input.setIsModifier(true);
+    input.addExtension(new Extension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION, new StringType("my Modifier")));
+    org.hl7.fhir.r4.model.ElementDefinition result = (org.hl7.fhir.r4.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNotNull(result);
+    assertTrue(result.getIsModifier());
+    assertThat(result.getIsModifierReason(), is("my Modifier"));
+    assertFalse(result.hasExtension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION));
+  }
+
+  @Test
+  public void convertDstu3oR4ModifierReasonModifierFalse() {
+    org.hl7.fhir.dstu3.model.ElementDefinition input = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    input.setIsModifier(false);
+    input.addExtension(new Extension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION, new StringType("my Modifier")));
+    org.hl7.fhir.r4.model.ElementDefinition result = (org.hl7.fhir.r4.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNotNull(result);
+    assertFalse(result.getIsModifier());
+    assertThat(result.getIsModifierReason(), is(nullValue()));
+    assertFalse(result.hasExtension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  public void convertDstu3oR4ModifierReasonEmpty(String modifierValue) {
+    org.hl7.fhir.dstu3.model.ElementDefinition input = new org.hl7.fhir.dstu3.model.ElementDefinition();
+    input.setIsModifier(true);
+    input.addExtension(new Extension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION, new StringType(modifierValue)));
+    org.hl7.fhir.r4.model.ElementDefinition result = (org.hl7.fhir.r4.model.ElementDefinition) VersionConvertorFactory_30_40.convertType(input);
+
+    assertNotNull(result);
+    assertTrue(result.getIsModifier());
+    assertThat(result.getIsModifierReason(), is(VersionConvertorConstants.EXT_MODIFIER_REASON_LEGACY));
+    assertFalse(result.hasExtension(VersionConvertorConstants.EXT_MODIFIER_REASON_EXTENSION));
+  }
+
+}


### PR DESCRIPTION
PR is part of https://github.com/hapifhir/org.hl7.fhir.core/issues/2021

