### PR TITLE
Fix Max decimal places validation for questionnaires

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/QuestionnaireValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/QuestionnaireValidator.java
@@ -1167,7 +1167,7 @@ public class QuestionnaireValidator extends BaseValidator {
         }
         if (qItem.hasExtension(ExtensionDefinitions.EXT_MAX_DECIMALS)) {
           int dt = Integer.parseInt(qItem.getExtensionByUrl(ExtensionDefinitions.EXT_MAX_DECIMALS).getValue().primitiveValue());
-          ok = rule(errors, "2024-05-07", IssueType.INVARIANT, vns, precision(vdt.getValueElement().primitiveValue()) <= dt, I18nConstants.QUESTIONNAIRE_QR_ITEM_DECIMAL_MAX_DECIMALS, v.primitiveValue(), dt) && ok;
+          ok = rule(errors, "2024-05-07", IssueType.INVARIANT, vns, precision(vdt.getValueElement().primitiveValue()) <= dt, I18nConstants.QUESTIONNAIRE_QR_ITEM_DECIMAL_MAX_DECIMALS, vdt.getValueElement().primitiveValue(), dt) && ok;
         }
         if (qItem.hasExtension(ExtensionDefinitions.EXT_Q_UNIT_OPTION)) {
           boolean matched = false;


### PR DESCRIPTION
fixes: #2145

added testcase:
https://github.com/FHIR/fhir-test-cases/pull/236

This pull request updates the decimal precision validation logic in the `QuestionnaireValidator` to correctly enforce the maximum number of allowed decimal places, and fixes a bug in the `precision` calculation. The changes ensure that values with exactly the allowed number of decimal places are accepted, and that the precision is calculated accurately.

**Validation logic improvements:**

* Changed the comparison operator in both `validateQuestionnaireResponseItemDecimal` and `validateQuestionnaireResponseItemQuantity` to allow values with a number of decimal places equal to the specified maximum (`<=` instead of `<`). [[1]](diffhunk://#diff-6a3d9af549222c181cd30d6df3e72a69004ca7df4d32583116a964ba621bb04dL1076-R1076) [[2]](diffhunk://#diff-6a3d9af549222c181cd30d6df3e72a69004ca7df4d32583116a964ba621bb04dL1170-R1170)

**Bug fix:**

* Corrected the `precision` method to subtract one from the calculated length, ensuring the number of decimal digits is counted correctly after the decimal point.

