### PR TITLE
Pick ips 2.0.0-ballot version to replace not found 2.0.0 in -ips option

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
@@ -273,7 +273,7 @@ public class ValidatorCli {
         res.add("4.0");
         res.add("-check-ips-codes");
         res.add("-ig");
-        res.add("hl7.fhir.uv.ips#2.0.0");
+        res.add("hl7.fhir.uv.ips#2.0.0-ballot");
         res.add("-profile");
         res.add("http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips");
         res.add("-extension");


### PR DESCRIPTION
The `-ips` option uses 2.0.0 of IPS, which is not yet released. This switches over to the 2.0.0-ballot version, which is available.