### PR TITLE
SQL on FHIR test runner and reporter

### DIFF
--- a/org.hl7.fhir.r4/pom.xml
+++ b/org.hl7.fhir.r4/pom.xml
@@ -155,6 +155,38 @@
 	</dependencies>
 
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<exclude>**/SqlOnFhirRunnerTests.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>sof-compliance-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/SqlOnFhirRunnerTests.java</include>
+							</includes>
+							<!-- This test is run but it does not fail the build if it fails. -->
+							<testFailureIgnore>true</testFailureIgnore>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
@@ -187,9 +187,10 @@ public class SqlOnFhirRunnerTests {
     // Add result to report.
     reportGenerator.addResult(fileName, result);
 
-    // Assert for JUnit.
+    // Assert test passed.
     if (!result.passed) {
-      fail(result.error != null ? result.error : "Test failed");
+      fail("SQL on FHIR test failed: " + fileName + " - " + testName +
+           (result.error != null ? " - " + result.error : ""));
     }
   }
 

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
@@ -1,0 +1,320 @@
+package org.hl7.fhir.r4.utils.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.context.IWorkerContext;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.test.utils.TestingUtilities;
+import org.hl7.fhir.r4.utils.sql.Runner;
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonElement;
+import org.hl7.fhir.utilities.json.model.JsonNull;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for SQL on FHIR Runner implementation based on the official test suite.
+ * Tests are loaded from JSON files in the resources/sof directory.
+ *
+ * @author John Grimes
+ */
+public class SqlOnFhirRunnerTests {
+
+  private static IWorkerContext context;
+  private static TestReportGenerator reportGenerator;
+  private static Map<String, JsonObject> testFiles = new HashMap<>();
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    context = TestingUtilities.context();
+    reportGenerator = new TestReportGenerator();
+    loadTestFiles();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    reportGenerator.writeReport("target/sof-test-report.json");
+  }
+
+  private static void loadTestFiles() throws IOException {
+    File testDir = new File("src/test/resources/sof");
+    if (testDir.exists() && testDir.isDirectory()) {
+      File[] files = testDir.listFiles((dir, name) -> name.endsWith(".json"));
+      if (files != null) {
+        for (File file : files) {
+          String content = Files.readString(file.toPath());
+          JsonObject testFile = org.hl7.fhir.utilities.json.parser.JsonParser.parseObject(content);
+          testFiles.put(file.getName(), testFile);
+        }
+      }
+    }
+  }
+
+  public static Stream<Arguments> testCases() {
+    List<Arguments> arguments = new ArrayList<>();
+
+    for (Map.Entry<String, JsonObject> entry : testFiles.entrySet()) {
+      String fileName = entry.getKey();
+      JsonObject testFile = entry.getValue();
+
+      if (testFile.has("tests")) {
+        JsonArray tests = testFile.getJsonArray("tests");
+        for (JsonElement element : tests) {
+          if (element instanceof JsonObject) {
+            JsonObject test = (JsonObject) element;
+            String testName = test.asString("title");
+            arguments.add(Arguments.of(fileName, testName, testFile, test));
+          }
+        }
+      }
+    }
+
+    return arguments.stream();
+  }
+
+  @ParameterizedTest(name = "{0}: {1}")
+  @MethodSource("testCases")
+  @DisplayName("SQL on FHIR Runner Test")
+  public void testRunner(String fileName, String testName, JsonObject testFile, JsonObject test) throws Exception {
+    System.out.println("Running test: " + fileName + " - " + testName);
+
+    TestResult result = new TestResult();
+    result.name = testName;
+
+    try {
+      // Extract view definition.
+      JsonObject view = test.getJsonObject("view");
+      if (view == null) {
+        throw new IllegalArgumentException("Test missing 'view' definition");
+      }
+
+      // Create test provider with resources.
+      TestProvider provider = new TestProvider();
+      if (testFile.has("resources")) {
+        JsonElement resources = testFile.get("resources");
+        if (resources instanceof JsonObject) {
+          loadResources((JsonObject) resources, provider);
+        }
+      }
+
+      // Create test storage.
+      TestStorage storage = new TestStorage();
+
+      // Create and configure runner.
+      Runner runner = new Runner();
+      runner.setContext(context);
+      runner.setProvider(provider);
+      runner.setStorage(storage);
+
+      // Check for expectError.
+      boolean expectError = test.has("expectError");
+
+      try {
+        // Execute the view.
+        runner.execute(view);
+
+        if (expectError) {
+          fail("Expected error but none was thrown");
+        }
+
+        // Get actual results.
+        JsonArray actualResults = storage.getResults();
+
+        // Compare with expected results.
+        if (test.has("expect")) {
+          JsonArray expectedResults = test.getJsonArray("expect");
+          compareResults(expectedResults, actualResults, result);
+        }
+
+        // Check column ordering if specified.
+        if (test.has("expectColumns")) {
+          JsonArray expectedColumns = test.getJsonArray("expectColumns");
+          checkColumnOrder(expectedColumns, actualResults, result);
+        }
+
+        result.passed = true;
+
+      } catch (Exception e) {
+        if (expectError) {
+          // Check if error matches expected error pattern.
+          if (test.has("expectErrorPattern")) {
+            String pattern = test.asString("expectErrorPattern");
+            if (!e.getMessage().contains(pattern)) {
+              result.passed = false;
+              result.error = "Error message did not match expected pattern: " + e.getMessage();
+            } else {
+              result.passed = true;
+            }
+          } else {
+            result.passed = true;
+          }
+        } else {
+          throw e;
+        }
+      }
+
+    } catch (Exception e) {
+      result.passed = false;
+      result.error = e.getClass().getSimpleName() + ": " + e.getMessage();
+      if (test.has("expectError")) {
+        // If we expected an error and got one, it's still a pass.
+        result.passed = true;
+      }
+    }
+
+    // Add result to report.
+    reportGenerator.addResult(fileName, result);
+
+    // Assert for JUnit.
+    if (!result.passed) {
+      fail(result.error != null ? result.error : "Test failed");
+    }
+  }
+
+  private void loadResources(JsonObject resources, TestProvider provider) throws IOException {
+    org.hl7.fhir.r4.formats.JsonParser fhirParser = new org.hl7.fhir.r4.formats.JsonParser();
+
+    for (String key : resources.getNames()) {
+      JsonElement value = resources.get(key);
+      Resource resource = null;
+
+      if (value instanceof JsonObject) {
+        // Single resource.
+        JsonObject resourceJson = (JsonObject) value;
+        String json = org.hl7.fhir.utilities.json.parser.JsonParser.compose(resourceJson, true);
+        resource = (Resource) fhirParser.parse(json);
+        provider.addResource(resource);
+      } else if (value instanceof JsonArray) {
+        // Array of resources.
+        JsonArray array = (JsonArray) value;
+        for (JsonElement element : array) {
+          if (element instanceof JsonObject) {
+            JsonObject resourceJson = (JsonObject) element;
+            String json = org.hl7.fhir.utilities.json.parser.JsonParser.compose(resourceJson, true);
+            resource = (Resource) fhirParser.parse(json);
+            provider.addResource(resource);
+          }
+        }
+      }
+    }
+  }
+
+  private void compareResults(JsonArray expected, JsonArray actual, TestResult result) {
+    if (expected.size() != actual.size()) {
+      result.passed = false;
+      result.error = String.format("Result count mismatch: expected %d, got %d",
+                                   expected.size(), actual.size());
+      return;
+    }
+
+    // Deep comparison of JSON results.
+    for (int i = 0; i < expected.size(); i++) {
+      JsonElement expectedRow = expected.get(i);
+      JsonElement actualRow = actual.get(i);
+
+      if (!compareJsonElements(expectedRow, actualRow)) {
+        result.passed = false;
+        result.error = String.format("Row %d mismatch: expected %s, got %s",
+                                     i, expectedRow, actualRow);
+        return;
+      }
+    }
+  }
+
+  private boolean compareJsonElements(JsonElement expected, JsonElement actual) {
+    if (expected instanceof JsonNull && actual instanceof JsonNull) {
+      return true;
+    }
+    if (expected instanceof JsonNull || actual instanceof JsonNull) {
+      return false;
+    }
+    if (expected.getClass() != actual.getClass()) {
+      return false;
+    }
+
+    if (expected instanceof JsonObject) {
+      JsonObject expectedObj = (JsonObject) expected;
+      JsonObject actualObj = (JsonObject) actual;
+
+      if (expectedObj.getNames().size() != actualObj.getNames().size()) {
+        return false;
+      }
+
+      for (String key : expectedObj.getNames()) {
+        if (!actualObj.has(key)) {
+          return false;
+        }
+        if (!compareJsonElements(expectedObj.get(key), actualObj.get(key))) {
+          return false;
+        }
+      }
+      return true;
+    } else if (expected instanceof JsonArray) {
+      JsonArray expectedArr = (JsonArray) expected;
+      JsonArray actualArr = (JsonArray) actual;
+
+      if (expectedArr.size() != actualArr.size()) {
+        return false;
+      }
+
+      for (int i = 0; i < expectedArr.size(); i++) {
+        if (!compareJsonElements(expectedArr.get(i), actualArr.get(i))) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      // Primitive comparison.
+      return expected.toString().equals(actual.toString());
+    }
+  }
+
+  private void checkColumnOrder(JsonArray expectedColumns, JsonArray results, TestResult result) {
+    if (results.size() == 0) {
+      return;
+    }
+
+    JsonElement firstRow = results.get(0);
+    if (firstRow instanceof JsonObject) {
+      JsonObject row = (JsonObject) firstRow;
+      List<String> actualColumns = new ArrayList<>(row.getNames());
+
+      List<String> expected = new ArrayList<>();
+      for (JsonElement col : expectedColumns) {
+        expected.add(col.toString().replaceAll("\"", ""));
+      }
+
+      if (!actualColumns.equals(expected)) {
+        result.passed = false;
+        result.error = String.format("Column order mismatch: expected %s, got %s",
+                                     expected, actualColumns);
+      }
+    }
+  }
+
+  /**
+   * Simple test result class.
+   */
+  static class TestResult {
+    String name;
+    boolean passed;
+    String error;
+  }
+}

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.IWorkerContext;
 import org.hl7.fhir.r4.model.Base;
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  *
  * @author John Grimes
  */
+@Slf4j
 public class SqlOnFhirRunnerTests {
 
   private static IWorkerContext context;
@@ -93,7 +95,7 @@ public class SqlOnFhirRunnerTests {
   @MethodSource("testCases")
   @DisplayName("SQL on FHIR Runner Test")
   public void testRunner(String fileName, String testName, JsonObject testFile, JsonObject test) throws Exception {
-    System.out.println("Running test: " + fileName + " - " + testName);
+    log.info("Running test: {} - {}", fileName, testName);
 
     TestResult result = new TestResult();
     result.name = testName;

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestProvider.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestProvider.java
@@ -1,0 +1,108 @@
+package org.hl7.fhir.r4.utils.sql;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+
+/**
+ * Test implementation of Provider interface for SQL on FHIR tests.
+ * Stores resources in memory and provides access by resource type.
+ *
+ * @author John Grimes
+ */
+public class TestProvider implements Provider {
+
+  private Map<String, List<Resource>> resourcesByType = new HashMap<>();
+  private Map<String, Resource> resourcesById = new HashMap<>();
+
+  /**
+   * Add a resource to the provider.
+   */
+  public void addResource(Resource resource) {
+    String resourceType = resource.getResourceType().toString();
+    resourcesByType.computeIfAbsent(resourceType, k -> new ArrayList<>()).add(resource);
+
+    // Store by ID for reference resolution.
+    if (resource.hasId()) {
+      String fullId = resourceType + "/" + resource.getIdElement().getIdPart();
+      resourcesById.put(fullId, resource);
+      // Also store without resource type prefix for relative references.
+      resourcesById.put(resource.getIdElement().getIdPart(), resource);
+    }
+  }
+
+  @Override
+  public List<Base> fetch(String resourceType) {
+    List<Base> result = new ArrayList<>();
+    List<Resource> resources = resourcesByType.get(resourceType);
+    if (resources != null) {
+      result.addAll(resources);
+    }
+    return result;
+  }
+
+  @Override
+  public Base resolveReference(Base rootResource, String ref, String specifiedResourceType) {
+    if (ref == null || ref.isEmpty()) {
+      return null;
+    }
+
+    // Handle different reference formats.
+    String resourceId = ref;
+
+    // Strip URL prefix if present.
+    if (ref.contains("/")) {
+      String[] parts = ref.split("/");
+      if (parts.length >= 2) {
+        resourceId = parts[parts.length - 1];
+      }
+    }
+
+    // Try direct lookup.
+    Resource resource = resourcesById.get(ref);
+    if (resource != null) {
+      return resource;
+    }
+
+    // Try with just the ID part.
+    resource = resourcesById.get(resourceId);
+    if (resource != null) {
+      // Check if resource type matches if specified.
+      if (specifiedResourceType != null && !specifiedResourceType.isEmpty()) {
+        String actualType = resource.getResourceType().toString();
+        if (specifiedResourceType.startsWith("FHIR.")) {
+          specifiedResourceType = specifiedResourceType.substring(5);
+        }
+        if (actualType.equals(specifiedResourceType)) {
+          return resource;
+        }
+      } else {
+        return resource;
+      }
+    }
+
+    // Try with resource type prefix.
+    if (specifiedResourceType != null && !specifiedResourceType.isEmpty()) {
+      String typedRef = specifiedResourceType + "/" + resourceId;
+      resource = resourcesById.get(typedRef);
+      if (resource != null) {
+        return resource;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Clear all resources.
+   */
+  public void clear() {
+    resourcesByType.clear();
+    resourcesById.clear();
+  }
+}

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestReportGenerator.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestReportGenerator.java
@@ -1,0 +1,145 @@
+package org.hl7.fhir.r4.utils.sql;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.hl7.fhir.utilities.json.parser.JsonParser;
+
+/**
+ * Generates test reports conforming to the SQL on FHIR test report schema.
+ * Report structure follows: https://github.com/FHIR/sql-on-fhir-v2/blob/master/test_report/test-report.schema.json
+ *
+ * @author John Grimes
+ */
+public class TestReportGenerator {
+
+  private Map<String, JsonArray> testResults = new HashMap<>();
+
+  /**
+   * Add a test result to the report.
+   *
+   * @param testFileName The name of the test file (e.g., "basic.json")
+   * @param result The test result
+   */
+  public void addResult(String testFileName, SqlOnFhirRunnerTests.TestResult result) {
+    JsonArray tests = testResults.computeIfAbsent(testFileName, k -> new JsonArray());
+
+    JsonObject testResult = new JsonObject();
+    testResult.add("name", result.name);
+
+    JsonObject resultObject = new JsonObject();
+    resultObject.add("passed", result.passed);
+
+    if (!result.passed && result.error != null) {
+      resultObject.add("error", result.error);
+    }
+
+    testResult.add("result", resultObject);
+    tests.add(testResult);
+  }
+
+  /**
+   * Write the test report to a file.
+   *
+   * @param filePath Path to write the report to
+   */
+  public void writeReport(String filePath) {
+    try {
+      JsonObject report = new JsonObject();
+
+      // Build the report structure.
+      for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+        JsonObject testSuite = new JsonObject();
+        testSuite.add("tests", entry.getValue());
+        report.add(entry.getKey(), testSuite);
+      }
+
+      // Write to file.
+      String json = JsonParser.compose(report, true);
+      try (FileWriter writer = new FileWriter(filePath)) {
+        writer.write(json);
+      }
+
+      System.out.println("Test report written to: " + filePath);
+      printSummary();
+
+    } catch (IOException e) {
+      System.err.println("Failed to write test report: " + e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Print a summary of test results to console.
+   */
+  private void printSummary() {
+    int totalTests = 0;
+    int passedTests = 0;
+    int failedTests = 0;
+
+    System.out.println("\n=== SQL on FHIR Test Results Summary ===");
+
+    for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+      String fileName = entry.getKey();
+      JsonArray tests = entry.getValue();
+
+      int filePassed = 0;
+      int fileFailed = 0;
+
+      for (int i = 0; i < tests.size(); i++) {
+        JsonObject test = (JsonObject) tests.get(i);
+        JsonObject result = test.getJsonObject("result");
+        if (result != null && result.has("passed")) {
+          boolean passed = result.asBoolean("passed");
+          if (passed) {
+            filePassed++;
+            passedTests++;
+          } else {
+            fileFailed++;
+            failedTests++;
+          }
+          totalTests++;
+        }
+      }
+
+      System.out.printf("%s: %d passed, %d failed (total: %d)%n",
+                        fileName, filePassed, fileFailed, filePassed + fileFailed);
+    }
+
+    System.out.println("\n=== Overall Summary ===");
+    System.out.printf("Total tests: %d%n", totalTests);
+    System.out.printf("Passed: %d (%.1f%%)%n", passedTests,
+                      totalTests > 0 ? (100.0 * passedTests / totalTests) : 0);
+    System.out.printf("Failed: %d (%.1f%%)%n", failedTests,
+                      totalTests > 0 ? (100.0 * failedTests / totalTests) : 0);
+
+    if (failedTests > 0) {
+      System.out.println("\nFailed tests:");
+      for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+        String fileName = entry.getKey();
+        JsonArray tests = entry.getValue();
+
+        for (int i = 0; i < tests.size(); i++) {
+          JsonObject test = (JsonObject) tests.get(i);
+          String name = test.asString("name");
+          JsonObject result = test.getJsonObject("result");
+          if (result != null && result.has("passed") && !result.asBoolean("passed")) {
+            String error = result.has("error") ? result.asString("error") : "Unknown error";
+            System.out.printf("  - %s: %s - %s%n", fileName, name, error);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear all test results.
+   */
+  public void clear() {
+    testResults.clear();
+  }
+}

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestReportGenerator.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestReportGenerator.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.utilities.json.model.JsonArray;
 import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.json.parser.JsonParser;
@@ -15,6 +16,7 @@ import org.hl7.fhir.utilities.json.parser.JsonParser;
  *
  * @author John Grimes
  */
+@Slf4j
 public class TestReportGenerator {
 
   private Map<String, JsonArray> testResults = new HashMap<>();
@@ -64,11 +66,11 @@ public class TestReportGenerator {
         writer.write(json);
       }
 
-      System.out.println("Test report written to: " + filePath);
+      log.info("Test report written to: {}", filePath);
       printSummary();
 
     } catch (IOException e) {
-      System.err.println("Failed to write test report: " + e.getMessage());
+      log.error("Failed to write test report: {}", e.getMessage());
       e.printStackTrace();
     }
   }
@@ -81,7 +83,7 @@ public class TestReportGenerator {
     int passedTests = 0;
     int failedTests = 0;
 
-    System.out.println("\n=== SQL on FHIR Test Results Summary ===");
+    log.info("\n=== SQL on FHIR Test Results Summary ===");
 
     for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
       String fileName = entry.getKey();
@@ -106,19 +108,19 @@ public class TestReportGenerator {
         }
       }
 
-      System.out.printf("%s: %d passed, %d failed (total: %d)%n",
-                        fileName, filePassed, fileFailed, filePassed + fileFailed);
+      log.info("{}: {} passed, {} failed (total: {})",
+               fileName, filePassed, fileFailed, filePassed + fileFailed);
     }
 
-    System.out.println("\n=== Overall Summary ===");
-    System.out.printf("Total tests: %d%n", totalTests);
-    System.out.printf("Passed: %d (%.1f%%)%n", passedTests,
-                      totalTests > 0 ? (100.0 * passedTests / totalTests) : 0);
-    System.out.printf("Failed: %d (%.1f%%)%n", failedTests,
-                      totalTests > 0 ? (100.0 * failedTests / totalTests) : 0);
+    log.info("\n=== Overall Summary ===");
+    log.info("Total tests: {}", totalTests);
+    log.info("Passed: {} ({:.1f}%)", passedTests,
+             totalTests > 0 ? (100.0 * passedTests / totalTests) : 0);
+    log.info("Failed: {} ({:.1f}%)", failedTests,
+             totalTests > 0 ? (100.0 * failedTests / totalTests) : 0);
 
     if (failedTests > 0) {
-      System.out.println("\nFailed tests:");
+      log.info("\nFailed tests:");
       for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
         String fileName = entry.getKey();
         JsonArray tests = entry.getValue();
@@ -129,7 +131,7 @@ public class TestReportGenerator {
           JsonObject result = test.getJsonObject("result");
           if (result != null && result.has("passed") && !result.asBoolean("passed")) {
             String error = result.has("error") ? result.asString("error") : "Unknown error";
-            System.out.printf("  - %s: %s - %s%n", fileName, name, error);
+            log.info("  - {}: {} - {}", fileName, name, error);
           }
         }
       }

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestStorage.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/TestStorage.java
@@ -1,0 +1,72 @@
+package org.hl7.fhir.r4.utils.sql;
+
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+
+/**
+ * Test implementation of Storage interface for SQL on FHIR tests.
+ * Extends StorageJson to capture results as JSON for comparison.
+ *
+ * @author John Grimes
+ */
+public class TestStorage extends StorageJson {
+
+  private JsonArray results;
+  private List<Column> columns;
+
+  @Override
+  public Store createStore(String name, List<Column> columns) {
+    this.columns = columns;
+    this.results = new JsonArray();
+    // Call parent to initialise internal state.
+    Store store = super.createStore(name, columns);
+    // Override the parent's rows array with our own.
+    this.results = super.getRows();
+    return store;
+  }
+
+  /**
+   * Get the captured results as a JsonArray.
+   */
+  public JsonArray getResults() {
+    return results != null ? results : new JsonArray();
+  }
+
+  /**
+   * Get the column definitions.
+   */
+  public List<Column> getColumns() {
+    return columns;
+  }
+
+  /**
+   * Clear all results.
+   */
+  public void clear() {
+    if (results != null) {
+      results = new JsonArray();
+    }
+    columns = null;
+  }
+
+  @Override
+  public String getKeyForSourceResource(Base res) {
+    // Return a simple key for testing.
+    if (res != null) {
+      return res.fhirType() + "/" + res.getIdBase();
+    }
+    return null;
+  }
+
+  @Override
+  public String getKeyForTargetResource(Base res) {
+    // Return a simple key for testing.
+    if (res != null) {
+      return res.fhirType() + "/" + res.getIdBase();
+    }
+    return null;
+  }
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/basic.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/basic.json
@@ -1,0 +1,496 @@
+{
+  "title": "basic",
+  "description": "basic view definition",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "F1"
+        }
+      ],
+      "active": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "F2"
+        }
+      ],
+      "active": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic attribute",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "boolean attribute with false",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "active",
+                "path": "active",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "active": true
+        },
+        {
+          "id": "pt2",
+          "active": false
+        },
+        {
+          "id": "pt3",
+          "active": null
+        }
+      ]
+    },
+    {
+      "title": "two columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "two selects with columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "where - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = true"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = false"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where returns non-boolean for some cases",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F2'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F1'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "select & column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "c_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "s_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "c_id": "pt1",
+          "s_id": "pt1"
+        },
+        {
+          "c_id": "pt2",
+          "s_id": "pt2"
+        },
+        {
+          "c_id": "pt3",
+          "s_id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column ordering",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "'A'",
+                "name": "a",
+                "type": "string"
+              },
+              {
+                "path": "'B'",
+                "name": "b",
+                "type": "string"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "path": "'C'",
+                    "name": "c",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'D'",
+                    "name": "d",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "'E1'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F1'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "path": "'E2'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F2'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "path": "'G'",
+                "name": "g",
+                "type": "string"
+              },
+              {
+                "path": "'H'",
+                "name": "h",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectColumns": ["a", "b", "c", "d", "e", "f", "g", "h"],
+      "expect": [
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/collection.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/collection.json
@@ -1,0 +1,244 @@
+{
+  "title": "collection",
+  "tags": ["shareable"],
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1.1",
+          "given": ["g1.1"]
+        },
+        {
+          "family": "f1.2",
+          "given": ["g1.2", "g1.3"]
+        }
+      ],
+      "gender": "male",
+      "birthDate": "1950-01-01",
+      "address": [
+        {
+          "city": "c1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "f2.1",
+          "given": ["g2.1"]
+        },
+        {
+          "use": "official",
+          "family": "f2.2",
+          "given": ["g2.2", "g2.3"]
+        }
+      ],
+      "gender": "female",
+      "birthDate": "1950-01-01"
+    }
+  ],
+  "tests": [
+    {
+      "title": "fail when 'collection' is not true",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family",
+                "type": "string",
+                "collection": false
+              },
+              {
+                "name": "first_name",
+                "path": "name.given",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "collection = true",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family",
+                "type": "string",
+                "collection": true
+              },
+              {
+                "name": "first_name",
+                "path": "name.given",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": ["f1.1", "f1.2"],
+          "first_name": ["g1.1", "g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": ["f2.1", "f2.2"],
+          "first_name": ["g2.1", "g2.2", "g2.3"]
+        }
+      ]
+    },
+    {
+      "title": "collection = false relative to forEach parent",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "last_name",
+                    "path": "family",
+                    "type": "string",
+                    "collection": false
+                  },
+                  {
+                    "name": "first_name",
+                    "path": "given",
+                    "type": "string",
+                    "collection": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "f1.1",
+          "first_name": ["g1.1"]
+        },
+        {
+          "id": "pt1",
+          "last_name": "f1.2",
+          "first_name": ["g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.1",
+          "first_name": ["g2.1"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.2",
+          "first_name": ["g2.2", "g2.3"]
+        }
+      ]
+    },
+    {
+      "title": "collection = false relative to forEachOrNull parent",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "last_name",
+                    "path": "family",
+                    "type": "string",
+                    "collection": false
+                  },
+                  {
+                    "name": "first_name",
+                    "path": "given",
+                    "type": "string",
+                    "collection": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "f1.1",
+          "first_name": ["g1.1"]
+        },
+        {
+          "id": "pt1",
+          "last_name": "f1.2",
+          "first_name": ["g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.1",
+          "first_name": ["g2.1"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.2",
+          "first_name": ["g2.2", "g2.3"]
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/combinations.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/combinations.json
@@ -1,0 +1,256 @@
+{
+  "title": "combinations",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "id": "pt1",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt2",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt3",
+      "resourceType": "Patient"
+    }
+  ],
+  "tests": [
+    {
+      "title": "select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column + select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "column_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "select_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "column_id": "pt1",
+          "select_id": "pt1"
+        },
+        {
+          "column_id": "pt2",
+          "select_id": "pt2"
+        },
+        {
+          "column_id": "pt3",
+          "select_id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "sibling select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id_1",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id_2",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id_1": "pt1",
+          "id_2": "pt1"
+        },
+        {
+          "id_1": "pt2",
+          "id_2": "pt2"
+        },
+        {
+          "id_1": "pt3",
+          "id_2": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "sibling select inside a select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id_1",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id_2",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id_1": "pt1",
+          "id_2": "pt1"
+        },
+        {
+          "id_1": "pt2",
+          "id_2": "pt2"
+        },
+        {
+          "id_1": "pt3",
+          "id_2": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column + select, with where",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "column_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "select_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "id = 'pt1'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "column_id": "pt1",
+          "select_id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "unionAll + forEach + column + select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/constant.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/constant.json
@@ -1,0 +1,331 @@
+{
+  "title": "constant",
+  "description": "constant substitution",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "Block",
+          "use": "usual"
+        },
+        {
+          "family": "Smith",
+          "use": "official"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "deceasedBoolean": true,
+      "name": [
+        {
+          "family": "Johnson",
+          "use": "usual"
+        },
+        {
+          "family": "Menendez",
+          "use": "old"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "constant in path",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name.where(use = %name_use).family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "official_name": "Smith"
+        },
+        {
+          "id": "pt2",
+          "official_name": null
+        }
+      ]
+    },
+    {
+      "title": "constant in forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "forEach": "name.where(use = %name_use)",
+            "column": [
+              {
+                "name": "official_name",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "official_name": "Smith"
+        }
+      ]
+    },
+    {
+      "title": "constant in where element",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = %name_use).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "constant in unionAll",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "use1",
+            "valueString": "official"
+          },
+          {
+            "name": "use2",
+            "valueString": "usual"
+          }
+        ],
+        "select": [
+          {
+            "unionAll": [
+              {
+                "forEach": "name.where(use = %use1)",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "family",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.where(use = %use2)",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "family",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "name": "Smith"
+        },
+        {
+          "name": "Block"
+        },
+        {
+          "name": "Johnson"
+        }
+      ]
+    },
+    {
+      "title": "integer constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_index",
+            "valueInteger": 1
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name[%name_index].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "official_name": "Smith"
+        },
+        {
+          "id": "pt2",
+          "official_name": "Menendez"
+        }
+      ]
+    },
+    {
+      "title": "boolean constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "is_deceased",
+            "valueBoolean": true
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "deceased.ofType(boolean).exists() and deceased.ofType(boolean) = %is_deceased"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "accessing an undefined constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "forEach": "name.where(use = %wrong_name)",
+            "column": [
+              {
+                "name": "official_name",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "incorrect constant definition",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name.where(use = %name_use).family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/constant_types.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/constant_types.json
@@ -1,0 +1,1032 @@
+{
+  "title": "constant_types",
+  "description": "tests for all types of constants",
+  "resources": [
+    {
+      "resourceType": "Organization",
+      "name": "o1",
+      "id": "o1"
+    },
+    {
+      "resourceType": "Device",
+      "id": "d1",
+      "udiCarrier": [
+        {
+          "carrierAIDC": "aGVsbG8K"
+        }
+      ]
+    },
+    {
+      "resourceType": "Device",
+      "id": "d2",
+      "udiCarrier": [
+        {
+          "carrierAIDC": "YnllCg=="
+        }
+      ]
+    },
+    {
+      "resourceType": "Device",
+      "id": "d3"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "gender": "female",
+      "birthDate": "1978-03-12"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "gender": "male",
+      "birthDate": "1941-09-09"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr1",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active",
+      "item": [
+        {
+          "itemSequence": 1,
+          "adjudication": [
+            {
+              "category": { "text": "category" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr2",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active",
+      "item": [
+        {
+          "itemSequence": 2,
+          "adjudication": [
+            {
+              "category": { "text": "category" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr3",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di1",
+      "status": "final",
+      "identifiedDateTime": "2023-02-08"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di2",
+      "status": "final",
+      "identifiedDateTime": "2016-11-12"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di3",
+      "status": "final"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueQuantity": { "value": 1.0 },
+      "effectiveInstant": "2015-02-07T13:28:17.239+02:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueQuantity": { "value": 1.8 },
+      "effectiveInstant": "2022-02-07T13:28:17.239+02:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "status": "final",
+      "code": { "text": "code" }
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o4",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueTime": "18:12:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o5",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueTime": "18:32:00"
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is1",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" },
+      "numberOfSeries": 9
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is2",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" },
+      "numberOfSeries": 12
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is3",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" }
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m1",
+      "url": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7",
+      "status": "active"
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m2",
+      "url": "urn:uuid:c4669fc3-0d14-4e54-a77f-525f6d4e8385",
+      "status": "active"
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m3",
+      "status": "active"
+    },
+    {
+      "resourceType": "Task",
+      "id": "t1",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUrl": "http://example.org"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t2",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUrl": "http://another.example.org"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t3",
+      "intent": "order",
+      "status": "requested"
+    },
+    {
+      "resourceType": "Task",
+      "id": "t4",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueOid": "urn:oid:1.0"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t5",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueOid": "urn:oid:1.2.3"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t6",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUuid": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t7",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUuid": "urn:uuid:c4669fc3-0d14-4e54-a77f-525f6d4e8385"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t8",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueId": "id1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t9",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueId": "id2"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "base64Binary",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Device",
+        "status": "active",
+        "constant": [
+          {
+            "name": "aidc",
+            "valueBase64Binary": "aGVsbG8K"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "aidc",
+                "path": "udiCarrier.first().carrierAIDC = %aidc",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "d1",
+          "aidc": true
+        },
+        {
+          "id": "d2",
+          "aidc": false
+        },
+        {
+          "id": "d3",
+          "aidc": null
+        }
+      ]
+    },
+    {
+      "title": "code",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "gender",
+            "valueCode": "female"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "gender = %gender",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "bool": true
+        },
+        {
+          "id": "pt2",
+          "bool": false
+        },
+        {
+          "id": "pt3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "date",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "bd",
+            "valueDate": "1978-03-12"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "birthDate = %bd",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "bool": true
+        },
+        {
+          "id": "pt2",
+          "bool": false
+        },
+        {
+          "id": "pt3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "dateTime",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "DetectedIssue",
+        "status": "active",
+        "constant": [
+          {
+            "name": "id_time",
+            "valueDateTime": "2016-11-12"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "identified.ofType(dateTime) = %id_time",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "di1",
+          "bool": false
+        },
+        {
+          "id": "di2",
+          "bool": true
+        },
+        {
+          "id": "di3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "decimal",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "v",
+            "valueDecimal": 1.2
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "value.ofType(Quantity).value < %v",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": true
+        },
+        {
+          "id": "o2",
+          "bool": false
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": null
+        },
+        {
+          "id": "o5",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "id",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "id",
+            "valueId": "id1"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(id) = %id",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": true
+        },
+        {
+          "id": "t9",
+          "bool": false
+        }
+      ]
+    },
+    {
+      "title": "instant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "eff",
+            "valueInstant": "2015-02-07T13:28:17.239+02:00"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "effective.ofType(instant) = %eff",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": true
+        },
+        {
+          "id": "o2",
+          "bool": false
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": null
+        },
+        {
+          "id": "o5",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "oid",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "oid",
+            "valueOid": "urn:oid:1.0"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(oid) = %oid",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": true
+        },
+        {
+          "id": "t5",
+          "bool": false
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "positiveInt",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "ClaimResponse",
+        "status": "active",
+        "constant": [
+          {
+            "name": "seq",
+            "valuePositiveInt": 1
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "item.first().itemSequence = %seq",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "cr1",
+          "bool": true
+        },
+        {
+          "id": "cr2",
+          "bool": false
+        },
+        {
+          "id": "cr3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "time",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "t",
+            "valueTime": "18:12:00"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "value.ofType(time) = %t",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": null
+        },
+        {
+          "id": "o2",
+          "bool": null
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": true
+        },
+        {
+          "id": "o5",
+          "bool": false
+        }
+      ]
+    },
+    {
+      "title": "unsignedInt",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "ImagingStudy",
+        "status": "active",
+        "constant": [
+          {
+            "name": "series",
+            "valueUnsignedInt": 9
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "numberOfSeries = %series",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "is1",
+          "bool": true
+        },
+        {
+          "id": "is2",
+          "bool": false
+        },
+        {
+          "id": "is3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "uri",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Measure",
+        "status": "active",
+        "constant": [
+          {
+            "name": "uri",
+            "valueUri": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "url = %uri",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m1",
+          "bool": true
+        },
+        {
+          "id": "m2",
+          "bool": false
+        },
+        {
+          "id": "m3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "url",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "url",
+            "valueUrl": "http://example.org"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(url) = %url",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": true
+        },
+        {
+          "id": "t2",
+          "bool": false
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "uuid",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "uuid",
+            "valueUuid": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(uuid) = %uuid",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": true
+        },
+        {
+          "id": "t7",
+          "bool": false
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fhirpath.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fhirpath.json
@@ -1,0 +1,412 @@
+{
+  "title": "fhirpath",
+  "description": "fhirpath features",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "managingOrganization": {
+        "reference": "Organization/o1"
+      },
+      "name": [
+        {
+          "family": "f1.1",
+          "use": "official",
+          "given": ["g1.1.1", "g1.1.2"]
+        },
+        {
+          "family": "f1.2",
+          "given": ["g1.2.1"]
+        }
+      ],
+      "active": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "managingOrganization": {
+        "reference": "http://myapp.com/prefix/Organization/o2"
+      },
+      "name": [
+        {
+          "family": "f2.1"
+        },
+        {
+          "family": "f2.2",
+          "use": "official"
+        }
+      ],
+      "active": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "one element",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "two elements + first",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.1"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "collection",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.family",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": ["f1.1", "f1.2"]
+        },
+        {
+          "v": ["f2.1", "f2.2"]
+        },
+        {
+          "v": []
+        }
+      ]
+    },
+    {
+      "title": "index[0]",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[0].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.1"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "index[1]",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[1].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.2"
+        },
+        {
+          "v": "f2.2"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "out of index",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[2].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": null
+        },
+        {
+          "v": null
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "where",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.where(use='official').family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.2"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "exists",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "has_name",
+                "path": "name.exists()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "has_name": true
+        },
+        {
+          "id": "pt2",
+          "has_name": true
+        },
+        {
+          "id": "pt3",
+          "has_name": false
+        }
+      ]
+    },
+    {
+      "title": "nested exists",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "has_given",
+                "path": "name.given.exists()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "has_given": true
+        },
+        {
+          "id": "pt2",
+          "has_given": false
+        },
+        {
+          "id": "pt3",
+          "has_given": false
+        }
+      ]
+    },
+    {
+      "title": "string join",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "given",
+                "path": "name.given.join(', ' )",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "given": "g1.1.1, g1.1.2, g1.2.1"
+        },
+        {
+          "id": "pt2",
+          "given": ""
+        },
+        {
+          "id": "pt3",
+          "given": ""
+        }
+      ]
+    },
+    {
+      "title": "string join: default separator",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "given",
+                "path": "name.given.join()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "given": "g1.1.1g1.1.2g1.2.1"
+        },
+        {
+          "id": "pt2",
+          "given": ""
+        },
+        {
+          "id": "pt3",
+          "given": ""
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fhirpath_numbers.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fhirpath_numbers.json
@@ -1,0 +1,103 @@
+{
+  "title": "fhirpath_numbers",
+  "description": "fhirpath features",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueRange": {
+        "low": {
+          "value": 2
+        },
+        "high": {
+          "value": 3
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "title": "add observation",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "add",
+                "path": "value.ofType(Range).low.value + value.ofType(Range).high.value",
+                "type": "decimal"
+              },
+              {
+                "name": "sub",
+                "path": "value.ofType(Range).high.value - value.ofType(Range).low.value",
+                "type": "decimal"
+              },
+              {
+                "name": "mul",
+                "path": "value.ofType(Range).low.value * value.ofType(Range).high.value",
+                "type": "decimal"
+              },
+              {
+                "name": "div",
+                "path": "value.ofType(Range).high.value / value.ofType(Range).low.value",
+                "type": "decimal"
+              },
+              {
+                "name": "eq",
+                "path": "value.ofType(Range).high.value = value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "gt",
+                "path": "value.ofType(Range).high.value > value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "ge",
+                "path": "value.ofType(Range).high.value >= value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "lt",
+                "path": "value.ofType(Range).high.value < value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "le",
+                "path": "value.ofType(Range).high.value <= value.ofType(Range).low.value",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "add": 5,
+          "sub": 1,
+          "mul": 6,
+          "div": 1.5,
+          "eq": false,
+          "gt": true,
+          "ge": true,
+          "lt": false,
+          "le": false
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_boundary.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_boundary.json
@@ -1,0 +1,362 @@
+{
+  "title": "fn_boundary",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueQuantity": {
+        "value": 1.0
+      }
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueDateTime": "2010-10-10"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o4",
+      "code": {
+        "text": "code"
+      },
+      "valueTime": "12:34"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "birthDate": "1970-06"
+    }
+  ],
+  "tests": [
+    {
+      "title": "decimal lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "decimal",
+                "path": "value.ofType(Quantity).value.lowBoundary()",
+                "type": "decimal"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "decimal": 0.95
+        },
+        {
+          "id": "o2",
+          "decimal": null
+        },
+        {
+          "id": "o3",
+          "decimal": null
+        },
+        {
+          "id": "o4",
+          "decimal": null
+        }
+      ]
+    },
+    {
+      "title": "decimal highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "decimal",
+                "path": "value.ofType(Quantity).value.highBoundary()",
+                "type": "decimal"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "decimal": 1.05
+        },
+        {
+          "id": "o2",
+          "decimal": null
+        },
+        {
+          "id": "o3",
+          "decimal": null
+        },
+        {
+          "id": "o4",
+          "decimal": null
+        }
+      ]
+    },
+    {
+      "title": "datetime lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "datetime",
+                "path": "value.ofType(dateTime).lowBoundary()",
+                "type": "dateTime"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "datetime": null
+        },
+        {
+          "id": "o2",
+          "datetime": "2010-10-10T00:00:00.000+14:00"
+        },
+        {
+          "id": "o3",
+          "datetime": null
+        },
+        {
+          "id": "o4",
+          "datetime": null
+        }
+      ]
+    },
+    {
+      "title": "datetime highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "datetime",
+                "path": "value.ofType(dateTime).highBoundary()",
+                "type": "dateTime"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "datetime": null
+        },
+        {
+          "id": "o2",
+          "datetime": "2010-10-10T23:59:59.999-12:00"
+        },
+        {
+          "id": "o3",
+          "datetime": null
+        },
+        {
+          "id": "o4",
+          "datetime": null
+        }
+      ]
+    },
+    {
+      "title": "date lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "date",
+                "path": "birthDate.lowBoundary()",
+                "type": "date"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "date": "1970-06-01"
+        }
+      ]
+    },
+    {
+      "title": "date highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "date",
+                "path": "birthDate.highBoundary()",
+                "type": "date"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "date": "1970-06-30"
+        }
+      ]
+    },
+    {
+      "title": "time lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "time",
+                "path": "value.ofType(time).lowBoundary()",
+                "type": "time"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "time": null
+        },
+        {
+          "id": "o2",
+          "time": null
+        },
+        {
+          "id": "o3",
+          "time": null
+        },
+        {
+          "id": "o4",
+          "time": "12:34:00.000"
+        }
+      ]
+    },
+    {
+      "title": "time highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "time",
+                "path": "value.ofType(time).highBoundary()",
+                "type": "time"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "time": null
+        },
+        {
+          "id": "o2",
+          "time": null
+        },
+        {
+          "id": "o3",
+          "time": null
+        },
+        {
+          "id": "o4",
+          "time": "12:34:59.999"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_empty.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_empty.json
@@ -1,0 +1,57 @@
+{
+  "title": "fn_empty",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2"
+    }
+  ],
+  "tests": [
+    {
+      "title": "empty names",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "name_empty",
+                "path": "name.empty()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "name_empty": false
+        },
+        {
+          "id": "p2",
+          "name_empty": true
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_extension.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_extension.json
@@ -1,0 +1,173 @@
+{
+  "title": "fn_extension",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": [
+        {
+          "id": "birthsex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          "valueCode": "F"
+        },
+        {
+          "id": "race",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "code": "2106-3",
+                "display": "White"
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Mixed"
+            }
+          ]
+        },
+        {
+          "id": "sex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
+          "valueCode": "248152002"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": [
+        {
+          "id": "birthsex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          "valueCode": "M"
+        },
+        {
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          "id": "race",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "code": "2135-2",
+                "display": "Hispanic or Latino"
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Mixed"
+            }
+          ]
+        },
+        {
+          "id": "sex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
+          "valueCode": "248152002"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": []
+    }
+  ],
+  "tests": [
+    {
+      "title": "simple extension",
+      "tags": ["shareable"],
+      "description": "flatten simple extension",
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "name": "birthsex",
+                "path": "extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex').value.ofType(code).first()",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "birthsex": "F"
+        },
+        {
+          "id": "pt2",
+          "birthsex": "M"
+        },
+        {
+          "id": "pt3",
+          "birthsex": null
+        }
+      ]
+    },
+    {
+      "title": "nested extension",
+      "tags": ["shareable"],
+      "description": "flatten simple extension",
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "name": "race_code",
+                "path": "extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('ombCategory').value.ofType(Coding).code.first()",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "race_code": "2106-3"
+        },
+        {
+          "id": "pt2",
+          "race_code": "2135-2"
+        },
+        {
+          "id": "pt3",
+          "race_code": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_first.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_first.json
@@ -1,0 +1,77 @@
+{
+  "title": "fn_first",
+  "description": "FHIRPath `first` function.",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1",
+          "given": ["g1.1", "g1.2"]
+        },
+        {
+          "use": "usual",
+          "given": ["g2.1"]
+        },
+        {
+          "use": "maiden",
+          "family": "f3",
+          "given": ["g3.1", "g3.2"],
+          "period": {
+            "end": "2002"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "table level first()",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "name.first().use",
+                "name": "use",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "use": "official"
+        }
+      ]
+    },
+    {
+      "title": "table and field level first()",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "name.first().given.first()",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": "g1.1"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_join.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_join.json
@@ -1,0 +1,106 @@
+{
+  "title": "fn_join",
+  "description": "FHIRPath `join` function.",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "given": ["p1.g1", "p1.g2"]
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "join with comma",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join(',')",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1,p1.g2"
+        }
+      ]
+    },
+    {
+      "title": "join with empty value",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join('')",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1p1.g2"
+        }
+      ]
+    },
+    {
+      "title": "join with no value - default to no separator",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join()",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1p1.g2"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_oftype.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_oftype.json
@@ -1,0 +1,111 @@
+{
+  "title": "fn_oftype",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueString": "foo"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueInteger": 42
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    }
+  ],
+  "tests": [
+    {
+      "title": "select string values",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "value.ofType(string)",
+                "name": "string_value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "string_value": "foo"
+        },
+        {
+          "id": "o2",
+          "string_value": null
+        },
+        {
+          "id": "o3",
+          "string_value": null
+        }
+      ]
+    },
+    {
+      "title": "select integer values",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "value.ofType(integer)",
+                "name": "integer_value",
+                "type": "integer"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "integer_value": null
+        },
+        {
+          "id": "o2",
+          "integer_value": 42
+        },
+        {
+          "id": "o3",
+          "integer_value": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/fn_reference_keys.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/fn_reference_keys.json
@@ -1,0 +1,109 @@
+{
+  "title": "fn_reference_keys",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p1"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p3"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "getReferenceKey result matches getResourceKey without type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey()",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with right type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Patient)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with wrong type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Observation)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": null
+        },
+        {
+          "key_equal_ref": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/foreach.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/foreach.json
@@ -1,0 +1,832 @@
+{
+  "title": "foreach",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "F1.1"
+        },
+        {
+          "family": "F1.2"
+        }
+      ],
+      "contact": [
+        {
+          "telecom": [
+            {
+              "system": "phone"
+            }
+          ],
+          "name": {
+            "family": "FC1.1",
+            "given": ["N1", "N1`"]
+          }
+        },
+        {
+          "telecom": [
+            {
+              "system": "email"
+            }
+          ],
+          "gender": "unknown",
+          "name": {
+            "family": "FC1.2",
+            "given": ["N2"]
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "F2.1"
+        },
+        {
+          "family": "F2.2"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "forEach: normal",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1"
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull: basic",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1"
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2"
+        },
+        {
+          "id": "pt3",
+          "family": null
+        }
+      ]
+    },
+    {
+      "title": "forEach: empty",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "forEach: two on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "cont_family",
+                "path": "name.family",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "pat_family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "pat_family": "F1.1",
+          "cont_family": "FC1.1"
+        },
+        {
+          "pat_family": "F1.1",
+          "cont_family": "FC1.2"
+        },
+        {
+          "pat_family": "F1.2",
+          "cont_family": "FC1.1"
+        },
+        {
+          "pat_family": "F1.2",
+          "cont_family": "FC1.2"
+        }
+      ]
+    },
+    {
+      "title": "forEach: two on the same level (empty result)",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "forEachOrNull: null case",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "value": null
+        },
+        {
+          "id": "pt3",
+          "value": null
+        }
+      ]
+    },
+    {
+      "title": "forEach and forEachOrNull on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1",
+          "value": null
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2",
+          "value": null
+        }
+      ]
+    },
+    {
+      "title": "nested forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "contact_type",
+                    "path": "telecom.system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "$this",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "contact_type": "phone",
+          "name": "N1",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "phone",
+          "name": "N1`",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "email",
+          "name": "N2",
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "nested forEach: select & column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "contact_type",
+                "path": "telecom.system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "$this",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "contact_type": "phone",
+          "name": "N1",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "phone",
+          "name": "N1`",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "email",
+          "name": "N2",
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull & unionAll on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "contact",
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1`"
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2"
+        },
+        {
+          "id": "pt1",
+          "name": "N2"
+        },
+        {
+          "id": "pt2",
+          "name": null
+        },
+        {
+          "id": "pt3",
+          "name": null
+        }
+      ]
+    },
+    {
+      "title": "forEach & unionAll on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1`"
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2"
+        },
+        {
+          "id": "pt1",
+          "name": "N2"
+        }
+      ]
+    },
+    {
+      "title": "forEach & unionAll & column & select on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "path": "telecom.system",
+                "name": "tel_system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "gender",
+                    "name": "gender",
+                    "type": "code"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1`",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt1",
+          "name": "N2",
+          "tel_system": "email",
+          "gender": "unknown"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull & unionAll & column & select on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "contact",
+            "column": [
+              {
+                "path": "telecom.system",
+                "name": "tel_system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "gender",
+                    "name": "gender",
+                    "type": "code"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1`",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt1",
+          "name": "N2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt2",
+          "name": null,
+          "tel_system": null,
+          "gender": null
+        },
+        {
+          "id": "pt3",
+          "name": null,
+          "tel_system": null,
+          "gender": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/logic.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/logic.json
@@ -1,0 +1,125 @@
+{
+  "title": "logic",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "m0",
+      "gender": "male",
+      "deceasedBoolean": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "f0",
+      "deceasedBoolean": false,
+      "gender": "female"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "m1",
+      "gender": "male",
+      "deceasedBoolean": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "f1",
+      "gender": "female"
+    }
+  ],
+  "tests": [
+    {
+      "title": "filtering with 'and'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "gender = 'male' and deceased.ofType(boolean) = false"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m0"
+        }
+      ]
+    },
+    {
+      "title": "filtering with 'or'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "gender = 'male' or deceased.ofType(boolean) = false"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m0"
+        },
+        {
+          "id": "f0"
+        },
+        {
+          "id": "m1"
+        }
+      ]
+    },
+    {
+      "title": "filtering with 'not'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "(gender = 'male').not()"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "f0"
+        },
+        {
+          "id": "f1"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/union.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/union.json
@@ -1,0 +1,842 @@
+{
+  "title": "union",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "telecom": [
+        {
+          "value": "t1.1",
+          "system": "phone"
+        },
+        {
+          "value": "t1.2",
+          "system": "fax"
+        },
+        {
+          "value": "t1.3",
+          "system": "email"
+        }
+      ],
+      "contact": [
+        {
+          "telecom": [
+            {
+              "value": "t1.c1.1",
+              "system": "pager"
+            }
+          ]
+        },
+        {
+          "telecom": [
+            {
+              "value": "t1.c2.1",
+              "system": "url"
+            },
+            {
+              "value": "t1.c2.2",
+              "system": "sms"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "telecom": [
+        {
+          "value": "t2.1",
+          "system": "phone"
+        },
+        {
+          "value": "t2.2",
+          "system": "fax"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3",
+      "contact": [
+        {
+          "telecom": [
+            {
+              "value": "t3.c1.1",
+              "system": "email"
+            },
+            {
+              "value": "t3.c1.2",
+              "system": "pager"
+            }
+          ]
+        },
+        {
+          "telecom": [
+            {
+              "value": "t3.c2.1",
+              "system": "sms"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt4"
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c1.1",
+          "sys": "pager",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.1",
+          "sys": "url",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.2",
+          "sys": "sms",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t3.c1.1",
+          "sys": "email",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c1.2",
+          "sys": "pager",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c2.1",
+          "sys": "sms",
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "unionAll + column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c1.1",
+          "sys": "pager",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.1",
+          "sys": "url",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.2",
+          "sys": "sms",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t3.c1.1",
+          "sys": "email",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c1.2",
+          "sys": "pager",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c2.1",
+          "sys": "sms",
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "duplicates",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "empty results",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "empty with forEachOrNull",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull and forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        }
+      ]
+    },
+    {
+      "title": "nested",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom[0]",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "unionAll": [
+                  {
+                    "forEach": "telecom[0]",
+                    "column": [
+                      {
+                        "name": "tel",
+                        "path": "value",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "forEach": "contact.telecom[0]",
+                    "column": [
+                      {
+                        "name": "tel",
+                        "path": "value",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "tel": "t1.1"
+        },
+        {
+          "id": "pt1",
+          "tel": "t1.1"
+        },
+        {
+          "id": "pt1",
+          "tel": "t1.c1.1"
+        },
+        {
+          "id": "pt2",
+          "tel": "t2.1"
+        },
+        {
+          "id": "pt2",
+          "tel": "t2.1"
+        },
+        {
+          "id": "pt3",
+          "tel": "t3.c1.1"
+        }
+      ]
+    },
+    {
+      "title": "one empty operand",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "telecom.where(false)",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "sys": "pager",
+          "tel": "t1.c1.1"
+        },
+        {
+          "id": "pt1",
+          "sys": "url",
+          "tel": "t1.c2.1"
+        },
+        {
+          "id": "pt1",
+          "sys": "sms",
+          "tel": "t1.c2.2"
+        },
+        {
+          "id": "pt3",
+          "sys": "email",
+          "tel": "t3.c1.1"
+        },
+        {
+          "id": "pt3",
+          "sys": "pager",
+          "tel": "t3.c1.2"
+        },
+        {
+          "id": "pt3",
+          "sys": "sms",
+          "tel": "t3.c2.1"
+        }
+      ]
+    },
+    {
+      "title": "column mismatch",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "c",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "column order mismatch",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/validate.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/validate.json
@@ -1,0 +1,99 @@
+{
+  "title": "validate",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "name": [
+        {
+          "family": "F1.1"
+        }
+      ],
+      "id": "pt1"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2"
+    }
+  ],
+  "tests": [
+    {
+      "title": "empty",
+      "tags": ["shareable"],
+      "view": {},
+      "expectError": true
+    },
+    {
+      "title": "missing resource",
+      "tags": ["shareable"],
+      "view": {
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "wrong fhirpath",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": "@@"
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "wrong type in forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": 1
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "where with path resolving to not boolean",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family"
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/view_resource.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/view_resource.json
@@ -1,0 +1,95 @@
+{
+  "title": "view_resource",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "id": "pt1",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt2",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "ob1",
+      "resourceType": "Observation",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    }
+  ],
+  "tests": [
+    {
+      "title": "only pts",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "only obs",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "ob1"
+        }
+      ]
+    },
+    {
+      "title": "resource not specified",
+      "tags": ["shareable"],
+      "view": {
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r4/src/test/resources/sof/where.json
+++ b/org.hl7.fhir.r4/src/test/resources/sof/where.json
@@ -1,0 +1,279 @@
+{
+  "title": "where",
+  "description": "FHIRPath `where` function.",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "name": [
+        {
+          "use": "nickname",
+          "family": "f2"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p3",
+      "name": [
+        {
+          "use": "nickname",
+          "given": ["g3"],
+          "family": "f3"
+        }
+      ]
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "valueInteger": 12
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "valueInteger": 10
+    }
+  ],
+  "tests": [
+    {
+      "title": "simple where path with result",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with no results",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'maiden').exists()"
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "where path with greater than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) > 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1"
+        }
+      ]
+    },
+    {
+      "title": "where path with less than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) < 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o2"
+        }
+      ]
+    },
+    {
+      "title": "multiple where paths",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          },
+          {
+            "path": "name.where(family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'and' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' and family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'or' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' or family = 'f2').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p2"
+        }
+      ]
+    },
+    {
+      "title": "where path that evaluates to true when empty",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(family = 'f2').empty()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p3"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -209,6 +209,36 @@
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<exclude>**/SqlOnFhirRunnerTests.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>sof-compliance-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/SqlOnFhirRunnerTests.java</include>
+							</includes>
+							<!-- This test is run but it does not fail the build if it fails. -->
+							<testFailureIgnore>true</testFailureIgnore>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/SqlOnFhirRunnerTests.java
@@ -187,9 +187,10 @@ public class SqlOnFhirRunnerTests {
     // Add result to report.
     reportGenerator.addResult(fileName, result);
 
-    // Assert for JUnit.
+    // Assert test passed.
     if (!result.passed) {
-      fail(result.error != null ? result.error : "Test failed");
+      fail("SQL on FHIR test failed: " + fileName + " - " + testName +
+           (result.error != null ? " - " + result.error : ""));
     }
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/SqlOnFhirRunnerTests.java
@@ -1,0 +1,312 @@
+package org.hl7.fhir.r5.utils.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.sql.Runner;
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonElement;
+import org.hl7.fhir.utilities.json.model.JsonNull;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for SQL on FHIR Runner implementation based on the official test suite.
+ * Tests are loaded from JSON files in the resources/sof directory.
+ *
+ * @author John Grimes
+ */
+@Slf4j
+public class SqlOnFhirRunnerTests {
+
+  private static IWorkerContext context;
+  private static TestReportGenerator reportGenerator;
+  private static Map<String, JsonObject> testFiles = new HashMap<>();
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    context = TestingUtilities.getSharedWorkerContext();
+    reportGenerator = new TestReportGenerator();
+    loadTestFiles();
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    reportGenerator.writeReport("target/sof-test-report.json");
+  }
+
+  private static void loadTestFiles() throws IOException {
+    File testDir = new File("src/test/resources/sof");
+    if (testDir.exists() && testDir.isDirectory()) {
+      File[] files = testDir.listFiles((dir, name) -> name.endsWith(".json"));
+      if (files != null) {
+        for (File file : files) {
+          String content = Files.readString(file.toPath());
+          JsonObject testFile = org.hl7.fhir.utilities.json.parser.JsonParser.parseObject(content);
+          testFiles.put(file.getName(), testFile);
+        }
+      }
+    }
+  }
+
+  public static Stream<Arguments> testCases() {
+    List<Arguments> arguments = new ArrayList<>();
+
+    for (Map.Entry<String, JsonObject> entry : testFiles.entrySet()) {
+      String fileName = entry.getKey();
+      JsonObject testFile = entry.getValue();
+
+      if (testFile.has("tests")) {
+        JsonArray tests = testFile.getJsonArray("tests");
+        for (JsonElement element : tests) {
+          if (element instanceof JsonObject) {
+            JsonObject test = (JsonObject) element;
+            String testName = test.asString("title");
+            arguments.add(Arguments.of(fileName, testName, testFile, test));
+          }
+        }
+      }
+    }
+
+    return arguments.stream();
+  }
+
+  @ParameterizedTest(name = "{0}: {1}")
+  @MethodSource("testCases")
+  @DisplayName("SQL on FHIR Runner Test")
+  public void testRunner(String fileName, String testName, JsonObject testFile, JsonObject test) throws Exception {
+    log.info("Running test: {} - {}", fileName, testName);
+
+    TestResult result = new TestResult();
+    result.name = testName;
+
+    try {
+      // Extract view definition.
+      JsonObject view = test.getJsonObject("view");
+      if (view == null) {
+        throw new IllegalArgumentException("Test missing 'view' definition");
+      }
+
+      // Create test provider with resources.
+      TestProvider provider = new TestProvider();
+      if (testFile.has("resources")) {
+        JsonElement resources = testFile.get("resources");
+        if (resources instanceof JsonArray) {
+          loadResources((JsonArray) resources, provider);
+        }
+      }
+
+      // Create test storage.
+      TestStorage storage = new TestStorage();
+
+      // Create and configure runner.
+      Runner runner = new Runner();
+      runner.setContext(context);
+      runner.setProvider(provider);
+      runner.setStorage(storage);
+
+      // Check for expectError.
+      boolean expectError = test.has("expectError");
+
+      try {
+        // Execute the view.
+        runner.execute(view);
+
+        if (expectError) {
+          fail("Expected error but none was thrown");
+        }
+
+        // Get actual results.
+        JsonArray actualResults = storage.getResults();
+
+        // Compare with expected results.
+        if (test.has("expect")) {
+          JsonArray expectedResults = test.getJsonArray("expect");
+          compareResults(expectedResults, actualResults, result);
+        }
+
+        // Check column ordering if specified.
+        if (test.has("expectColumns")) {
+          JsonArray expectedColumns = test.getJsonArray("expectColumns");
+          checkColumnOrder(expectedColumns, actualResults, result);
+        }
+
+        result.passed = true;
+
+      } catch (Exception e) {
+        if (expectError) {
+          // Check if error matches expected error pattern.
+          if (test.has("expectErrorPattern")) {
+            String pattern = test.asString("expectErrorPattern");
+            if (!e.getMessage().contains(pattern)) {
+              result.passed = false;
+              result.error = "Error message did not match expected pattern: " + e.getMessage();
+            } else {
+              result.passed = true;
+            }
+          } else {
+            result.passed = true;
+          }
+        } else {
+          throw e;
+        }
+      }
+
+    } catch (Exception e) {
+      result.passed = false;
+      result.error = e.getClass().getSimpleName() + ": " + e.getMessage();
+      if (test.has("expectError")) {
+        // If we expected an error and got one, it's still a pass.
+        result.passed = true;
+      }
+    }
+
+    // Add result to report.
+    reportGenerator.addResult(fileName, result);
+
+    // Assert for JUnit.
+    if (!result.passed) {
+      fail(result.error != null ? result.error : "Test failed");
+    }
+  }
+
+  private void loadResources(JsonArray resources, TestProvider provider) throws IOException {
+    org.hl7.fhir.r5.formats.JsonParser fhirParser = new org.hl7.fhir.r5.formats.JsonParser();
+
+    for (JsonElement element : resources) {
+      if (element instanceof JsonObject) {
+        JsonObject resourceJson = (JsonObject) element;
+        String json = org.hl7.fhir.utilities.json.parser.JsonParser.compose(resourceJson, true);
+        try (InputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+          Resource resource = fhirParser.parse(inputStream);
+          provider.addResource(resource);
+        }
+      }
+    }
+  }
+
+  private void compareResults(JsonArray expected, JsonArray actual, TestResult result) {
+    if (expected.size() != actual.size()) {
+      result.passed = false;
+      result.error = String.format("Result count mismatch: expected %d, got %d",
+                                   expected.size(), actual.size());
+      return;
+    }
+
+    // Deep comparison of JSON results.
+    for (int i = 0; i < expected.size(); i++) {
+      JsonElement expectedRow = expected.get(i);
+      JsonElement actualRow = actual.get(i);
+
+      if (!compareJsonElements(expectedRow, actualRow)) {
+        result.passed = false;
+        result.error = String.format("Row %d mismatch: expected %s, got %s",
+                                     i, expectedRow, actualRow);
+        return;
+      }
+    }
+  }
+
+  private boolean compareJsonElements(JsonElement expected, JsonElement actual) {
+    if (expected instanceof JsonNull && actual instanceof JsonNull) {
+      return true;
+    }
+    if (expected instanceof JsonNull || actual instanceof JsonNull) {
+      return false;
+    }
+    if (expected.getClass() != actual.getClass()) {
+      return false;
+    }
+
+    if (expected instanceof JsonObject) {
+      JsonObject expectedObj = (JsonObject) expected;
+      JsonObject actualObj = (JsonObject) actual;
+
+      if (expectedObj.getNames().size() != actualObj.getNames().size()) {
+        return false;
+      }
+
+      for (String key : expectedObj.getNames()) {
+        if (!actualObj.has(key)) {
+          return false;
+        }
+        if (!compareJsonElements(expectedObj.get(key), actualObj.get(key))) {
+          return false;
+        }
+      }
+      return true;
+    } else if (expected instanceof JsonArray) {
+      JsonArray expectedArr = (JsonArray) expected;
+      JsonArray actualArr = (JsonArray) actual;
+
+      if (expectedArr.size() != actualArr.size()) {
+        return false;
+      }
+
+      for (int i = 0; i < expectedArr.size(); i++) {
+        if (!compareJsonElements(expectedArr.get(i), actualArr.get(i))) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      // Primitive comparison.
+      return expected.toString().equals(actual.toString());
+    }
+  }
+
+  private void checkColumnOrder(JsonArray expectedColumns, JsonArray results, TestResult result) {
+    if (results.size() == 0) {
+      return;
+    }
+
+    JsonElement firstRow = results.get(0);
+    if (firstRow instanceof JsonObject) {
+      JsonObject row = (JsonObject) firstRow;
+      List<String> actualColumns = new ArrayList<>(row.getNames());
+
+      List<String> expected = new ArrayList<>();
+      for (JsonElement col : expectedColumns) {
+        expected.add(col.toString().replaceAll("\"", ""));
+      }
+
+      if (!actualColumns.equals(expected)) {
+        result.passed = false;
+        result.error = String.format("Column order mismatch: expected %s, got %s",
+                                     expected, actualColumns);
+      }
+    }
+  }
+
+  /**
+   * Simple test result class.
+   */
+  static class TestResult {
+    String name;
+    boolean passed;
+    String error;
+  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestProvider.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestProvider.java
@@ -1,0 +1,108 @@
+package org.hl7.fhir.r5.utils.sql;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.Reference;
+import org.hl7.fhir.r5.model.Resource;
+
+/**
+ * Test implementation of Provider interface for SQL on FHIR tests.
+ * Stores resources in memory and provides access by resource type.
+ *
+ * @author John Grimes
+ */
+public class TestProvider implements Provider {
+
+  private Map<String, List<Resource>> resourcesByType = new HashMap<>();
+  private Map<String, Resource> resourcesById = new HashMap<>();
+
+  /**
+   * Add a resource to the provider.
+   */
+  public void addResource(Resource resource) {
+    String resourceType = resource.getResourceType().toString();
+    resourcesByType.computeIfAbsent(resourceType, k -> new ArrayList<>()).add(resource);
+
+    // Store by ID for reference resolution.
+    if (resource.hasId()) {
+      String fullId = resourceType + "/" + resource.getIdElement().getIdPart();
+      resourcesById.put(fullId, resource);
+      // Also store without resource type prefix for relative references.
+      resourcesById.put(resource.getIdElement().getIdPart(), resource);
+    }
+  }
+
+  @Override
+  public List<Base> fetch(String resourceType) {
+    List<Base> result = new ArrayList<>();
+    List<Resource> resources = resourcesByType.get(resourceType);
+    if (resources != null) {
+      result.addAll(resources);
+    }
+    return result;
+  }
+
+  @Override
+  public Base resolveReference(Base rootResource, String ref, String specifiedResourceType) {
+    if (ref == null || ref.isEmpty()) {
+      return null;
+    }
+
+    // Handle different reference formats.
+    String resourceId = ref;
+
+    // Strip URL prefix if present.
+    if (ref.contains("/")) {
+      String[] parts = ref.split("/");
+      if (parts.length >= 2) {
+        resourceId = parts[parts.length - 1];
+      }
+    }
+
+    // Try direct lookup.
+    Resource resource = resourcesById.get(ref);
+    if (resource != null) {
+      return resource;
+    }
+
+    // Try with just the ID part.
+    resource = resourcesById.get(resourceId);
+    if (resource != null) {
+      // Check if resource type matches if specified.
+      if (specifiedResourceType != null && !specifiedResourceType.isEmpty()) {
+        String actualType = resource.getResourceType().toString();
+        if (specifiedResourceType.startsWith("FHIR.")) {
+          specifiedResourceType = specifiedResourceType.substring(5);
+        }
+        if (actualType.equals(specifiedResourceType)) {
+          return resource;
+        }
+      } else {
+        return resource;
+      }
+    }
+
+    // Try with resource type prefix.
+    if (specifiedResourceType != null && !specifiedResourceType.isEmpty()) {
+      String typedRef = specifiedResourceType + "/" + resourceId;
+      resource = resourcesById.get(typedRef);
+      if (resource != null) {
+        return resource;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Clear all resources.
+   */
+  public void clear() {
+    resourcesByType.clear();
+    resourcesById.clear();
+  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestReportGenerator.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestReportGenerator.java
@@ -1,0 +1,147 @@
+package org.hl7.fhir.r5.utils.sql;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.hl7.fhir.utilities.json.parser.JsonParser;
+
+/**
+ * Generates test reports conforming to the SQL on FHIR test report schema.
+ * Report structure follows: https://github.com/FHIR/sql-on-fhir-v2/blob/master/test_report/test-report.schema.json
+ *
+ * @author John Grimes
+ */
+@Slf4j
+public class TestReportGenerator {
+
+  private Map<String, JsonArray> testResults = new HashMap<>();
+
+  /**
+   * Add a test result to the report.
+   *
+   * @param testFileName The name of the test file (e.g., "basic.json")
+   * @param result The test result
+   */
+  public void addResult(String testFileName, SqlOnFhirRunnerTests.TestResult result) {
+    JsonArray tests = testResults.computeIfAbsent(testFileName, k -> new JsonArray());
+
+    JsonObject testResult = new JsonObject();
+    testResult.add("name", result.name);
+
+    JsonObject resultObject = new JsonObject();
+    resultObject.add("passed", result.passed);
+
+    if (!result.passed && result.error != null) {
+      resultObject.add("error", result.error);
+    }
+
+    testResult.add("result", resultObject);
+    tests.add(testResult);
+  }
+
+  /**
+   * Write the test report to a file.
+   *
+   * @param filePath Path to write the report to
+   */
+  public void writeReport(String filePath) {
+    try {
+      JsonObject report = new JsonObject();
+
+      // Build the report structure.
+      for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+        JsonObject testSuite = new JsonObject();
+        testSuite.add("tests", entry.getValue());
+        report.add(entry.getKey(), testSuite);
+      }
+
+      // Write to file.
+      String json = JsonParser.compose(report, true);
+      try (FileWriter writer = new FileWriter(filePath)) {
+        writer.write(json);
+      }
+
+      log.info("Test report written to: {}", filePath);
+      printSummary();
+
+    } catch (IOException e) {
+      log.error("Failed to write test report: {}", e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Print a summary of test results to console.
+   */
+  private void printSummary() {
+    int totalTests = 0;
+    int passedTests = 0;
+    int failedTests = 0;
+
+    log.info("\n=== SQL on FHIR Test Results Summary ===");
+
+    for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+      String fileName = entry.getKey();
+      JsonArray tests = entry.getValue();
+
+      int filePassed = 0;
+      int fileFailed = 0;
+
+      for (int i = 0; i < tests.size(); i++) {
+        JsonObject test = (JsonObject) tests.get(i);
+        JsonObject result = test.getJsonObject("result");
+        if (result != null && result.has("passed")) {
+          boolean passed = result.asBoolean("passed");
+          if (passed) {
+            filePassed++;
+            passedTests++;
+          } else {
+            fileFailed++;
+            failedTests++;
+          }
+          totalTests++;
+        }
+      }
+
+      log.info("{}: {} passed, {} failed (total: {})",
+               fileName, filePassed, fileFailed, filePassed + fileFailed);
+    }
+
+    log.info("\n=== Overall Summary ===");
+    log.info("Total tests: {}", totalTests);
+    log.info("Passed: {} ({:.1f}%)", passedTests,
+             totalTests > 0 ? (100.0 * passedTests / totalTests) : 0);
+    log.info("Failed: {} ({:.1f}%)", failedTests,
+             totalTests > 0 ? (100.0 * failedTests / totalTests) : 0);
+
+    if (failedTests > 0) {
+      log.info("\nFailed tests:");
+      for (Map.Entry<String, JsonArray> entry : testResults.entrySet()) {
+        String fileName = entry.getKey();
+        JsonArray tests = entry.getValue();
+
+        for (int i = 0; i < tests.size(); i++) {
+          JsonObject test = (JsonObject) tests.get(i);
+          String name = test.asString("name");
+          JsonObject result = test.getJsonObject("result");
+          if (result != null && result.has("passed") && !result.asBoolean("passed")) {
+            String error = result.has("error") ? result.asString("error") : "Unknown error";
+            log.info("  - {}: {} - {}", fileName, name, error);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Clear all test results.
+   */
+  public void clear() {
+    testResults.clear();
+  }
+}

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestStorage.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/TestStorage.java
@@ -1,0 +1,72 @@
+package org.hl7.fhir.r5.utils.sql;
+
+import java.util.List;
+
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.utilities.json.model.JsonArray;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+
+/**
+ * Test implementation of Storage interface for SQL on FHIR tests.
+ * Extends StorageJson to capture results as JSON for comparison.
+ *
+ * @author John Grimes
+ */
+public class TestStorage extends StorageJson {
+
+  private JsonArray results;
+  private List<Column> columns;
+
+  @Override
+  public Store createStore(String name, List<Column> columns) {
+    this.columns = columns;
+    this.results = new JsonArray();
+    // Call parent to initialise internal state.
+    Store store = super.createStore(name, columns);
+    // Override the parent's rows array with our own.
+    this.results = super.getRows();
+    return store;
+  }
+
+  /**
+   * Get the captured results as a JsonArray.
+   */
+  public JsonArray getResults() {
+    return results != null ? results : new JsonArray();
+  }
+
+  /**
+   * Get the column definitions.
+   */
+  public List<Column> getColumns() {
+    return columns;
+  }
+
+  /**
+   * Clear all results.
+   */
+  public void clear() {
+    if (results != null) {
+      results = new JsonArray();
+    }
+    columns = null;
+  }
+
+  @Override
+  public String getKeyForSourceResource(Base res) {
+    // Return a simple key for testing.
+    if (res != null) {
+      return res.fhirType() + "/" + res.getIdBase();
+    }
+    return null;
+  }
+
+  @Override
+  public String getKeyForTargetResource(Base res) {
+    // Return a simple key for testing.
+    if (res != null) {
+      return res.fhirType() + "/" + res.getIdBase();
+    }
+    return null;
+  }
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/basic.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/basic.json
@@ -1,0 +1,496 @@
+{
+  "title": "basic",
+  "description": "basic view definition",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "F1"
+        }
+      ],
+      "active": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "F2"
+        }
+      ],
+      "active": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic attribute",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "boolean attribute with false",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "active",
+                "path": "active",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "active": true
+        },
+        {
+          "id": "pt2",
+          "active": false
+        },
+        {
+          "id": "pt3",
+          "active": null
+        }
+      ]
+    },
+    {
+      "title": "two columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "two selects with columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "where - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = true"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = false"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where returns non-boolean for some cases",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F2'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F1'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "select & column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "c_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "s_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "c_id": "pt1",
+          "s_id": "pt1"
+        },
+        {
+          "c_id": "pt2",
+          "s_id": "pt2"
+        },
+        {
+          "c_id": "pt3",
+          "s_id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column ordering",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "'A'",
+                "name": "a",
+                "type": "string"
+              },
+              {
+                "path": "'B'",
+                "name": "b",
+                "type": "string"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "path": "'C'",
+                    "name": "c",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'D'",
+                    "name": "d",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "'E1'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F1'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "path": "'E2'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F2'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "path": "'G'",
+                "name": "g",
+                "type": "string"
+              },
+              {
+                "path": "'H'",
+                "name": "h",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectColumns": ["a", "b", "c", "d", "e", "f", "g", "h"],
+      "expect": [
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/collection.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/collection.json
@@ -1,0 +1,244 @@
+{
+  "title": "collection",
+  "tags": ["shareable"],
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1.1",
+          "given": ["g1.1"]
+        },
+        {
+          "family": "f1.2",
+          "given": ["g1.2", "g1.3"]
+        }
+      ],
+      "gender": "male",
+      "birthDate": "1950-01-01",
+      "address": [
+        {
+          "city": "c1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "f2.1",
+          "given": ["g2.1"]
+        },
+        {
+          "use": "official",
+          "family": "f2.2",
+          "given": ["g2.2", "g2.3"]
+        }
+      ],
+      "gender": "female",
+      "birthDate": "1950-01-01"
+    }
+  ],
+  "tests": [
+    {
+      "title": "fail when 'collection' is not true",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family",
+                "type": "string",
+                "collection": false
+              },
+              {
+                "name": "first_name",
+                "path": "name.given",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "collection = true",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family",
+                "type": "string",
+                "collection": true
+              },
+              {
+                "name": "first_name",
+                "path": "name.given",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": ["f1.1", "f1.2"],
+          "first_name": ["g1.1", "g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": ["f2.1", "f2.2"],
+          "first_name": ["g2.1", "g2.2", "g2.3"]
+        }
+      ]
+    },
+    {
+      "title": "collection = false relative to forEach parent",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "last_name",
+                    "path": "family",
+                    "type": "string",
+                    "collection": false
+                  },
+                  {
+                    "name": "first_name",
+                    "path": "given",
+                    "type": "string",
+                    "collection": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "f1.1",
+          "first_name": ["g1.1"]
+        },
+        {
+          "id": "pt1",
+          "last_name": "f1.2",
+          "first_name": ["g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.1",
+          "first_name": ["g2.1"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.2",
+          "first_name": ["g2.2", "g2.3"]
+        }
+      ]
+    },
+    {
+      "title": "collection = false relative to forEachOrNull parent",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "last_name",
+                    "path": "family",
+                    "type": "string",
+                    "collection": false
+                  },
+                  {
+                    "name": "first_name",
+                    "path": "given",
+                    "type": "string",
+                    "collection": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "f1.1",
+          "first_name": ["g1.1"]
+        },
+        {
+          "id": "pt1",
+          "last_name": "f1.2",
+          "first_name": ["g1.2", "g1.3"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.1",
+          "first_name": ["g2.1"]
+        },
+        {
+          "id": "pt2",
+          "last_name": "f2.2",
+          "first_name": ["g2.2", "g2.3"]
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/combinations.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/combinations.json
@@ -1,0 +1,256 @@
+{
+  "title": "combinations",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "id": "pt1",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt2",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt3",
+      "resourceType": "Patient"
+    }
+  ],
+  "tests": [
+    {
+      "title": "select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column + select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "column_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "select_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "column_id": "pt1",
+          "select_id": "pt1"
+        },
+        {
+          "column_id": "pt2",
+          "select_id": "pt2"
+        },
+        {
+          "column_id": "pt3",
+          "select_id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "sibling select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id_1",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id_2",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id_1": "pt1",
+          "id_2": "pt1"
+        },
+        {
+          "id_1": "pt2",
+          "id_2": "pt2"
+        },
+        {
+          "id_1": "pt3",
+          "id_2": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "sibling select inside a select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id_1",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id_2",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id_1": "pt1",
+          "id_2": "pt1"
+        },
+        {
+          "id_1": "pt2",
+          "id_2": "pt2"
+        },
+        {
+          "id_1": "pt3",
+          "id_2": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column + select, with where",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "column_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "select_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "id = 'pt1'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "column_id": "pt1",
+          "select_id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "unionAll + forEach + column + select",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/constant.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/constant.json
@@ -1,0 +1,331 @@
+{
+  "title": "constant",
+  "description": "constant substitution",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "Block",
+          "use": "usual"
+        },
+        {
+          "family": "Smith",
+          "use": "official"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "deceasedBoolean": true,
+      "name": [
+        {
+          "family": "Johnson",
+          "use": "usual"
+        },
+        {
+          "family": "Menendez",
+          "use": "old"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "constant in path",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name.where(use = %name_use).family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "official_name": "Smith"
+        },
+        {
+          "id": "pt2",
+          "official_name": null
+        }
+      ]
+    },
+    {
+      "title": "constant in forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "forEach": "name.where(use = %name_use)",
+            "column": [
+              {
+                "name": "official_name",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "official_name": "Smith"
+        }
+      ]
+    },
+    {
+      "title": "constant in where element",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = %name_use).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "constant in unionAll",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "use1",
+            "valueString": "official"
+          },
+          {
+            "name": "use2",
+            "valueString": "usual"
+          }
+        ],
+        "select": [
+          {
+            "unionAll": [
+              {
+                "forEach": "name.where(use = %use1)",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "family",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.where(use = %use2)",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "family",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "name": "Smith"
+        },
+        {
+          "name": "Block"
+        },
+        {
+          "name": "Johnson"
+        }
+      ]
+    },
+    {
+      "title": "integer constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_index",
+            "valueInteger": 1
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name[%name_index].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "official_name": "Smith"
+        },
+        {
+          "id": "pt2",
+          "official_name": "Menendez"
+        }
+      ]
+    },
+    {
+      "title": "boolean constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "is_deceased",
+            "valueBoolean": true
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "deceased.ofType(boolean).exists() and deceased.ofType(boolean) = %is_deceased"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "accessing an undefined constant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use",
+            "valueString": "official"
+          }
+        ],
+        "select": [
+          {
+            "forEach": "name.where(use = %wrong_name)",
+            "column": [
+              {
+                "name": "official_name",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "incorrect constant definition",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "name_use"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "official_name",
+                "path": "name.where(use = %name_use).family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/constant_types.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/constant_types.json
@@ -1,0 +1,1032 @@
+{
+  "title": "constant_types",
+  "description": "tests for all types of constants",
+  "resources": [
+    {
+      "resourceType": "Organization",
+      "name": "o1",
+      "id": "o1"
+    },
+    {
+      "resourceType": "Device",
+      "id": "d1",
+      "udiCarrier": [
+        {
+          "carrierAIDC": "aGVsbG8K"
+        }
+      ]
+    },
+    {
+      "resourceType": "Device",
+      "id": "d2",
+      "udiCarrier": [
+        {
+          "carrierAIDC": "YnllCg=="
+        }
+      ]
+    },
+    {
+      "resourceType": "Device",
+      "id": "d3"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "gender": "female",
+      "birthDate": "1978-03-12"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "gender": "male",
+      "birthDate": "1941-09-09"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr1",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active",
+      "item": [
+        {
+          "itemSequence": 1,
+          "adjudication": [
+            {
+              "category": { "text": "category" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr2",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active",
+      "item": [
+        {
+          "itemSequence": 2,
+          "adjudication": [
+            {
+              "category": { "text": "category" }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "ClaimResponse",
+      "id": "cr3",
+      "use": "claim",
+      "patient": { "reference": "Patient/p1" },
+      "created": "2021-09-02",
+      "insurer": { "reference": "Organization/o1" },
+      "type": { "text": "type" },
+      "outcome": "complete",
+      "status": "active"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di1",
+      "status": "final",
+      "identifiedDateTime": "2023-02-08"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di2",
+      "status": "final",
+      "identifiedDateTime": "2016-11-12"
+    },
+    {
+      "resourceType": "DetectedIssue",
+      "id": "di3",
+      "status": "final"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueQuantity": { "value": 1.0 },
+      "effectiveInstant": "2015-02-07T13:28:17.239+02:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueQuantity": { "value": 1.8 },
+      "effectiveInstant": "2022-02-07T13:28:17.239+02:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "status": "final",
+      "code": { "text": "code" }
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o4",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueTime": "18:12:00"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o5",
+      "status": "final",
+      "code": { "text": "code" },
+      "valueTime": "18:32:00"
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is1",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" },
+      "numberOfSeries": 9
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is2",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" },
+      "numberOfSeries": 12
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "id": "is3",
+      "status": "available",
+      "subject": { "reference": "Patient/p1" }
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m1",
+      "url": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7",
+      "status": "active"
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m2",
+      "url": "urn:uuid:c4669fc3-0d14-4e54-a77f-525f6d4e8385",
+      "status": "active"
+    },
+    {
+      "resourceType": "Measure",
+      "id": "m3",
+      "status": "active"
+    },
+    {
+      "resourceType": "Task",
+      "id": "t1",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUrl": "http://example.org"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t2",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUrl": "http://another.example.org"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t3",
+      "intent": "order",
+      "status": "requested"
+    },
+    {
+      "resourceType": "Task",
+      "id": "t4",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueOid": "urn:oid:1.0"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t5",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueOid": "urn:oid:1.2.3"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t6",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUuid": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t7",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueUuid": "urn:uuid:c4669fc3-0d14-4e54-a77f-525f6d4e8385"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t8",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueId": "id1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Task",
+      "id": "t9",
+      "intent": "order",
+      "status": "requested",
+      "output": [
+        {
+          "type": { "text": "type" },
+          "valueId": "id2"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "base64Binary",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Device",
+        "status": "active",
+        "constant": [
+          {
+            "name": "aidc",
+            "valueBase64Binary": "aGVsbG8K"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "aidc",
+                "path": "udiCarrier.first().carrierAIDC = %aidc",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "d1",
+          "aidc": true
+        },
+        {
+          "id": "d2",
+          "aidc": false
+        },
+        {
+          "id": "d3",
+          "aidc": null
+        }
+      ]
+    },
+    {
+      "title": "code",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "gender",
+            "valueCode": "female"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "gender = %gender",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "bool": true
+        },
+        {
+          "id": "pt2",
+          "bool": false
+        },
+        {
+          "id": "pt3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "date",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "constant": [
+          {
+            "name": "bd",
+            "valueDate": "1978-03-12"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "birthDate = %bd",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "bool": true
+        },
+        {
+          "id": "pt2",
+          "bool": false
+        },
+        {
+          "id": "pt3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "dateTime",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "DetectedIssue",
+        "status": "active",
+        "constant": [
+          {
+            "name": "id_time",
+            "valueDateTime": "2016-11-12"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "identified.ofType(dateTime) = %id_time",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "di1",
+          "bool": false
+        },
+        {
+          "id": "di2",
+          "bool": true
+        },
+        {
+          "id": "di3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "decimal",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "v",
+            "valueDecimal": 1.2
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "value.ofType(Quantity).value < %v",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": true
+        },
+        {
+          "id": "o2",
+          "bool": false
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": null
+        },
+        {
+          "id": "o5",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "id",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "id",
+            "valueId": "id1"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(id) = %id",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": true
+        },
+        {
+          "id": "t9",
+          "bool": false
+        }
+      ]
+    },
+    {
+      "title": "instant",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "eff",
+            "valueInstant": "2015-02-07T13:28:17.239+02:00"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "effective.ofType(instant) = %eff",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": true
+        },
+        {
+          "id": "o2",
+          "bool": false
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": null
+        },
+        {
+          "id": "o5",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "oid",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "oid",
+            "valueOid": "urn:oid:1.0"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(oid) = %oid",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": true
+        },
+        {
+          "id": "t5",
+          "bool": false
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "positiveInt",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "ClaimResponse",
+        "status": "active",
+        "constant": [
+          {
+            "name": "seq",
+            "valuePositiveInt": 1
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "item.first().itemSequence = %seq",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "cr1",
+          "bool": true
+        },
+        {
+          "id": "cr2",
+          "bool": false
+        },
+        {
+          "id": "cr3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "time",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "constant": [
+          {
+            "name": "t",
+            "valueTime": "18:12:00"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "value.ofType(time) = %t",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "bool": null
+        },
+        {
+          "id": "o2",
+          "bool": null
+        },
+        {
+          "id": "o3",
+          "bool": null
+        },
+        {
+          "id": "o4",
+          "bool": true
+        },
+        {
+          "id": "o5",
+          "bool": false
+        }
+      ]
+    },
+    {
+      "title": "unsignedInt",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "ImagingStudy",
+        "status": "active",
+        "constant": [
+          {
+            "name": "series",
+            "valueUnsignedInt": 9
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "numberOfSeries = %series",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "is1",
+          "bool": true
+        },
+        {
+          "id": "is2",
+          "bool": false
+        },
+        {
+          "id": "is3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "uri",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Measure",
+        "status": "active",
+        "constant": [
+          {
+            "name": "uri",
+            "valueUri": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "url = %uri",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m1",
+          "bool": true
+        },
+        {
+          "id": "m2",
+          "bool": false
+        },
+        {
+          "id": "m3",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "url",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "url",
+            "valueUrl": "http://example.org"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(url) = %url",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": true
+        },
+        {
+          "id": "t2",
+          "bool": false
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": null
+        },
+        {
+          "id": "t7",
+          "bool": null
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    },
+    {
+      "title": "uuid",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Task",
+        "status": "active",
+        "constant": [
+          {
+            "name": "uuid",
+            "valueUuid": "urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "bool",
+                "path": "output.first().value.ofType(uuid) = %uuid",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "t1",
+          "bool": null
+        },
+        {
+          "id": "t2",
+          "bool": null
+        },
+        {
+          "id": "t3",
+          "bool": null
+        },
+        {
+          "id": "t4",
+          "bool": null
+        },
+        {
+          "id": "t5",
+          "bool": null
+        },
+        {
+          "id": "t6",
+          "bool": true
+        },
+        {
+          "id": "t7",
+          "bool": false
+        },
+        {
+          "id": "t8",
+          "bool": null
+        },
+        {
+          "id": "t9",
+          "bool": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fhirpath.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fhirpath.json
@@ -1,0 +1,412 @@
+{
+  "title": "fhirpath",
+  "description": "fhirpath features",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "managingOrganization": {
+        "reference": "Organization/o1"
+      },
+      "name": [
+        {
+          "family": "f1.1",
+          "use": "official",
+          "given": ["g1.1.1", "g1.1.2"]
+        },
+        {
+          "family": "f1.2",
+          "given": ["g1.2.1"]
+        }
+      ],
+      "active": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "managingOrganization": {
+        "reference": "http://myapp.com/prefix/Organization/o2"
+      },
+      "name": [
+        {
+          "family": "f2.1"
+        },
+        {
+          "family": "f2.2",
+          "use": "official"
+        }
+      ],
+      "active": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "one element",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "two elements + first",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.1"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "collection",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.family",
+                "type": "string",
+                "collection": true
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": ["f1.1", "f1.2"]
+        },
+        {
+          "v": ["f2.1", "f2.2"]
+        },
+        {
+          "v": []
+        }
+      ]
+    },
+    {
+      "title": "index[0]",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[0].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.1"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "index[1]",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[1].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.2"
+        },
+        {
+          "v": "f2.2"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "out of index",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name[2].family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": null
+        },
+        {
+          "v": null
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "where",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "v",
+                "path": "name.where(use='official').family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "v": "f1.1"
+        },
+        {
+          "v": "f2.2"
+        },
+        {
+          "v": null
+        }
+      ]
+    },
+    {
+      "title": "exists",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "has_name",
+                "path": "name.exists()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "has_name": true
+        },
+        {
+          "id": "pt2",
+          "has_name": true
+        },
+        {
+          "id": "pt3",
+          "has_name": false
+        }
+      ]
+    },
+    {
+      "title": "nested exists",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "has_given",
+                "path": "name.given.exists()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "has_given": true
+        },
+        {
+          "id": "pt2",
+          "has_given": false
+        },
+        {
+          "id": "pt3",
+          "has_given": false
+        }
+      ]
+    },
+    {
+      "title": "string join",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "given",
+                "path": "name.given.join(', ' )",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "given": "g1.1.1, g1.1.2, g1.2.1"
+        },
+        {
+          "id": "pt2",
+          "given": ""
+        },
+        {
+          "id": "pt3",
+          "given": ""
+        }
+      ]
+    },
+    {
+      "title": "string join: default separator",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "given",
+                "path": "name.given.join()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "given": "g1.1.1g1.1.2g1.2.1"
+        },
+        {
+          "id": "pt2",
+          "given": ""
+        },
+        {
+          "id": "pt3",
+          "given": ""
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fhirpath_numbers.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fhirpath_numbers.json
@@ -1,0 +1,103 @@
+{
+  "title": "fhirpath_numbers",
+  "description": "fhirpath features",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueRange": {
+        "low": {
+          "value": 2
+        },
+        "high": {
+          "value": 3
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "title": "add observation",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "add",
+                "path": "value.ofType(Range).low.value + value.ofType(Range).high.value",
+                "type": "decimal"
+              },
+              {
+                "name": "sub",
+                "path": "value.ofType(Range).high.value - value.ofType(Range).low.value",
+                "type": "decimal"
+              },
+              {
+                "name": "mul",
+                "path": "value.ofType(Range).low.value * value.ofType(Range).high.value",
+                "type": "decimal"
+              },
+              {
+                "name": "div",
+                "path": "value.ofType(Range).high.value / value.ofType(Range).low.value",
+                "type": "decimal"
+              },
+              {
+                "name": "eq",
+                "path": "value.ofType(Range).high.value = value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "gt",
+                "path": "value.ofType(Range).high.value > value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "ge",
+                "path": "value.ofType(Range).high.value >= value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "lt",
+                "path": "value.ofType(Range).high.value < value.ofType(Range).low.value",
+                "type": "boolean"
+              },
+              {
+                "name": "le",
+                "path": "value.ofType(Range).high.value <= value.ofType(Range).low.value",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "add": 5,
+          "sub": 1,
+          "mul": 6,
+          "div": 1.5,
+          "eq": false,
+          "gt": true,
+          "ge": true,
+          "lt": false,
+          "le": false
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_boundary.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_boundary.json
@@ -1,0 +1,362 @@
+{
+  "title": "fn_boundary",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueQuantity": {
+        "value": 1.0
+      }
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueDateTime": "2010-10-10"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o4",
+      "code": {
+        "text": "code"
+      },
+      "valueTime": "12:34"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "birthDate": "1970-06"
+    }
+  ],
+  "tests": [
+    {
+      "title": "decimal lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "decimal",
+                "path": "value.ofType(Quantity).value.lowBoundary()",
+                "type": "decimal"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "decimal": 0.95
+        },
+        {
+          "id": "o2",
+          "decimal": null
+        },
+        {
+          "id": "o3",
+          "decimal": null
+        },
+        {
+          "id": "o4",
+          "decimal": null
+        }
+      ]
+    },
+    {
+      "title": "decimal highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "decimal",
+                "path": "value.ofType(Quantity).value.highBoundary()",
+                "type": "decimal"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "decimal": 1.05
+        },
+        {
+          "id": "o2",
+          "decimal": null
+        },
+        {
+          "id": "o3",
+          "decimal": null
+        },
+        {
+          "id": "o4",
+          "decimal": null
+        }
+      ]
+    },
+    {
+      "title": "datetime lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "datetime",
+                "path": "value.ofType(dateTime).lowBoundary()",
+                "type": "dateTime"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "datetime": null
+        },
+        {
+          "id": "o2",
+          "datetime": "2010-10-10T00:00:00.000+14:00"
+        },
+        {
+          "id": "o3",
+          "datetime": null
+        },
+        {
+          "id": "o4",
+          "datetime": null
+        }
+      ]
+    },
+    {
+      "title": "datetime highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "datetime",
+                "path": "value.ofType(dateTime).highBoundary()",
+                "type": "dateTime"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "datetime": null
+        },
+        {
+          "id": "o2",
+          "datetime": "2010-10-10T23:59:59.999-12:00"
+        },
+        {
+          "id": "o3",
+          "datetime": null
+        },
+        {
+          "id": "o4",
+          "datetime": null
+        }
+      ]
+    },
+    {
+      "title": "date lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "date",
+                "path": "birthDate.lowBoundary()",
+                "type": "date"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "date": "1970-06-01"
+        }
+      ]
+    },
+    {
+      "title": "date highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "date",
+                "path": "birthDate.highBoundary()",
+                "type": "date"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "date": "1970-06-30"
+        }
+      ]
+    },
+    {
+      "title": "time lowBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "time",
+                "path": "value.ofType(time).lowBoundary()",
+                "type": "time"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "time": null
+        },
+        {
+          "id": "o2",
+          "time": null
+        },
+        {
+          "id": "o3",
+          "time": null
+        },
+        {
+          "id": "o4",
+          "time": "12:34:00.000"
+        }
+      ]
+    },
+    {
+      "title": "time highBoundary",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "time",
+                "path": "value.ofType(time).highBoundary()",
+                "type": "time"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "time": null
+        },
+        {
+          "id": "o2",
+          "time": null
+        },
+        {
+          "id": "o3",
+          "time": null
+        },
+        {
+          "id": "o4",
+          "time": "12:34:59.999"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_empty.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_empty.json
@@ -1,0 +1,57 @@
+{
+  "title": "fn_empty",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2"
+    }
+  ],
+  "tests": [
+    {
+      "title": "empty names",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "name_empty",
+                "path": "name.empty()",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "name_empty": false
+        },
+        {
+          "id": "p2",
+          "name_empty": true
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_extension.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_extension.json
@@ -1,0 +1,173 @@
+{
+  "title": "fn_extension",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": [
+        {
+          "id": "birthsex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          "valueCode": "F"
+        },
+        {
+          "id": "race",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "code": "2106-3",
+                "display": "White"
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Mixed"
+            }
+          ]
+        },
+        {
+          "id": "sex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
+          "valueCode": "248152002"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": [
+        {
+          "id": "birthsex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+          "valueCode": "M"
+        },
+        {
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          "id": "race",
+          "extension": [
+            {
+              "url": "ombCategory",
+              "valueCoding": {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "code": "2135-2",
+                "display": "Hispanic or Latino"
+              }
+            },
+            {
+              "url": "text",
+              "valueString": "Mixed"
+            }
+          ]
+        },
+        {
+          "id": "sex",
+          "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex",
+          "valueCode": "248152002"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3",
+      "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+      },
+      "extension": []
+    }
+  ],
+  "tests": [
+    {
+      "title": "simple extension",
+      "tags": ["shareable"],
+      "description": "flatten simple extension",
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "name": "birthsex",
+                "path": "extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex').value.ofType(code).first()",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "birthsex": "F"
+        },
+        {
+          "id": "pt2",
+          "birthsex": "M"
+        },
+        {
+          "id": "pt3",
+          "birthsex": null
+        }
+      ]
+    },
+    {
+      "title": "nested extension",
+      "tags": ["shareable"],
+      "description": "flatten simple extension",
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "name": "race_code",
+                "path": "extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension('ombCategory').value.ofType(Coding).code.first()",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "race_code": "2106-3"
+        },
+        {
+          "id": "pt2",
+          "race_code": "2135-2"
+        },
+        {
+          "id": "pt3",
+          "race_code": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_first.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_first.json
@@ -1,0 +1,77 @@
+{
+  "title": "fn_first",
+  "description": "FHIRPath `first` function.",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1",
+          "given": ["g1.1", "g1.2"]
+        },
+        {
+          "use": "usual",
+          "given": ["g2.1"]
+        },
+        {
+          "use": "maiden",
+          "family": "f3",
+          "given": ["g3.1", "g3.2"],
+          "period": {
+            "end": "2002"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "table level first()",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "name.first().use",
+                "name": "use",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "use": "official"
+        }
+      ]
+    },
+    {
+      "title": "table and field level first()",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "name.first().given.first()",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": "g1.1"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_join.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_join.json
@@ -1,0 +1,106 @@
+{
+  "title": "fn_join",
+  "description": "FHIRPath `join` function.",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "given": ["p1.g1", "p1.g2"]
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "join with comma",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join(',')",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1,p1.g2"
+        }
+      ]
+    },
+    {
+      "title": "join with empty value",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join('')",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1p1.g2"
+        }
+      ]
+    },
+    {
+      "title": "join with no value - default to no separator",
+      "tags": ["experimental"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "name.given.join()",
+                "name": "given",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1",
+          "given": "p1.g1p1.g2"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_oftype.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_oftype.json
@@ -1,0 +1,111 @@
+{
+  "title": "fn_oftype",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueString": "foo"
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "code": {
+        "text": "code"
+      },
+      "status": "final",
+      "valueInteger": 42
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o3",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    }
+  ],
+  "tests": [
+    {
+      "title": "select string values",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "value.ofType(string)",
+                "name": "string_value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "string_value": "foo"
+        },
+        {
+          "id": "o2",
+          "string_value": null
+        },
+        {
+          "id": "o3",
+          "string_value": null
+        }
+      ]
+    },
+    {
+      "title": "select integer values",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              },
+              {
+                "path": "value.ofType(integer)",
+                "name": "integer_value",
+                "type": "integer"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1",
+          "integer_value": null
+        },
+        {
+          "id": "o2",
+          "integer_value": 42
+        },
+        {
+          "id": "o3",
+          "integer_value": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/fn_reference_keys.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/fn_reference_keys.json
@@ -1,0 +1,109 @@
+{
+  "title": "fn_reference_keys",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p1"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p3"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "getReferenceKey result matches getResourceKey without type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey()",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with right type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Patient)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with wrong type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Observation)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": null
+        },
+        {
+          "key_equal_ref": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/foreach.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/foreach.json
@@ -1,0 +1,832 @@
+{
+  "title": "foreach",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "F1.1"
+        },
+        {
+          "family": "F1.2"
+        }
+      ],
+      "contact": [
+        {
+          "telecom": [
+            {
+              "system": "phone"
+            }
+          ],
+          "name": {
+            "family": "FC1.1",
+            "given": ["N1", "N1`"]
+          }
+        },
+        {
+          "telecom": [
+            {
+              "system": "email"
+            }
+          ],
+          "gender": "unknown",
+          "name": {
+            "family": "FC1.2",
+            "given": ["N2"]
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "F2.1"
+        },
+        {
+          "family": "F2.2"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "forEach: normal",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1"
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull: basic",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1"
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1"
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2"
+        },
+        {
+          "id": "pt3",
+          "family": null
+        }
+      ]
+    },
+    {
+      "title": "forEach: empty",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "forEach: two on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "cont_family",
+                "path": "name.family",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "pat_family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "pat_family": "F1.1",
+          "cont_family": "FC1.1"
+        },
+        {
+          "pat_family": "F1.1",
+          "cont_family": "FC1.2"
+        },
+        {
+          "pat_family": "F1.2",
+          "cont_family": "FC1.1"
+        },
+        {
+          "pat_family": "F1.2",
+          "cont_family": "FC1.2"
+        }
+      ]
+    },
+    {
+      "title": "forEach: two on the same level (empty result)",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "forEachOrNull: null case",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "value": null
+        },
+        {
+          "id": "pt3",
+          "value": null
+        }
+      ]
+    },
+    {
+      "title": "forEach and forEachOrNull on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "identifier",
+            "column": [
+              {
+                "name": "value",
+                "path": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "family": "F1.1",
+          "value": null
+        },
+        {
+          "id": "pt1",
+          "family": "F1.2",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "family": "F2.1",
+          "value": null
+        },
+        {
+          "id": "pt2",
+          "family": "F2.2",
+          "value": null
+        }
+      ]
+    },
+    {
+      "title": "nested forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "contact_type",
+                    "path": "telecom.system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "$this",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "contact_type": "phone",
+          "name": "N1",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "phone",
+          "name": "N1`",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "email",
+          "name": "N2",
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "nested forEach: select & column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "contact_type",
+                "path": "telecom.system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "name": "name",
+                    "path": "$this",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "contact_type": "phone",
+          "name": "N1",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "phone",
+          "name": "N1`",
+          "id": "pt1"
+        },
+        {
+          "contact_type": "email",
+          "name": "N2",
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull & unionAll on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "contact",
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1`"
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2"
+        },
+        {
+          "id": "pt1",
+          "name": "N2"
+        },
+        {
+          "id": "pt2",
+          "name": null
+        },
+        {
+          "id": "pt3",
+          "name": null
+        }
+      ]
+    },
+    {
+      "title": "forEach & unionAll on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1"
+        },
+        {
+          "id": "pt1",
+          "name": "N1`"
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2"
+        },
+        {
+          "id": "pt1",
+          "name": "N2"
+        }
+      ]
+    },
+    {
+      "title": "forEach & unionAll & column & select on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "path": "telecom.system",
+                "name": "tel_system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "gender",
+                    "name": "gender",
+                    "type": "code"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1`",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt1",
+          "name": "N2",
+          "tel_system": "email",
+          "gender": "unknown"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull & unionAll & column & select on the same level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "contact",
+            "column": [
+              {
+                "path": "telecom.system",
+                "name": "tel_system",
+                "type": "code"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "gender",
+                    "name": "gender",
+                    "type": "code"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "name.family",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name.given",
+                "column": [
+                  {
+                    "path": "$this",
+                    "name": "name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name": "FC1.1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "N1`",
+          "tel_system": "phone",
+          "gender": null
+        },
+        {
+          "id": "pt1",
+          "name": "FC1.2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt1",
+          "name": "N2",
+          "tel_system": "email",
+          "gender": "unknown"
+        },
+        {
+          "id": "pt2",
+          "name": null,
+          "tel_system": null,
+          "gender": null
+        },
+        {
+          "id": "pt3",
+          "name": null,
+          "tel_system": null,
+          "gender": null
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/logic.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/logic.json
@@ -1,0 +1,125 @@
+{
+  "title": "logic",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "m0",
+      "gender": "male",
+      "deceasedBoolean": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "f0",
+      "deceasedBoolean": false,
+      "gender": "female"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "m1",
+      "gender": "male",
+      "deceasedBoolean": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "f1",
+      "gender": "female"
+    }
+  ],
+  "tests": [
+    {
+      "title": "filtering with 'and'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "gender = 'male' and deceased.ofType(boolean) = false"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m0"
+        }
+      ]
+    },
+    {
+      "title": "filtering with 'or'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "gender = 'male' or deceased.ofType(boolean) = false"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "m0"
+        },
+        {
+          "id": "f0"
+        },
+        {
+          "id": "m1"
+        }
+      ]
+    },
+    {
+      "title": "filtering with 'not'",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "where": [
+          {
+            "path": "(gender = 'male').not()"
+          }
+        ],
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "f0"
+        },
+        {
+          "id": "f1"
+        }
+      ]
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/union.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/union.json
@@ -1,0 +1,842 @@
+{
+  "title": "union",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "telecom": [
+        {
+          "value": "t1.1",
+          "system": "phone"
+        },
+        {
+          "value": "t1.2",
+          "system": "fax"
+        },
+        {
+          "value": "t1.3",
+          "system": "email"
+        }
+      ],
+      "contact": [
+        {
+          "telecom": [
+            {
+              "value": "t1.c1.1",
+              "system": "pager"
+            }
+          ]
+        },
+        {
+          "telecom": [
+            {
+              "value": "t1.c2.1",
+              "system": "url"
+            },
+            {
+              "value": "t1.c2.2",
+              "system": "sms"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "telecom": [
+        {
+          "value": "t2.1",
+          "system": "phone"
+        },
+        {
+          "value": "t2.2",
+          "system": "fax"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3",
+      "contact": [
+        {
+          "telecom": [
+            {
+              "value": "t3.c1.1",
+              "system": "email"
+            },
+            {
+              "value": "t3.c1.2",
+              "system": "pager"
+            }
+          ]
+        },
+        {
+          "telecom": [
+            {
+              "value": "t3.c2.1",
+              "system": "sms"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt4"
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c1.1",
+          "sys": "pager",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.1",
+          "sys": "url",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.2",
+          "sys": "sms",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t3.c1.1",
+          "sys": "email",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c1.2",
+          "sys": "pager",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c2.1",
+          "sys": "sms",
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "unionAll + column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c1.1",
+          "sys": "pager",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.1",
+          "sys": "url",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.c2.2",
+          "sys": "sms",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t3.c1.1",
+          "sys": "email",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c1.2",
+          "sys": "pager",
+          "id": "pt3"
+        },
+        {
+          "tel": "t3.c2.1",
+          "sys": "sms",
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "duplicates",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.1",
+          "sys": "phone",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.2",
+          "sys": "fax",
+          "id": "pt1"
+        },
+        {
+          "tel": "t1.3",
+          "sys": "email",
+          "id": "pt1"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.1",
+          "sys": "phone",
+          "id": "pt2"
+        },
+        {
+          "tel": "t2.2",
+          "sys": "fax",
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "empty results",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "empty with forEachOrNull",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        }
+      ]
+    },
+    {
+      "title": "forEachOrNull and forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEachOrNull": "name",
+                "column": [
+                  {
+                    "name": "given",
+                    "path": "given",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "given": null,
+          "id": "pt1"
+        },
+        {
+          "given": null,
+          "id": "pt2"
+        },
+        {
+          "given": null,
+          "id": "pt3"
+        },
+        {
+          "given": null,
+          "id": "pt4"
+        }
+      ]
+    },
+    {
+      "title": "nested",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ],
+            "unionAll": [
+              {
+                "forEach": "telecom[0]",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "unionAll": [
+                  {
+                    "forEach": "telecom[0]",
+                    "column": [
+                      {
+                        "name": "tel",
+                        "path": "value",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "forEach": "contact.telecom[0]",
+                    "column": [
+                      {
+                        "name": "tel",
+                        "path": "value",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "tel": "t1.1"
+        },
+        {
+          "id": "pt1",
+          "tel": "t1.1"
+        },
+        {
+          "id": "pt1",
+          "tel": "t1.c1.1"
+        },
+        {
+          "id": "pt2",
+          "tel": "t2.1"
+        },
+        {
+          "id": "pt2",
+          "tel": "t2.1"
+        },
+        {
+          "id": "pt3",
+          "tel": "t3.c1.1"
+        }
+      ]
+    },
+    {
+      "title": "one empty operand",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "telecom.where(false)",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact.telecom",
+                "column": [
+                  {
+                    "name": "tel",
+                    "path": "value",
+                    "type": "string"
+                  },
+                  {
+                    "name": "sys",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "sys": "pager",
+          "tel": "t1.c1.1"
+        },
+        {
+          "id": "pt1",
+          "sys": "url",
+          "tel": "t1.c2.1"
+        },
+        {
+          "id": "pt1",
+          "sys": "sms",
+          "tel": "t1.c2.2"
+        },
+        {
+          "id": "pt3",
+          "sys": "email",
+          "tel": "t3.c1.1"
+        },
+        {
+          "id": "pt3",
+          "sys": "pager",
+          "tel": "t3.c1.2"
+        },
+        {
+          "id": "pt3",
+          "sys": "sms",
+          "tel": "t3.c2.1"
+        }
+      ]
+    },
+    {
+      "title": "column mismatch",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "c",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "column order mismatch",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "name": "b",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "a",
+                    "path": "id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/validate.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/validate.json
@@ -1,0 +1,99 @@
+{
+  "title": "validate",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "name": [
+        {
+          "family": "F1.1"
+        }
+      ],
+      "id": "pt1"
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2"
+    }
+  ],
+  "tests": [
+    {
+      "title": "empty",
+      "tags": ["shareable"],
+      "view": {},
+      "expectError": true
+    },
+    {
+      "title": "missing resource",
+      "tags": ["shareable"],
+      "view": {
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "wrong fhirpath",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": "@@"
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "wrong type in forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "forEach": 1
+          }
+        ]
+      },
+      "expectError": true
+    },
+    {
+      "title": "where with path resolving to not boolean",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family"
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/view_resource.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/view_resource.json
@@ -1,0 +1,95 @@
+{
+  "title": "view_resource",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "id": "pt1",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "pt2",
+      "resourceType": "Patient"
+    },
+    {
+      "id": "ob1",
+      "resourceType": "Observation",
+      "code": {
+        "text": "code"
+      },
+      "status": "final"
+    }
+  ],
+  "tests": [
+    {
+      "title": "only pts",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "only obs",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "ob1"
+        }
+      ]
+    },
+    {
+      "title": "resource not specified",
+      "tags": ["shareable"],
+      "view": {
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expectError": true
+    }
+  ]
+}

--- a/org.hl7.fhir.r5/src/test/resources/sof/where.json
+++ b/org.hl7.fhir.r5/src/test/resources/sof/where.json
@@ -1,0 +1,279 @@
+{
+  "title": "where",
+  "description": "FHIRPath `where` function.",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "name": [
+        {
+          "use": "nickname",
+          "family": "f2"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p3",
+      "name": [
+        {
+          "use": "nickname",
+          "given": ["g3"],
+          "family": "f3"
+        }
+      ]
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "valueInteger": 12
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "valueInteger": 10
+    }
+  ],
+  "tests": [
+    {
+      "title": "simple where path with result",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with no results",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'maiden').exists()"
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "where path with greater than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) > 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1"
+        }
+      ]
+    },
+    {
+      "title": "where path with less than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) < 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o2"
+        }
+      ]
+    },
+    {
+      "title": "multiple where paths",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          },
+          {
+            "path": "name.where(family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'and' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' and family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'or' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' or family = 'f2').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p2"
+        }
+      ]
+    },
+    {
+      "title": "where path that evaluates to true when empty",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(family = 'f2').empty()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p3"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR implements a test runner for SQL on FHIR functionality that executes the tests within the official SQL on FHIR v2 test suite.

It includes the following test classes in both the R4 and R5 modules:

- **SqlOnFhirRunnerTests.java**: Parameterised JUnit test runner that loads and executes SQL on FHIR test cases from JSON files
- **TestProvider.java**: In-memory FHIR resource provider for test execution
- **TestReportGenerator.java**: Generates structured test reports with pass/fail statistics
- **TestStorage.java**: Test implementation of SQL on FHIR storage interface

I didn't make any attempt to de-duplicate code here, happy to look at that if you think it is desirable. I also just copied in the SQL on FHIR test cases. We could look at other approaches to this, such as Git submodules, but I didn't want to add this without any precedent within this repository.

The SQL on FHIR tests don't fail the build if they don't pass - they emit a JSON report into the target folder. It would be great if we could publish this to GitHub pages so that we can include it on the [implementations page](https://sql-on-fhir.org/extra/impls.html).

There are some failures, I anticipate that we can address these in follow-up PRs once the test reporting is in place.

/cc @grahamegrieve