### PR TITLE
mulithreading issues in R5 validation with defaultDisplayLanguage / locale /

### DIFF
--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.utilities</artifactId>
+			<version>6.6.5</version>
 		</dependency>
 
 		<dependency>

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -347,6 +347,9 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   protected String userAgent;
   protected ContextUtilities cutils;
   private List<String> suppressedMappings;
+  
+  // matchbox patch  https://github.com/ahdis/matchbox/issues/425 
+  private Locale locale;
 
   protected BaseWorkerContext() throws FileNotFoundException, IOException, FHIRException {
     setValidationMessageLanguage(getLocale());
@@ -436,7 +439,8 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       cachingAllowed = other.cachingAllowed;
       suppressedMappings = other.suppressedMappings;
       cutils.setSuppressedMappings(other.suppressedMappings);
-    }
+      locale = other.locale;
+      }
   }
   
   
@@ -3766,7 +3770,21 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
   
   public void setLocale(Locale locale) {
-    super.setLocale(locale);
+    // matchbox patch https://github.com/ahdis/matchbox/issues/425
+    if (this.locale == null) {
+      this.locale = locale;
+      super.setLocale(locale);
+    } else {
+      if (!this.locale.equals(locale)) {
+        this.locale = locale;
+        super.setLocale(locale);
+        if (locale != null) {
+          log.info("changing locale to" + locale.toLanguageTag());
+        } else {
+          log.info("resetting locale");
+        }
+      }
+    }
     if (locale != null) {
       String lt = locale.toLanguageTag();
       if ("und".equals(lt)) {
@@ -3774,9 +3792,15 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       }
       if (expParameters != null) {
         for (ParametersParameterComponent p : expParameters.getParameter()) {
-          if ("displayLanguage".equals(p.getName())) {
+          // matchbox patch https://github.com/ahdis/matchbox/issues/425 change from
+          // displayLanguage to defaultDisplayLanguage
+          if ("defaultDisplayLanguage".equals(p.getName())) {
             if (p.hasUserData(UserDataNames.auto_added_parameter)) {
-              p.setValue(new CodeType(lt));
+              if (p.getValueCodeType() != null && !p.getValueCodeType().getCode().equals(lt)) {
+                log.error("should this acutally happenen that the defaultDisplayLanguage is overerwritten from "
+                    + p.getValueCodeType().getCode() + " to " + lt);
+                p.setValue(new CodeType(lt));
+              }
               return;
             } else {
               // user supplied, we leave it alone

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -430,7 +430,7 @@ public class TerminologyCache {
       nameCacheToken(vs, ct);
       JsonParser json = new JsonParser();
       json.setOutputStyle(OutputStyle.PRETTY);
-      String expJS = expParameters == null ? "" : json.composeString(expParameters);
+      String expJS = expParameters == null ? "" : json.composeString(expParameters.copy());
 
       if (vs != null && vs.hasUrl() && vs.hasVersion()) {
         ct.request = "{\"code\" : "+json.composeString(code, "codeableConcept")+", \"url\": \""+Utilities.escapeJson(vs.getUrl())
@@ -460,7 +460,7 @@ public class TerminologyCache {
       ct.setName(vsUrl);
       JsonParser json = new JsonParser();
       json.setOutputStyle(OutputStyle.PRETTY);
-      String expJS = json.composeString(expParameters);
+      String expJS = json.composeString(expParameters.copy());
 
       ct.request = "{\"code\" : "+json.composeString(code, "code")+", \"valueSet\" :"+(vsUrl == null ? "null" : vsUrl)+(options == null ? "" : ", "+options.toJson())+", \"profile\": "+expJS+"}";
       ct.key = String.valueOf(hashJson(ct.request));
@@ -492,7 +492,7 @@ public class TerminologyCache {
       nameCacheToken(vs, ct);
       JsonParser json = new JsonParser();
       json.setOutputStyle(OutputStyle.PRETTY);
-      String expJS = json.composeString(expParameters);
+      String expJS = json.composeString(expParameters.copy());
       if (vs != null && vs.hasUrl() && vs.hasVersion()) {
         ct.request = "{\"code\" : "+json.composeString(code, "codeableConcept")+", \"url\": \""+Utilities.escapeJson(vs.getUrl())+
             "\", \"version\": \""+Utilities.escapeJson(vs.getVersion())+"\""+(options == null ? "" : ", "+options.toJson())+", \"profile\": "+expJS+"}\r\n";      
@@ -1194,7 +1194,7 @@ public class TerminologyCache {
       ct.hasVersion = parent.hasVersion() || child.hasVersion();
       JsonParser json = new JsonParser();
       json.setOutputStyle(OutputStyle.PRETTY);
-      String expJS = json.composeString(expParameters);
+      String expJS = json.composeString(expParameters.copy());
       ct.request = "{\"op\": \"subsumes\", \"parent\" : "+json.composeString(parent, "code")+", \"child\" :"+json.composeString(child, "code")+(options == null ? "" : ", "+options.toJson())+", \"profile\": "+expJS+"}";
       ct.key = String.valueOf(hashJson(ct.request));
       return ct;


### PR DESCRIPTION
we encountered memory and multithreading issues with our latest matchbox version which incorporates the java validator.

1.) we have seen a huge memory increase when performing the same validation multiple times. Root cause we think is multiple defaultDisplayLanguage parameters that are added to the expansion Parameters, this leads to that for every validation new cache token are generated, this PR reduces it to one instance

2) the modification with the defaultDisplayLanguage in expansionParameters led in our setup to a Concurrent Modification Exception, we could solve that, that we make a copy before serializing it in generationCacheToken

3) Similiar setting the locale again led to a Nullpointer Exception in the BaseContext because this.messages was zero, we set the local only explicitly now if it changed.

I don't know how I could reproduce this directly in the ValidatorCli but we might think it might also have an impact in ValidatorCli or derived solutions. see also https://github.com/ahdis/matchbox/issues/425

