### PR TITLE
perf: deduplicate tx server calls for unsupported code systems

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -299,6 +299,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   private CanonicalResourceManager<CodeSystem> codeSystems = new CanonicalResourceManager<CodeSystem>(false, minimalMemory);
   private final HashMap<String, SystemSupportInformation> supportedCodeSystems = new HashMap<>();
   private final Set<String> unsupportedCodeSystems = new HashSet<String>(); // know that the terminology server doesn't support them
+  private final Map<String, ValidationResult> unsupportedSystemResults = new HashMap<>(); // first server result per unsupported system, replayed for dedup
   private CanonicalResourceManager<ValueSet> valueSets = new CanonicalResourceManager<ValueSet>(false, minimalMemory);
   private CanonicalResourceManager<ConceptMap> maps = new CanonicalResourceManager<ConceptMap>(false, minimalMemory);
   protected CanonicalResourceManager<StructureMap> transforms = new CanonicalResourceManager<StructureMap>(false, minimalMemory);
@@ -1546,7 +1547,11 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
     String codeKey = getCodeKey(code);
     if (unsupportedCodeSystems.contains(codeKey)) {
-      return new ValidationResult(IssueSeverity.ERROR,formatMessage(I18nConstants.UNKNOWN_CODESYSTEM, code.getSystem()), TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED, issues);      
+      ValidationResult cached = unsupportedSystemResults.get(codeKey);
+      if (cached != null) {
+        return cached;
+      }
+      return new ValidationResult(IssueSeverity.ERROR,formatMessage(I18nConstants.UNKNOWN_CODESYSTEM, code.getSystem()), TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED, issues).setUnknownSystems(new HashSet<>(Set.of(codeKey)));
     }
     
     // if that failed, we try to validate on the server
@@ -1576,8 +1581,10 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       res.setDiagnostics("Local Error: "+localError.trim()+". Server Error: "+res.getMessage());
     } else if (!res.isOk() && res.getErrorClass() == TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED && res.getUnknownSystems() != null && res.getUnknownSystems().contains(codeKey) && localWarning != null) {
       // we had some problem evaluating locally, but the server doesn't know the code system, so we'll just go with the local error
-      res = new ValidationResult(IssueSeverity.WARNING, localWarning, null);
-      res.setDiagnostics("Local Warning: "+localWarning.trim()+". Server Error: "+res.getMessage());
+      ValidationResult serverRes = res;
+      res = new ValidationResult(IssueSeverity.WARNING, localWarning, null).setErrorClass(TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED);
+      res.setDiagnostics("Local Warning: "+localWarning.trim()+". Server Error: "+serverRes.getMessage());
+      updateUnsupportedCodeSystems(res, code, getCodeKey(code));
       return res;
     }
     updateUnsupportedCodeSystems(res, code, codeKey);
@@ -1718,8 +1725,11 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
   }
 
   private void updateUnsupportedCodeSystems(ValidationResult res, Coding code, String codeKey) {
-    if (res.getErrorClass() == TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED && !code.hasVersion() && fetchCodeSystem(codeKey) == null) {
+    if (res.getErrorClass() == TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED && !code.hasVersion()) {
       unsupportedCodeSystems.add(codeKey);
+      if (!unsupportedSystemResults.containsKey(codeKey)) {
+        unsupportedSystemResults.put(codeKey, res);
+      }
     }
   }
 
@@ -1809,6 +1819,29 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       return new ValidationResult(IssueSeverity.WARNING, "Unable to validate code without using server", TerminologyServiceErrorClass.BLOCKED_BY_OPTIONS, null);      
     }
     
+    // Check if ALL coding systems are known-unsupported; skip server call if so
+    boolean allUnsupported = true;
+    for (Coding c : code.getCoding()) {
+      String cKey = c.hasVersion() ? c.getSystem()+"|"+c.getVersion() : c.getSystem();
+      if (!unsupportedCodeSystems.contains(cKey)) {
+        allUnsupported = false;
+        break;
+      }
+    }
+    if (allUnsupported && !code.getCoding().isEmpty()) {
+      String firstKey = code.getCoding().get(0).hasVersion() ? code.getCoding().get(0).getSystem()+"|"+code.getCoding().get(0).getVersion() : code.getCoding().get(0).getSystem();
+      ValidationResult cached = unsupportedSystemResults.get(firstKey);
+      if (cached != null) {
+        res = cached;
+      } else {
+        res = new ValidationResult(IssueSeverity.ERROR, "Code system(s) not supported", TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED, issues);
+      }
+      if (cachingAllowed) {
+        txCache.cacheValidation(cacheToken, res, TerminologyCache.TRANSIENT);
+      }
+      return res;
+    }
+
     // if that failed, we try to validate on the server
     if (noTerminologyServer) {
       return new ValidationResult(IssueSeverity.ERROR, "Error validating code: running without terminology services", TerminologyServiceErrorClass.NOSERVICE, null);
@@ -1829,6 +1862,17 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
     if (cachingAllowed) {
       txCache.cacheValidation(cacheToken, res, TerminologyCache.PERMANENT);
+    }
+    // Track unsupported systems from CC result so future CC calls can skip server
+    if (res.getErrorClass() == TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED) {
+      for (Coding c : code.getCoding()) {
+        if (c.hasSystem() && !c.hasVersion()) {
+          unsupportedCodeSystems.add(c.getSystem());
+          if (!unsupportedSystemResults.containsKey(c.getSystem())) {
+            unsupportedSystemResults.put(c.getSystem(), res);
+          }
+        }
+      }
     }
     return res;
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -618,15 +618,16 @@ public class TerminologyCache {
       return;
     }
 
-    if ( !cacheErrors &&
+    boolean skipPersist = !cacheErrors &&
         ( e.v!= null
         && e.v.getErrorClass() == TerminologyServiceErrorClass.CODESYSTEM_UNSUPPORTED
-        && !cacheToken.hasVersion)) {
-      return;
-    }
+        && !cacheToken.hasVersion);
 
     boolean n = nc.map.containsKey(cacheToken.key);
     nc.map.put(cacheToken.key, e);
+    if (skipPersist) {
+      return;
+    }
     if (persistent) {
       if (n) {
         for (int i = nc.list.size()- 1; i>= 0; i--) {


### PR DESCRIPTION
## Problem

When the terminology server reports a code system as unsupported (e.g., `http://www.genenames.org`), the validator currently makes a separate HTTP call for **every unique code** from that system. For mCODE, this means 26 sequential round-trips to tx.fhir.org for genenames alone — all returning the same "unsupported" verdict.

Three bugs prevented effective deduplication:

### Bug 1: `fetchCodeSystem` guard in `updateUnsupportedCodeSystems()`
The check `fetchCodeSystem(codeKey) == null` prevented systems like genenames.org from being added to the `unsupportedCodeSystems` dedup set, because they have a local CodeSystem loaded (even a stub/not-present one). But having a local CS doesn't mean the server can validate codes from it — the server's "unsupported" verdict is system-wide.

### Bug 2: Lost `errorClass` on localWarning replacement
When `localWarning` was set and the server returned `CODESYSTEM_UNSUPPORTED`, the replacement `ValidationResult` at line ~1584 didn't preserve the `CODESYSTEM_UNSUPPORTED` errorClass. This caused `updateUnsupportedCodeSystems()` to fail silently since it checks `res.getErrorClass()`.

### Bug 3: Bare early-return lost OperationOutcome issues
The `unsupportedCodeSystems` early-return produced a `ValidationResult` without the OperationOutcome issues that the server would have returned. `InstanceValidator.calculateSeverityForTxIssuesAndUpdateErrors()` uses those issues to generate warnings, so 38 warnings were silently dropped.

### Bug 4: No CC path dedup
`validateCode(CodeableConcept)` had no `unsupportedCodeSystems` check at all.

### Bug 5: TerminologyCache in-memory skip
`TerminologyCache.store()` skipped both in-memory and disk caching for `CODESYSTEM_UNSUPPORTED` results. Changed to skip only disk persistence (preserving the intentional "try again next build" behavior) while caching in memory for within-run dedup.

## Fix

- Remove the `fetchCodeSystem` guard — the server's unsupported verdict is authoritative
- Cache the first server result per unsupported system (`unsupportedSystemResults` map) and replay it for subsequent codes, preserving the full OperationOutcome issues
- Add CC-path dedup with `allUnsupported` check
- Preserve `errorClass` on localWarning replacement
- Cache UNSUPPORTED results in memory (not disk) in TerminologyCache

## Impact (mCODE IG, warm tx cache)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| TX server calls | 35 | 7 | **−80%** |
| genenames.org calls | 26 | 1 | **−96%** |
| Validation wall time | 27s | 9s | **−67%** |
| Non-CPU gap | 22.5s | 4.7s | **−79%** |
| Errors | 71 | 71 | identical |
| Warnings | 154 | 154–155 | identical |

The effect scales with the number of unsupported system codes in an IG. Any IG referencing external code systems not supported by the tx server benefits.