### PR TITLE
Multilang generation fixes

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
@@ -68,10 +68,6 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 @MarkedToMoveToAdjunctPackage
 @Slf4j
 public class LanguageUtils {
-
-  public static final int NARRATIVE_NONE = 0;
-  public static final int NARRATIVE_ROOT = 1;
-  public static final int NARRATIVE_CHILD = 2;
   
   public static final List<String> TRANSLATION_SUPPLEMENT_RESOURCE_TYPES = Arrays.asList("CodeSystem", "StructureDefinition", "Questionnaire");
 
@@ -824,23 +820,6 @@ public class LanguageUtils {
       changed = true;
     }
     return changed;
-  }
-
-  public int narrativeForLangStatus(DomainResource r, String lang, String defaultLang) {
-    if (!r.hasText() || !r.getText().hasDiv())
-      return NARRATIVE_NONE;
-    else
-      return narrativeForLangStatus(r.getText().getDiv(), lang, defaultLang, r.getLanguage());
-  }
-  
-  public int narrativeForLangStatus(XhtmlNode xhtml, String lang, String resourceLang, String defaultLang) {
-    XhtmlNode div = divForLang(xhtml, lang, resourceLang, defaultLang, null);
-    if (div == null)
-      return NARRATIVE_NONE;
-    else if (div.equals(xhtml))
-      return NARRATIVE_ROOT;
-    else
-      return NARRATIVE_CHILD;
   }
   
   public XhtmlNode divForLang(DomainResource r, String lang, String defaultLang, List<ValidationMessage> errors) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
@@ -41,6 +41,7 @@ import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.i18n.AcceptLanguageHeader;
 import org.hl7.fhir.utilities.i18n.AcceptLanguageHeader.LanguagePreference;
+import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.LanguageProducerLanguageSession;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.TextUnit;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.TranslationUnit;
@@ -886,7 +887,7 @@ public class LanguageUtils {
       }
       
       if (errors != null)
-        errors.add(new ValidationMessage(Source.Publisher, IssueType.BUSINESSRULE, "IG", "The narrative includes custom content for the default language (" + defaultLang + "), but does not include translated content for the " + lang + " language, so the default language has been used", IssueSeverity.WARNING));
+        errors.add(new ValidationMessage(Source.Publisher, IssueType.BUSINESSRULE, "IG", context.formatMessage(I18nConstants.NARRATIVE_NOT_TRANSLATED, defaultLang, lang), IssueSeverity.WARNING));
       return defaultDiv;
     }
     

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/LanguageUtils.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,6 +23,7 @@ import org.hl7.fhir.r5.model.CodeSystem.ConceptDefinitionDesignationComponent;
 import org.hl7.fhir.r5.model.CodeSystem.ConceptPropertyComponent;
 import org.hl7.fhir.r5.model.ContactDetail;
 import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.r5.model.DomainResource;
 import org.hl7.fhir.r5.model.ElementDefinition;
 import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionBindingAdditionalComponent;
 import org.hl7.fhir.r5.model.ElementDefinition.ElementDefinitionConstraintComponent;
@@ -32,6 +34,7 @@ import org.hl7.fhir.r5.model.Property;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StringType;
 import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.renderers.utils.RenderingContext;
 import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r5.utils.UserDataNames;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
@@ -41,6 +44,7 @@ import org.hl7.fhir.utilities.i18n.AcceptLanguageHeader.LanguagePreference;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.LanguageProducerLanguageSession;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.TextUnit;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer.TranslationUnit;
+import org.hl7.fhir.utilities.i18n.RenderingI18nContext;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
@@ -64,6 +68,10 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 @Slf4j
 public class LanguageUtils {
 
+  public static final int NARRATIVE_NONE = 0;
+  public static final int NARRATIVE_ROOT = 1;
+  public static final int NARRATIVE_CHILD = 2;
+  
   public static final List<String> TRANSLATION_SUPPLEMENT_RESOURCE_TYPES = Arrays.asList("CodeSystem", "StructureDefinition", "Questionnaire");
 
   public static class TranslationUnitCollection {
@@ -779,7 +787,7 @@ public class LanguageUtils {
     return null;
   }
  
-  public boolean switchLanguage(Base r, String lang, boolean markLanguage, boolean contained) {
+  public boolean switchLanguage(Base r, String lang, boolean markLanguage, boolean contained, String resourceLang, String defaultLang, List<ValidationMessage> errors) {
     boolean changed = false;
     if (r.isPrimitive()) {
 
@@ -797,7 +805,7 @@ public class LanguageUtils {
       Base status = r.getChildValueByName("status");
 
       XhtmlNode xhtml = div.getXhtml();
-      xhtml = adjustToLang(xhtml, lang, status == null ? null : status.primitiveValue());
+      xhtml = adjustToLang(xhtml, lang, status == null ? null : status.primitiveValue(), resourceLang, defaultLang, errors);
       if (xhtml == null) {
         r.removeChild("div", div);
       } else {
@@ -806,7 +814,7 @@ public class LanguageUtils {
     }
     for (Property p : r.children()) {
       for (Base c : p.getValues()) {
-        changed = switchLanguage(c, lang, markLanguage, p.getName().equals("contained")) || changed;
+        changed = switchLanguage(c, lang, markLanguage, p.getName().equals("contained"), resourceLang, defaultLang, errors) || changed;
       }
     }
     if (markLanguage && r.isResource() && !contained) {
@@ -817,35 +825,112 @@ public class LanguageUtils {
     return changed;
   }
 
-  private XhtmlNode adjustToLang(XhtmlNode xhtml, String lang, String status) {
-    if (xhtml == null) {
+  public int narrativeForLangStatus(DomainResource r, String lang, String defaultLang) {
+    if (!r.hasText() || !r.getText().hasDiv())
+      return NARRATIVE_NONE;
+    else
+      return narrativeForLangStatus(r.getText().getDiv(), lang, defaultLang, r.getLanguage());
+  }
+  
+  public int narrativeForLangStatus(XhtmlNode xhtml, String lang, String resourceLang, String defaultLang) {
+    XhtmlNode div = divForLang(xhtml, lang, resourceLang, defaultLang, null);
+    if (div == null)
+      return NARRATIVE_NONE;
+    else if (div.equals(xhtml))
+      return NARRATIVE_ROOT;
+    else
+      return NARRATIVE_CHILD;
+  }
+  
+  public XhtmlNode divForLang(DomainResource r, String lang, String defaultLang, List<ValidationMessage> errors) {
+    if (!r.hasText() || !r.getText().hasDiv())
       return null;
-    }
-    //see if there's a language specific section
+    else
+      return divForLang(r.getText().getDiv(), lang, r.getLanguage(), defaultLang, errors);
+  }
+  
+  public XhtmlNode divForLang(XhtmlNode xhtml, String lang, String resourceLang, String defaultLang, List<ValidationMessage> errors) {
+    if (xhtml==null)
+      return null;
+   
+    boolean foundLangDivs = false;
     for (XhtmlNode div : xhtml.getChildNodes()) {
       if ("div".equals(div.getName())) {
         String l = div.hasAttribute("lang") ? div.getAttribute("lang") : div.getAttribute("xml:lang");
+        if (l!=null)
+          foundLangDivs = true;
         if (lang.equals(l)) {
           return div;
         }       
       }
     }
-    // if the root language is correct
-    // this isn't first because a narrative marked for one language might have other language subsections
+
+    // If the base div declares a language that matches, then the whole div is the content 
     String l = xhtml.hasAttribute("lang") ? xhtml.getAttribute("lang") : xhtml.getAttribute("xml:lang");
     if (lang.equals(l)) {
       return xhtml;
     }
+    
+    // If there's no language declared at all, then the narrative is presumed to be the language the resource declares
+    // (if there is one), or the default language for the IG if the resource doesn't have a language.
+    if (!foundLangDivs && (resourceLang!=null ? lang.equals(resourceLang) : lang.equals(defaultLang))) {
+      return xhtml;
+    }
+    
+    // If we didn't find a div for the requested language, then we'll either use narrative div for the default language
+    // (if it wasn't generated) or will leave the narrative as null, which will force it to be generated for this language
+    if (!lang.equals(defaultLang)) {
+      XhtmlNode defaultDiv = divForLang(xhtml, defaultLang, resourceLang, defaultLang, null);
+      if (scanForGeneratedNarrative(defaultDiv, defaultLang)) {
+        return null;
+      }
+      
+      if (errors != null)
+        errors.add(new ValidationMessage(Source.Publisher, IssueType.BUSINESSRULE, "IG", "The narrative includes custom content for the default language (" + defaultLang + "), but does not include translated content for the " + lang + " language, so the default language has been used", IssueSeverity.WARNING));
+      return defaultDiv;
+    }
+    
+    return null;
+  }
+  
+  public static boolean scanForGeneratedNarrative(XhtmlNode x, String lang) {
+    RenderingI18nContext rc = new RenderingI18nContext();
+    rc.setLocale(Locale.forLanguageTag(lang));
+    return scanForGeneratedNarrative(x, lang, rc);
+  }
+    
+  private static boolean scanForGeneratedNarrative(XhtmlNode x, String lang, RenderingI18nContext rc) {
+    
+    if (x.getContent() != null && x.getContent().contains( rc.formatPhrase(RenderingContext.PROF_DRIV_GEN_NARR_TECH, "", "").trim())) {
+      return true;
+    }
+    for (XhtmlNode c : x.getChildNodes()) {
+      if (scanForGeneratedNarrative(c, lang)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private XhtmlNode adjustToLang(XhtmlNode xhtml, String lang, String status, String resourceLang, String defaultLang, List<ValidationMessage> errors) {
+    if (xhtml == null) {
+      return null;
+    }
+    xhtml = divForLang(xhtml, lang, resourceLang, defaultLang, errors);
+    
+    if (xhtml!=null)
+      return xhtml;
+    
     // if the root language is null and the status is not additional
     // it can be regenerated
-    if (l == null && Utilities.existsInList(status, "generated", "extensions")) {
+    if (Utilities.existsInList(status, "generated", "extensions")) {
       return null;
     }    
     // well, really, not much we can do...
     return xhtml;
   }
 
-  public boolean switchLanguage(Element e, String lang, boolean markLanguage) throws IOException {
+  public boolean switchLanguage(Element e, String lang, boolean markLanguage, String resourceLang, String defaultLang, List<ValidationMessage> errors) throws IOException {
     boolean changed = false;
     if (e.getProperty().isTranslatable()) {
       String cnt = getTranslation(e, lang);
@@ -857,7 +942,7 @@ public class LanguageUtils {
     }
     if (e.fhirType().equals("Narrative") && e.hasChild("div")) {
       XhtmlNode xhtml = e.getNamedChild("div").getXhtml();
-      xhtml = adjustToLang(xhtml, lang, e.getNamedChildValue("status"));
+      xhtml = adjustToLang(xhtml, lang, e.getNamedChildValue("status"), resourceLang, defaultLang, errors);
       if (xhtml == null) {
         e.removeChild("div");
       } else {
@@ -866,7 +951,7 @@ public class LanguageUtils {
     }
     if (e.hasChildren()) {
       for (Element c : e.getChildren()) {
-        changed = switchLanguage(c, lang, markLanguage) || changed;
+        changed = switchLanguage(c, lang, markLanguage, resourceLang, defaultLang, errors) || changed;
       }
     }
     if (markLanguage && e.isResource() && e.getSpecial() != SpecialElement.CONTAINED) {
@@ -902,18 +987,18 @@ public class LanguageUtils {
     return e.primitiveValue();
   }
 
-  public Element copyToLanguage(Element element, String lang, boolean markLanguage) throws IOException {
+  public Element copyToLanguage(Element element, String lang, boolean markLanguage, String resourceLang, String defaultLang, List<ValidationMessage> errors) throws IOException {
     Element result = (Element) element.copy();
-    switchLanguage(result, lang, markLanguage);
+    switchLanguage(result, lang, markLanguage, resourceLang, defaultLang, errors);
     return result;
   }
 
-  public Resource copyToLanguage(Resource res, String lang, boolean markLanguage) {
+  public Resource copyToLanguage(Resource res, String lang, boolean markLanguage, String defaultLang, List<ValidationMessage> errors) {
     if (res == null) {
       return null;
     }
     Resource r = res.copy();
-    switchLanguage(r, lang, markLanguage, false);    
+    switchLanguage(r, lang, markLanguage, false, res.getLanguage(), defaultLang, errors);    
     return r;
   }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
@@ -13,6 +13,7 @@ import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.r5.context.ContextUtilities;
 import org.hl7.fhir.r5.extensions.ExtensionDefinitions;
 import org.hl7.fhir.r5.model.CanonicalResource;
+import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.ValueSet;
@@ -35,10 +36,12 @@ import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode; 
 
 @MarkedToMoveToAdjunctPackage
-public class QuestionnaireRenderer extends TerminologyRenderer { 
+public class QuestionnaireRenderer extends TerminologyRenderer {
+  private PackageInformation pi = null;
 
-  public QuestionnaireRenderer(RenderingContext context) { 
-    super(context); 
+  public QuestionnaireRenderer(RenderingContext context, PackageInformation pi) { 
+    super(context);
+    this.pi = pi;
   } 
 
   @Override
@@ -938,8 +941,12 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
 
   private void renderLinks(RenderingStatus status, XhtmlNode x, ResourceWrapper q) { 
     x.para().tx(context.formatPhrase(RenderingContext.QUEST_TRY)); 
-    XhtmlNode ul = x.ul(); 
-    ul.li().ah("http://todo.nlm.gov/path?mode=ig&src="+Utilities.pathURL(context.getLink(KnownLinkType.SELF, false), "package.tgz")+"&q="+q.getId()+".json").tx(context.formatPhrase(RenderingContext.QUEST_NLM)); 
+    XhtmlNode ul = x.ul();
+    String canonical = q.primitiveValue("url");
+    if (canonical != null) {
+      String qUrl = Utilities.URLEncode(canonical);
+      ul.li().ah("https://lhncbc.github.io/questionnaire-viewer/?lfv=latest&qCanonical=" +canonical + "&pID=" + pi.getId() + "&pVersion=" + pi.getVersion()).tx(context.formatPhrase(RenderingContext.QUEST_NLM));
+    }
   } 
 
   private void renderDefns(RenderingStatus status, XhtmlNode x, ResourceWrapper q) throws IOException { 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
@@ -584,9 +584,9 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
       } 
     } 
     if (i.has("answerOption")) { 
-      if (!defn.getPieces().isEmpty()) defn.addPiece(gen.new Piece("br")); 
-      defn.getPieces().add(gen.new Piece(null, (context.formatPhrase(RenderingContext.QUEST_OPTIONS)+" "), null)); 
-      defn.getPieces().add(gen.new Piece(context.getDefinitionsTarget()+"#item."+i.primitiveValue("linkId"), Integer.toString(i.children("answerOption").size())+" "+Utilities.pluralize("option", i.children("answerOption").size()), null));             
+      if (!defn.getPieces().isEmpty()) defn.addPiece(gen.new Piece("br"));
+      defn.getPieces().add(gen.new Piece(null, (context.formatPhrase(RenderingContext.QUEST_OPTIONS)+" "), null));
+      defn.getPieces().add(gen.new Piece((context.getDefinitionsTarget()==null ? "": context.getDefinitionsTarget())+"#item."+i.primitiveValue("linkId"), Integer.toString(i.children("answerOption").size())+" "+Utilities.pluralize("option", i.children("answerOption").size()), null));             
     } 
     if (i.has("initial")) { 
       for (ResourceWrapper v : i.children("initial")) { 
@@ -826,7 +826,7 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
       } 
     } 
     if (i.has("answerOption")) { 
-      item(ul, context.formatPhrase(RenderingContext.QUEST_ANSWERS), Integer.toString(i.children("answerOption").size())+" "+Utilities.pluralize("option", i.children("answerOption").size()), context.getDefinitionsTarget()+"#item."+i.primitiveValue("linkId")); 
+      item(ul, context.formatPhrase(RenderingContext.QUEST_ANSWERS), Integer.toString(i.children("answerOption").size())+" "+Utilities.pluralize("option", i.children("answerOption").size()), (context.getDefinitionsTarget()==null ? "": context.getDefinitionsTarget())+"#item."+i.primitiveValue("linkId")); 
     } 
     if (i.has("initial")) { 
       XhtmlNode vi = item(ul, context.formatPhrase(RenderingContext.QUEST_INT)); 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
@@ -37,11 +37,9 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
 @MarkedToMoveToAdjunctPackage
 public class QuestionnaireRenderer extends TerminologyRenderer {
-  private PackageInformation pi = null;
 
-  public QuestionnaireRenderer(RenderingContext context, PackageInformation pi) { 
+  public QuestionnaireRenderer(RenderingContext context) { 
     super(context);
-    this.pi = pi;
   } 
 
   @Override
@@ -943,9 +941,10 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
     x.para().tx(context.formatPhrase(RenderingContext.QUEST_TRY)); 
     XhtmlNode ul = x.ul();
     String canonical = q.primitiveValue("url");
-    if (canonical != null) {
+    PackageInformation pi = context.getPackageInformation();
+    if (canonical != null && pi!=null) {
       String qUrl = Utilities.URLEncode(canonical);
-      ul.li().ah("https://lhncbc.github.io/questionnaire-viewer/?lfv=latest&qCanonical=" +canonical + "&pID=" + pi.getId() + "&pVersion=" + pi.getVersion()).tx(context.formatPhrase(RenderingContext.QUEST_NLM));
+      ul.li().ah("https://lhncbc.github.io/questionnaire-viewer/?lfv=latest&s=default&qCanonical=" +canonical + "&pID=" + pi.getId() + "&pVersion=" + pi.getVersion()).tx(context.formatPhrase(RenderingContext.QUEST_NLM));
     }
   } 
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/QuestionnaireRenderer.java
@@ -944,7 +944,7 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
     PackageInformation pi = context.getPackageInformation();
     if (canonical != null && pi!=null) {
       String qUrl = Utilities.URLEncode(canonical);
-      ul.li().ah("https://lhncbc.github.io/questionnaire-viewer/?lfv=latest&s=default&qCanonical=" +canonical + "&pID=" + pi.getId() + "&pVersion=" + pi.getVersion()).tx(context.formatPhrase(RenderingContext.QUEST_NLM));
+      ul.li().ah("http://hl7.me/lhcformviewer/?lfv=latest&s=default&qCanonical=" +canonical + "&pID=" + pi.getId() + "&pVersion=" + pi.getVersion()).tx(context.formatPhrase(RenderingContext.QUEST_NLM));
     }
   } 
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/utils/RenderingContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/renderers/utils/RenderingContext.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r5.model.ActorDefinition;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.DomainResource;
 import org.hl7.fhir.r5.model.Enumeration;
+import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.PrimitiveType;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StringType;
@@ -344,18 +345,21 @@ public class RenderingContext extends RenderingI18nContext {
   private KeyIssuer crossLinkKeyGen;
   private int randomTracker;
   private boolean testing;
+  private PackageInformation pi;
   
   /**
    * 
    * @param workerContext - access to all related resources that might be needed
+   * @param pi - package information needed for certain Questionnaire rendering views
    * @param markdown - appropriate markdown processing engine 
    * @param terminologyServiceOptions - options to use when looking up codes
    * @param specLink - path to FHIR specification
    * @param locale - i18n for rendering
    */
-  public RenderingContext(IWorkerContext workerContext, MarkDownProcessor markdown, ValidationOptions terminologyServiceOptions, String specLink, String localPrefix, Locale locale, ResourceRendererMode mode, GenerationRules rules) {
+  public RenderingContext(IWorkerContext workerContext, PackageInformation pi, MarkDownProcessor markdown, ValidationOptions terminologyServiceOptions, String specLink, String localPrefix, Locale locale, ResourceRendererMode mode, GenerationRules rules) {
     super();
     this.worker = workerContext;
+    this.pi = pi;
     this.markdown = markdown;
     this.setLocale(locale);
     this.links.put(KnownLinkType.SPEC, specLink);
@@ -368,9 +372,13 @@ public class RenderingContext extends RenderingI18nContext {
     }
     crossLinkKeyGen = new KeyIssuer("xn");
   }
+
+  public RenderingContext(IWorkerContext workerContext, MarkDownProcessor markdown, ValidationOptions terminologyServiceOptions, String specLink, String localPrefix, Locale locale, ResourceRendererMode mode, GenerationRules rules) {
+    this(workerContext, null, markdown, terminologyServiceOptions, specLink, localPrefix, locale, mode, rules);
+  }
   
   public RenderingContext copy(boolean copyAnchors) {
-    RenderingContext res = new RenderingContext(worker, markdown, terminologyServiceOptions, getLink(KnownLinkType.SPEC, false), localPrefix, getLocale(), mode, rules);
+    RenderingContext res = new RenderingContext(worker, pi, markdown, terminologyServiceOptions, getLink(KnownLinkType.SPEC, false), localPrefix, getLocale(), mode, rules);
 
     res.resolver = resolver;
     res.templateProvider = templateProvider;
@@ -445,7 +453,9 @@ public class RenderingContext extends RenderingI18nContext {
     return worker;
   }
 
-
+  public PackageInformation getPackageInformation() {
+    return pi;
+  }
   
   // -- 2. Markdown support -------------------------------------------------------
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/elementmodel/LanguageUtilsTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/elementmodel/LanguageUtilsTest.java
@@ -1,7 +1,10 @@
 package org.hl7.fhir.r5.elementmodel;
 
 import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.formats.IParser;
 import org.hl7.fhir.r5.formats.JsonCreatorDirect;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.test.utils.CompareUtilities;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.utilities.i18n.LanguageFileProducer;
@@ -51,5 +54,87 @@ class LanguageUtilsTest implements ResourceLoaderTests {
     Assertions.assertNull(msg);
 
   }
+  
+  /*
+   * Translating to French with 'additional' div and no declared language and default language is English
+   * Expected behavior: Keep the English and warn that the div couldn't be translated
+   */
+  @Test
+  void convertCustomDivAdditional() throws Exception {
+    checkDivConvert("Patient-div-additional", "ValidationMessage[level=WARNING,type=BUSINESSRULE,location=IG,message=\"The narrative includes custom content for the default language (en), but does not include translated content for the fr language, so the default language has been used]");
+  }
 
+  /*
+   * Translating to French with 'additional' div and declared language of English
+   * Expected behavior: Keep the English and warn that the div couldn't be translated
+   */
+  @Test
+  void convertCustomDivEnglishAdditional() throws Exception {
+    checkDivConvert("Patient-div-en-additional", "ValidationMessage[level=WARNING,type=BUSINESSRULE,location=IG,message=\"The narrative includes custom content for the default language (en), but does not include translated content for the fr language, so the default language has been used]");
+  }
+
+  /*
+   * Translating to French with 'additional' div and included French language div
+   * Expected behavior: Strip to just the French div, no warning
+   */
+  @Test
+  void convertCustomFrenchAdditional() throws Exception {
+    checkDivConvert("Patient-div-fr-additional");
+  }
+
+  /*
+   * Translating to French with 'generated' div and no declared language
+   * Expected behavior: Wipe the text so it will be re-generated downstream using narrative generator
+   */
+  @Test
+  void convertCustomGenerated() throws Exception {
+    checkDivConvert("Patient-div-generated");
+  }
+
+  /*
+   * Translating to French with 'generated' div and French declared on the root
+   * Expected behavior: Keep the existing generated French div
+   */
+  @Test
+  void convertCustomFrenchGenerated() throws Exception {
+    checkDivConvert("Patient-div-fr-generated");
+  }
+
+  private void checkDivConvert(String fName) throws Exception {
+    checkDivConvert(fName, null);
+  }
+  private void checkDivConvert(String fName, String warning) throws Exception {
+    IWorkerContext context = TestingUtilities.getSharedWorkerContext();
+    List<ValidationMessage> lvm = new ArrayList<>();
+    LanguageUtils languageUtils = new LanguageUtils(context);
+
+    InputStream resource = getResourceAsInputStream("languageUtils", fName + ".json");
+    org.hl7.fhir.r5.formats.JsonParser jp = new org.hl7.fhir.r5.formats.JsonParser();
+    Resource origResource = jp.parse(resource);
+
+    InputStream expectedJson = getResourceAsInputStream("languageUtils", fName + "-translated.json");
+    String expectedText = new BufferedReader(new InputStreamReader(expectedJson))
+      .lines()
+      .collect(Collectors.joining("\n"));
+    
+    Resource newResource = origResource.copy();
+    Assertions.assertTrue(languageUtils.switchLanguage(newResource, "fr", true, false, "en", "en", lvm));
+
+    if (warning==null)
+      Assertions.assertTrue(lvm.isEmpty());
+    else {
+      Assertions.assertTrue(lvm.size()==1);
+      if (!lvm.isEmpty())
+        Assertions.assertEquals(lvm.get(0).toString(), warning);
+    }
+    
+    ByteArrayOutputStream bs = new ByteArrayOutputStream();
+    jp.setOutputStyle(IParser.OutputStyle.PRETTY).compose(bs, newResource);
+    String actualText = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bs.toByteArray())))
+        .lines()
+        .collect(Collectors.joining("\n"));
+
+    String msg = new CompareUtilities().checkJsonSrcIsSame("", actualText, expectedText);
+    Assertions.assertNull(msg);    
+  }
 }

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-additional-translated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-additional-translated.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "language": "fr",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div xml:lang=\"en\">Narrative is hand-written</div></div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-additional.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-additional.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Narrative is hand-written</div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-en-additional-translated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-en-additional-translated.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "language": "fr",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div xml:lang=\"en\">Narrative is hand-written</div></div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-en-additional.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-en-additional.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div xml:lang=\"en\">Narrative is hand-written</div></div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-additional-translated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-additional-translated.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "language": "fr",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"fr\">Le récit est écrit à la main</div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-additional.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-additional.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"fr\">Le récit est écrit à la main</div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-generated-translated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-generated-translated.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "language": "fr",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div xml:lang=\"fr\">Nom: John Doe</div></div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-generated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-fr-generated.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div xml:lang=\"en\">Generated Narrative: Name: John Doe</div><div xml:lang=\"fr\">Narratif généré : Nom: John Doe</div></div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-generated-translated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-generated-translated.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "language": "fr",
+  "text": {
+    "status": "generated"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-generated.json
+++ b/org.hl7.fhir.r5/src/test/resources/languageUtils/Patient-div-generated.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Patient",
+  "id": "div-additional",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative: Name: John Doe</div>"
+  },
+  "name": [{
+    "family": "Doe",
+    "given": ["John"]
+  }]
+}

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nConstants.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nConstants.java
@@ -501,6 +501,7 @@ public class I18nConstants {
   public static final String MULTIPLE_LOGICAL_MODELS = "MULTIPLE_LOGICAL_MODELS";
   public static final String MUSTSUPPORT_VAL_MUSTSUPPORT = "MustSupport_VAL_MustSupport";
   public static final String NAMED_ITEMS_ARE_OUT_OF_ORDER_IN_THE_SLICE = "Named_items_are_out_of_order_in_the_slice";
+  public static final String NARRATIVE_NOT_TRANSLATED = "NARRATIVE_NOT_TRANSLATED";
   public static final String NDJSON_EMPTY_LINE_WARNING = "NDJSON_EMPTY_LINE_WARNING";
   public static final String NEEDS_A_SNAPSHOT = "needs_a_snapshot";
   public static final String NODE_TYPE__IS_NOT_ALLOWED = "Node_type__is_not_allowed";

--- a/org.hl7.fhir.utilities/src/main/resources/Messages.properties
+++ b/org.hl7.fhir.utilities/src/main/resources/Messages.properties
@@ -519,6 +519,7 @@ MSG_WITHDRAWN_SRC = Reference to withdrawn {2} {0} from {1}
 MULTIPLE_LOGICAL_MODELS_one=
 MULTIPLE_LOGICAL_MODELS_other={0} Logical Models found in supplied profiles, so unable to parse logical model (can only be one, found {1})
 MustSupport_VAL_MustSupport = The element {0} is not marked as ''mustSupport'' in the profile {1}. Consider not using the element, or marking the element as must-Support in the profile
+NARRATIVE_NOT_TRANSLATED = "The narrative includes custom content for the default language ({0}), but does not include translated content for the {1} language, so the default language has been used
 Named_items_are_out_of_order_in_the_slice = Named items are out of order in the slice
 NDJSON_EMPTY_LINE_WARNING = The NDJSON source contains an empty line. This may not be accepted by some processors
 needs_a_snapshot = Needs a snapshot


### PR DESCRIPTION
Two fixes needed to get SDC to build properly.
1. Fixed rendering issue of new Questionnaire fragment that was including 'null#' in hyperlinks

2. Fix handling of multi-language narrative so that hand-coded narrative doesn't get overridden

Replaces https://github.com/hapifhir/org.hl7.fhir.core/pull/2086