### PR TITLE
Move fields between ValidationEngineParameters and InstanceValidatorParameters

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/parsers/InstanceValidatorParametersParser.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/parsers/InstanceValidatorParametersParser.java
@@ -1,5 +1,8 @@
 package org.hl7.fhir.validation.cli.param.parsers;
 
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.terminologies.JurisdictionUtilities;
+import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
 import org.hl7.fhir.r5.utils.validation.constants.BestPracticeWarningLevel;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.validation.cli.param.Arg;
@@ -12,7 +15,6 @@ import org.hl7.fhir.validation.service.utils.ValidationLevel;
 public class InstanceValidatorParametersParser implements IParamParser<InstanceValidatorParameters> {
 
   public static final String ASSUME_VALID_REST_REF = "-assumeValidRestReferences";
-  public static final String NO_EXTENSIBLE_BINDING_WARNINGS = "-no-extensible-binding-warnings";
   public static final String SHOW_TIMES = "-show-times";
   public static final String HINT_ABOUT_NON_MUST_SUPPORT = "-hintAboutNonMustSupport";
   public static final String HTML_OUTPUT = "-html-output";
@@ -22,7 +24,6 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
   public static final String WANT_INVARIANTS_IN_MESSAGES = "-want-invariants-in-messages";
   public static final String NO_INVARIANTS = "-no-invariants";
   public static final String QUESTIONNAIRE = "-questionnaire";
-  public static final String DISPLAY_WARNINGS = "-display-issues-are-warnings";
   public static final String UNKNOWN_CODESYSTEMS_CAUSE_ERROR = "-unknown-codesystems-cause-errors";
   public static final String LEVEL = "-level";
   public static final String BEST_PRACTICE = "-best-practice";
@@ -41,6 +42,11 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
   public static final String PROFILE = "-profile";
   public static final String PROFILES = "-profiles";
   public static final String EXP_PARAMS = "-expansion-parameters";
+  public static final String CHECK_IPS_CODES = "-check-ips-codes";
+  public static final String DO_IMPLICIT_FHIRPATH_STRING_CONVERSION = "-implicit-fhirpath-string-conversions";
+  public static final String ALLOW_DOUBLE_QUOTES = "-allow-double-quotes-in-fhirpath";
+  public static final String BUNDLE = "-bundle";
+  public static final String JURISDICTION = "-jurisdiction";
 
   InstanceValidatorParameters instanceValidatorParameters = new InstanceValidatorParameters();
 
@@ -57,9 +63,6 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
       }
       if (args[i].getValue().equals(ASSUME_VALID_REST_REF)) {
         instanceValidatorParameters.setAssumeValidRestReferences(true);
-        args[i].setProcessed(true);
-      } else if (args[i].getValue().equals(NO_EXTENSIBLE_BINDING_WARNINGS)) {
-        instanceValidatorParameters.setNoExtensibleBindingMessages(true);
         args[i].setProcessed(true);
       } else if (args[i].getValue().equals(SHOW_TIMES)) {
         instanceValidatorParameters.setShowTimes(true);
@@ -108,9 +111,6 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
           );
           Arg.setProcessed(args, i, 2, true);
         }
-      } else if (args[i].getValue().equals(DISPLAY_WARNINGS)) {
-        instanceValidatorParameters.setDisplayWarnings(true);
-        args[i].setProcessed(true);
       } else if (args[i].getValue().equals(UNKNOWN_CODESYSTEMS_CAUSE_ERROR)) {
         instanceValidatorParameters.setUnknownCodeSystemsCauseErrors(true);
         args[i].setProcessed(true);
@@ -222,6 +222,35 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
           instanceValidatorParameters.setExpansionParameters(args[i + 1].getValue());
           Arg.setProcessed(args, i, 2, true);
         }
+      } else if (args[i].getValue().equals(CHECK_IPS_CODES)) {
+        instanceValidatorParameters.setCheckIPSCodes(true);
+        args[i].setProcessed(true);
+      } else if (args[i].getValue().equals(DO_IMPLICIT_FHIRPATH_STRING_CONVERSION)) {
+        instanceValidatorParameters.setDoImplicitFHIRPathStringConversion(true);
+        args[i].setProcessed(true);
+      } else if (args[i].getValue().equals(ALLOW_DOUBLE_QUOTES)) {
+        instanceValidatorParameters.setAllowDoubleQuotesInFHIRPath(true);
+        args[i].setProcessed(true);
+      } else if (args[i].getValue().equals(BUNDLE)) {
+        if (i + 1 == args.length) {
+          throw new Error("Specified -bundle without indicating bundle rule");
+        } else {
+          String rule = args[i + 1].getValue();
+          if (i + 2 == args.length) {
+            throw new Error("Specified -bundle without indicating profile source");
+          } else {
+            String profile = args[i + 2].getValue();
+            instanceValidatorParameters.addBundleValidationRule(new BundleValidationRule().setRule(rule).setProfile(profile));
+            Arg.setProcessed(args, i, 3, true);
+          }
+        }
+      } else if (args[i].getValue().equals(JURISDICTION)) {
+        if (i + 1 == args.length) {
+          throw new Error("Specified -jurisdiction without indicating jurisdiction");
+        } else {
+          instanceValidatorParameters.setJurisdiction(processJurisdiction(args[i + 1].getValue()));
+          Arg.setProcessed(args, i, 2, true);
+        }
       }
     }
   }
@@ -241,5 +270,18 @@ public class InstanceValidatorParametersParser implements IParamParser<InstanceV
       case "i" : return BestPracticeWarningLevel.Ignore;
     }
     throw new Error("The best-practice level ''" + s + "'' is not valid");
+  }
+
+  private static String processJurisdiction(String s) {
+    if (s.startsWith("urn:iso:std:iso:3166#") || s.startsWith("urn:iso:std:iso:3166:-2#") || s.startsWith("http://unstats.un.org/unsd/methods/m49/m49.htm#")) {
+      return s;
+    } else {
+      String v = JurisdictionUtilities.getJurisdictionFromLocale(s);
+      if (v != null) {
+        return v;
+      } else {
+        throw new FHIRException("Unable to understand Jurisdiction '"+s+"'");
+      }
+    }
   }
 }

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/parsers/ValidationEngineParametersParser.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/param/parsers/ValidationEngineParametersParser.java
@@ -1,14 +1,10 @@
 package org.hl7.fhir.validation.cli.param.parsers;
 
-import org.hl7.fhir.exceptions.FHIRException;
-import org.hl7.fhir.r5.terminologies.JurisdictionUtilities;
-import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.validation.cli.param.Arg;
 import org.hl7.fhir.validation.cli.param.IParamParser;
-import org.hl7.fhir.validation.cli.param.Params;
 import org.hl7.fhir.validation.service.model.ValidationEngineParameters;
 
 import java.io.File;
@@ -24,18 +20,13 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
   public static final String IMPLEMENTATION_GUIDE = "-ig";
   public static final String DEFINITION = "-defn";
   public static final String RESOLUTION_CONTEXT = "-resolution-context";
-  public static final String JURISDICTION = "-jurisdiction";
   public static final String AI_SERVICE = "-ai-service";
   public static final String CERT = "-cert";
   public static final String TERMINOLOGY = "-tx";
   public static final String TERMINOLOGY_LOG = "-txLog";
   public static final String TERMINOLOGY_CACHE = "-txCache";
   public static final String TERMINOLOGY_CACHE_CLEAR = "-clear-tx-cache";
-  public static final String CHECK_IPS_CODES = "-check-ips-codes";
-  public static final String DO_IMPLICIT_FHIRPATH_STRING_CONVERSION = "-implicit-fhirpath-string-conversions";
-  public static final String ALLOW_DOUBLE_QUOTES = "-allow-double-quotes-in-fhirpath";
   public static final String ADVISOR_FILE = "-advisor-file";
-  public static final String BUNDLE = "-bundle";
   public static final String LOCALE = "-locale";
   public static final String LANGUAGE = "-language";
   public static final String CHECK_REFERENCES = "-check-references";
@@ -43,6 +34,8 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
   public static final String NO_INTERNAL_CACHING = "-no-internal-caching";
   public static final String DISABLE_DEFAULT_RESOURCE_FETCHER = "-disable-default-resource-fetcher";
   public static final String LOG = "-log";
+  public static final String DISPLAY_WARNINGS = "-display-issues-are-warnings";
+  public static final String NO_EXTENSIBLE_BINDING_WARNINGS = "-no-extensible-binding-warnings";
 
   ValidationEngineParameters validationEngineParameters = new ValidationEngineParameters();
   @Override
@@ -91,13 +84,6 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
       } else if (args[i].getValue().equals(RESOLUTION_CONTEXT)) {
         validationEngineParameters.setResolutionContext(args[i + 1].getValue());
         Arg.setProcessed(args, i, 2, true);
-      } else if (args[i].getValue().equals(JURISDICTION)) {
-        if (i + 1 == args.length)
-          throw new Error("Specified -jurisdiction without indicating jurisdiction");
-        else {
-          validationEngineParameters.setJurisdiction(processJurisdiction(args[i + 1].getValue()));
-          Arg.setProcessed(args, i, 2, true);
-        }
       } else if (args[i].getValue().equals(AI_SERVICE)) {
         validationEngineParameters.setAIService(args[i + 1].getValue());
         Arg.setProcessed(args, i, 2, true);
@@ -145,15 +131,6 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
       } else if (args[i].getValue().equals(TERMINOLOGY_CACHE_CLEAR)) {
         validationEngineParameters.setClearTxCache(true);
         args[i].setProcessed(true);
-      } else if (args[i].getValue().equals(CHECK_IPS_CODES)) {
-        validationEngineParameters.setCheckIPSCodes(true);
-        args[i].setProcessed(true);
-      } else if (args[i].getValue().equals(DO_IMPLICIT_FHIRPATH_STRING_CONVERSION)) {
-        validationEngineParameters.setDoImplicitFHIRPathStringConversion(true);
-        args[i].setProcessed(true);
-      } else if (args[i].getValue().equals(ALLOW_DOUBLE_QUOTES)) {
-        validationEngineParameters.setAllowDoubleQuotesInFHIRPath(true);
-        args[i].setProcessed(true);
       } else if (args[i].getValue().equals(ADVISOR_FILE)) {
         if (i + 1 == args.length)
           throw new Error("Specified -advisor-file without indicating file");
@@ -173,19 +150,6 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
             validationEngineParameters.setAdvisorFile(advisorFile);
           }
           Arg.setProcessed(args, i, 2, true);
-        }
-      } else if (args[i].getValue().equals(BUNDLE)) {
-        if (i + 1 == args.length) {
-          throw new Error("Specified -bundle without indicating bundle rule");
-        } else {
-          String rule = args[i + 1].getValue();
-          if (i + 2 == args.length) {
-            throw new Error("Specified -bundle without indicating profile source");
-          } else {
-            String profile = args[i + 2].getValue();
-            validationEngineParameters.addBundleValidationRule(new BundleValidationRule().setRule(rule).setProfile(profile));
-            Arg.setProcessed(args, i, 3, true);
-          }
         }
       } else if (args[i].getValue().equals(LOCALE)) {
         if (i + 1 == args.length) {
@@ -231,19 +195,12 @@ public class ValidationEngineParametersParser implements IParamParser<Validation
           validationEngineParameters.setMapLog(args[i + 1].getValue());
           Arg.setProcessed(args, i, 2, true);
         }
-      }
-    }
-  }
-
-  private static String processJurisdiction(String s) {
-    if (s.startsWith("urn:iso:std:iso:3166#") || s.startsWith("urn:iso:std:iso:3166:-2#") || s.startsWith("http://unstats.un.org/unsd/methods/m49/m49.htm#")) {
-      return s;
-    } else {
-      String v = JurisdictionUtilities.getJurisdictionFromLocale(s);
-      if (v != null) {
-        return v;
-      } else {
-        throw new FHIRException("Unable to understand Jurisdiction '"+s+"'");
+      } else if (args[i].getValue().equals(DISPLAY_WARNINGS)) {
+        validationEngineParameters.setDisplayWarnings(true);
+        args[i].setProcessed(true);
+      } else if (args[i].getValue().equals(NO_EXTENSIBLE_BINDING_WARNINGS)) {
+        validationEngineParameters.setNoExtensibleBindingMessages(true);
+        args[i].setProcessed(true);
       }
     }
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
@@ -590,9 +590,13 @@ public class ValidationService {
   @Nonnull
   protected ValidationEngine buildValidationEngine(ValidationContext validationContext, String definitions, TimeTracker timeTracker) throws IOException, URISyntaxException {
     log.info("  Loading FHIR v" + validationContext.getSv() + " from " + definitions);
-    ValidationEngine validationEngine = getValidationEngineBuilder().withVersion(validationContext.getSv()).withTimeTracker(timeTracker)
-        .withUserAgent(Common.getValidatorUserAgent()).withThoVersion(Constants.THO_WORKING_VERSION)
-        .withExtensionsVersion(Constants.EXTENSIONS_WORKING_VERSION).fromSource(definitions);
+    ValidationEngine validationEngine = getValidationEngineBuilder()
+      .withVersion(validationContext.getSv())
+      .withTimeTracker(timeTracker)
+      .withUserAgent(Common.getValidatorUserAgent())
+      .withThoVersion(Constants.THO_WORKING_VERSION)
+      .withExtensionsVersion(Constants.EXTENSIONS_WORKING_VERSION)
+      .fromSource(definitions);
     FhirPublication ver = FhirPublication.fromCode(validationContext.getSv());
     log.info("  Loaded FHIR - " + validationEngine.getContext().countAllCaches() + " resources (" + timeTracker.milestone() + ")");
     final String lineStart = "  Terminology server " + validationContext.getTxServer();

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/InstanceValidatorParameters.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/InstanceValidatorParameters.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 import org.hl7.fhir.r5.utils.validation.constants.BestPracticeWarningLevel;
 import org.hl7.fhir.utilities.validation.ValidationOptions.R5BundleRelativeReferencePolicy;
-import org.hl7.fhir.validation.service.model.HtmlInMarkdownCheck;
 import org.hl7.fhir.validation.service.utils.QuestionnaireMode;
 import org.hl7.fhir.validation.service.utils.ValidationLevel;
 
@@ -27,23 +26,6 @@ public class InstanceValidatorParameters {
   @JsonProperty("assumeValidRestReferences")
   public InstanceValidatorParameters setAssumeValidRestReferences(boolean assumeValidRestReferences) {
     this.assumeValidRestReferences = assumeValidRestReferences;
-    return this;
-  }
-
-  @JsonProperty("noExtensibleBindingMessages")
-  @SerializedName("noExtensibleBindingMessages")
-  private boolean noExtensibleBindingMessages = false;
-
-  @SerializedName("noExtensibleBindingMessages")
-  @JsonProperty("noExtensibleBindingMessages")
-  public boolean isNoExtensibleBindingMessages() {
-    return noExtensibleBindingMessages;
-  }
-
-  @SerializedName("noExtensibleBindingMessages")
-  @JsonProperty("noExtensibleBindingMessages")
-  public InstanceValidatorParameters setNoExtensibleBindingMessages(boolean noExtensibleBindingMessages) {
-    this.noExtensibleBindingMessages = noExtensibleBindingMessages;
     return this;
   }
 
@@ -203,10 +185,6 @@ public class InstanceValidatorParameters {
     return this;
   }
 
-  @JsonProperty("displayWarnings")
-  @SerializedName("displayWarnings")
-  private boolean displayWarnings = false;
-
   @JsonProperty("unknownCodeSystemsCauseErrors")
   @SerializedName("unknownCodeSystemsCauseErrors")
   private boolean unknownCodeSystemsCauseErrors;
@@ -270,19 +248,6 @@ public class InstanceValidatorParameters {
   @JsonProperty("profiles")
   @SerializedName("profiles")
   private List<String> profiles = new ArrayList<String>();
-
-  @SerializedName("displayWarnings")
-  @JsonProperty("displayWarnings")
-  public boolean isDisplayWarnings() {
-    return displayWarnings;
-  }
-
-  @SerializedName("displayWarnings")
-  @JsonProperty("displayWarnings")
-  public InstanceValidatorParameters setDisplayWarnings(boolean displayWarnings) {
-    this.displayWarnings = displayWarnings;
-    return this;
-  }
 
   @SerializedName("unknownCodeSystemsCauseErrors")
   @JsonProperty("unknownCodeSystemsCauseErrors")
@@ -485,18 +450,111 @@ public class InstanceValidatorParameters {
     return this;
   }
 
+  @JsonProperty("doImplicitFHIRPathStringConversion")
+  @SerializedName("doImplicitFHIRPathStringConversion")
+  private
+  boolean doImplicitFHIRPathStringConversion = false;
+
+  @SerializedName("doImplicitFHIRPathStringConversion")
+  @JsonProperty("doImplicitFHIRPathStringConversion")
+  public boolean isDoImplicitFHIRPathStringConversion() {
+    return doImplicitFHIRPathStringConversion;
+  }
+
+  @SerializedName("doImplicitFHIRPathStringConversion")
+  @JsonProperty("doImplicitFHIRPathStringConversion")
+  public InstanceValidatorParameters setDoImplicitFHIRPathStringConversion(boolean doImplicitFHIRPathStringConversion) {
+    this.doImplicitFHIRPathStringConversion = doImplicitFHIRPathStringConversion;
+    return this;
+  }
+
+  @JsonProperty("allowDoubleQuotesInFHIRPath")
+  @SerializedName("allowDoubleQuotesInFHIRPath")
+  private
+  boolean allowDoubleQuotesInFHIRPath = false;
+
+  @SerializedName("allowDoubleQuotesInFHIRPath")
+  @JsonProperty("allowDoubleQuotesInFHIRPath")
+  public boolean isAllowDoubleQuotesInFHIRPath() {
+    return allowDoubleQuotesInFHIRPath;
+  }
+
+  @SerializedName("allowDoubleQuotesInFHIRPath")
+  @JsonProperty("allowDoubleQuotesInFHIRPath")
+  public InstanceValidatorParameters setAllowDoubleQuotesInFHIRPath(boolean allowDoubleQuotesInFHIRPath) {
+    this.allowDoubleQuotesInFHIRPath = allowDoubleQuotesInFHIRPath;
+    return this;
+  }
+
+  @JsonProperty("checkIPSCodes")
+  @SerializedName("checkIPSCodes")
+  private
+  boolean checkIPSCodes;
+
+  @SerializedName("checkIPSCodes")
+  @JsonProperty("checkIPSCodes")
+  public boolean isCheckIPSCodes() {
+    return checkIPSCodes;
+  }
+
+  @SerializedName("checkIPSCodes")
+  @JsonProperty("checkIPSCodes")
+  public InstanceValidatorParameters setCheckIPSCodes(boolean checkIPSCodes) {
+    this.checkIPSCodes = checkIPSCodes;
+    return this;
+  }
+
+  @JsonProperty("bundleValidationRules")
+  @SerializedName("bundleValidationRules")
+  private
+  List<org.hl7.fhir.r5.utils.validation.BundleValidationRule> bundleValidationRules = new ArrayList<>();
+
+  @SerializedName("bundleValidationRules")
+  @JsonProperty("bundleValidationRules")
+  public List<org.hl7.fhir.r5.utils.validation.BundleValidationRule> getBundleValidationRules() {
+    return bundleValidationRules;
+  }
+
+  @SerializedName("bundleValidationRules")
+  @JsonProperty("bundleValidationRules")
+  public InstanceValidatorParameters setBundleValidationRules(List<org.hl7.fhir.r5.utils.validation.BundleValidationRule> bundleValidationRules) {
+    this.bundleValidationRules = bundleValidationRules;
+    return this;
+  }
+
+  public InstanceValidatorParameters addBundleValidationRule(org.hl7.fhir.r5.utils.validation.BundleValidationRule bundleValidationRule) {
+    this.bundleValidationRules.add(bundleValidationRule);
+    return this;
+  }
+
+  @JsonProperty("jurisdiction")
+  @SerializedName("jurisdiction")
+  private
+  String jurisdiction = org.hl7.fhir.r5.terminologies.JurisdictionUtilities.getJurisdictionFromLocale(java.util.Locale.getDefault().getCountry());
+
+  @SerializedName("jurisdiction")
+  @JsonProperty("jurisdiction")
+  public String getJurisdiction() {
+    return jurisdiction;
+  }
+
+  @SerializedName("jurisdiction")
+  @JsonProperty("jurisdiction")
+  public InstanceValidatorParameters setJurisdiction(String jurisdiction) {
+    this.jurisdiction = jurisdiction;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     InstanceValidatorParameters that = (InstanceValidatorParameters) o;
     return assumeValidRestReferences == that.assumeValidRestReferences
-      && noExtensibleBindingMessages == that.noExtensibleBindingMessages
       && showTimes == that.showTimes
       && hintAboutNonMustSupport == that.hintAboutNonMustSupport
       && wantInvariantsInMessages == that.wantInvariantsInMessages
       && noInvariants == that.noInvariants
-      && displayWarnings == that.displayWarnings
       && unknownCodeSystemsCauseErrors == that.unknownCodeSystemsCauseErrors
       && forPublication == that.forPublication
       && noUnicodeBiDiControlChars == that.noUnicodeBiDiControlChars
@@ -507,6 +565,9 @@ public class InstanceValidatorParameters {
       && securityChecks == that.securityChecks
       && noExperimentalContent == that.noExperimentalContent
       && showTerminologyRouting == that.showTerminologyRouting
+      && doImplicitFHIRPathStringConversion == that.doImplicitFHIRPathStringConversion
+      && allowDoubleQuotesInFHIRPath == that.allowDoubleQuotesInFHIRPath
+      && checkIPSCodes == that.checkIPSCodes
       && Objects.equals(htmlOutput, that.htmlOutput)
       && Objects.equals(outputStyle, that.outputStyle)
       && Objects.equals(r5BundleRelativeReferencePolicy, that.r5BundleRelativeReferencePolicy)
@@ -517,19 +578,20 @@ public class InstanceValidatorParameters {
       && Objects.equals(htmlInMarkdownCheck, that.htmlInMarkdownCheck)
       && Objects.equals(matchetypes, that.matchetypes)
       && Objects.equals(expansionParameters, that.expansionParameters)
-      && Objects.equals(profiles, that.profiles);
+      && Objects.equals(profiles, that.profiles)
+      && Objects.equals(bundleValidationRules, that.bundleValidationRules)
+      && Objects.equals(jurisdiction, that.jurisdiction);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(assumeValidRestReferences, noExtensibleBindingMessages, showTimes, hintAboutNonMustSupport, htmlOutput, outputStyle, r5BundleRelativeReferencePolicy, extensions, wantInvariantsInMessages, noInvariants, questionnaireMode, displayWarnings, unknownCodeSystemsCauseErrors, level, bestPracticeLevel, forPublication, htmlInMarkdownCheck, noUnicodeBiDiControlChars, crumbTrails, showMessageIds, allowExampleUrls, showMessagesFromReferences, securityChecks, noExperimentalContent, showTerminologyRouting, matchetypes, expansionParameters, profiles);
+    return Objects.hash(assumeValidRestReferences, showTimes, hintAboutNonMustSupport, htmlOutput, outputStyle, r5BundleRelativeReferencePolicy, extensions, wantInvariantsInMessages, noInvariants, questionnaireMode, unknownCodeSystemsCauseErrors, level, bestPracticeLevel, forPublication, htmlInMarkdownCheck, noUnicodeBiDiControlChars, crumbTrails, showMessageIds, allowExampleUrls, showMessagesFromReferences, securityChecks, noExperimentalContent, showTerminologyRouting, matchetypes, expansionParameters, profiles, doImplicitFHIRPathStringConversion, allowDoubleQuotesInFHIRPath, checkIPSCodes, bundleValidationRules, jurisdiction);
   }
 
   @Override
   public String toString() {
     return "InstanceValidatorParameters{" +
       "assumeValidRestReferences=" + assumeValidRestReferences +
-      ", noExtensibleBindingMessages=" + noExtensibleBindingMessages +
       ", showTimes=" + showTimes +
       ", hintAboutNonMustSupport=" + hintAboutNonMustSupport +
       ", htmlOutput='" + htmlOutput + '\'' +
@@ -539,7 +601,6 @@ public class InstanceValidatorParameters {
       ", wantInvariantsInMessages=" + wantInvariantsInMessages +
       ", noInvariants=" + noInvariants +
       ", questionnaireMode=" + questionnaireMode +
-      ", displayWarnings=" + displayWarnings +
       ", unknownCodeSystemsCauseErrors=" + unknownCodeSystemsCauseErrors +
       ", level=" + level +
       ", bestPracticeLevel=" + bestPracticeLevel +
@@ -556,6 +617,11 @@ public class InstanceValidatorParameters {
       ", matchetypes=" + matchetypes +
       ", expansionParameters='" + expansionParameters + '\'' +
       ", profiles=" + profiles +
+      ", doImplicitFHIRPathStringConversion=" + doImplicitFHIRPathStringConversion +
+      ", allowDoubleQuotesInFHIRPath=" + allowDoubleQuotesInFHIRPath +
+      ", checkIPSCodes=" + checkIPSCodes +
+      ", bundleValidationRules=" + bundleValidationRules +
+      ", jurisdiction='" + jurisdiction + '\'' +
       '}';
   }
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContextUtilities.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContextUtilities.java
@@ -21,7 +21,6 @@ public class ValidationContextUtilities {
     }
     validationContext.setBaseEngine(validationEngineParameters.getBaseEngine());
     validationContext.setResolutionContext(validationEngineParameters.getResolutionContext());
-    validationContext.setJurisdiction(validationEngineParameters.getJurisdiction());
     validationContext.setAIService(validationEngineParameters.getAIService());
     for (String certSource : validationEngineParameters.getCertSources()) {
       validationContext.addCertSource(certSource);
@@ -31,17 +30,15 @@ public class ValidationContextUtilities {
     validationContext.setTxLog(validationEngineParameters.getTxLog());
     validationContext.setTxCache(validationEngineParameters.getTxCache());
     validationContext.setClearTxCache(validationEngineParameters.isClearTxCache());
-    validationContext.setCheckIPSCodes(validationEngineParameters.isCheckIPSCodes());
-    validationContext.setDoImplicitFHIRPathStringConversion(validationEngineParameters.isDoImplicitFHIRPathStringConversion());
-    validationContext.setAllowDoubleQuotesInFHIRPath(validationEngineParameters.isAllowDoubleQuotesInFHIRPath());
     validationContext.setAdvisorFile(validationEngineParameters.getAdvisorFile());
-    validationContext.setBundleValidationRules(validationEngineParameters.getBundleValidationRules());
     validationContext.setLocale(validationEngineParameters.getLanguageCode());
     validationContext.setLang(validationEngineParameters.getLang());
     validationContext.setCheckReferences(validationEngineParameters.isCheckReferences());
     validationContext.setNoInternalCaching(validationEngineParameters.isNoInternalCaching());
     validationContext.setDisableDefaultResourceFetcher(validationEngineParameters.isDisableDefaultResourceFetcher());
     validationContext.setMapLog(validationEngineParameters.getMapLog());
+    validationContext.setDisplayWarnings(validationEngineParameters.isDisplayWarnings());
+    validationContext.setNoExtensibleBindingMessages(validationEngineParameters.isNoExtensibleBindingMessages());
   }
 
   public static void addWatchParameters(ValidationContext validationContext, WatchParameters watchParameters) {
@@ -72,7 +69,6 @@ public class ValidationContextUtilities {
 
   public static void addInstanceValidatorParameters(ValidationContext validationContext, InstanceValidatorParameters instanceValidatorParameters) {
     validationContext.setAssumeValidRestReferences(instanceValidatorParameters.isAssumeValidRestReferences());
-    validationContext.setNoExtensibleBindingMessages(instanceValidatorParameters.isNoExtensibleBindingMessages());
     validationContext.setShowTimes(instanceValidatorParameters.isShowTimes());
     validationContext.setHintAboutNonMustSupport(instanceValidatorParameters.isHintAboutNonMustSupport());
     validationContext.setHtmlOutput(instanceValidatorParameters.getHtmlOutput());
@@ -82,7 +78,6 @@ public class ValidationContextUtilities {
     validationContext.setWantInvariantsInMessages(instanceValidatorParameters.isWantInvariantsInMessages());
     validationContext.setNoInvariants(instanceValidatorParameters.isNoInvariants());
     validationContext.setQuestionnaireMode(instanceValidatorParameters.getQuestionnaireMode());
-    validationContext.setDisplayWarnings(instanceValidatorParameters.isDisplayWarnings());
     validationContext.setUnknownCodeSystemsCauseErrors(instanceValidatorParameters.isUnknownCodeSystemsCauseErrors());
     validationContext.setLevel(instanceValidatorParameters.getLevel());
     validationContext.setBestPracticeLevel(instanceValidatorParameters.getBestPracticeLevel());
@@ -99,6 +94,11 @@ public class ValidationContextUtilities {
     validationContext.setMatchetypes(new ArrayList<>(instanceValidatorParameters.getMatchetypes()));
     validationContext.setExpansionParameters(instanceValidatorParameters.getExpansionParameters());
     validationContext.setProfiles(instanceValidatorParameters.getProfiles());
+    validationContext.setDoImplicitFHIRPathStringConversion(instanceValidatorParameters.isDoImplicitFHIRPathStringConversion());
+    validationContext.setAllowDoubleQuotesInFHIRPath(instanceValidatorParameters.isAllowDoubleQuotesInFHIRPath());
+    validationContext.setCheckIPSCodes(instanceValidatorParameters.isCheckIPSCodes());
+    validationContext.setBundleValidationRules(new ArrayList<>(instanceValidatorParameters.getBundleValidationRules()));
+    validationContext.setJurisdiction(instanceValidatorParameters.getJurisdiction());
   }
 
   public static void addOutputParameters(ValidationContext validationContext, OutputParameters outputParameters) {
@@ -156,7 +156,6 @@ public class ValidationContextUtilities {
     }
     validationEngineParameters.setBaseEngine(validationContext.getBaseEngine());
     validationEngineParameters.setResolutionContext(validationContext.getResolutionContext());
-    validationEngineParameters.setJurisdiction(validationContext.getJurisdiction());
     validationEngineParameters.setAIService(validationContext.getAIService());
     for (String certSource : validationContext.getCertSources()) {
       validationEngineParameters.addCertSource(certSource);
@@ -166,17 +165,15 @@ public class ValidationContextUtilities {
     validationEngineParameters.setTxLog(validationContext.getTxLog());
     validationEngineParameters.setTxCache(validationContext.getTxCache());
     validationEngineParameters.setClearTxCache(validationContext.isClearTxCache());
-    validationEngineParameters.setCheckIPSCodes(validationContext.isCheckIPSCodes());
-    validationEngineParameters.setDoImplicitFHIRPathStringConversion(validationContext.isDoImplicitFHIRPathStringConversion());
-    validationEngineParameters.setAllowDoubleQuotesInFHIRPath(validationContext.isAllowDoubleQuotesInFHIRPath());
     validationEngineParameters.setAdvisorFile(validationContext.getAdvisorFile());
-    validationEngineParameters.setBundleValidationRules(validationContext.getBundleValidationRules());
     validationEngineParameters.setLocale(validationContext.getLanguageCode());
     validationEngineParameters.setLang(validationContext.getLang());
     validationEngineParameters.setCheckReferences(validationContext.isCheckReferences());
     validationEngineParameters.setNoInternalCaching(validationContext.isNoInternalCaching());
     validationEngineParameters.setDisableDefaultResourceFetcher(validationContext.isDisableDefaultResourceFetcher());
     validationEngineParameters.setMapLog(validationContext.getMapLog());
+    validationEngineParameters.setDisplayWarnings(validationContext.isDisplayWarnings());
+    validationEngineParameters.setNoExtensibleBindingMessages(validationContext.isNoExtensibleBindingMessages());
     return validationEngineParameters;
   }
 
@@ -207,7 +204,6 @@ public class ValidationContextUtilities {
   public static InstanceValidatorParameters getInstanceValidatorParameters(ValidationContext validationContext) {
     InstanceValidatorParameters instanceValidatorParameters = new InstanceValidatorParameters();
     instanceValidatorParameters.setAssumeValidRestReferences(validationContext.isAssumeValidRestReferences());
-    instanceValidatorParameters.setNoExtensibleBindingMessages(validationContext.isNoExtensibleBindingMessages());
     instanceValidatorParameters.setShowTimes(validationContext.isShowTimes());
     instanceValidatorParameters.setHintAboutNonMustSupport(validationContext.isHintAboutNonMustSupport());
     instanceValidatorParameters.setHtmlOutput(validationContext.getHtmlOutput());
@@ -217,7 +213,6 @@ public class ValidationContextUtilities {
     instanceValidatorParameters.setWantInvariantsInMessages(validationContext.isWantInvariantsInMessages());
     instanceValidatorParameters.setNoInvariants(validationContext.isNoInvariants());
     instanceValidatorParameters.setQuestionnaireMode(validationContext.getQuestionnaireMode());
-    instanceValidatorParameters.setDisplayWarnings(validationContext.isDisplayWarnings());
     instanceValidatorParameters.setUnknownCodeSystemsCauseErrors(validationContext.isUnknownCodeSystemsCauseErrors());
     instanceValidatorParameters.setLevel(validationContext.getLevel());
     instanceValidatorParameters.setBestPracticeLevel(validationContext.getBestPracticeLevel());
@@ -234,6 +229,11 @@ public class ValidationContextUtilities {
     instanceValidatorParameters.setMatchetypes(new ArrayList<>(validationContext.getMatchetypes()));
     instanceValidatorParameters.setExpansionParameters(validationContext.getExpansionParameters());
     instanceValidatorParameters.setProfiles(validationContext.getProfiles());
+    instanceValidatorParameters.setDoImplicitFHIRPathStringConversion(validationContext.isDoImplicitFHIRPathStringConversion());
+    instanceValidatorParameters.setAllowDoubleQuotesInFHIRPath(validationContext.isAllowDoubleQuotesInFHIRPath());
+    instanceValidatorParameters.setCheckIPSCodes(validationContext.isCheckIPSCodes());
+    instanceValidatorParameters.setBundleValidationRules(new ArrayList<>(validationContext.getBundleValidationRules()));
+    instanceValidatorParameters.setJurisdiction(validationContext.getJurisdiction());
     return instanceValidatorParameters;
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationEngineParameters.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationEngineParameters.java
@@ -158,23 +158,6 @@ public class ValidationEngineParameters {
     return this;
   }
 
-  @JsonProperty("jurisdiction")
-  @SerializedName("jurisdiction")
-  private
-  String jurisdiction = JurisdictionUtilities.getJurisdictionFromLocale(Locale.getDefault().getCountry());
-
-  @SerializedName("jurisdiction")
-  @JsonProperty("jurisdiction")
-  public String getJurisdiction() {
-    return jurisdiction;
-  }
-
-  @SerializedName("jurisdiction")
-  @JsonProperty("jurisdiction")
-  public ValidationEngineParameters setJurisdiction(String jurisdiction) {
-    this.jurisdiction = jurisdiction;
-    return this;
-  }
 
   @JsonProperty("aiService")
   @SerializedName("aiService")
@@ -307,60 +290,6 @@ public class ValidationEngineParameters {
     return this;
   }
 
-  @JsonProperty("checkIPSCodes")
-  @SerializedName("checkIPSCodes")
-  private
-  boolean checkIPSCodes;
-
-  @SerializedName("checkIPSCodes")
-  @JsonProperty("checkIPSCodes")
-  public boolean isCheckIPSCodes() {
-    return checkIPSCodes;
-  }
-
-  @SerializedName("checkIPSCodes")
-  @JsonProperty("checkIPSCodes")
-  public ValidationEngineParameters setCheckIPSCodes(boolean checkIPSCodes) {
-    this.checkIPSCodes = checkIPSCodes;
-    return this;
-  }
-
-  @JsonProperty("doImplicitFHIRPathStringConversion")
-  @SerializedName("doImplicitFHIRPathStringConversion")
-  private
-  boolean doImplicitFHIRPathStringConversion = false;
-
-  @SerializedName("doImplicitFHIRPathStringConversion")
-  @JsonProperty("doImplicitFHIRPathStringConversion")
-  public boolean isDoImplicitFHIRPathStringConversion() {
-    return doImplicitFHIRPathStringConversion;
-  }
-
-  @SerializedName("doImplicitFHIRPathStringConversion")
-  @JsonProperty("doImplicitFHIRPathStringConversion")
-  public ValidationEngineParameters setDoImplicitFHIRPathStringConversion(boolean doImplicitFHIRPathStringConversion) {
-    this.doImplicitFHIRPathStringConversion = doImplicitFHIRPathStringConversion;
-    return this;
-  }
-
-  @JsonProperty("allowDoubleQuotesInFHIRPath")
-  @SerializedName("allowDoubleQuotesInFHIRPath")
-  private
-  boolean allowDoubleQuotesInFHIRPath = false;
-
-  @SerializedName("allowDoubleQuotesInFHIRPath")
-  @JsonProperty("allowDoubleQuotesInFHIRPath")
-  public boolean isAllowDoubleQuotesInFHIRPath() {
-    return allowDoubleQuotesInFHIRPath;
-  }
-
-  @SerializedName("allowDoubleQuotesInFHIRPath")
-  @JsonProperty("allowDoubleQuotesInFHIRPath")
-  public ValidationEngineParameters setAllowDoubleQuotesInFHIRPath(boolean allowDoubleQuotesInFHIRPath) {
-    this.allowDoubleQuotesInFHIRPath = allowDoubleQuotesInFHIRPath;
-    return this;
-  }
-
   @JsonProperty("advisorFile")
   @SerializedName("advisorFile")
   private
@@ -376,29 +305,6 @@ public class ValidationEngineParameters {
   @JsonProperty("advisorFile")
   public ValidationEngineParameters setAdvisorFile(String advisorFile) {
     this.advisorFile = advisorFile;
-    return this;
-  }
-
-  @JsonProperty("bundleValidationRules")
-  @SerializedName("bundleValidationRules")
-  private
-  List<BundleValidationRule> bundleValidationRules = new ArrayList<>();
-
-  @SerializedName("bundleValidationRules")
-  @JsonProperty("bundleValidationRules")
-  public List<BundleValidationRule> getBundleValidationRules() {
-    return bundleValidationRules;
-  }
-
-  @SerializedName("bundleValidationRules")
-  @JsonProperty("bundleValidationRules")
-  public ValidationEngineParameters setBundleValidationRules(List<BundleValidationRule> bundleValidationRules) {
-    this.bundleValidationRules = bundleValidationRules;
-    return this;
-  }
-
-  public ValidationEngineParameters addBundleValidationRule(BundleValidationRule bundleValidationRule) {
-    this.bundleValidationRules.add(bundleValidationRule);
     return this;
   }
 
@@ -519,6 +425,40 @@ public class ValidationEngineParameters {
     return this;
   }
 
+  @JsonProperty("displayWarnings")
+  @SerializedName("displayWarnings")
+  private boolean displayWarnings = false;
+
+  @SerializedName("displayWarnings")
+  @JsonProperty("displayWarnings")
+  public boolean isDisplayWarnings() {
+    return displayWarnings;
+  }
+
+  @SerializedName("displayWarnings")
+  @JsonProperty("displayWarnings")
+  public ValidationEngineParameters setDisplayWarnings(boolean displayWarnings) {
+    this.displayWarnings = displayWarnings;
+    return this;
+  }
+
+  @JsonProperty("noExtensibleBindingMessages")
+  @SerializedName("noExtensibleBindingMessages")
+  private boolean noExtensibleBindingMessages = false;
+
+  @SerializedName("noExtensibleBindingMessages")
+  @JsonProperty("noExtensibleBindingMessages")
+  public boolean isNoExtensibleBindingMessages() {
+    return noExtensibleBindingMessages;
+  }
+
+  @SerializedName("noExtensibleBindingMessages")
+  @JsonProperty("noExtensibleBindingMessages")
+  public ValidationEngineParameters setNoExtensibleBindingMessages(boolean noExtensibleBindingMessages) {
+    this.noExtensibleBindingMessages = noExtensibleBindingMessages;
+    return this;
+  }
+
   private Boolean inferFhirVersion = true;
 
   public Boolean isInferFhirVersion() {
@@ -543,21 +483,18 @@ public class ValidationEngineParameters {
       && isInferFhirVersion() == that.isInferFhirVersion()
       && noEcosystem == that.noEcosystem
       && clearTxCache == that.clearTxCache
-      && checkIPSCodes == that.checkIPSCodes
-      && doImplicitFHIRPathStringConversion == that.doImplicitFHIRPathStringConversion
-      && allowDoubleQuotesInFHIRPath == that.allowDoubleQuotesInFHIRPath
       && checkReferences == that.checkReferences
       && noInternalCaching == that.noInternalCaching
       && disableDefaultResourceFetcher == that.disableDefaultResourceFetcher
+      && displayWarnings == that.displayWarnings
+      && noExtensibleBindingMessages == that.noExtensibleBindingMessages
       && Objects.equals(resolutionContext, that.resolutionContext)
-      && Objects.equals(jurisdiction, that.jurisdiction)
       && Objects.equals(aiService, that.aiService)
       && Objects.equals(certSources, that.certSources)
       && Objects.equals(txServer, that.txServer)
       && Objects.equals(txLog, that.txLog)
       && Objects.equals(txCache, that.txCache)
       && Objects.equals(advisorFile, that.advisorFile)
-      && Objects.equals(bundleValidationRules, that.bundleValidationRules)
       && Objects.equals(locale, that.locale)
       && Objects.equals(lang, that.lang)
       && Objects.equals(mapLog, that.mapLog);
@@ -573,7 +510,6 @@ public class ValidationEngineParameters {
       sv,
       inferFhirVersion,
       resolutionContext,
-      jurisdiction,
       aiService,
       certSources,
       txServer,
@@ -581,17 +517,15 @@ public class ValidationEngineParameters {
       txLog,
       txCache,
       clearTxCache,
-      checkIPSCodes,
-      doImplicitFHIRPathStringConversion,
-      allowDoubleQuotesInFHIRPath,
       advisorFile,
-      bundleValidationRules,
       locale,
       lang,
       checkReferences,
       noInternalCaching,
       disableDefaultResourceFetcher,
-      mapLog);
+      mapLog,
+      displayWarnings,
+      noExtensibleBindingMessages);
   }
 
   @Override
@@ -604,7 +538,6 @@ public class ValidationEngineParameters {
       ", sv=" + sv +
       ", inferFhirVersion=" + inferFhirVersion +
       ", resolutionContext='" + resolutionContext + '\'' +
-      ", jurisdiction='" + jurisdiction + '\'' +
       ", aiService='" + aiService + '\'' +
       ", certSources=" + certSources +
       ", txServer='" + txServer + '\'' +
@@ -612,17 +545,15 @@ public class ValidationEngineParameters {
       ", txLog='" + txLog + '\'' +
       ", txCache='" + txCache + '\'' +
       ", clearTxCache=" + clearTxCache +
-      ", checkIPSCodes=" + checkIPSCodes +
-      ", doImplicitFHIRPathStringConversion=" + doImplicitFHIRPathStringConversion +
-      ", allowDoubleQuotesInFHIRPath=" + allowDoubleQuotesInFHIRPath +
       ", advisorFile='" + advisorFile + '\'' +
-      ", bundleValidationRules=" + bundleValidationRules +
       ", locale='" + locale + '\'' +
       ", lang='" + lang + '\'' +
       ", checkReferences=" + checkReferences +
       ", noInternalCaching=" + noInternalCaching +
       ", disableDefaultResourceFetcher=" + disableDefaultResourceFetcher +
       ", mapLog='" + mapLog + '\'' +
+      ", displayWarnings=" + displayWarnings +
+      ", noExtensibleBindingMessages=" + noExtensibleBindingMessages +
       "}";
   }
 }


### PR DESCRIPTION
The following fields were moved to the correct parameter object class:

displayWarnings and noExtensibleBindingMessages to ValidationEngineParameters

doImplicitFHIRPathStringConversion, allowDoubleQuotesInFHIRPath, checkIPSCodes, bundleValidationRules, and jurisdiction to InstanceValidatorParameters

None of these parameter object classes are currently in use except for parameter parsing, which remains unchanged (for now, it still compiles all params into the monolithic ValidationContext).