### PR TITLE
Add allowHttp configuration for internal servers

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedWebAccess.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedWebAccess.java
@@ -162,7 +162,21 @@ public class ManagedWebAccess {
     URI uri;
     try {
       uri = new URI(url);
-      // todo: check in serverAuthDetails to see if policy is set for this server
+      
+      // Check if this URL matches a configured server with allowHttp: true
+      // This allows HTTP for trusted internal servers (e.g., Docker service names)
+      if (serverAuthDetails != null) {
+        for (ServerDetailsPOJO server : serverAuthDetails) {
+          if (server.getAllowHttp() != null && server.getAllowHttp() && server.getUrl() != null && !server.getUrl().isEmpty()) {
+            // Match if the URL starts with the configured server URL
+            if (url.startsWith(server.getUrl())) {
+              return true;
+            }
+          }
+        }
+      }
+      
+      // Fall back to hardcoded local addresses
       return Utilities.existsInList(uri.getHost(), "localhost", "local.fhir.org", "127.0.0.1", "[::1]") || (uri.getHost() != null && uri.getHost().endsWith(".localhost"));
     } catch (URISyntaxException e) {
       return false;

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/settings/FhirSettings.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/settings/FhirSettings.java
@@ -212,7 +212,28 @@ public class FhirSettings {
     final ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     final InputStream inputStream = ManagedFileAccess.inStream(file);
-    return objectMapper.readValue(inputStream, FhirSettingsPOJO.class);
+    FhirSettingsPOJO settings = objectMapper.readValue(inputStream, FhirSettingsPOJO.class);
+    normalizeSettings(settings);
+    return settings;
+  }
+
+  /**
+   * Normalizes settings after deserialization to ensure required fields have safe defaults.
+   * This prevents NPEs when switch statements expect non-null values.
+   */
+  private static void normalizeSettings(FhirSettingsPOJO settings) {
+    if (settings == null || settings.getServers() == null) {
+      return;
+    }
+
+    for (ServerDetailsPOJO server : settings.getServers()) {
+      if (server == null) {
+        continue;
+      }
+      if (server.getAuthenticationType() == null) {
+        server.setAuthenticationType("none");
+      }
+    }
   }
 
   protected static String getDefaultSettingsPath() throws IOException {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/settings/ServerDetailsPOJO.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/settings/ServerDetailsPOJO.java
@@ -40,5 +40,11 @@ public class ServerDetailsPOJO {
 
     String apikey;
 
+    /**
+     * When true, allows HTTP connections to this server without upgrading to HTTPS.
+     * Use this for internal servers (e.g. Docker service names) that don't support HTTPS.
+     */
+    Boolean allowHttp;
+
     Map<String, String> headers;
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedWebAccessAuthTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedWebAccessAuthTests.java
@@ -168,7 +168,7 @@ public class ManagedWebAccessAuthTests {
       "fhir",
       DUMMY_USERNAME,
       DUMMY_PASSWORD,
-      null, null, null);
+      null, null, null, null);
   }
 
 @Test
@@ -187,7 +187,7 @@ public void testTokenAuthFromSettings() throws IOException, InterruptedException
       "fhir",
      null,
       null,
-      DUMMY_TOKEN, null, null);
+      DUMMY_TOKEN, null, null, null);
   }
 
   @Test
@@ -206,7 +206,7 @@ public void testTokenAuthFromSettings() throws IOException, InterruptedException
       "fhir",
       null,
       null,
-     null, DUMMY_API_KEY, null);
+     null, DUMMY_API_KEY, null, null);
   }
 
   @Test

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedWebAccessSecurityTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedWebAccessSecurityTest.java
@@ -1,0 +1,228 @@
+package org.hl7.fhir.utilities.http;
+
+import org.hl7.fhir.utilities.settings.ServerDetailsPOJO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManagedWebAccessSecurityTest {
+
+  @AfterEach
+  void cleanup() {
+    // Reset to default state after each test
+    ManagedWebAccess.loadFromFHIRSettings();
+  }
+
+  /**
+   * Helper method to set server auth details in ManagedWebAccess using reflection
+   * since serverAuthDetails is private and only settable via loadFromFHIRSettings()
+   */
+  private void setServerAuthDetails(List<ServerDetailsPOJO> servers) throws Exception {
+    Field field = ManagedWebAccess.class.getDeclaredField("serverAuthDetails");
+    field.setAccessible(true);
+    field.set(null, servers);
+  }
+
+  @Test
+  public void testMakeSecureRef_withAllowHttp_keepsHttp() throws Exception {
+    // Setup: Configure a server with allowHttp: true
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://my-term-server:8080/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(true)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: HTTP URL matching the configured server should remain HTTP
+    String httpUrl = "http://my-term-server:8080/fhir/ValueSet/$validate-code";
+    String result = ManagedWebAccess.makeSecureRef(httpUrl);
+    
+    assertThat(result).isEqualTo(httpUrl);
+  }
+
+  @Test
+  public void testMakeSecureRef_withoutAllowHttp_upgradesHttps() throws Exception {
+    // Setup: Configure a server without allowHttp
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://external-server.com/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(false)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: HTTP URL should be upgraded to HTTPS when allowHttp is false
+    String httpUrl = "http://external-server.com/fhir/metadata";
+    String result = ManagedWebAccess.makeSecureRef(httpUrl);
+    
+    assertThat(result).isEqualTo("https://external-server.com/fhir/metadata");
+  }
+
+  @Test
+  public void testMakeSecureRef_withNullAllowHttp_upgradesHttps() throws Exception {
+    // Setup: Configure a server with null allowHttp (default behavior)
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://some-server.com/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(null)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: HTTP URL should be upgraded to HTTPS when allowHttp is null
+    String httpUrl = "http://some-server.com/fhir/metadata";
+    String result = ManagedWebAccess.makeSecureRef(httpUrl);
+    
+    assertThat(result).isEqualTo("https://some-server.com/fhir/metadata");
+  }
+
+  @Test
+  public void testMakeSecureRef_emptyUrlConfig_doesNotMatchAll() throws Exception {
+    // Setup: Configure a server with empty URL (security vulnerability test)
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(true)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: Empty URL config should NOT allow HTTP for all URLs
+    String httpUrl = "http://malicious-site.com/data";
+    String result = ManagedWebAccess.makeSecureRef(httpUrl);
+    
+    // Should be upgraded to HTTPS because empty URL shouldn't match
+    assertThat(result).isEqualTo("https://malicious-site.com/data");
+  }
+
+  @Test
+  public void testMakeSecureRef_localhost_alwaysAllowsHttp() {
+    // Test: Hardcoded localhost addresses should remain HTTP
+    assertThat(ManagedWebAccess.makeSecureRef("http://localhost:8080/fhir"))
+      .isEqualTo("http://localhost:8080/fhir");
+    
+    assertThat(ManagedWebAccess.makeSecureRef("http://127.0.0.1:8080/fhir"))
+      .isEqualTo("http://127.0.0.1:8080/fhir");
+    
+    assertThat(ManagedWebAccess.makeSecureRef("http://[::1]:8080/fhir"))
+      .isEqualTo("http://[::1]:8080/fhir");
+    
+    assertThat(ManagedWebAccess.makeSecureRef("http://local.fhir.org/fhir"))
+      .isEqualTo("http://local.fhir.org/fhir");
+    
+    assertThat(ManagedWebAccess.makeSecureRef("http://myapp.localhost/fhir"))
+      .isEqualTo("http://myapp.localhost/fhir");
+  }
+
+  @Test
+  public void testMakeSecureRef_httpsUrl_remainsHttps() {
+    // Test: HTTPS URLs should never be downgraded
+    String httpsUrl = "https://secure-server.com/fhir";
+    String result = ManagedWebAccess.makeSecureRef(httpsUrl);
+    
+    assertThat(result).isEqualTo(httpsUrl);
+  }
+
+  @Test
+  public void testMakeSecureRef_nullUrl_returnsNull() {
+    // Test: Null URL should be handled gracefully
+    String result = ManagedWebAccess.makeSecureRef(null);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void testMakeSecureRef_partialUrlMatch_doesNotAllowHttp() throws Exception {
+    // Setup: Configure a server with allowHttp for a specific base URL
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://my-term-server:8080/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(true)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: URL that doesn't start with configured URL should be upgraded
+    String httpUrl = "http://different-server:8080/fhir/metadata";
+    String result = ManagedWebAccess.makeSecureRef(httpUrl);
+    
+    assertThat(result).isEqualTo("https://different-server:8080/fhir/metadata");
+  }
+
+  @Test
+  public void testMakeSecureRef_dockerServiceName_withAllowHttp() throws Exception {
+    // Setup: Docker scenario with service names
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://blaze-terminology:8080/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(true)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: Docker service name URL should remain HTTP
+    String dockerUrl = "http://blaze-terminology:8080/fhir/metadata";
+    String result = ManagedWebAccess.makeSecureRef(dockerUrl);
+    
+    assertThat(result).isEqualTo(dockerUrl);
+  }
+
+  @Test
+  public void testMakeSecureRef_multipleServers_correctMatching() throws Exception {
+    // Setup: Multiple servers, some with allowHttp, some without
+    List<ServerDetailsPOJO> servers = new ArrayList<>();
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://internal-server:8080/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(true)
+      .build());
+    servers.add(ServerDetailsPOJO.builder()
+      .url("http://external-server.com/fhir")
+      .type("fhir")
+      .authenticationType("none")
+      .allowHttp(false)
+      .build());
+
+    setServerAuthDetails(servers);
+    ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.DIRECT);
+    ManagedWebAccess.setUserAgent("test-agent");
+
+    // Test: Internal server URL should remain HTTP
+    assertThat(ManagedWebAccess.makeSecureRef("http://internal-server:8080/fhir/metadata"))
+      .isEqualTo("http://internal-server:8080/fhir/metadata");
+
+    // Test: External server URL should be upgraded to HTTPS
+    assertThat(ManagedWebAccess.makeSecureRef("http://external-server.com/fhir/metadata"))
+      .isEqualTo("https://external-server.com/fhir/metadata");
+  }
+}


### PR DESCRIPTION
- Add allowHttp field to ServerDetailsPOJO to allow HTTP for trusted internal servers (e.g., Docker service names)
- Update ManagedWebAccess.isLocal() to check configured servers with allowHttp: true
- Add normalizeSettings() to prevent NPE when authenticationType is missing
- Add empty URL validation to prevent security vulnerability
- Add tests

Fixes #2312