### PR TITLE
Fix spelling error in `*Connection` queries

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/GraphQLSchemaGenerator.java
@@ -212,7 +212,7 @@ public class GraphQLSchemaGenerator {
   private void generateConnectionAccess(BufferedWriter writer, List<SearchParameter> parameters, String name)
       throws IOException {
     writer.write("type " + name + "ConnectionType {\r\n");
-    writer.write("  " + name + "Conection(");
+    writer.write("  " + name + "Connection(");
     param(writer, "_filter", "String", false, false);
     for (SearchParameter sp : parameters)
       param(writer, sp.getName().replace("-", "_"), getGqlname(sp.getType().toCode()), true, true);

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/GraphQLSchemaGenerator.java
@@ -215,7 +215,7 @@ public class GraphQLSchemaGenerator {
   private void generateConnectionAccess(BufferedWriter writer, List<SearchParameter> parameters, String name)
       throws IOException {
     writer.write("type " + name + "ConnectionType {\r\n");
-    writer.write("  " + name + "Conection(");
+    writer.write("  " + name + "Connection(");
     param(writer, "_filter", "String", false, false);
     for (SearchParameter sp : parameters)
       param(writer, sp.getName().replace("-", "_"), getGqlname(sp.getType().toCode()), true, true);

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/GraphQLSchemaGenerator.java
@@ -260,7 +260,7 @@ public class GraphQLSchemaGenerator {
   }
 
   public void generateConnectionAccessQuery(Writer writer, List<SearchParameter> parameters, String name) throws IOException {
-    writer.write(name + "Conection(");
+    writer.write(name + "Connection(");
     param(writer, "_filter", "String", false, false);
     for (SearchParameter sp : parameters)
       param(writer, sp.getName().replace("-", "_"), getGqlname(requireNonNull(sp.getType().toCode())), true, true);


### PR DESCRIPTION
There seems to be a spelling error when generating connection queries. Queries such as `PatientConnection` appear as `PatientConection` (notice the missing `n` in `Connection`) in the GraphQL schema.

When used with HAPI FHIR, executing `PatientConection` doesn't result in an error but also doesn't result in data being retrieved. Executing `PatientConnection` produces the expected result, but will get flagged as invalid when using tools that perform schema validation.