### PR TITLE
Allow -allow-example-urls to work with true/false as well

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/InstanceValidatorOptions.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/InstanceValidatorOptions.java
@@ -100,7 +100,7 @@ public class InstanceValidatorOptions {
 
   @CommandLine.Option(names = {"-allow-example-urls"},
     description = "Allow references to example.org URLs in resources to be treated as valid",
-    arity = "0")
+    arity = "0..1")
   @With
   public boolean allowExampleUrls = false;
 


### PR DESCRIPTION
"-allow-example-urls true" is included in our documentation, but the new Picocli implementation only accepts "-allow-example-urls". This PR restores the original functionality, as well as allowing "-allow-example-urls" to work without a boolean value following.