### PR TITLE
possible fix for #2138

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -4073,7 +4073,16 @@ public class ProfileUtilities {
     if (source != null && source.getSourcePackage() != null && source.getSourcePackage().isCore()) {
       source = null;
     }
-    return context.fetchResource(StructureDefinition.class, u, v, source);
+    StructureDefinition sd = context.fetchResource(StructureDefinition.class, u, v, source);
+    if (sd == null) {
+      if (makeXVer().matchingUrl(u) && xver.status(u) == XVerExtensionStatus.Valid) {
+        sd = xver.getDefinition(u);
+        if (sd!=null) {
+          generateSnapshot(context.fetchTypeDefinition("Extension"), sd, sd.getUrl(), context.getSpecUrl(), sd.getName());
+        }
+      }
+    }
+    return sd;
   }
 
   // generate a CSV representation of the structure definition


### PR DESCRIPTION
we got noted in matchbox https://github.com/ahdis/matchbox/issues/424 that r5 extensions in r4 are throwing an error when validating against a profile where the r5 extensions are listed as discriminators. after a second validation in the same context the problem disappeared. we tracked it down that the xversion where not considered inside the slicing, attached a fix which helped solved our problem and i assume it should also fix #2138 