### PR TITLE
Fix package cache lookup to allow substring match for canonical URIs

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -779,7 +779,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       for (String pf : listPackages()) {
         if (ManagedFileAccess.file(Utilities.path(cacheFolder, pf, "package", "package.json")).exists()) {
           JsonObject npm = JsonParser.parseObjectFromFile(Utilities.path(cacheFolder, pf, "package", "package.json"));
-          if (canonicalUrl.equals(npm.asString("canonical"))) {
+          if (canonicalUrl.contains(npm.asString("canonical"))) {
             return npm.asString("name");
           }
         }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageManagerTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/FilesystemPackageManagerTests.java
@@ -206,6 +206,20 @@ public class FilesystemPackageManagerTests {
     lockThread.join();
   }
 
+  @Test
+  public void testCacheHitWithCanonicalSubstringMatch() throws IOException {
+    File cacheDirectory = ManagedFileAccess.fromPath(Files.createTempDirectory("fpcm-canonicalSubstringTest"));
+    FilesystemPackageCacheManager pcm = new FilesystemPackageCacheManager.Builder().withCacheFolder(cacheDirectory.getAbsolutePath()).build();
+
+    pcm.addPackageToCache("example.fhir.uv.myig", "1.2.3", this.getClass().getResourceAsStream("/npm/dummy-package.tgz"), "https://packages.fhir.org/example.fhir.uv.myig/1.2.3");
+
+    String dependsOnUri = "http://somewhere.org/fhir/uv/myig/ImplementationGuide/hl7.fhir.uv.extensions";
+
+    String npmPackageName = pcm.findCanonicalInLocalCache(dependsOnUri);
+    assertThat(npmPackageName).isNotNull();
+    assertThat(npmPackageName).isEqualTo("example.fhir.uv.myig");
+  }
+
   /**
     We repeat the same tests multiple times here, in order to catch very rare edge cases.
    */


### PR DESCRIPTION
Proposed solution for #2168