### PR TITLE
Restore system exit output to CLI validate

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/SystemExitManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/SystemExitManager.java
@@ -1,33 +1,29 @@
 package org.hl7.fhir.utilities;
 
+import lombok.Getter;
+
 /**
  * A few places in the code, we call System.exit(int) to pass on the exit code to 
  * other tools (for integration in scripts)
- * 
+ * <p/>
  * But you don't want to do that while running the failing things under JUnit 
  * This class does two things 
- * 
+ * <p/>
  * * Remember the exit code while shutdown / cleanup happens 
- * * Allow for a test case to turn exiting off altogther 
+ * * Allow for a test case to turn exiting off altogether
  *  
  * @author grahamegrieve
  *
  */
 public class SystemExitManager {
 
+  @Getter
   private static int error;
+  @Getter
   private static boolean noExit;
-
-  public static int getError() {
-    return error;
-  }
 
   public static void setError(int error) {
     SystemExitManager.error = error;
-  }
-
-  public static boolean isNoExit() {
-    return noExit;
   }
 
   public static void setNoExit(boolean noExit) {

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/ValidateCommand.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/ValidateCommand.java
@@ -3,6 +3,7 @@ package org.hl7.fhir.validation.cli.picocli.commands;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.utilities.SystemExitManager;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.cli.picocli.options.*;
 import org.hl7.fhir.validation.service.ValidateSourceParameters;
@@ -151,7 +152,9 @@ public class ValidateCommand extends ValidationEngineCommand {
     if (validationEngineOptions.advisorFile != null) {
       log.info("Note: Some validation issues might be hidden by the advisor settings in the file "+ validationEngineOptions.advisorFile);
     }
-
+    if (SystemExitManager.getError() > 0) {
+      return 1;
+    }
     return 0;
   }
 


### PR DESCRIPTION
The validate command wasn't producing system exit values (0 for success, positive int values for failure).

This restores that functionality.