### PR TITLE
Fix for null sources in getSources()

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/CompareCommand.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/CompareCommand.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -51,7 +52,7 @@ public class CompareCommand extends ValidationEngineCommand implements Callable<
 
   @Override
   public List<String> getSources() {
-    return List.of(sources);
+    return sources == null ? Collections.emptyList() : List.of(sources);
   }
 
   @Override


### PR DESCRIPTION
If the 'sources' array was null, as it would be with no listed sources, this would cause a NullPointerException to the thrown. This fix implements the same null check all other commands are already using.