### PR TITLE
Feat/resolve logical

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -5648,8 +5648,10 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         Property p = item.getChildByName("reference");
         if (p != null && p.hasValues()) {
           s = convertToString(p.getValues().get(0));
-        } else {
-          s = null; // a reference without any valid actual reference (just identifier or display, but we can't resolve it)
+        } else if (hostServices == null) {
+          // a reference without any valid actual reference (just identifier or display, but we can't resolve it)
+          // if hostServices is != null, we'll give it a change to try resolve it
+          s = null;
         }
       }
       if (item.fhirType().equals("canonical")) {


### PR DESCRIPTION
This pull request introduces improvements to the handling and testing of logical references in FHIRPath resolution. The main changes ensure that logical references can be resolved when `hostServices` are provided, and adds tests to verify this behavior as well as the fallback when `hostServices` are absent.

Enhancements to reference resolution:

* Updated `funcResolve` in `FHIRPathEngine.java` to attempt resolution of logical references using `hostServices` when available, instead of defaulting to `null.

Testing improvements:

* Added `testResolve_LogicalReferenceWithHostServices` to verify that logical references are resolved correctly when custom `hostServices` are set.
* Added `testResolve_LogicalReferenceWithoutHostServices` to confirm that logical references are not resolved when `hostServices` are not provided.