### PR TITLE
Update sql-on-fhir package name

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/ValidatorCli.java
@@ -334,7 +334,7 @@ public class ValidatorCli {
         res.add("-version");
         res.add("5.0");
         res.add("-ig");
-        res.add("hl7.fhir.uv.sql-on-fhir#current");
+        res.add("org.sql-on-fhir.ig#current");
       } else {
         res.add(a);
       }


### PR DESCRIPTION
The SQL on FHIR option used by the `-view-definition` param in the CLI is out of date.

The following change in the IG contains the new package name as used in this PR:

https://github.com/FHIR/sql-on-fhir-v2/commit/91f3bdd4d19652ba92e1d2148618b0b52be6c6c5#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4