### PR TITLE
Test performance of CanonicalResourceManager in multithreaded environments

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -1364,6 +1364,7 @@ public class CanonicalResourceManagerTests {
       Multithread Test
      */
   @Test
+  // This timeout value was evaluated based on an observed time of 1400 ms for a single run, with a tolerance of 20%.
   @Timeout(value = 1500, unit = TimeUnit.MILLISECONDS)
   public void testCachedCanonicalResourceGetWithMultiThread() {
     //Create a single resource and then try to get it with multiple threads.


### PR DESCRIPTION
Adds a test to ensure multithreaded environments don't display performance issues when proxy resources are used.