### PR TITLE
Improve backwards compatibility for 'transform' and 're-package'

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/CLI.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/CLI.java
@@ -93,6 +93,7 @@ public class CLI {
     argMap.put("-factory", "factory");
     argMap.put("-server", "server");
     argMap.put("-re-package", "re-package");
+    argMap.put("-tx-pack", "re-package");
     argMap.put("-?", "-help");
     argMap.put("/?", "-help");
 


### PR DESCRIPTION
There were missing backwards compatibility mappings for these two sub-commands. 

'-tx-pack' appeared in the docs but not in the codebase before the Picocli conversion, but is now included in case anyone complains.