### PR TITLE
SonarQube: Add at least one assertion to this test case

### DIFF
--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/Convertor_Factory_40_50Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/Convertor_Factory_40_50Test.java
@@ -1,10 +1,8 @@
 package org.hl7.fhir.convertors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
@@ -31,23 +29,27 @@ class Convertor_Factory_40_50Test  {
 
 
   @Test
-  void convertResource() throws IOException {
-    JsonParser r4parser = new JsonParser();
-    org.hl7.fhir.r5.formats.JsonParser r5parser = new org.hl7.fhir.r5.formats.JsonParser();
-    InputStream accountr4InputStream = this.getClass().getResourceAsStream("/account_r4.json");
-    org.hl7.fhir.r4.model.Account account_r4 = (org.hl7.fhir.r4.model.Account) r4parser.parse(accountr4InputStream);
-    Resource account_r5 = VersionConvertorFactory_40_50.convertResource(account_r4);
-    System.out.println(r5parser.composeString(account_r5));
+  void convertResource() {
+    assertDoesNotThrow(() -> {
+      JsonParser r4parser = new JsonParser();
+      org.hl7.fhir.r5.formats.JsonParser r5parser = new org.hl7.fhir.r5.formats.JsonParser();
+      InputStream accountr4InputStream = this.getClass().getResourceAsStream("/account_r4.json");
+      org.hl7.fhir.r4.model.Account account_r4 = (org.hl7.fhir.r4.model.Account) r4parser.parse(accountr4InputStream);
+      Resource account_r5 = VersionConvertorFactory_40_50.convertResource(account_r4);
+      System.out.println(r5parser.composeString(account_r5));
+    });
   }
 
   @Test
-  void convertBundleContainingAccountsToTestPathing() throws IOException {
-    JsonParser r4parser = new JsonParser();
-    org.hl7.fhir.r5.formats.JsonParser r5parser = new org.hl7.fhir.r5.formats.JsonParser();
-    InputStream accountr4InputStream = this.getClass().getResourceAsStream("/bundle_of_accounts_path_test_r4.json");
-    org.hl7.fhir.r4.model.Bundle bundle_r4 = (org.hl7.fhir.r4.model.Bundle) r4parser.parse(accountr4InputStream);
-    Resource account_r5 = VersionConvertorFactory_40_50.convertResource(bundle_r4);
-    System.out.println(r5parser.composeString(account_r5));
+  void convertBundleContainingAccountsToTestPathing() {
+    assertDoesNotThrow(() -> {
+      JsonParser r4parser = new JsonParser();
+      org.hl7.fhir.r5.formats.JsonParser r5parser = new org.hl7.fhir.r5.formats.JsonParser();
+      InputStream accountr4InputStream = this.getClass().getResourceAsStream("/bundle_of_accounts_path_test_r4.json");
+      org.hl7.fhir.r4.model.Bundle bundle_r4 = (org.hl7.fhir.r4.model.Bundle) r4parser.parse(accountr4InputStream);
+      Resource account_r5 = VersionConvertorFactory_40_50.convertResource(bundle_r4);
+      System.out.println(r5parser.composeString(account_r5));
+    });
   }
 
   static final String CONTENT = "map \"http://example.org/qr2patgender\" = \"qr2patgender\"\n"+

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/AdministrativeGender10_30Test.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/conv10_30/AdministrativeGender10_30Test.java
@@ -1,6 +1,5 @@
 package org.hl7.fhir.convertors.conv10_30;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_10_30;
@@ -8,13 +7,17 @@ import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_30;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 public class AdministrativeGender10_30Test {
 
     @Test
     @DisplayName("Test 10_30 extension present, value is not")
-    public void testMedicationRequestConversion() throws IOException {
+    public void testMedicationRequestConversion() {
+      assertDoesNotThrow(() -> {
         InputStream dstu2_input = this.getClass().getResourceAsStream("/administrative_gender_null.json");
         org.hl7.fhir.dstu2.model.Patient dstu2 = (org.hl7.fhir.dstu2.model.Patient) new org.hl7.fhir.dstu2.formats.JsonParser().parse(dstu2_input);
-      VersionConvertorFactory_10_30.convertResource(dstu2, new BaseAdvisor_10_30());
+        VersionConvertorFactory_10_30.convertResource(dstu2, new BaseAdvisor_10_30());
+      });
     }
 }

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/rendering/R4RenderingTestCases.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/rendering/R4RenderingTestCases.java
@@ -9,9 +9,6 @@ import org.hl7.fhir.convertors.context.ContextResourceLoaderFactory;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
 import org.hl7.fhir.convertors.loaders.loaderR5.NullLoaderKnowledgeProviderR5;
 import org.hl7.fhir.convertors.wrapper.ResourceWrapperR4;
-import org.hl7.fhir.exceptions.DefinitionException;
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.HumanName;
@@ -24,7 +21,6 @@ import org.hl7.fhir.r5.renderers.RendererFactory;
 import org.hl7.fhir.r5.renderers.ResourceRenderer;
 import org.hl7.fhir.r5.renderers.utils.RenderingContext;
 import org.hl7.fhir.r5.renderers.utils.ResourceWrapper;
-import org.hl7.fhir.r5.utils.EOperationOutcome;
 import org.hl7.fhir.utilities.FhirPublication;
 import org.hl7.fhir.utilities.MarkDownProcessor;
 import org.hl7.fhir.utilities.VersionUtilities;
@@ -35,31 +31,37 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class R4RenderingTestCases {
 
   @Test
-  void test() throws IOException, FHIRFormatError, DefinitionException, FHIRException, EOperationOutcome {
-    Patient patient = makePatient();
-    org.hl7.fhir.r5.model.Resource r5p = VersionConvertorFactory_40_50.convertResource(patient);
-    
-    RenderingContext rc = makeContext("5.0.0", FhirPublication.R5);
-    XhtmlNode x = new XhtmlNode(NodeType.Element, "div");
-    ResourceRenderer pr = RendererFactory.factory(r5p.fhirType(), rc);
-    pr.buildNarrative(new Renderer.RenderingStatus(), x, ResourceWrapper.forResource(rc, r5p));
-    String html = new XhtmlComposer(false, true).compose(x);
-    System.out.println(html);
+  void test()  {
+    assertDoesNotThrow(() -> {
+      Patient patient = makePatient();
+      org.hl7.fhir.r5.model.Resource r5p = VersionConvertorFactory_40_50.convertResource(patient);
+
+      RenderingContext rc = makeContext("5.0.0", FhirPublication.R5);
+      XhtmlNode x = new XhtmlNode(NodeType.Element, "div");
+      ResourceRenderer pr = RendererFactory.factory(r5p.fhirType(), rc);
+      pr.buildNarrative(new Renderer.RenderingStatus(), x, ResourceWrapper.forResource(rc, r5p));
+      String html = new XhtmlComposer(false, true).compose(x);
+      System.out.println(html);
+    });
   }
 
   @Test
-  void testR4() throws IOException, FHIRFormatError, DefinitionException, FHIRException, EOperationOutcome {
-    Patient patient = makePatient();
-    RenderingContext rc = makeContext("4.0.1", FhirPublication.R4);
+  void testR4() {
+    assertDoesNotThrow(() -> {
+      Patient patient = makePatient();
+      RenderingContext rc = makeContext("4.0.1", FhirPublication.R4);
 
-    XhtmlNode x = new XhtmlNode(NodeType.Element, "div");
-    ResourceRenderer pr = RendererFactory.factory(patient.fhirType(), rc);
-    pr.buildNarrative(new Renderer.RenderingStatus(), x, ResourceWrapperR4.forResource(rc, patient));
-    String html = new XhtmlComposer(false, true).compose(x);
-    System.out.println(html);
+      XhtmlNode x = new XhtmlNode(NodeType.Element, "div");
+      ResourceRenderer pr = RendererFactory.factory(patient.fhirType(), rc);
+      pr.buildNarrative(new Renderer.RenderingStatus(), x, ResourceWrapperR4.forResource(rc, patient));
+      String html = new XhtmlComposer(false, true).compose(x);
+      System.out.println(html);
+    });
   }
 
   public Patient makePatient() {

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/Base64BinaryTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/Base64BinaryTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class Base64BinaryTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    Base64BinaryType nullBase64 = new Base64BinaryType();
-    System.out.println("Value -> " + nullBase64);
+    assertDoesNotThrow(() -> {
+      Base64BinaryType nullBase64 = new Base64BinaryType();
+      System.out.println("Value -> " + nullBase64);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/BooleanTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/BooleanTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class BooleanTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    BooleanType nullBoolean = new BooleanType();
-    System.out.println("Value -> " + nullBoolean);
+    assertDoesNotThrow(() -> {
+      BooleanType nullBoolean = new BooleanType();
+      System.out.println("Value -> " + nullBoolean);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/CodeTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/CodeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CodeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CodeType nullCode = new CodeType();
-    System.out.println("Value -> " + nullCode);
+    assertDoesNotThrow(() -> {
+      CodeType nullCode = new CodeType();
+      System.out.println("Value -> " + nullCode);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DateTimeTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DateTimeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateTimeType nullDateTime = new DateTimeType();
-    System.out.println("Value -> " + nullDateTime);
+    assertDoesNotThrow(() -> {
+      DateTimeType nullDateTime = new DateTimeType();
+      System.out.println("Value -> " + nullDateTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DateTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DateTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateType nullDate = new DateType();
-    System.out.println("Value -> " + nullDate);
+    assertDoesNotThrow(() -> {
+      DateType nullDate = new DateType();
+      System.out.println("Value -> " + nullDate);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/DecimalTypeNullTest.java
@@ -10,13 +10,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/IdTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/IdTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IdTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IdType nullId = new IdType();
-    System.out.println("Value -> " + nullId);
+    assertDoesNotThrow(() -> {
+      IdType nullId = new IdType();
+      System.out.println("Value -> " + nullId);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/InstantTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/InstantTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class InstantTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    InstantType nullInstant = new InstantType();
-    System.out.println("Value -> " + nullInstant);
+    assertDoesNotThrow(() -> {
+      InstantType nullInstant = new InstantType();
+      System.out.println("Value -> " + nullInstant);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/IntegerTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/IntegerTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IntegerTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IntegerType nullInteger = new IntegerType();
-    System.out.println("Value -> " + nullInteger);
+    assertDoesNotThrow(() -> {
+      IntegerType nullInteger = new IntegerType();
+      System.out.println("Value -> " + nullInteger);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/MarkdownTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/MarkdownTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class MarkdownTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    MarkdownType nullMarkdown = new MarkdownType();
-    System.out.println("Value -> " + nullMarkdown);
+    assertDoesNotThrow(() -> {
+      MarkdownType nullMarkdown = new MarkdownType();
+      System.out.println("Value -> " + nullMarkdown);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/OidTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/OidTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class OidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    OidType nullOid = new OidType();
-    System.out.println("Value -> " + nullOid);
+    assertDoesNotThrow(() -> {
+      OidType nullOid = new OidType();
+      System.out.println("Value -> " + nullOid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/PositiveIntTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/PositiveIntTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class PositiveIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    PositiveIntType nullPositiveInt = new PositiveIntType();
-    System.out.println("Value -> " + nullPositiveInt);
+    assertDoesNotThrow(() -> {
+      PositiveIntType nullPositiveInt = new PositiveIntType();
+      System.out.println("Value -> " + nullPositiveInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/StringTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/StringTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class StringTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    StringType nullString = new StringType();
-    System.out.println("Value -> " + nullString);
+    assertDoesNotThrow(() -> {
+      StringType nullString = new StringType();
+      System.out.println("Value -> " + nullString);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/TimeTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/TimeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class TimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    TimeType nullTime = new TimeType();
-    System.out.println("Value -> " + nullTime);
+    assertDoesNotThrow(() -> {
+      TimeType nullTime = new TimeType();
+      System.out.println("Value -> " + nullTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UnsignedIntTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UnsignedIntTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UnsignedIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UnsignedIntType nullUnsignedInt = new UnsignedIntType();
-    System.out.println("Value -> " + nullUnsignedInt);
+    assertDoesNotThrow(() -> {
+      UnsignedIntType nullUnsignedInt = new UnsignedIntType();
+      System.out.println("Value -> " + nullUnsignedInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UriTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UriTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UriTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UriType nullUri = new UriType();
-    System.out.println("Value -> " + nullUri);
+    assertDoesNotThrow(() -> {
+      UriType nullUri = new UriType();
+      System.out.println("Value -> " + nullUri);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UuidTypeNullTest.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/test/UuidTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UuidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UuidType nullUuid = new UuidType();
-    System.out.println("Value -> " + nullUuid);
+    assertDoesNotThrow(() -> {
+      UuidType nullUuid = new UuidType();
+      System.out.println("Value -> " + nullUuid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/model/DecimalTypeNullTest.java
@@ -9,13 +9,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/Base64BinaryTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/Base64BinaryTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class Base64BinaryTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    Base64BinaryType nullBase64 = new Base64BinaryType();
-    System.out.println("Value -> " + nullBase64);
+    assertDoesNotThrow(() -> {
+      Base64BinaryType nullBase64 = new Base64BinaryType();
+      System.out.println("Value -> " + nullBase64);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BooleanTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/BooleanTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class BooleanTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    BooleanType nullBoolean = new BooleanType();
-    System.out.println("Value -> " + nullBoolean);
+    assertDoesNotThrow(() -> {
+      BooleanType nullBoolean = new BooleanType();
+      System.out.println("Value -> " + nullBoolean);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/CodeTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/CodeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CodeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CodeType nullCode = new CodeType();
-    System.out.println("Value -> " + nullCode);
+    assertDoesNotThrow(() -> {
+      CodeType nullCode = new CodeType();
+      System.out.println("Value -> " + nullCode);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTimeTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateTimeType nullDateTime = new DateTimeType();
-    System.out.println("Value -> " + nullDateTime);
+    assertDoesNotThrow(() -> {
+      DateTimeType nullDateTime = new DateTimeType();
+      System.out.println("Value -> " + nullDateTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DateTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateType nullDate = new DateType();
-    System.out.println("Value -> " + nullDate);
+    assertDoesNotThrow(() -> {
+      DateType nullDate = new DateType();
+      System.out.println("Value -> " + nullDate);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/DecimalTypeNullTest.java
@@ -9,13 +9,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/IdTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/IdTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IdTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IdType nullId = new IdType();
-    System.out.println("Value -> " + nullId);
+    assertDoesNotThrow(() -> {
+      IdType nullId = new IdType();
+      System.out.println("Value -> " + nullId);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/InstantTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/InstantTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class InstantTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    InstantType nullInstant = new InstantType();
-    System.out.println("Value -> " + nullInstant);
+    assertDoesNotThrow(() -> {
+      InstantType nullInstant = new InstantType();
+      System.out.println("Value -> " + nullInstant);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/IntegerTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/IntegerTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IntegerTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IntegerType nullInteger = new IntegerType();
-    System.out.println("Value -> " + nullInteger);
+    assertDoesNotThrow(() -> {
+      IntegerType nullInteger = new IntegerType();
+      System.out.println("Value -> " + nullInteger);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/MarkdownTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/MarkdownTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class MarkdownTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    MarkdownType nullMarkdown = new MarkdownType();
-    System.out.println("Value -> " + nullMarkdown);
+    assertDoesNotThrow(() -> {
+      MarkdownType nullMarkdown = new MarkdownType();
+      System.out.println("Value -> " + nullMarkdown);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/OidTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/OidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class OidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    OidType nullOid = new OidType();
-    System.out.println("Value -> " + nullOid);
+    assertDoesNotThrow(() -> {
+      OidType nullOid = new OidType();
+      System.out.println("Value -> " + nullOid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/PositiveIntTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/PositiveIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class PositiveIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    PositiveIntType nullPositiveInt = new PositiveIntType();
-    System.out.println("Value -> " + nullPositiveInt);
+    assertDoesNotThrow(() -> {
+      PositiveIntType nullPositiveInt = new PositiveIntType();
+      System.out.println("Value -> " + nullPositiveInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/StringTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/StringTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class StringTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    StringType nullString = new StringType();
-    System.out.println("Value -> " + nullString);
+    assertDoesNotThrow(() -> {
+      StringType nullString = new StringType();
+      System.out.println("Value -> " + nullString);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/TimeTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/TimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class TimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    TimeType nullTime = new TimeType();
-    System.out.println("Value -> " + nullTime);
+    assertDoesNotThrow(() -> {
+      TimeType nullTime = new TimeType();
+      System.out.println("Value -> " + nullTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UnsignedIntTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UnsignedIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UnsignedIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UnsignedIntType nullUnsignedInt = new UnsignedIntType();
-    System.out.println("Value -> " + nullUnsignedInt);
+    assertDoesNotThrow(() -> {
+      UnsignedIntType nullUnsignedInt = new UnsignedIntType();
+      System.out.println("Value -> " + nullUnsignedInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UriTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UriTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UriTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UriType nullUri = new UriType();
-    System.out.println("Value -> " + nullUri);
+    assertDoesNotThrow(() -> {
+      UriType nullUri = new UriType();
+      System.out.println("Value -> " + nullUri);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UuidTypeNullTest.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/model/UuidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UuidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UuidType nullUuid = new UuidType();
-    System.out.println("Value -> " + nullUuid);
+    assertDoesNotThrow(() -> {
+      UuidType nullUuid = new UuidType();
+      System.out.println("Value -> " + nullUuid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/Base64BinaryTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/Base64BinaryTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class Base64BinaryTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    Base64BinaryType nullBase64 = new Base64BinaryType();
-    System.out.println("Value -> " + nullBase64);
+    assertDoesNotThrow(() -> {
+      Base64BinaryType nullBase64 = new Base64BinaryType();
+      System.out.println("Value -> " + nullBase64);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BooleanTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/BooleanTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class BooleanTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    BooleanType nullBoolean = new BooleanType();
-    System.out.println("Value -> " + nullBoolean);
+    assertDoesNotThrow(() -> {
+      BooleanType nullBoolean = new BooleanType();
+      System.out.println("Value -> " + nullBoolean);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/CanonicalTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/CanonicalTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CanonicalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CanonicalType nullCanonical = new CanonicalType();
-    System.out.println("Value -> " + nullCanonical);
+    assertDoesNotThrow(() -> {
+      CanonicalType nullCanonical = new CanonicalType();
+      System.out.println("Value -> " + nullCanonical);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/CodeTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/CodeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CodeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CodeType nullCode = new CodeType();
-    System.out.println("Value -> " + nullCode);
+    assertDoesNotThrow(() -> {
+      CodeType nullCode = new CodeType();
+      System.out.println("Value -> " + nullCode);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateTimeType nullDateTime = new DateTimeType();
-    System.out.println("Value -> " + nullDateTime);
+    assertDoesNotThrow(() -> {
+      DateTimeType nullDateTime = new DateTimeType();
+      System.out.println("Value -> " + nullDateTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DateTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateType nullDate = new DateType();
-    System.out.println("Value -> " + nullDate);
+    assertDoesNotThrow(() -> {
+      DateType nullDate = new DateType();
+      System.out.println("Value -> " + nullDate);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/DecimalTypeNullTest.java
@@ -9,13 +9,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/IdTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/IdTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IdTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IdType nullId = new IdType();
-    System.out.println("Value -> " + nullId);
+    assertDoesNotThrow(() -> {
+      IdType nullId = new IdType();
+      System.out.println("Value -> " + nullId);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/InstantTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/InstantTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class InstantTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    InstantType nullInstant = new InstantType();
-    System.out.println("Value -> " + nullInstant);
+    assertDoesNotThrow(() -> {
+      InstantType nullInstant = new InstantType();
+      System.out.println("Value -> " + nullInstant);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/IntegerTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/IntegerTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IntegerTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IntegerType nullInteger = new IntegerType();
-    System.out.println("Value -> " + nullInteger);
+    assertDoesNotThrow(() -> {
+      IntegerType nullInteger = new IntegerType();
+      System.out.println("Value -> " + nullInteger);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/MarkdownTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/MarkdownTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class MarkdownTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    MarkdownType nullMarkdown = new MarkdownType();
-    System.out.println("Value -> " + nullMarkdown);
+    assertDoesNotThrow(() -> {
+      MarkdownType nullMarkdown = new MarkdownType();
+      System.out.println("Value -> " + nullMarkdown);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/OidTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/OidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class OidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    OidType nullOid = new OidType();
-    System.out.println("Value -> " + nullOid);
+    assertDoesNotThrow(() -> {
+      OidType nullOid = new OidType();
+      System.out.println("Value -> " + nullOid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/PositiveIntTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/PositiveIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class PositiveIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    PositiveIntType nullPositiveInt = new PositiveIntType();
-    System.out.println("Value -> " + nullPositiveInt);
+    assertDoesNotThrow(() -> {
+      PositiveIntType nullPositiveInt = new PositiveIntType();
+      System.out.println("Value -> " + nullPositiveInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/StringTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/StringTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class StringTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    StringType nullString = new StringType();
-    System.out.println("Value -> " + nullString);
+    assertDoesNotThrow(() -> {
+      StringType nullString = new StringType();
+      System.out.println("Value -> " + nullString);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/TimeTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/TimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class TimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    TimeType nullTime = new TimeType();
-    System.out.println("Value -> " + nullTime);
+    assertDoesNotThrow(() -> {
+      TimeType nullTime = new TimeType();
+      System.out.println("Value -> " + nullTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UnsignedIntTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UnsignedIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UnsignedIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UnsignedIntType nullUnsignedInt = new UnsignedIntType();
-    System.out.println("Value -> " + nullUnsignedInt);
+    assertDoesNotThrow(() -> {
+      UnsignedIntType nullUnsignedInt = new UnsignedIntType();
+      System.out.println("Value -> " + nullUnsignedInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UriTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UriTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UriTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UriType nullUri = new UriType();
-    System.out.println("Value -> " + nullUri);
+    assertDoesNotThrow(() -> {
+      UriType nullUri = new UriType();
+      System.out.println("Value -> " + nullUri);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UrlTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UrlTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UrlTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UrlType nullUrl = new UrlType();
-    System.out.println("Value -> " + nullUrl);
+    assertDoesNotThrow(() -> {
+      UrlType nullUrl = new UrlType();
+      System.out.println("Value -> " + nullUrl);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UuidTypeNullTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/model/UuidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UuidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UuidType nullUuid = new UuidType();
-    System.out.println("Value -> " + nullUuid);
+    assertDoesNotThrow(() -> {
+      UuidType nullUuid = new UuidType();
+      System.out.println("Value -> " + nullUuid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/Base64BinaryTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/Base64BinaryTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class Base64BinaryTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    Base64BinaryType nullBase64 = new Base64BinaryType();
-    System.out.println("Value -> " + nullBase64);
+    assertDoesNotThrow(() -> {
+      Base64BinaryType nullBase64 = new Base64BinaryType();
+      System.out.println("Value -> " + nullBase64);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BooleanTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/BooleanTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class BooleanTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    BooleanType nullBoolean = new BooleanType();
-    System.out.println("Value -> " + nullBoolean);
+    assertDoesNotThrow(() -> {
+      BooleanType nullBoolean = new BooleanType();
+      System.out.println("Value -> " + nullBoolean);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/CanonicalTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/CanonicalTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CanonicalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CanonicalType nullCanonical = new CanonicalType();
-    System.out.println("Value -> " + nullCanonical);
+    assertDoesNotThrow(() -> {
+      CanonicalType nullCanonical = new CanonicalType();
+      System.out.println("Value -> " + nullCanonical);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/CodeTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/CodeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CodeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CodeType nullCode = new CodeType();
-    System.out.println("Value -> " + nullCode);
+    assertDoesNotThrow(() -> {
+      CodeType nullCode = new CodeType();
+      System.out.println("Value -> " + nullCode);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTimeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateTimeType nullDateTime = new DateTimeType();
-    System.out.println("Value -> " + nullDateTime);
+    assertDoesNotThrow(() -> {
+      DateTimeType nullDateTime = new DateTimeType();
+      System.out.println("Value -> " + nullDateTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DateTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateType nullDate = new DateType();
-    System.out.println("Value -> " + nullDate);
+    assertDoesNotThrow(() -> {
+      DateType nullDate = new DateType();
+      System.out.println("Value -> " + nullDate);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/DecimalTypeNullTest.java
@@ -9,13 +9,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/IdTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/IdTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IdTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IdType nullId = new IdType();
-    System.out.println("Value -> " + nullId);
+    assertDoesNotThrow(() -> {
+      IdType nullId = new IdType();
+      System.out.println("Value -> " + nullId);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/InstantTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/InstantTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class InstantTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    InstantType nullInstant = new InstantType();
-    System.out.println("Value -> " + nullInstant);
+    assertDoesNotThrow(() -> {
+      InstantType nullInstant = new InstantType();
+      System.out.println("Value -> " + nullInstant);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/IntegerTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/IntegerTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IntegerTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IntegerType nullInteger = new IntegerType();
-    System.out.println("Value -> " + nullInteger);
+    assertDoesNotThrow(() -> {
+      IntegerType nullInteger = new IntegerType();
+      System.out.println("Value -> " + nullInteger);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/MarkdownTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/MarkdownTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class MarkdownTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    MarkdownType nullMarkdown = new MarkdownType();
-    System.out.println("Value -> " + nullMarkdown);
+    assertDoesNotThrow(() -> {
+      MarkdownType nullMarkdown = new MarkdownType();
+      System.out.println("Value -> " + nullMarkdown);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/OidTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/OidTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class OidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    OidType nullOid = new OidType();
-    System.out.println("Value -> " + nullOid);
+    assertDoesNotThrow(() -> {
+      OidType nullOid = new OidType();
+      System.out.println("Value -> " + nullOid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/PositiveIntTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/PositiveIntTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class PositiveIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    PositiveIntType nullPositiveInt = new PositiveIntType();
-    System.out.println("Value -> " + nullPositiveInt);
+    assertDoesNotThrow(() -> {
+      PositiveIntType nullPositiveInt = new PositiveIntType();
+      System.out.println("Value -> " + nullPositiveInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/StringTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/StringTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class StringTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    StringType nullString = new StringType();
-    System.out.println("Value -> " + nullString);
+    assertDoesNotThrow(() -> {
+      StringType nullString = new StringType();
+      System.out.println("Value -> " + nullString);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/TimeTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/TimeTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class TimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    TimeType nullTime = new TimeType();
-    System.out.println("Value -> " + nullTime);
+    assertDoesNotThrow(() -> {
+      TimeType nullTime = new TimeType();
+      System.out.println("Value -> " + nullTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UnsignedIntTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UnsignedIntTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UnsignedIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UnsignedIntType nullUnsignedInt = new UnsignedIntType();
-    System.out.println("Value -> " + nullUnsignedInt);
+    assertDoesNotThrow(() -> {
+      UnsignedIntType nullUnsignedInt = new UnsignedIntType();
+      System.out.println("Value -> " + nullUnsignedInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UriTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UriTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UriTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UriType nullUri = new UriType();
-    System.out.println("Value -> " + nullUri);
+    assertDoesNotThrow(() -> {
+      UriType nullUri = new UriType();
+      System.out.println("Value -> " + nullUri);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UrlTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UrlTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UrlTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UrlType nullUrl = new UrlType();
-    System.out.println("Value -> " + nullUrl);
+    assertDoesNotThrow(() -> {
+      UrlType nullUrl = new UrlType();
+      System.out.println("Value -> " + nullUrl);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UuidTypeNullTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/model/UuidTypeNullTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UuidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UuidType nullUuid = new UuidType();
-    System.out.println("Value -> " + nullUuid);
+    assertDoesNotThrow(() -> {
+      UuidType nullUuid = new UuidType();
+      System.out.println("Value -> " + nullUuid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/Base64BinaryTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/Base64BinaryTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class Base64BinaryTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    Base64BinaryType nullBase64 = new Base64BinaryType();
-    System.out.println("Value -> " + nullBase64);
+    assertDoesNotThrow(() -> {
+      Base64BinaryType nullBase64 = new Base64BinaryType();
+      System.out.println("Value -> " + nullBase64);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BooleanTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/BooleanTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class BooleanTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    BooleanType nullBoolean = new BooleanType();
-    System.out.println("Value -> " + nullBoolean);
+    assertDoesNotThrow(() -> {
+      BooleanType nullBoolean = new BooleanType();
+      System.out.println("Value -> " + nullBoolean);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/CanonicalTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/CanonicalTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CanonicalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CanonicalType nullCanonical = new CanonicalType();
-    System.out.println("Value -> " + nullCanonical);
+    assertDoesNotThrow(() -> {
+      CanonicalType nullCanonical = new CanonicalType();
+      System.out.println("Value -> " + nullCanonical);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/CodeTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/CodeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class CodeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    CodeType nullCode = new CodeType();
-    System.out.println("Value -> " + nullCode);
+    assertDoesNotThrow(() -> {
+      CodeType nullCode = new CodeType();
+      System.out.println("Value -> " + nullCode);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateTimeType nullDateTime = new DateTimeType();
-    System.out.println("Value -> " + nullDateTime);
+    assertDoesNotThrow(() -> {
+      DateTimeType nullDateTime = new DateTimeType();
+      System.out.println("Value -> " + nullDateTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DateTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class DateTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DateType nullDate = new DateType();
-    System.out.println("Value -> " + nullDate);
+    assertDoesNotThrow(() -> {
+      DateType nullDate = new DateType();
+      System.out.println("Value -> " + nullDate);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DecimalTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/DecimalTypeNullTest.java
@@ -7,16 +7,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class DecimalTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    DecimalType nullDecimal = new DecimalType();
-    System.out.println("Value -> " + nullDecimal);
+    assertDoesNotThrow(() -> {
+      DecimalType nullDecimal = new DecimalType();
+      System.out.println("Value -> " + nullDecimal);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IdTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IdTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IdTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IdType nullId = new IdType();
-    System.out.println("Value -> " + nullId);
+    assertDoesNotThrow(() -> {
+      IdType nullId = new IdType();
+      System.out.println("Value -> " + nullId);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/InstantTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/InstantTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class InstantTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    InstantType nullInstant = new InstantType();
-    System.out.println("Value -> " + nullInstant);
+    assertDoesNotThrow(() -> {
+      InstantType nullInstant = new InstantType();
+      System.out.println("Value -> " + nullInstant);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IntegerTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/IntegerTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class IntegerTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    IntegerType nullInteger = new IntegerType();
-    System.out.println("Value -> " + nullInteger);
+    assertDoesNotThrow(() -> {
+      IntegerType nullInteger = new IntegerType();
+      System.out.println("Value -> " + nullInteger);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/MarkdownTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/MarkdownTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class MarkdownTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    MarkdownType nullMarkdown = new MarkdownType();
-    System.out.println("Value -> " + nullMarkdown);
+    assertDoesNotThrow(() -> {
+      MarkdownType nullMarkdown = new MarkdownType();
+      System.out.println("Value -> " + nullMarkdown);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/OidTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/OidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class OidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    OidType nullOid = new OidType();
-    System.out.println("Value -> " + nullOid);
+    assertDoesNotThrow(() -> {
+      OidType nullOid = new OidType();
+      System.out.println("Value -> " + nullOid);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/PositiveIntTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/PositiveIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class PositiveIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    PositiveIntType nullPositiveInt = new PositiveIntType();
-    System.out.println("Value -> " + nullPositiveInt);
+    assertDoesNotThrow(() -> {
+      PositiveIntType nullPositiveInt = new PositiveIntType();
+      System.out.println("Value -> " + nullPositiveInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/StringTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/StringTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class StringTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    StringType nullString = new StringType();
-    System.out.println("Value -> " + nullString);
+    assertDoesNotThrow(() -> {
+      StringType nullString = new StringType();
+      System.out.println("Value -> " + nullString);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/TimeTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/TimeTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class TimeTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    TimeType nullTime = new TimeType();
-    System.out.println("Value -> " + nullTime);
+    assertDoesNotThrow(() -> {
+      TimeType nullTime = new TimeType();
+      System.out.println("Value -> " + nullTime);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UnsignedIntTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UnsignedIntTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UnsignedIntTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UnsignedIntType nullUnsignedInt = new UnsignedIntType();
-    System.out.println("Value -> " + nullUnsignedInt);
+    assertDoesNotThrow(() -> {
+      UnsignedIntType nullUnsignedInt = new UnsignedIntType();
+      System.out.println("Value -> " + nullUnsignedInt);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UriTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UriTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UriTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UriType nullUri = new UriType();
-    System.out.println("Value -> " + nullUri);
+    assertDoesNotThrow(() -> {
+      UriType nullUri = new UriType();
+      System.out.println("Value -> " + nullUri);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UrlTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UrlTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UrlTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UrlType nullUrl = new UrlType();
-    System.out.println("Value -> " + nullUrl);
+    assertDoesNotThrow(() -> {
+      UrlType nullUrl = new UrlType();
+      System.out.println("Value -> " + nullUrl);
+    });
   }
 
   @Test

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UuidTypeNullTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/model/UuidTypeNullTest.java
@@ -4,13 +4,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 class UuidTypeNullTest {
 
   @Test
   @DisplayName("Test null value toString()")
   void testToString() {
-    UuidType nullUuid = new UuidType();
-    System.out.println("Value -> " + nullUuid);
+    assertDoesNotThrow(() -> {
+      UuidType nullUuid = new UuidType();
+      System.out.println("Value -> " + nullUuid);
+    });
   }
 
   @Test


### PR DESCRIPTION
Many of our tests simply run a piece of code to verify that it runs, and rely on exceptions to cause fatal test cases instead of failures.

Fixing these allows Sonarqube to catch instances where we actually might have removed or neglected to add assertions to our tests.