### PR TITLE
Fix missing fields in ValidationEngine copy constructor

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
@@ -184,7 +184,7 @@ public class ValidationService {
           response.addOutcome(validationOutcome);
         }
 
-        if (validationEngine.isShowTimes()) {
+        if (request.getValidationContext().isShowTimes()) {
           response.getValidationTimes().put(fileToValidate.getFileName(), validatedFragments.getValidationTime());
         }
         


### PR DESCRIPTION
Some fields were missing from ValidationEngine copy.