### PR TITLE
Make ips:au param use new definitions from hl7.fhir.au.ps

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
@@ -286,14 +286,14 @@ public class ValidatorCli {
         res.add("4.0");
         res.add("-check-ips-codes");
         res.add("-ig");
-        res.add("hl7.fhir.au.ips#current");
+        res.add("hl7.fhir.au.ps#current");
         res.add("-profile");
-        res.add("http://hl7.org.au/fhir/ips/StructureDefinition/Bundle-au-ips");
+        res.add("http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-bundle");
         res.add("-extension");
         res.add("any");
         res.add("-bundle");
         res.add("Composition:0");
-        res.add("http://hl7.org.au/fhir/ips/StructureDefinition/Composition-au-ips");
+        res.add("http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition");
       } else if (a.startsWith("-ips#")) {
         res.add("-version");
         res.add("4.0");


### PR DESCRIPTION
The `-ips:au` param in the validator CLI was using an older version of the IG. This has been updated with the new IG name and updated profile URLs