### PR TITLE
Atomically set expansionParameters in BaseWorkerContext

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -423,7 +423,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
         txCache = other.txCache; // no copy. for now?
       expandCodesLimit = other.expandCodesLimit;
       logger = other.logger;
-      expansionParameters = other.expansionParameters != null ? new AtomicReference<>(other.getExpansionParameters()) : null;
+      expansionParameters = other.expansionParameters != null ? new AtomicReference<>(other.copyExpansionParametersWithUserData()) : null;
       version = other.version;
       supportedCodeSystems.putAll(other.supportedCodeSystems);
       unsupportedCodeSystems.addAll(other.unsupportedCodeSystems);
@@ -3784,15 +3784,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     In both cases, we are done.
     */
 
-    Parameters newExpansionParameters = new Parameters();
-    // Copy all existing parameters include userData (not usually included in copyies)
-    if (this.expansionParameters.get().hasParameter()) {
-      for (ParametersParameterComponent expParameter : this.expansionParameters.get().getParameter()) {
-        Parameters.ParametersParameterComponent copy = newExpansionParameters.addParameter();
-        expParameter.copyValues(copy);
-        copy.copyUserData(expParameter);
-      }
-    }
+    Parameters newExpansionParameters = copyExpansionParametersWithUserData();
 
     int displayLanguageCount = 0;
     for (ParametersParameterComponent expParameter : newExpansionParameters.getParameter()) {
@@ -3832,7 +3824,20 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
     this.expansionParameters.set(newExpansionParameters);
   }
-  
+
+  private Parameters copyExpansionParametersWithUserData() {
+    Parameters newExpansionParameters = new Parameters();
+    // Copy all existing parameters include userData (not usually included in copyies)
+    if (this.expansionParameters.get().hasParameter()) {
+      for (ParametersParameterComponent expParameter : this.expansionParameters.get().getParameter()) {
+        ParametersParameterComponent copy = newExpansionParameters.addParameter();
+        expParameter.copyValues(copy);
+        copy.copyUserData(expParameter);
+      }
+    }
+    return newExpansionParameters;
+  }
+
   @Override
   public OperationOutcome validateTxResource(ValidationOptions options, Resource resource) {
     if (resource instanceof ValueSet) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -3785,6 +3785,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     */
 
     Parameters newExpansionParameters = new Parameters();
+    // Copy all existing parameters include userData (not usually included in copyies)
     if (this.expansionParameters.get().hasParameter()) {
       for (ParametersParameterComponent expParameter : this.expansionParameters.get().getParameter()) {
         Parameters.ParametersParameterComponent copy = newExpansionParameters.addParameter();

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -48,6 +48,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -339,7 +340,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   private int expandCodesLimit = 1000;
   protected org.hl7.fhir.r5.context.ILoggingService logger = new Slf4JLoggingService(log);
   protected final TerminologyClientManager terminologyClientManager = new TerminologyClientManager(new TerminologyClientR5.TerminologyClientR5Factory(), UUID.randomUUID().toString(), logger);
-  protected Parameters expParameters;
+  protected AtomicReference<Parameters> expansionParameters = new AtomicReference<>(null);
   private Map<String, PackageInformation> packages = new HashMap<>();
 
   @Getter
@@ -422,7 +423,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
         txCache = other.txCache; // no copy. for now?
       expandCodesLimit = other.expandCodesLimit;
       logger = other.logger;
-      expParameters = other.expParameters != null ? other.expParameters.copy() : null;
+      expansionParameters = other.expansionParameters != null ? new AtomicReference<>(other.getExpansionParameters()) : null;
       version = other.version;
       supportedCodeSystems.putAll(other.supportedCodeSystems);
       unsupportedCodeSystems.addAll(other.unsupportedCodeSystems);
@@ -1014,30 +1015,29 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
 
   @Override
   public ValueSetExpansionOutcome expandVS(ValueSet vs, boolean cacheOk, boolean heirarchical) {
-    if (expParameters == null)
+    if (expansionParameters.get() == null)
       throw new Error(formatMessage(I18nConstants.NO_EXPANSION_PARAMETERS_PROVIDED));
-    Parameters p = expParameters.copy(); 
-    return expandVS(vs, cacheOk, heirarchical, false, p);
+    return expandVS(vs, cacheOk, heirarchical, false, getExpansionParameters());
   }
 
   @Override
   public ValueSetExpansionOutcome expandVS(ValueSet vs, boolean cacheOk, boolean heirarchical, int count) {
-    if (expParameters == null)
+    if (expansionParameters.get() == null)
       throw new Error(formatMessage(I18nConstants.NO_EXPANSION_PARAMETERS_PROVIDED));
-    Parameters p = expParameters.copy(); 
+    Parameters p = getExpansionParameters();
     p.addParameter("count", count);
     return expandVS(vs, cacheOk, heirarchical, false, p);
   }
 
   @Override
   public ValueSetExpansionOutcome expandVS(String url, boolean cacheOk, boolean hierarchical, int count) {
-    if (expParameters == null)
+    if (expansionParameters.get() == null)
       throw new Error(formatMessage(I18nConstants.NO_EXPANSION_PARAMETERS_PROVIDED));
     if (noTerminologyServer) {
       return new ValueSetExpansionOutcome(formatMessage(I18nConstants.ERROR_EXPANDING_VALUESET_RUNNING_WITHOUT_TERMINOLOGY_SERVICES), TerminologyServiceErrorClass.NOSERVICE, null, false);
     }
 
-    Parameters p = expParameters.copy(); 
+    Parameters p = getExpansionParameters();
     p.addParameter("count", count);
     p.addParameter("url", new UriType(url));
     p.setParameter("_limit",new IntegerType("10000"));
@@ -1084,10 +1084,10 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
 
   @Override
   public ValueSetExpansionOutcome expandVS(ValueSet vs, boolean cacheOk, boolean heirarchical, boolean incompleteOk) {
-    if (expParameters == null)
+    if (expansionParameters.get() == null)
       throw new Error(formatMessage(I18nConstants.NO_EXPANSION_PARAMETERS_PROVIDED));
-    Parameters p = expParameters.copy(); 
-    return expandVS(vs, cacheOk, heirarchical, incompleteOk, p);
+
+    return expandVS(vs, cacheOk, heirarchical, incompleteOk, getExpansionParameters());
   }
 
   public ValueSetExpansionOutcome expandVS(ValueSet vs, boolean cacheOk, boolean hierarchical, boolean incompleteOk, Parameters pIn)  {
@@ -1244,7 +1244,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     // 2nd pass: What can we do internally 
     // 3rd pass: hit the server
     for (CodingValidationRequest t : codes) {
-      t.setCacheToken(txCache != null ? txCache.generateValidationToken(options, t.getCoding(), vs, expParameters) : null);
+      t.setCacheToken(txCache != null ? txCache.generateValidationToken(options, t.getCoding(), vs, getExpansionParameters()) : null);
       if (t.getCoding().hasSystem()) {
         codeSystemsUsed.add(t.getCoding().getSystem());
       }
@@ -1282,7 +1282,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       }
     }
     
-    if (expParameters == null)
+    if (expansionParameters.get() == null)
       throw new Error(formatMessage(I18nConstants.NO_EXPANSIONPROFILE_PROVIDED));
     // for those that that failed, we try to validate on the server
     Parameters batch = new Parameters();
@@ -1468,7 +1468,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       codeSystemsUsed.add(code.getSystem());
     }
 
-    final CacheToken cacheToken = cachingAllowed && txCache != null ? txCache.generateValidationToken(options, code, vs, expParameters) : null;
+    final CacheToken cacheToken = cachingAllowed && txCache != null ? txCache.generateValidationToken(options, code, vs, getExpansionParameters()) : null;
     ValidationResult res = null;
     if (cachingAllowed && txCache != null) {
       res = txCache.getValidation(cacheToken);
@@ -1604,7 +1604,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       return null;
     }
 
-    final CacheToken cacheToken = cachingAllowed && txCache != null ? txCache.generateSubsumesToken(options, parent, child, expParameters) : null;
+    final CacheToken cacheToken = cachingAllowed && txCache != null ? txCache.generateSubsumesToken(options, parent, child, getExpansionParameters()) : null;
     if (cachingAllowed && txCache != null) {
       Boolean res = txCache.getSubsumes(cacheToken);
       if (res != null) {
@@ -1666,15 +1666,15 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
 
   protected ValueSetValidator constructValueSetCheckerSimple(ValidationOptions options,  ValueSet vs,  ValidationContextCarrier ctxt) {
-    return new ValueSetValidator(this, new TerminologyOperationContext(this, options, "validation"), options, vs, ctxt, expParameters, terminologyClientManager, registry);
+    return new ValueSetValidator(this, new TerminologyOperationContext(this, options, "validation"), options, vs, ctxt, getExpansionParameters(), terminologyClientManager, registry);
   }
 
   protected ValueSetValidator constructValueSetCheckerSimple( ValidationOptions options,  ValueSet vs) {
-    return new ValueSetValidator(this, new TerminologyOperationContext(this, options, "validation"), options, vs, expParameters, terminologyClientManager, registry);
+    return new ValueSetValidator(this, new TerminologyOperationContext(this, options, "validation"), options, vs, getExpansionParameters(), terminologyClientManager, registry);
   }
 
   protected Parameters constructParameters(ITerminologyOperationDetails opCtxt, TerminologyClientContext tcd, ValueSet vs, boolean hierarchical) {
-    Parameters p = expParameters.copy();
+    Parameters p = getExpansionParameters();
     p.setParameter("includeDefinition", false);
     p.setParameter("excludeNested", !hierarchical);
 
@@ -1710,7 +1710,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     } else {      
       pIn.addParameter().setName("coding").setValue(codingValidationRequest.getCoding());
     }
-    pIn.addParameters(expParameters);
+    pIn.addParameters(getExpansionParameters());
     return pIn;
   }
 
@@ -1737,7 +1737,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
 
   @Override
   public ValidationResult validateCode(ValidationOptions options, CodeableConcept code, ValueSet vs) {
-    CacheToken cacheToken = txCache.generateValidationToken(options, code, vs, expParameters);
+    CacheToken cacheToken = txCache.generateValidationToken(options, code, vs, getExpansionParameters());
     ValidationResult res = null;
     if (cachingAllowed) {
       res = txCache.getValidation(cacheToken);
@@ -1965,11 +1965,11 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
         throw new Error(formatMessage(I18nConstants.CAN_ONLY_SPECIFY_PROFILE_IN_THE_CONTEXT));
       }
     }
-    if (expParameters == null) {
+    if (expansionParameters.get() == null) {
       throw new Error(formatMessage(I18nConstants.NO_EXPANSIONPROFILE_PROVIDED));
     }
     String defLang = null;
-    for (ParametersParameterComponent pp : expParameters.getParameter()) {
+    for (ParametersParameterComponent pp : expansionParameters.get().getParameter()) {
       if ("defaultDisplayLanguage".equals(pp.getName())) {
         defLang = pp.getValue().primitiveValue();
       } else if (!pin.hasParameter(pp.getName())) {
@@ -2276,12 +2276,12 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
 
   public Parameters getExpansionParameters() {
-    return expParameters;
+    return expansionParameters.get().copy();
   }
 
-  public void setExpansionParameters(Parameters expParameters) {
-    this.expParameters = expParameters;
-    this.terminologyClientManager.setExpansionParameters(expParameters);
+  public void setExpansionParameters(Parameters expansionParameters) {
+    this.expansionParameters.set(expansionParameters);
+    this.terminologyClientManager.setExpansionParameters(expansionParameters);
   }
 
   @Override
@@ -3759,61 +3759,77 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
     return res;
   }
-  
+
   public void setLocale(Locale locale) {
     super.setLocale(locale);
-    if (locale != null) {
-      final String languageTag = locale.toLanguageTag();
-      if ("und".equals(languageTag)) {
-        throw new FHIRException("The locale "+locale.toString()+" is not valid");
-      }
-      /* If displayLanguage is an existing parameter, we check to see if it was added automatically or explicitly set by
-       the user
+    if (locale == null) {
+      return;
+    }
+    final String languageTag = locale.toLanguageTag();
+    if ("und".equals(languageTag)) {
+      throw new FHIRException("The locale " + locale.toString() + " is not valid");
+    }
 
-       * If it was added automatically, we update it to the new locale
-       * If it was set by the user, we do not update it.
+    if (expansionParameters.get() == null) {
+      return;
+    }
 
-       In both cases, we are done.
-       */
+    /*
+    If displayLanguage is an existing parameter, we check to see if it was added automatically or explicitly set by
+    the user
 
-      if (expParameters != null) {
-        int displayLanguageCount = 0;
-        for (ParametersParameterComponent expParameter : expParameters.getParameter()) {
-          if ("displayLanguage".equals(expParameter.getName())) {
-            if (expParameter.hasUserData(UserDataNames.auto_added_parameter)) {
-              expParameter.setValue(new CodeType(languageTag));
-            }
-            displayLanguageCount++;
-          }
-        }
-        if (displayLanguageCount > 1) {
-          throw new FHIRException("Multiple displayLanguage parameters found");
-        }
-        if (displayLanguageCount == 1) {
-          return;
-        }
+      * If it was added automatically, we update it to the new locale
+      * If it was set by the user, we do not update it.
 
-        // There is no displayLanguage parameter so we are free to add a "defaultDisplayLanguage" instead.
+    In both cases, we are done.
+    */
 
-        int defaultDisplayLanguageCount = 0;
-        for (ParametersParameterComponent expParameter : expParameters.getParameter()) {
-          if ("defaultDisplayLanguage".equals(expParameter.getName())) {
-            expParameter.setValue(new CodeType(languageTag));
-            expParameter.setUserData(UserDataNames.auto_added_parameter, true);
-            defaultDisplayLanguageCount++;
-          }
-        }
-        if (defaultDisplayLanguageCount > 1) {
-          throw new FHIRException("Multiple defaultDisplayLanguage parameters found");
-        }
-        if (defaultDisplayLanguageCount == 0) {
-          ParametersParameterComponent p = expParameters.addParameter();
-          p.setName("defaultDisplayLanguage");
-          p.setValue(new CodeType(languageTag));
-          p.setUserData(UserDataNames.auto_added_parameter, true);
-        }
+    Parameters newExpansionParameters = new Parameters();
+    if (this.expansionParameters.get().hasParameter()) {
+      for (ParametersParameterComponent expParameter : this.expansionParameters.get().getParameter()) {
+        Parameters.ParametersParameterComponent copy = newExpansionParameters.addParameter();
+        expParameter.copyValues(copy);
+        copy.copyUserData(expParameter);
       }
     }
+
+    int displayLanguageCount = 0;
+    for (ParametersParameterComponent expParameter : newExpansionParameters.getParameter()) {
+      if ("displayLanguage".equals(expParameter.getName())) {
+        if (expParameter.hasUserData(UserDataNames.auto_added_parameter)) {
+          expParameter.setValue(new CodeType(languageTag));
+        }
+        displayLanguageCount++;
+      }
+    }
+    if (displayLanguageCount > 1) {
+      throw new FHIRException("Multiple displayLanguage parameters found");
+    }
+    if (displayLanguageCount == 1) {
+      this.expansionParameters.set(newExpansionParameters);
+      return;
+    }
+
+    // There is no displayLanguage parameter so we are free to add a "defaultDisplayLanguage" instead.
+
+    int defaultDisplayLanguageCount = 0;
+    for (ParametersParameterComponent expansionParameter : newExpansionParameters.getParameter()) {
+      if ("defaultDisplayLanguage".equals(expansionParameter.getName())) {
+        expansionParameter.setValue(new CodeType(languageTag));
+        expansionParameter.setUserData(UserDataNames.auto_added_parameter, true);
+        defaultDisplayLanguageCount++;
+      }
+    }
+    if (defaultDisplayLanguageCount > 1) {
+      throw new FHIRException("Multiple defaultDisplayLanguage parameters found");
+    }
+    if (defaultDisplayLanguageCount == 0) {
+      ParametersParameterComponent p = newExpansionParameters.addParameter();
+      p.setName("defaultDisplayLanguage");
+      p.setValue(new CodeType(languageTag));
+      p.setUserData(UserDataNames.auto_added_parameter, true);
+    }
+    this.expansionParameters.set(newExpansionParameters);
   }
   
   @Override

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -2275,6 +2275,14 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     getTxClientManager().setLogger(logger);
   }
 
+  /**
+   * Returns a copy of the expansion parameters used by this context. Note that because the return value is a copy, any
+   * changes done to it will not be reflected in the context and any changes to the context will likewise not be
+   * reflected in the return value after it is returned. If you need to change the expansion parameters, use
+   * {@link #setExpansionParameters(Parameters)}.
+   *
+   * @return a copy of the expansion parameters
+   */
   public Parameters getExpansionParameters() {
     return expansionParameters.get().copy();
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -3828,7 +3828,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   private Parameters copyExpansionParametersWithUserData() {
     Parameters newExpansionParameters = new Parameters();
     // Copy all existing parameters include userData (not usually included in copyies)
-    if (this.expansionParameters.get().hasParameter()) {
+    if (this.expansionParameters.get() != null && this.expansionParameters.get().hasParameter()) {
       for (ParametersParameterComponent expParameter : this.expansionParameters.get().getParameter()) {
         ParametersParameterComponent copy = newExpansionParameters.addParameter();
         expParameter.copyValues(copy);

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
@@ -552,6 +552,15 @@ public interface IWorkerContext {
    * @return
    */
   Locale getLocale();
+
+  /**
+   * Sets the locale for this worker context.
+   *
+   * @param locale The locale to use.
+   * @deprecated Usage of this method is discouraged outside very specific scenarios in testing and the IG publisher.
+   * It is preferred to set the locale via the constructor of the implementing class.
+   */
+  @Deprecated
   void setLocale(Locale locale);
 
   @Deprecated

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxServiceTestHelper.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxServiceTestHelper.java
@@ -69,17 +69,20 @@ public class TxServiceTestHelper {
       if (p.hasParameter("activeOnly") && "true".equals(p.getParameterString("activeOnly"))) {
         options = options.setActiveOnly(true);
       }
+      Parameters newParameters = context.getExpansionParameters();
       for (ParametersParameterComponent pp : p.getParameter()) {
         if (Utilities.existsInList(pp.getName(), "default-valueset-version", "system-version", "force-system-version", "default-system-version")) {
-          context.getExpansionParameters().getParameter().add(pp);
+          //FIXME this is changing a reference to a copied object so breaks.
+          newParameters.getParameter().add(pp);
         }
       }
-      context.getExpansionParameters().clearParameters("includeAlternateCodes");
+      newParameters.clearParameters("includeAlternateCodes");
       for (Parameters.ParametersParameterComponent pp : p.getParameter()) {
         if ("includeAlternateCodes".equals(pp.getName())) {
-          context.getExpansionParameters().addParameter(pp.copy());
+          newParameters.addParameter(pp.copy());
         }
       }
+      context.setExpansionParameters(newParameters);
       if (p.hasParameter("code")) {
         code = p.getParameterString("code");
         system = p.getParameterString(isCodeSystem ? "url" : "system");


### PR DESCRIPTION
BaseWorkerContext modified the contents of expansionParameters and passed references to them. When accessed from multiple threads, it was possible for the lists in Parameters to be modified (by `setLocale` in particular) while another thread was in the process of reading.

This ensures that expansionParameters is only ever returned as a copy, and that whenever its value is modified, it is done so with an AtomicReference `set` call instead of modified directrly.