### PR TITLE
Fix for invalid package versions in package listing JSON

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/VersionUtilities.java
@@ -1164,7 +1164,7 @@ public class VersionUtilities {
     }
   }
 
-  private static String checkVersionNotNullAndValid(String s, String label) {
+  public static String checkVersionNotNullAndValid(String s, String label) {
     if (s == null) {
       throw new FHIRException("Invalid " + label + " version: null");
     } else if (!isSemVer(s)) {
@@ -1241,7 +1241,7 @@ public class VersionUtilities {
     }
   }
 
-  private static String fixForSpecialValue(String version) {
+  public static String fixForSpecialValue(String version) {
     if (Utilities.noString(version)) {
       return null;
     }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageClient.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageClient.java
@@ -246,21 +246,21 @@ public class PackageClient {
   }
 
   protected PackageInfo getPackageInfoFromJSON(JsonObject o, String name, String canonical, String fhirVersion) {
-      String id = o.asString("npm-name");
-      String pname = o.asString("name");
-      String pcanonical = o.asString("canonical");
-      String description = o.asString("description");
-      Instant d = o.has("date") ? o.asDate("date") : null;
+      String packageId = o.asString("npm-name");
+      String packageName = o.asString("name");
+      String packageCanonical = o.asString("canonical");
+      String packageDescription = o.asString("description");
+      Instant packageDate = o.has("date") ? o.asDate("date") : null;
       boolean ok = true;
       if (ok && !Utilities.noString(name)) {
-        ok = (pname != null && pname.contains(name)) || (description != null && description.contains(name)) || (id != null && id.contains(name));
+        ok = (packageName != null && packageName.contains(name)) || (packageDescription != null && packageDescription.contains(name)) || (packageId != null && packageId.contains(name));
       }
       if (ok && !Utilities.noString(canonical)) {
-        ok = pcanonical.contains(canonical);
+        ok = packageCanonical.contains(canonical);
       }
-      String version = null;
-      String fVersion = null;
-      String url = null;
+      String currentVersion = null;
+      String currentFhirVersion = null;
+      String currentUrl = null;
 
       if (ok) {
         // Get the latest version out of the available valid editions of this IG.
@@ -269,24 +269,25 @@ public class PackageClient {
             String igVersion = edition.asString("ig-version");
             try {
               // If this version is valid, check if it is later than the current version
-              if (version == null || VersionUtilities.isThisOrLater(version, igVersion, VersionUtilities.VersionPrecision.MINOR)) {
-                version = igVersion;
-                fVersion = edition.getJsonArray("fhir-version").get(0).asString();
-                url = edition.asString("url");
+              if (currentVersion == null || VersionUtilities.isThisOrLater(currentVersion, igVersion, VersionUtilities.VersionPrecision.MINOR)) {
+                currentVersion = igVersion;
+                currentFhirVersion = edition.getJsonArray("fhir-version").get(0).asString();
+                currentUrl = edition.asString("url");
 
                 String npmPackage = edition.asString("package");
-                if (npmPackage != null && id == null) {
-                  id = npmPackage.substring(0, npmPackage.indexOf("#"));
+                if (npmPackage != null && packageId == null) {
+
+                  packageId = npmPackage.substring(0, npmPackage.indexOf("#"));
                 }
               }
             }
             catch (org.hl7.fhir.exceptions.FHIRException fhirException) {
-              log.error("Error comparing versions \"{}\" and \"{}\" while getting package info from JSON", version, igVersion, fhirException);
+              log.error("Error comparing versions \"{}\" and \"{}\" while getting package info from JSON", currentVersion, igVersion, fhirException);
             }
           }
         }
       }
-      return new PackageInfo(id, version, fVersion, description, url, pcanonical, address, d);
+      return new PackageInfo(packageId, currentVersion, currentFhirVersion, packageDescription, currentUrl, packageCanonical, address, packageDate);
   }
   
   public List<PackageInfo> listFromRegistry(String name, String canonical, String fhirVersion) throws IOException {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageClient.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageClient.java
@@ -26,6 +26,9 @@ import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.json.model.JsonProperty;
 import org.hl7.fhir.utilities.json.parser.JsonParser;
 
+import static org.hl7.fhir.utilities.VersionUtilities.checkVersionNotNullAndValid;
+import static org.hl7.fhir.utilities.VersionUtilities.fixForSpecialValue;
+
 @Slf4j
 public class PackageClient {
 
@@ -268,6 +271,8 @@ public class PackageClient {
           if (fhirVersion == null || fhirVersion.equals(edition.asString("fhir-version"))) {
             String igVersion = edition.asString("ig-version");
             try {
+
+              VersionUtilities.checkVersionNotNullAndValid(fixForSpecialValue(igVersion), "candidate");
               // If this version is valid, check if it is later than the current version
               if (currentVersion == null || VersionUtilities.isThisOrLater(currentVersion, igVersion, VersionUtilities.VersionPrecision.MINOR)) {
                 currentVersion = igVersion;
@@ -282,7 +287,7 @@ public class PackageClient {
               }
             }
             catch (org.hl7.fhir.exceptions.FHIRException fhirException) {
-              log.error("Error comparing versions \"{}\" and \"{}\" while getting package info from JSON", currentVersion, igVersion, fhirException);
+              log.error("Error evaluating edition with version \"{}\" while getting package info from JSON", igVersion, fhirException);
             }
           }
         }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/PackageClientTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/PackageClientTest.java
@@ -35,6 +35,15 @@ public class PackageClientTest implements ResourceLoaderTests {
   }
 
   @Test
+  @DisplayName("test getting package from valid JSON with invalid version field")
+  public void getPacakgeInfoFromJSONWithInvalidVersionTest() throws java.io.IOException {
+    final JsonObject jsonObject = JsonParser.parseObject(getResourceAsInputStream("npm","PackageClient-invalidVersion.json"));
+    final PackageInfo packageInfo = packageClient.getPackageInfoFromJSON(jsonObject, null, null, null);
+
+    assertExpectedFields(packageInfo);
+  }
+
+  @Test
   @DisplayName("test getting package from JSON works")
   public void getPackageInfoWithIdFromJSONTest() throws java.io.IOException {
     final JsonObject jsonObject = JsonParser.parseObject(getResourceAsInputStream("npm", "PackageClient-testCaseWithId.json"));

--- a/org.hl7.fhir.utilities/src/test/resources/npm/PackageClient-invalidVersion.json
+++ b/org.hl7.fhir.utilities/src/test/resources/npm/PackageClient-invalidVersion.json
@@ -5,8 +5,8 @@
   "editions": [
     {
       "name": "Dummy name",
-      "ig-version": "0.2.30 ",
-      "package": "dummy.package#0.2.30",
+      "ig-version": "1.2.4 ",
+      "package": "dummy.package#1.2.4",
       "fhir-version": [
         "4.5.6"
       ],
@@ -14,8 +14,8 @@
     },
     {
       "name": "Dummy name",
-      "ig-version": "0.2.31",
-      "package": "dummy.package#0.2.31",
+      "ig-version": "1.2.3",
+      "package": "dummy.package#1.2.3",
       "fhir-version": [
         "4.5.6"
       ],

--- a/org.hl7.fhir.utilities/src/test/resources/npm/PackageClient-invalidVersion.json
+++ b/org.hl7.fhir.utilities/src/test/resources/npm/PackageClient-invalidVersion.json
@@ -1,0 +1,26 @@
+{
+  "name": "Pan-Canadian Patient Summary",
+  "description": "Dummy description",
+  "canonical": "https://a.b.c",
+  "editions": [
+    {
+      "name": "Dummy name",
+      "ig-version": "0.2.30 ",
+      "package": "dummy.package#0.2.30",
+      "fhir-version": [
+        "4.5.6"
+      ],
+      "url": "https://d.e.f"
+    },
+    {
+      "name": "Dummy name",
+      "ig-version": "0.2.31",
+      "package": "dummy.package#0.2.31",
+      "fhir-version": [
+        "4.5.6"
+      ],
+      "url": "https://d.e.f"
+    }
+
+  ]
+}


### PR DESCRIPTION
If an invalid version existed in the package listing JSON, it would produce an exception when comparing, and cause the entire loading process to fail. 

This reports invalid versions via logging, and doesn't accept invalid versions as the current version of an IG.