### PR TITLE
Add tests to Params in preparation for more refactoring

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/Params.java
@@ -18,7 +18,6 @@ import org.hl7.fhir.utilities.validation.ValidationOptions.R5BundleRelativeRefer
 import org.hl7.fhir.validation.service.model.ValidationContext;
 import org.hl7.fhir.validation.service.model.HtmlInMarkdownCheck;
 import org.hl7.fhir.validation.service.ValidatorWatchMode;
-import org.hl7.fhir.validation.service.utils.EngineMode;
 import org.hl7.fhir.validation.service.utils.QuestionnaireMode;
 import org.hl7.fhir.validation.service.utils.ValidationLevel;
 
@@ -117,7 +116,7 @@ public class Params {
   public static final String SHOW_TIMES = "-show-times";
   public static final String ALLOW_EXAMPLE_URLS = "-allow-example-urls";
   public static final String OUTPUT_STYLE = "-output-style";
-  public static final String ADVSIOR_FILE = "-advisor-file";
+  public static final String ADVISOR_FILE = "-advisor-file";
   public static final String DO_IMPLICIT_FHIRPATH_STRING_CONVERSION = "-implicit-fhirpath-string-conversions";
   public static final String JURISDICTION = "-jurisdiction";
   public static final String HTML_IN_MARKDOWN = "-html-in-markdown";
@@ -220,21 +219,21 @@ public class Params {
       } else if (args[i].equals(HTTPS_PROXY)) {
         i++;
       } else if (args[i].equals(PROFILE)) {
-        String p = null;
+        String profile = null;
         if (i + 1 == args.length) {
           throw new Error("Specified -profile without indicating profile url");
         } else {
-          p = args[++i];
-          validationContext.addProfile(p);
+          profile = args[++i];
+          validationContext.addProfile(profile);
         }
       } else if (args[i].equals(PROFILES)) {
-        String p = null;
+        String profiles = null;
         if (i + 1 == args.length) {
           throw new Error("Specified -profiles without indicating profile urls");
         } else {
-          p = args[++i];
-          for (String s : p.split("\\,")) {
-            validationContext.addProfile(s);
+          profiles = args[++i];
+          for (String profile : profiles.split("\\,")) {
+            validationContext.addProfile(profile);
           }
         }
       } else if (args[i].equals(OPTION)) {
@@ -268,7 +267,7 @@ public class Params {
         } else {
           profile = args[++i];
         }
-        validationContext.getBundleValidationRules().add(new BundleValidationRule().setRule(rule).setProfile(profile));
+        validationContext.addBundleValidationRule(new BundleValidationRule().setRule(rule).setProfile(profile));
       } else if (args[i].equals(QUESTIONNAIRE)) {
         if (i + 1 == args.length)
           throw new Error("Specified -questionnaire without indicating questionnaire mode");
@@ -287,15 +286,15 @@ public class Params {
         if (i + 1 == args.length)
           throw new Error("Specified -mode without indicating mode");
         else {
-          String q = args[++i];
-          validationContext.getModeParams().add(q);
+          String mode = args[++i];
+          validationContext.addModeParam(mode);
         }
       } else if (args[i].equals(INPUT)) {
         if (i + 1 == args.length)
           throw new Error("Specified -input without providing value");
         else {
-          String inp = args[++i];
-          validationContext.getInputs().add(inp);
+          String input = args[++i];
+          validationContext.addInput(input);
         }
       } else if (args[i].equals(NATIVE)) {
         validationContext.setDoNative(true);
@@ -366,27 +365,27 @@ public class Params {
       } else if (args[i].equals(PACKAGE_NAME)) {
         validationContext.setPackageName(args[++i]);
       } else if (args[i].equals(TX_PACK)) {
-        String pn = args[++i];
-        if (pn != null) {
-          if (pn.contains(",")) {
-            for (String s : pn.split("\\,")) {
-              validationContext.getIgs().add(s);
+        String packageArg = args[++i];
+        if (packageArg != null) {
+          if (packageArg.contains(",")) {
+            for (String packageName : packageArg.split("\\,")) {
+              validationContext.getIgs().add(packageName);
             }
           } else {
-            validationContext.getIgs().add(pn);
+            validationContext.getIgs().add(packageArg);
           }
         }
-        validationContext.getModeParams().add("tx");
-        validationContext.getModeParams().add("expansions");
+        validationContext.addModeParam("tx");
+        validationContext.addModeParam("expansions");
       } else if (args[i].equals(RE_PACK)) {
-        String pn = args[++i];
-        if (pn != null) {
-          if (pn.contains(",")) {
-            for (String s : pn.split("\\,")) {
-              validationContext.getIgs().add(s);
+        String packageArg = args[++i];
+        if (packageArg != null) {
+          if (packageArg.contains(",")) {
+            for (String packageName : packageArg.split("\\,")) {
+              validationContext.getIgs().add(packageName);
             }
           } else {
-            validationContext.getIgs().add(pn);
+            validationContext.getIgs().add(packageArg);
           }
         }
         validationContext.getModeParams().add("tx");
@@ -456,7 +455,7 @@ public class Params {
         validationContext.setShowTimes(true);
       } else if (args[i].equals(OUTPUT_STYLE)) {
         validationContext.setOutputStyle(args[++i]);
-      } else if (args[i].equals(ADVSIOR_FILE)) {
+      } else if (args[i].equals(ADVISOR_FILE)) {
         validationContext.setAdvisorFile(args[++i]);
         File f = ManagedFileAccess.file(validationContext.getAdvisorFile());
         if (!f.exists()) {

--- a/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/param/ParamsValidationContextTests.java
+++ b/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/param/ParamsValidationContextTests.java
@@ -1,0 +1,406 @@
+package org.hl7.fhir.validation.cli.param;
+
+
+import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
+import org.hl7.fhir.r5.utils.validation.constants.BestPracticeWarningLevel;
+import org.hl7.fhir.utilities.validation.ValidationOptions.R5BundleRelativeReferencePolicy;
+import org.hl7.fhir.validation.service.ValidatorWatchMode;
+import org.hl7.fhir.validation.service.model.HtmlInMarkdownCheck;
+import org.hl7.fhir.validation.service.model.ValidationContext;
+import org.hl7.fhir.validation.service.utils.QuestionnaireMode;
+import org.hl7.fhir.validation.service.utils.ValidationLevel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ParamsValidationContextTests {
+
+  // Created by Claude Sonnet 4.5
+  public static Stream<Arguments> testCases() {
+    List<Arguments> objects = new ArrayList<>();
+    //Base case
+    objects.add(Arguments.of(
+      "source",
+      new ValidationContext().addSource("source")));
+
+    //IGs
+    objects.add(Arguments.of(
+      "-ig implementation.guide#1.2.3 source",
+      new ValidationContext().addSource("source").addIg("implementation.guide#1.2.3")));
+
+    // Output tests
+    objects.add(Arguments.of(
+      "-output output.json source",
+      new ValidationContext().addSource("source").setOutput("output.json")));
+
+    objects.add(Arguments.of(
+      "-outputSuffix json source",
+      new ValidationContext().addSource("source").setOutputSuffix("json")));
+
+    objects.add(Arguments.of(
+      "-html-output report.html source",
+      new ValidationContext().addSource("source").setHtmlOutput("report.html")));
+
+    // Profile tests
+    objects.add(Arguments.of(
+      "-profile https://example.org/profile source",
+      new ValidationContext().addSource("source").addProfile("https://example.org/profile")));
+
+    objects.add(Arguments.of(
+      "-profiles https://ex.org/p1,https://ex.org/p2 source",
+      new ValidationContext().addSource("source").addProfile("https://ex.org/p1").addProfile("https://ex.org/p2")));
+
+    // Options tests
+    objects.add(Arguments.of(
+      "-option narrative source",
+      new ValidationContext().addSource("source").addOption("narrative")));
+
+    objects.add(Arguments.of(
+      "-options narrative,meta source",
+      new ValidationContext().addSource("source").addOption("narrative").addOption("meta")));
+
+    // Bundle tests
+    objects.add(Arguments.of(
+      "-bundle Composition:0 http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition source",
+      new ValidationContext().addSource("source").addBundleValidationRule(new BundleValidationRule().setRule("Composition:0").setProfile("http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition"))));
+
+    // Mode tests
+    objects.add(Arguments.of(
+      "-questionnaire check source",
+      new ValidationContext().addSource("source").setQuestionnaireMode(QuestionnaireMode.CHECK)));
+
+    objects.add(Arguments.of(
+      "-questionnaire none source",
+      new ValidationContext().addSource("source").setQuestionnaireMode(QuestionnaireMode.NONE)));
+
+    objects.add(Arguments.of(
+      "-questionnaire required source",
+      new ValidationContext().addSource("source").setQuestionnaireMode(QuestionnaireMode.REQUIRED)));
+
+
+    objects.add(Arguments.of(
+      "-level hints source",
+      new ValidationContext().addSource("source").setLevel(ValidationLevel.HINTS)));
+
+    objects.add(Arguments.of(
+      "-level warnings source",
+      new ValidationContext().addSource("source").setLevel(ValidationLevel.WARNINGS)));
+
+    objects.add(Arguments.of(
+      "-level errors source",
+      new ValidationContext().addSource("source").setLevel(ValidationLevel.ERRORS)));
+
+    objects.add(Arguments.of(
+      "-mode cnt source",
+      new ValidationContext().addSource("source").addModeParam("cnt")));
+
+    objects.add(Arguments.of(
+      "-input input.json source",
+      new ValidationContext().addSource("source").addInput("input.json")));
+
+    // Boolean flag tests
+    objects.add(Arguments.of(
+      "-native source",
+      new ValidationContext().addSource("source").setDoNative(true)));
+
+    objects.add(Arguments.of(
+      "-assumeValidRestReferences source",
+      new ValidationContext().addSource("source").setAssumeValidRestReferences(true)));
+
+    objects.add(Arguments.of(
+      "-check-references source",
+      new ValidationContext().addSource("source").setCheckReferences(true)));
+
+    objects.add(Arguments.of(
+      "-recurse source",
+      new ValidationContext().addSource("source").setRecursive(true)));
+
+    objects.add(Arguments.of(
+      "-showReferenceMessages source",
+      new ValidationContext().addSource("source").setShowMessagesFromReferences(true)));
+
+    objects.add(Arguments.of(
+      "-implicit-fhirpath-string-conversions source",
+      new ValidationContext().addSource("source").setDoImplicitFHIRPathStringConversion(true)));
+
+    objects.add(Arguments.of(
+      "-security-checks source",
+      new ValidationContext().addSource("source").setSecurityChecks(true)));
+
+    objects.add(Arguments.of(
+      "-crumb-trails source",
+      new ValidationContext().addSource("source").setCrumbTrails(true)));
+
+    objects.add(Arguments.of(
+      "-show-message-ids source",
+      new ValidationContext().addSource("source").setShowMessageIds(true)));
+
+    objects.add(Arguments.of(
+      "-forPublication source",
+      new ValidationContext().addSource("source").setForPublication(true)));
+
+    objects.add(Arguments.of(
+      "-verbose source",
+      new ValidationContext().addSource("source").setCrumbTrails(true).setShowMessageIds(true)));
+
+    objects.add(Arguments.of(
+      "-no-internal-caching source",
+      new ValidationContext().addSource("source").setNoInternalCaching(true)));
+
+    objects.add(Arguments.of(
+      "-no-extensible-binding-warnings source",
+      new ValidationContext().addSource("source").setNoExtensibleBindingMessages(true)));
+
+    objects.add(Arguments.of(
+      "-allow-double-quotes-in-fhirpath source",
+      new ValidationContext().addSource("source").setAllowDoubleQuotesInFHIRPath(true)));
+
+    objects.add(Arguments.of(
+      "-disable-default-resource-fetcher source",
+      new ValidationContext().addSource("source").setDisableDefaultResourceFetcher(true)));
+
+    objects.add(Arguments.of(
+      "-check-ips-codes source",
+      new ValidationContext().addSource("source").setCheckIPSCodes(true)));
+
+    objects.add(Arguments.of(
+      "-no_unicode_bidi_control_chars source",
+      new ValidationContext().addSource("source").setNoUnicodeBiDiControlChars(true)));
+
+    objects.add(Arguments.of(
+      "-no-invariants source",
+      new ValidationContext().addSource("source").setNoInvariants(true)));
+
+    objects.add(Arguments.of(
+      "-display-issues-are-warnings source",
+      new ValidationContext().addSource("source").setDisplayWarnings(true)));
+
+    objects.add(Arguments.of(
+      "-want-invariants-in-messages source",
+      new ValidationContext().addSource("source").setWantInvariantsInMessages(true)));
+
+    objects.add(Arguments.of(
+      "-hintAboutNonMustSupport source",
+      new ValidationContext().addSource("source").setHintAboutNonMustSupport(true)));
+
+    objects.add(Arguments.of(
+      "-unknown-codesystems-cause-errors source",
+      new ValidationContext().addSource("source").setUnknownCodeSystemsCauseErrors(true)));
+
+    objects.add(Arguments.of(
+      "-no-experimental-content source",
+      new ValidationContext().addSource("source").setNoExperimentalContent(true)));
+
+    // Advanced parameter tests
+    objects.add(Arguments.of(
+      "-sct us source",
+      new ValidationContext().addSource("source").setSnomedCT("us")));
+
+    objects.add(Arguments.of(
+      "-locale en-US source",
+      new ValidationContext().addSource("source").setLocale(Locale.forLanguageTag("en-US"))));
+
+    objects.add(Arguments.of(
+      "-extension https://example.org/ext source",
+      new ValidationContext().addSource("source").addExtension("https://example.org/ext")));
+
+    objects.add(Arguments.of(
+      "-to-version 5.0 source",
+      new ValidationContext().addSource("source").setTargetVer("5.0")));
+
+    objects.add(Arguments.of(
+      "-package-name my.package source",
+      new ValidationContext().addSource("source").setPackageName("my.package")));
+
+    objects.add(Arguments.of(
+      "-tx-pack hl7.terminology source",
+      new ValidationContext().addSource("source").addIg("hl7.terminology").addModeParam("tx").addModeParam("expansions")));
+
+    objects.add(Arguments.of(
+      "-tx-pack hl7.terminology,some.other.package source",
+      new ValidationContext().addSource("source").addIg("hl7.terminology").addIg("some.other.package").addModeParam("tx").addModeParam("expansions")));
+
+    objects.add(Arguments.of(
+      "-pin source",
+      new ValidationContext().addSource("source").addModeParam("pin")));
+
+    objects.add(Arguments.of(
+      "-expand source",
+      new ValidationContext().addSource("source").addModeParam("expand")));
+
+    objects.add(Arguments.of(
+      "-do-native source",
+      new ValidationContext().addSource("source").setCanDoNative(true)));
+
+    objects.add(Arguments.of(
+      "-no-native source",
+      new ValidationContext().addSource("source").setCanDoNative(false)));
+
+    objects.add(Arguments.of(
+      "-transform map.fml source",
+      new ValidationContext().addSource("source").setMap("map.fml")));
+
+    objects.add(Arguments.of(
+      "-format json source",
+      new ValidationContext().addSource("source").setFormat(FhirFormat.JSON)));
+
+    objects.add(Arguments.of(
+      "-format xml source",
+      new ValidationContext().addSource("source").setFormat(FhirFormat.XML)));
+
+    objects.add(Arguments.of(
+      "-format ttl source",
+      new ValidationContext().addSource("source").setFormat(FhirFormat.TURTLE)));
+
+    objects.add(Arguments.of(
+      "-lang-transform translate.map source",
+      new ValidationContext().addSource("source").setLangTransform("translate.map")));
+
+    objects.add(Arguments.of(
+      "-expansion-parameters params.json source",
+      new ValidationContext().addSource("source").setExpansionParameters("params.json")));
+
+    objects.add(Arguments.of(
+      "-html-in-markdown warning source",
+      new ValidationContext().addSource("source").setHtmlInMarkdownCheck(HtmlInMarkdownCheck.WARNING)));
+
+    objects.add(Arguments.of(
+      "-html-in-markdown ignore source",
+      new ValidationContext().addSource("source").setHtmlInMarkdownCheck(HtmlInMarkdownCheck.NONE)));
+
+    objects.add(Arguments.of(
+      "-html-in-markdown error source",
+      new ValidationContext().addSource("source").setHtmlInMarkdownCheck(HtmlInMarkdownCheck.ERROR)));
+
+
+    objects.add(Arguments.of(
+      "-best-practice error source",
+      new ValidationContext().addSource("source").setBestPracticeLevel(BestPracticeWarningLevel.Error)));
+
+    objects.add(Arguments.of(
+      "-allow-example-urls true source",
+      new ValidationContext().addSource("source").setAllowExampleUrls(true)));
+
+    objects.add(Arguments.of(
+      "-allow-example-urls false source",
+      new ValidationContext().addSource("source").setAllowExampleUrls(false)));
+
+    objects.add(Arguments.of(
+      "-tx-routing source",
+      new ValidationContext().addSource("source").setShowTerminologyRouting(true)));
+
+    objects.add(Arguments.of(
+      "-clear-tx-cache source",
+      new ValidationContext().addSource("source").setClearTxCache(true)));
+
+    objects.add(Arguments.of(
+      "-show-times source",
+      new ValidationContext().addSource("source").setShowTimes(true)));
+
+    objects.add(Arguments.of(
+      "-output-style compact source",
+      new ValidationContext().addSource("source").setOutputStyle("compact")));
+
+    objects.add(Arguments.of(
+      "-tx n/a source",
+      new ValidationContext().addSource("source").setTxServer(null).setNoEcosystem(true)));
+
+    objects.add(Arguments.of(
+      "-txLog tx.log source",
+      new ValidationContext().addSource("source").setTxLog("tx.log")));
+
+    objects.add(Arguments.of(
+      "-txCache cache/ source",
+      new ValidationContext().addSource("source").setTxCache("cache/")));
+
+    objects.add(Arguments.of(
+      "-log map.log source",
+      new ValidationContext().addSource("source").setMapLog("map.log")));
+
+    objects.add(Arguments.of(
+      "-language de source",
+      new ValidationContext().addSource("source").setLang("de")));
+
+    objects.add(Arguments.of(
+      "-src-lang en source",
+      new ValidationContext().addSource("source").setSrcLang("en")));
+
+    objects.add(Arguments.of(
+      "-tgt-lang de source",
+      new ValidationContext().addSource("source").setTgtLang("de")));
+
+    objects.add(Arguments.of(
+      "-map transform.map source",
+      new ValidationContext().addSource("source").setMap("transform.map")));
+
+    objects.add(Arguments.of(
+      "-compile compile.map source",
+      new ValidationContext().addSource("source").setMap("compile.map")));
+
+    objects.add(Arguments.of(
+      "-watch-mode all source",
+      new ValidationContext().addSource("source").setWatchMode(ValidatorWatchMode.ALL)));
+
+    objects.add(Arguments.of(
+      "-watch-mode none source",
+      new ValidationContext().addSource("source").setWatchMode(ValidatorWatchMode.NONE)));
+
+    objects.add(Arguments.of(
+      "-watch-mode single source",
+      new ValidationContext().addSource("source").setWatchMode(ValidatorWatchMode.SINGLE)));
+
+    objects.add(Arguments.of(
+      "-watch-mode all -watch-scan-delay 1000 -watch-settle-time 500 source",
+      new ValidationContext().addSource("source")
+        .setWatchMode(ValidatorWatchMode.ALL)
+        .setWatchScanDelay(1000)
+        .setWatchSettleTime(500)));
+
+    objects.add(Arguments.of(
+      "-fhirpath Patient.name.given source",
+      new ValidationContext().addSource("source").setFhirpath("Patient.name.given")));
+
+    objects.add(Arguments.of(
+      "-resolution-context https://example.org source",
+      new ValidationContext().addSource("source").setResolutionContext("https://example.org")));
+
+    objects.add(Arguments.of(
+      "-ai-service openai source",
+      new ValidationContext().addSource("source").setAIService("openai")));
+
+    objects.add(Arguments.of(
+      "r5-bundle-relative-reference-policy always source",
+      new ValidationContext().addSource("source").setR5BundleRelativeReferencePolicy(R5BundleRelativeReferencePolicy.ALWAYS)));
+
+    objects.add(Arguments.of(
+      "r5-bundle-relative-reference-policy default source",
+      new ValidationContext().addSource("source").setR5BundleRelativeReferencePolicy(R5BundleRelativeReferencePolicy.DEFAULT)));
+
+    objects.add(Arguments.of(
+      "r5-bundle-relative-reference-policy never source",
+      new ValidationContext().addSource("source").setR5BundleRelativeReferencePolicy(R5BundleRelativeReferencePolicy.NEVER)));
+
+
+    // Multiple sources test
+    objects.add(Arguments.of(
+      "source1 source2 source3",
+      new ValidationContext().addSource("source1").addSource("source2").addSource("source3")));
+
+    return objects.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  void testParamsToValidationContext(String argsLine, ValidationContext expectedValidationContext) throws Exception {
+    ValidationContext actualValidationContext = Params.loadValidationContext(argsLine.split("\\s"));
+    assertThat(actualValidationContext).isEqualTo(expectedValidationContext);
+  }
+}

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContext.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContext.java
@@ -460,6 +460,11 @@ public class ValidationContext {
     return this;
   }
 
+  public ValidationContext addBundleValidationRule(BundleValidationRule bundleValidationRule) {
+    this.bundleValidationRules.add(bundleValidationRule);
+    return this;
+  }
+
   public ValidationContext addIg(String ig) {
     if (this.igs == null) {
       this.igs = new ArrayList<>();
@@ -546,6 +551,11 @@ public class ValidationContext {
     return this;
   }
 
+  public ValidationContext addExtension(String extension) {
+    this.extensions.add(extension);
+    return this;
+  }
+
   @SerializedName("certSources")
   @JsonProperty("certSources")
   public List<String> getCertSources() {
@@ -619,8 +629,9 @@ public class ValidationContext {
 
   @SerializedName("doImplicitFHIRPathStringConversion")
   @JsonProperty("doImplicitFHIRPathStringConversion")
-  public void setDoImplicitFHIRPathStringConversion(boolean doImplicitFHIRPathStringConversion) {
+  public ValidationContext setDoImplicitFHIRPathStringConversion(boolean doImplicitFHIRPathStringConversion) {
     this.doImplicitFHIRPathStringConversion = doImplicitFHIRPathStringConversion;
+    return this;
   }
 
   @SerializedName("htmlInMarkdownCheck")
@@ -631,8 +642,9 @@ public class ValidationContext {
 
   @SerializedName("htmlInMarkdownCheck")
   @JsonProperty("htmlInMarkdownCheck")
-  public void setHtmlInMarkdownCheck(HtmlInMarkdownCheck htmlInMarkdownCheck) {
+  public ValidationContext setHtmlInMarkdownCheck(HtmlInMarkdownCheck htmlInMarkdownCheck) {
     this.htmlInMarkdownCheck = htmlInMarkdownCheck;
+    return this;
   }
 
   @SerializedName("allowDoubleQuotesInFHIRPath")
@@ -643,8 +655,9 @@ public class ValidationContext {
 
   @SerializedName("allowDoubleQuotesInFHIRPath")
   @JsonProperty("allowDoubleQuotesInFHIRPath")
-  public void setAllowDoubleQuotesInFHIRPath(boolean allowDoubleQuotesInFHIRPath) {
+  public ValidationContext setAllowDoubleQuotesInFHIRPath(boolean allowDoubleQuotesInFHIRPath) {
     this.allowDoubleQuotesInFHIRPath = allowDoubleQuotesInFHIRPath;
+    return this;
   }
 
   @SerializedName("disableDefaultResourceFetcher")
@@ -819,11 +832,20 @@ public class ValidationContext {
     return inputs;
   }
 
+  public ValidationContext addInput(String input) {
+    inputs.add(input);
+    return this;
+  }
 
   @SerializedName("modeParams")
   @JsonProperty("modeParams")
   public Set<String> getModeParams() {
     return modeParams;
+  }
+
+  public ValidationContext addModeParam(String modeParam) {
+    modeParams.add(modeParam);
+    return this;
   }
 
   @SerializedName("sources")
@@ -1083,8 +1105,9 @@ public class ValidationContext {
 
   @SerializedName("noInvariants")
   @JsonProperty("noInvariants")
-  public void setNoInvariants(boolean noInvariants) {
+  public ValidationContext setNoInvariants(boolean noInvariants) {
     this.noInvariants = noInvariants;
+    return this;
   }
 
   @SerializedName("displayWarnings")
@@ -1095,8 +1118,9 @@ public class ValidationContext {
 
   @SerializedName("displayWarnings")
   @JsonProperty("displayWarnings")
-  public void setDisplayWarnings(boolean displayWarnings) {
+  public ValidationContext setDisplayWarnings(boolean displayWarnings) {
     this.displayWarnings = displayWarnings;
+    return this;
   }
 
   @SerializedName("wantInvariantsInMessages")
@@ -1107,8 +1131,9 @@ public class ValidationContext {
 
   @SerializedName("wantInvariantsInMessages")
   @JsonProperty("wantInvariantsInMessages")
-  public void setWantInvariantsInMessages(boolean wantInvariantsInMessages) {
+  public ValidationContext setWantInvariantsInMessages(boolean wantInvariantsInMessages) {
     this.wantInvariantsInMessages = wantInvariantsInMessages;
+    return this;
   }
 
   @SerializedName("securityChecks")
@@ -1128,96 +1153,108 @@ public class ValidationContext {
     return crumbTrails;
   }
 
-  public void setCrumbTrails(boolean crumbTrails) {
+  public ValidationContext setCrumbTrails(boolean crumbTrails) {
     this.crumbTrails = crumbTrails;
+    return this;
   }
 
   public boolean isShowMessageIds() {
     return showMessageIds;
   }
 
-  public void setShowMessageIds(boolean showMessageIds) {
+  public ValidationContext setShowMessageIds(boolean showMessageIds) {
     this.showMessageIds = showMessageIds;
+    return this;
   }
 
   public boolean isForPublication() {
     return forPublication;
   }
 
-  public void setForPublication(boolean forPublication) {
+  public ValidationContext setForPublication(boolean forPublication) {
     this.forPublication = forPublication;
+    return this;
   }
 
   public String getAIService() {
     return aiService;
   }
 
-  public void setAIService(String aiService) {
+  public ValidationContext setAIService(String aiService) {
     this.aiService = aiService;
+    return this;
   }
   
   public R5BundleRelativeReferencePolicy getR5BundleRelativeReferencePolicy() {
     return r5BundleRelativeReferencePolicy;
   }
 
-  public void setR5BundleRelativeReferencePolicy(R5BundleRelativeReferencePolicy r5BundleRelativeReferencePolicy) {
+  public ValidationContext setR5BundleRelativeReferencePolicy(R5BundleRelativeReferencePolicy r5BundleRelativeReferencePolicy) {
     this.r5BundleRelativeReferencePolicy = r5BundleRelativeReferencePolicy;
+    return this;
   }
 
   public boolean isAllowExampleUrls() {
     return allowExampleUrls;
   }
 
-  public void setAllowExampleUrls(boolean allowExampleUrls) {
+  public ValidationContext setAllowExampleUrls(boolean allowExampleUrls) {
     this.allowExampleUrls = allowExampleUrls;
+    return this;
   }
 
   public boolean isShowTimes() {
     return showTimes;
   }
 
-  public void setShowTimes(boolean showTimes) {
+  public ValidationContext setShowTimes(boolean showTimes) {
     this.showTimes = showTimes;
+    return this;
   }
 
   public boolean isShowTerminologyRouting() {
     return showTerminologyRouting;
   }
 
-  public void setShowTerminologyRouting(boolean showTerminologyRouting) {
+  public ValidationContext setShowTerminologyRouting(boolean showTerminologyRouting) {
     this.showTerminologyRouting = showTerminologyRouting;
+    return this;
   }
 
   public boolean isClearTxCache() {
     return clearTxCache;
   }
 
-  public void setClearTxCache(boolean clearTxCache) {
+  public ValidationContext setClearTxCache(boolean clearTxCache) {
     this.clearTxCache = clearTxCache;
+    return this;
   }
 
   public String getOutputStyle() {
     return outputStyle;
   }
 
-  public void setOutputStyle(String outputStyle) {
+  public ValidationContext setOutputStyle(String outputStyle) {
     this.outputStyle = outputStyle;
+    return this;
   }
 
   public boolean isNoUnicodeBiDiControlChars() {
     return noUnicodeBiDiControlChars;
   }
 
-  public void setNoUnicodeBiDiControlChars(boolean noUnicodeBiDiControlChars) {
+  public ValidationContext setNoUnicodeBiDiControlChars(boolean noUnicodeBiDiControlChars) {
     this.noUnicodeBiDiControlChars = noUnicodeBiDiControlChars;
+    return this;
   }
 
   public String getJurisdiction() {
     return jurisdiction;
   }
 
-  public void setJurisdiction(String jurisdiction) {
+  public ValidationContext setJurisdiction(String jurisdiction) {
     this.jurisdiction = jurisdiction;
+    return this;
   }
 
 
@@ -1225,16 +1262,18 @@ public class ValidationContext {
     return srcLang;
   }
 
-  public void setSrcLang(String srcLang) {
+  public ValidationContext setSrcLang(String srcLang) {
     this.srcLang = srcLang;
+    return this;
   }
 
   public String getTgtLang() {
     return tgtLang;
   }
 
-  public void setTgtLang(String tgtLang) {
+  public ValidationContext setTgtLang(String tgtLang) {
     this.tgtLang = tgtLang;
+    return this;
   }
 
   @Override
@@ -1421,8 +1460,9 @@ public class ValidationContext {
 
   @SerializedName("watchScanDelay")
   @JsonProperty("watchScanDelay")
-  public void setWatchScanDelay(int watchScanDelay) {
+  public ValidationContext setWatchScanDelay(int watchScanDelay) {
     this.watchScanDelay = watchScanDelay;
+    return this;
   }
 
   @SerializedName("watchSettleTime")
@@ -1433,8 +1473,9 @@ public class ValidationContext {
 
   @SerializedName("watchSettleTime")
   @JsonProperty("watchSettleTime")
-  public void setWatchSettleTime(int watchSettleTime) {
+  public ValidationContext setWatchSettleTime(int watchSettleTime) {
     this.watchSettleTime = watchSettleTime;
+    return this;
   }
 
 
@@ -1461,8 +1502,9 @@ public class ValidationContext {
 
   @SerializedName("unknownCodeSystemsCauseErrors")
   @JsonProperty("unknownCodeSystemsCauseErrors")
-  public void setUnknownCodeSystemsCauseErrors(boolean unknownCodeSystemsCauseErrors) {
+  public ValidationContext setUnknownCodeSystemsCauseErrors(boolean unknownCodeSystemsCauseErrors) {
     this.unknownCodeSystemsCauseErrors = unknownCodeSystemsCauseErrors;
+    return this;
   }
 
   @SerializedName("noExperimentalContent")
@@ -1474,8 +1516,9 @@ public class ValidationContext {
 
   @SerializedName("noExperimentalContent")
   @JsonProperty("noExperimentalContent")
-  public void setNoExperimentalContent(boolean noExperimentalContent) {
+  public ValidationContext setNoExperimentalContent(boolean noExperimentalContent) {
     this.noExperimentalContent = noExperimentalContent;
+    return this;
   }
 
   @SerializedName("advisorFile")
@@ -1486,8 +1529,9 @@ public class ValidationContext {
 
   @SerializedName("advisorFile")
   @JsonProperty("advisorFile")
-  public void setAdvisorFile(String advisorFile) {
+  public ValidationContext setAdvisorFile(String advisorFile) {
     this.advisorFile = advisorFile;
+    return this;
   }
 
   @SerializedName("expansionParameters")
@@ -1498,8 +1542,9 @@ public class ValidationContext {
 
   @SerializedName("expansionParameters")
   @JsonProperty("expansionParameters")
-  public void setExpansionParameters(String expansionParameters) {
+  public ValidationContext setExpansionParameters(String expansionParameters) {
     this.expansionParameters = expansionParameters;
+    return this;
   }
 
   @SerializedName("format")
@@ -1510,8 +1555,9 @@ public class ValidationContext {
 
   @SerializedName("format")
   @JsonProperty("format")
-  public void setFormat(FhirFormat format) {
+  public ValidationContext setFormat(FhirFormat format) {
     this.format = format;
+    return this;
   }
 
   public void addLangRegenParam(String value) {


### PR DESCRIPTION
Adds tests to Params, trying to cover as many common cases in translating args to ValidationContext as possible.

This will allow greater confidence when args are separated according to task.