### PR TITLE
perf: cache SemverParser results, getResourceNames, and JsonFactory

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/SimpleWorkerContext.java
@@ -746,14 +746,21 @@ public class SimpleWorkerContext extends BaseWorkerContext implements IWorkerCon
 	  return validatorFactory.makeValidator(this, xverManager, null).setJurisdiction(JurisdictionUtilities.getJurisdictionCodingFromLocale(Locale.getDefault().getCountry()));
 	}
 
+  private volatile List<String> cachedResourceNames;
+
   @Override
   public List<String> getResourceNames() {
-    Set<String> result = new HashSet<String>();
-    for (StructureDefinition sd : listStructures()) {
-      if (sd.getKind() == StructureDefinitionKind.RESOURCE && sd.getDerivation() == TypeDerivationRule.SPECIALIZATION && !sd.hasUserData(UserDataNames.loader_urls_patched))
-        result.add(sd.getName());
+    List<String> result = cachedResourceNames;
+    if (result == null) {
+      Set<String> names = new HashSet<String>();
+      for (StructureDefinition sd : listStructures()) {
+        if (sd.getKind() == StructureDefinitionKind.RESOURCE && sd.getDerivation() == TypeDerivationRule.SPECIALIZATION && !sd.hasUserData(UserDataNames.loader_urls_patched))
+          names.add(sd.getName());
+      }
+      result = Utilities.sorted(names);
+      cachedResourceNames = result;
     }
-    return Utilities.sorted(result);
+    return result;
   }
 
  

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/SemverParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/SemverParser.java
@@ -2,8 +2,11 @@ package org.hl7.fhir.utilities;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SemverParser {
+  private static final Map<String, ParseResult> PARSE_CACHE = new ConcurrentHashMap<>();
   private final String input;
   private int pos;
   private final List<String> parts;
@@ -548,8 +551,14 @@ public class SemverParser {
 
   // Static convenience method
   public static ParseResult parseSemver(String input) {
+    ParseResult cached = PARSE_CACHE.get(input);
+    if (cached != null) {
+      return cached;
+    }
     SemverParser parser = new SemverParser(input);
-    return parser.parse();
+    ParseResult result = parser.parse();
+    PARSE_CACHE.put(input, result);
+    return result;
   }
 
   public static ParseResult parseSemver(String input, boolean allowWildcards) {
@@ -558,7 +567,14 @@ public class SemverParser {
   }
 
   public static ParseResult parseSemver(String input, boolean allowWildcards, boolean requirePatch) {
+    String cacheKey = input + "|" + allowWildcards + "|" + requirePatch;
+    ParseResult cached = PARSE_CACHE.get(cacheKey);
+    if (cached != null) {
+      return cached;
+    }
     SemverParser parser = new SemverParser(input, allowWildcards, requirePatch);
-    return parser.parse();
+    ParseResult result = parser.parse();
+    PARSE_CACHE.put(cacheKey, result);
+    return result;
   }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/NpmPackageIndexBuilder.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/NpmPackageIndexBuilder.java
@@ -39,6 +39,7 @@ public class NpmPackageIndexBuilder {
   private static INpmPackageIndexBuilderDBImplFactory extensionFactory;
 
   public static final Integer CURRENT_INDEX_VERSION = 2;
+  private static final JsonFactory JSON_FACTORY = new JsonFactory(); // reuse across all seeFile calls
   private JsonObject index;
   private JsonArray files;
   private String dbFilename;
@@ -68,7 +69,7 @@ public class NpmPackageIndexBuilder {
        * We can then use a streaming parser to get the values of these fields instead of parsing the whole file and
        * allocating memory for everything in it.
        */
-      try (final var parser = new JsonFactory().createParser(content)) {
+      try (final var parser = JSON_FACTORY.createParser(content)) {
         final var fi = new JsonObject();
         int level = 0;
 


### PR DESCRIPTION
## Summary

Three small caching fixes:

1. **`SemverParser.parseSemver()`**: Add a `ConcurrentHashMap` cache for parse results. This method is called frequently from `CanonicalResourceManager` version comparisons via `VersionUtilities.isSemVer()`. (113 CPU samples in profiling)

2. **`SimpleWorkerContext.getResourceNames()`**: Cache the result with a lazy-init `volatile` field instead of rebuilding the list on every call. (Part of the `getResourceNames` 3% hotspot)

3. **`NpmPackageIndexBuilder`**: Share a single static `JsonFactory` instance instead of creating a new one per use.

## A/B Benchmark

Part of a set of independent changes producing 31% overall speedup. Full details: https://github.com/jmandel/igpublisher-perf