### PR TITLE
Fix StructureMapUtilities failures  by updating the StructureMap runtime in R4, R4B, and R5.

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -53,6 +53,7 @@ import org.hl7.fhir.r4.conformance.ProfileUtilities.ProfileKnowledgeProvider;
 import org.hl7.fhir.r4.context.IWorkerContext;
 import org.hl7.fhir.r4.context.IWorkerContext.ValidationResult;
 import org.hl7.fhir.r4.elementmodel.Element;
+import org.hl7.fhir.r4.elementmodel.ObjectConverter;
 import org.hl7.fhir.r4.elementmodel.Property;
 import org.hl7.fhir.r4.fhirpath.ExpressionNode;
 import org.hl7.fhir.r4.fhirpath.FHIRLexer;
@@ -1717,30 +1718,46 @@ public class StructureMapUtilities {
       return res;
     }
 
+    Set<String> visitedMapUrls = new HashSet<String>();
+    visitedMapUrls.add(getMapVisitKey(map));
+    resolveGroupReferenceInImports(map, name, res, visitedMapUrls);
+    if (res.target == null)
+      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
+    source.setUserData(kn, res);
+    return res;
+  }
+
+  private void resolveGroupReferenceInImports(StructureMap map, String name, ResolvedGroup res, Set<String> visitedMapUrls)
+      throws FHIRException {
     for (UriType imp : map.getImport()) {
       List<StructureMap> impMapList = findMatchingMaps(imp.getValue());
       if (impMapList.size() == 0)
         throw new FHIRException("Unable to find map(s) for " + imp.getValue());
       for (StructureMap impMap : impMapList) {
-        if (!impMap.getUrl().equals(map.getUrl())) {
-          for (StructureMapGroupComponent grp : impMap.getGroup()) {
-            if (grp.getName().equals(name)) {
-              if (res.targetMap == null) {
-                res.targetMap = impMap;
-                res.target = grp;
-              } else
-                throw new FHIRException(
-                    "Multiple possible matches for rule group '" + name + "' in " + res.targetMap.getUrl() + "#"
-                        + res.target.getName() + " and " + impMap.getUrl() + "#" + grp.getName());
-            }
+        String visitKey = getMapVisitKey(impMap);
+        if (visitedMapUrls.contains(visitKey))
+          continue;
+
+        visitedMapUrls.add(visitKey);
+        for (StructureMapGroupComponent grp : impMap.getGroup()) {
+          if (grp.getName().equals(name)) {
+            if (res.targetMap == null) {
+              res.targetMap = impMap;
+              res.target = grp;
+            } else
+              throw new FHIRException(
+                  "Multiple possible matches for rule group '" + name + "' in " + res.targetMap.getUrl() + "#"
+                      + res.target.getName() + " and " + impMap.getUrl() + "#" + grp.getName());
           }
         }
+
+        resolveGroupReferenceInImports(impMap, name, res, visitedMapUrls);
       }
     }
-    if (res.target == null)
-      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
-    source.setUserData(kn, res);
-    return res;
+  }
+
+  private String getMapVisitKey(StructureMap map) {
+    return map.getUrl() == null ? Integer.toHexString(System.identityHashCode(map)) : map.getUrl();
   }
 
   private List<Variables> processSource(String ruleId, TransformContext context, Variables vars,
@@ -1886,10 +1903,18 @@ public class StructureMapUtilities {
     Base v = null;
     if (tgt.hasTransform()) {
       v = runTransform(ruleId, context, map, group, tgt, vars, dest, tgt.getElement(), srcVar, atRoot);
-      if (v != null && dest != null)
+      if (v != null && dest != null) {
+        if (dest instanceof Element && v instanceof Type && !v.isPrimitive() && !(v instanceof Element)) {
+          Type typedValue = (Type) v;
+          Property childProperty = resolveTargetChildProperty((Element) dest, tgt.getElement());
+          if (childProperty != null) {
+            v = normalizeConvertedTypeValue(childProperty, typedValue, new ObjectConverter(worker).convert(childProperty, typedValue));
+          }
+        }
         v = dest.setProperty(tgt.getElement().hashCode(), tgt.getElement(), v); // reset v because some implementations
                                                                                 // may have to rewrite v when setting
                                                                                 // the value
+      }
     } else if (dest != null) {
       if (tgt.hasListMode(StructureMapTargetListMode.SHARE)) {
         v = sharedVars.get(VariableMode.SHARED, tgt.getListRuleId());
@@ -1903,6 +1928,38 @@ public class StructureMapUtilities {
     }
     if (tgt.hasVariable() && v != null)
       vars.add(VariableMode.OUTPUT, tgt.getVariable(), v);
+  }
+
+  private Property resolveTargetChildProperty(Element theDestination, String theChildName) throws FHIRException {
+    if (theDestination.getProperty() == null) {
+      return null;
+    }
+    Property child = theDestination.getProperty().getChild(theDestination.getType(), theChildName);
+    if (child == null) {
+      child = theDestination.getProperty().getChildSimpleName(theDestination.getType(), theChildName);
+    }
+    if (child == null) {
+      child = theDestination.getProperty().getChild(theChildName);
+    }
+    return child;
+  }
+
+  private Element normalizeConvertedTypeValue(Property theChildProperty, Type theSourceValue, Element theConvertedValue) {
+    if (theConvertedValue == null) {
+      return null;
+    }
+    String actualType = theSourceValue.fhirType();
+    if (Utilities.noString(actualType)) {
+      return theConvertedValue;
+    }
+    Element normalized = new Element(theConvertedValue.getName(), theChildProperty, actualType, theConvertedValue.getValue());
+    if (theConvertedValue.hasChildren()) {
+      normalized.getChildren().addAll(theConvertedValue.getChildren());
+    }
+    if (theConvertedValue.hasComments()) {
+      normalized.getComments().addAll(theConvertedValue.getComments());
+    }
+    return normalized;
   }
 
   private Base runTransform(String ruleId, TransformContext context, StructureMap map, StructureMapGroupComponent group,

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/elementmodel/StructureMapUtilitiesTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/elementmodel/StructureMapUtilitiesTest.java
@@ -1,0 +1,287 @@
+package org.hl7.fhir.r4.elementmodel;
+
+/*
+  Copyright (c) 2011+, HL7, Inc.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
+     prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.hl7.fhir.r4.context.IWorkerContext;
+import org.hl7.fhir.r4.context.SimpleWorkerContext;
+import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.test.utils.TestingUtilities;
+import org.hl7.fhir.r4.utils.StructureMapUtilities;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StructureMapUtilitiesTest {
+
+  @Test
+  void transitiveImportsShouldResolveNamedGroups() throws Exception {
+    SimpleWorkerContext delegate = (SimpleWorkerContext) TestingUtilities.context();
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/shared/FhirDatatypeCopies\" = \"FhirDatatypeCopies\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as target\n"
+            + "\n"
+            + "group CopyHumanName(source src : HumanName, target tgt : HumanName) {\n"
+            + "  src.family as s -> tgt.family = s \"copy-family\";\n"
+            + "  src.given as s -> tgt.given = s \"copy-given\";\n"
+            + "}\n",
+        "FhirDatatypeCopies.map");
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/mid/Mid\" = \"Mid\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/shared/FhirDatatypeCopies\"\n"
+            + "\n"
+            + "group Mid(source src : Patient, target tgt : Patient) {\n"
+            + "  src -> tgt \"noop\";\n"
+            + "}\n",
+        "Mid.map");
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/Top\" = \"Top\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/mid/Mid\"\n"
+            + "\n"
+            + "group Top(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact = create('BackboneElement') as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.name as s -> tgt.name as t then CopyHumanName(s, t) \"copy-name\";\n"
+            + "}\n",
+        "Top.map");
+
+    Patient source = new Patient();
+    source.addContact(new Patient.ContactComponent().setName(new HumanName().setFamily("Jansen").addGiven("Anja")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertThat(patientDefinition).isNotNull();
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    mapUtilities.transform(null, source, topMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertThat(result.getContact()).hasSize(1);
+    assertThat(result.getContactFirstRep().getName().getFamily()).isEqualTo("Jansen");
+    assertThat(result.getContactFirstRep().getName().getGivenAsSingleString()).isEqualTo("Anja");
+  }
+
+  @Test
+  void anonymousBackboneSupplementShouldPopulateExtensionValueReference() throws Exception {
+    SimpleWorkerContext delegate = (SimpleWorkerContext) TestingUtilities.context();
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/TopAnonymous\" = \"TopAnonymous\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "group TopAnonymous(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.organization as s -> tgt.extension = create('Extension') as t then SetRelatedPersonExtension(s, t) \"copy-related-person\";\n"
+            + "}\n"
+            + "\n"
+            + "group SetRelatedPersonExtension(source src : Reference, target tgt : Extension) {\n"
+            + "  src -> tgt.url = 'http://example.org/StructureDefinition/patient-relatedPerson' \"set-url\";\n"
+            + "  src -> tgt.value = create('Reference') as t then CopyReference(src, t) \"set-value\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyReference(source src : Reference, target tgt : Reference) {\n"
+            + "  src.reference as s -> tgt.reference = s \"copy-reference\";\n"
+            + "  src.display as s -> tgt.display = s \"copy-display\";\n"
+            + "}\n",
+        "TopAnonymous.map");
+
+    Patient source = new Patient();
+    source.addContact(new Patient.ContactComponent().setOrganization(new Reference("Organization/123").setDisplay("St. Antonius")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertThat(patientDefinition).isNotNull();
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    StructureMap supplementMap = buildAnonymousBackboneSupplementMap(topMap, "contact", "CopyContact");
+    mapUtilities.transform(null, source.getContactFirstRep(), supplementMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertThat(result.getContact()).hasSize(1);
+    assertThat(result.getContactFirstRep().getExtension()).hasSize(1);
+    assertThat(result.getContactFirstRep().getExtensionFirstRep().getUrl())
+        .isEqualTo("http://example.org/StructureDefinition/patient-relatedPerson");
+    assertThat(result.getContactFirstRep().getExtensionFirstRep().getValue()).isInstanceOf(Reference.class);
+    Reference value = (Reference) result.getContactFirstRep().getExtensionFirstRep().getValue();
+    assertThat(value.getReference()).isEqualTo("Organization/123");
+    assertThat(value.getDisplay()).isEqualTo("St. Antonius");
+  }
+
+  private static StructureMap buildAnonymousBackboneSupplementMap(StructureMap theMap, String theTargetElementName,
+      String theSubgroupName) {
+    StructureMap copied = theMap.copy();
+    StructureMap.StructureMapGroupComponent subgroup = copied.getGroup().stream()
+        .filter(group -> theSubgroupName.equals(group.getName()))
+        .findFirst()
+        .orElseThrow(IllegalStateException::new);
+    subgroup.getInput().stream()
+        .filter(input -> input.getMode() == StructureMap.StructureMapInputMode.TARGET)
+        .findFirst()
+        .ifPresent(input -> input.setType(null));
+
+    StructureMap.StructureMapGroupComponent rootGroup = new StructureMap.StructureMapGroupComponent();
+    rootGroup.setName("SupplementContact");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setName("src");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.TARGET).setName("tgt").setType("Patient");
+    rootGroup.addRule()
+        .setName("supplement-contact")
+        .addSource(new StructureMap.StructureMapGroupRuleSourceComponent().setContext("src").setVariable("s"))
+        .addTarget(new StructureMap.StructureMapGroupRuleTargetComponent().setContext("tgt").setElement(theTargetElementName)
+            .setVariable("t"))
+        .addDependent(new StructureMap.StructureMapGroupRuleDependentComponent().setName(theSubgroupName).addVariable("s")
+            .addVariable("t"));
+
+    copied.getGroup().add(0, rootGroup);
+    copied.setName(rootGroup.getName());
+    copied.setId(rootGroup.getName());
+    copied.setUrl(theMap.getUrl() + "#" + rootGroup.getName());
+    return copied;
+  }
+
+  private static StructureMap parseAndRegister(StructureMapUtilities theMapUtilities, Map<String, StructureMap> theMapsByUrl,
+      String theMapText, String theName) throws Exception {
+    StructureMap map = (StructureMap) theMapUtilities.parse(theMapText, theName);
+    theMapsByUrl.put(map.getUrl(), map);
+    return map;
+  }
+
+  private static IWorkerContext mapAwareWorkerContext(IWorkerContext theDelegate, Map<String, StructureMap> theMapsByUrl) {
+    InvocationHandler handler = (theProxy, theMethod, theArgs) -> {
+      String name = theMethod.getName();
+      if ("getTransform".equals(name)) {
+        String url = (String) theArgs[0];
+        StructureMap fromRegistry = theMapsByUrl.get(url);
+        return fromRegistry != null ? fromRegistry : theMethod.invoke(theDelegate, theArgs);
+      }
+      if ("listTransforms".equals(name)) {
+        Map<String, StructureMap> combined = new LinkedHashMap<String, StructureMap>();
+        for (StructureMap next : theDelegate.listTransforms()) {
+          combined.put(next.getUrl(), next);
+        }
+        combined.putAll(theMapsByUrl);
+        return List.copyOf(combined.values());
+      }
+      if ("getTypeNames".equals(name)) {
+        List<String> typeNames = new ArrayList<String>(theDelegate.getTypeNames());
+        typeNames.addAll(List.of("Address", "BackboneElement", "CodeableConcept", "Coding", "ContactPoint", "Extension",
+            "HumanName", "Meta", "Period", "Reference"));
+        return typeNames;
+      }
+      return theMethod.invoke(theDelegate, theArgs);
+    };
+    return (IWorkerContext) Proxy.newProxyInstance(IWorkerContext.class.getClassLoader(), new Class<?>[] { IWorkerContext.class },
+        handler);
+  }
+
+  private static class TestTransformerServices implements StructureMapUtilities.ITransformerServices {
+    private final IWorkerContext myWorkerContext;
+
+    private TestTransformerServices(IWorkerContext theWorkerContext) {
+      myWorkerContext = theWorkerContext;
+    }
+
+    @Override
+    public void log(String message) {
+      // nothing
+    }
+
+    @Override
+    public Base createType(Object appInfo, String name) {
+      if (name == null || name.isBlank()) {
+        return new StringType();
+      }
+      try {
+        return ResourceFactory.createType(name);
+      } catch (Exception e) {
+        try {
+          return new Factory().create(name);
+        } catch (Exception ignored) {
+          StructureDefinition definition = myWorkerContext.fetchTypeDefinition(name);
+          if (definition == null) {
+            definition = myWorkerContext.fetchResource(StructureDefinition.class, name);
+          }
+          if (definition == null) {
+            throw new IllegalArgumentException("Unknown data type " + name, e);
+          }
+          return Manager.build(myWorkerContext, definition);
+        }
+      }
+    }
+
+    @Override
+    public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+      return res;
+    }
+
+    @Override
+    public Coding translate(Object appInfo, Coding source, String conceptMapUrl) {
+      return source;
+    }
+
+    @Override
+    public Base resolveReference(Object appContext, String url) {
+      return null;
+    }
+
+    @Override
+    public List<Base> performSearch(Object appContext, String url) {
+      return List.of();
+    }
+  }
+}

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/StructureMapUtilities.java
@@ -44,6 +44,7 @@ import org.hl7.fhir.r4b.conformance.ProfileUtilities.ProfileKnowledgeProvider;
 import org.hl7.fhir.r4b.context.IWorkerContext;
 import org.hl7.fhir.r4b.context.IWorkerContext.ValidationResult;
 import org.hl7.fhir.r4b.elementmodel.Element;
+import org.hl7.fhir.r4b.elementmodel.ObjectConverter;
 import org.hl7.fhir.r4b.elementmodel.Property;
 import org.hl7.fhir.r4b.fhirpath.ExpressionNode;
 import org.hl7.fhir.r4b.fhirpath.FHIRLexer;
@@ -1608,30 +1609,45 @@ public class StructureMapUtilities {
       return res;
     }
 
+    Set<String> visitedMapUrls = new HashSet<String>();
+    visitedMapUrls.add(getMapVisitKey(map));
+    resolveGroupReferenceInImports(map, name, res, visitedMapUrls);
+    if (res.target == null)
+      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
+    source.setUserData(kn, res);
+    return res;
+  }
+
+  private void resolveGroupReferenceInImports(StructureMap map, String name, ResolvedGroup res,
+      Set<String> visitedMapUrls) throws FHIRException {
     for (UriType imp : map.getImport()) {
       List<StructureMap> impMapList = findMatchingMaps(imp.getValue());
       if (impMapList.size() == 0)
         throw new FHIRException("Unable to find map(s) for " + imp.getValue());
       for (StructureMap impMap : impMapList) {
-        if (!impMap.getUrl().equals(map.getUrl())) {
-          for (StructureMapGroupComponent grp : impMap.getGroup()) {
-            if (grp.getName().equals(name)) {
-              if (res.targetMap == null) {
-                res.targetMap = impMap;
-                res.target = grp;
-              } else
-                throw new FHIRException(
-                    "Multiple possible matches for rule group '" + name + "' in " + res.targetMap.getUrl() + "#"
-                        + res.target.getName() + " and " + impMap.getUrl() + "#" + grp.getName());
-            }
+        String visitKey = getMapVisitKey(impMap);
+        if (visitedMapUrls.contains(visitKey))
+          continue;
+
+        visitedMapUrls.add(visitKey);
+        for (StructureMapGroupComponent grp : impMap.getGroup()) {
+          if (grp.getName().equals(name)) {
+            if (res.targetMap == null) {
+              res.targetMap = impMap;
+              res.target = grp;
+            } else
+              throw new FHIRException(
+                  "Multiple possible matches for rule group '" + name + "' in " + res.targetMap.getUrl() + "#"
+                      + res.target.getName() + " and " + impMap.getUrl() + "#" + grp.getName());
           }
         }
+        resolveGroupReferenceInImports(impMap, name, res, visitedMapUrls);
       }
     }
-    if (res.target == null)
-      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
-    source.setUserData(kn, res);
-    return res;
+  }
+
+  private String getMapVisitKey(StructureMap map) {
+    return map.getUrl() == null ? Integer.toHexString(System.identityHashCode(map)) : map.getUrl();
   }
 
   private List<Variables> processSource(String ruleId, TransformContext context, Variables vars,
@@ -1775,10 +1791,19 @@ public class StructureMapUtilities {
     Base v = null;
     if (tgt.hasTransform()) {
       v = runTransform(ruleId, context, map, group, tgt, vars, dest, tgt.getElement(), srcVar, atRoot);
-      if (v != null && dest != null)
+      if (v != null && dest != null) {
+        if (dest instanceof Element && v instanceof DataType && !v.isPrimitive() && !(v instanceof Element)) {
+          DataType typedValue = (DataType) v;
+          Property childProperty = resolveTargetChildProperty((Element) dest, tgt.getElement());
+          if (childProperty != null) {
+            v = normalizeConvertedTypeValue(childProperty, typedValue,
+                new ObjectConverter(worker).convert(childProperty, typedValue));
+          }
+        }
         v = dest.setProperty(tgt.getElement().hashCode(), tgt.getElement(), v); // reset v because some implementations
                                                                                 // may have to rewrite v when setting
                                                                                 // the value
+      }
     } else if (dest != null) {
       if (tgt.hasListMode(StructureMapTargetListMode.SHARE)) {
         v = sharedVars.get(VariableMode.SHARED, tgt.getListRuleId());
@@ -1792,6 +1817,40 @@ public class StructureMapUtilities {
     }
     if (tgt.hasVariable() && v != null)
       vars.add(VariableMode.OUTPUT, tgt.getVariable(), v);
+  }
+
+  private Property resolveTargetChildProperty(Element theDestination, String theChildName) throws FHIRException {
+    if (theDestination.getProperty() == null) {
+      return null;
+    }
+    Property child = theDestination.getProperty().getChild(theDestination.getType(), theChildName);
+    if (child == null) {
+      child = theDestination.getProperty().getChildSimpleName(theDestination.getType(), theChildName);
+    }
+    if (child == null) {
+      child = theDestination.getProperty().getChild(theChildName);
+    }
+    return child;
+  }
+
+  private Element normalizeConvertedTypeValue(Property theChildProperty, DataType theSourceValue,
+      Element theConvertedValue) {
+    if (theConvertedValue == null) {
+      return null;
+    }
+    String actualType = theSourceValue.fhirType();
+    if (Utilities.noString(actualType)) {
+      return theConvertedValue;
+    }
+    Element normalized = new Element(theConvertedValue.getName(), theChildProperty, actualType,
+        theConvertedValue.getValue());
+    if (theConvertedValue.hasChildren()) {
+      normalized.getChildren().addAll(theConvertedValue.getChildren());
+    }
+    if (theConvertedValue.hasComments()) {
+      normalized.getComments().addAll(theConvertedValue.getComments());
+    }
+    return normalized;
   }
 
   private Base runTransform(String ruleId, TransformContext context, StructureMap map, StructureMapGroupComponent group,

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/StructureMapUtilitiesRegressionTest.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/StructureMapUtilitiesRegressionTest.java
@@ -1,0 +1,274 @@
+package org.hl7.fhir.r4b.test;
+
+import org.hl7.fhir.r4b.context.IWorkerContext;
+import org.hl7.fhir.r4b.context.SimpleWorkerContext;
+import org.hl7.fhir.r4b.elementmodel.Element;
+import org.hl7.fhir.r4b.elementmodel.Manager;
+import org.hl7.fhir.r4b.elementmodel.ObjectConverter;
+import org.hl7.fhir.r4b.model.Base;
+import org.hl7.fhir.r4b.model.Coding;
+import org.hl7.fhir.r4b.model.Factory;
+import org.hl7.fhir.r4b.model.HumanName;
+import org.hl7.fhir.r4b.model.Patient;
+import org.hl7.fhir.r4b.model.Reference;
+import org.hl7.fhir.r4b.model.ResourceFactory;
+import org.hl7.fhir.r4b.model.StringType;
+import org.hl7.fhir.r4b.model.StructureDefinition;
+import org.hl7.fhir.r4b.model.StructureMap;
+import org.hl7.fhir.r4b.test.utils.TestingUtilities;
+import org.hl7.fhir.r4b.utils.structuremap.ITransformerServices;
+import org.hl7.fhir.r4b.utils.structuremap.StructureMapUtilities;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StructureMapUtilitiesRegressionTest {
+
+  @Test
+  void transitiveImportsShouldResolveNamedGroups() throws Exception {
+    SimpleWorkerContext delegate = (SimpleWorkerContext) TestingUtilities.context();
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/shared/FhirDatatypeCopies\" = \"FhirDatatypeCopies\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as target\n"
+            + "\n"
+            + "group CopyHumanName(source src : HumanName, target tgt : HumanName) {\n"
+            + "  src.family as s -> tgt.family = s \"copy-family\";\n"
+            + "  src.given as s -> tgt.given = s \"copy-given\";\n"
+            + "}\n",
+        "FhirDatatypeCopies.map");
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/mid/Mid\" = \"Mid\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/shared/FhirDatatypeCopies\"\n"
+            + "\n"
+            + "group Mid(source src : Patient, target tgt : Patient) {\n"
+            + "  src -> tgt \"noop\";\n"
+            + "}\n",
+        "Mid.map");
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/Top\" = \"Top\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/mid/Mid\"\n"
+            + "\n"
+            + "group Top(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact = create('BackboneElement') as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.name as s -> tgt.name as t then CopyHumanName(s, t) \"copy-name\";\n"
+            + "}\n",
+        "Top.map");
+
+    Patient source = new Patient();
+    source.addContact(new Patient.ContactComponent().setName(new HumanName().setFamily("Jansen").addGiven("Anja")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertNotNull(patientDefinition);
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    mapUtilities.transform(null, source, topMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertEquals(1, result.getContact().size());
+    assertEquals("Jansen", result.getContactFirstRep().getName().getFamily());
+    assertEquals("Anja", result.getContactFirstRep().getName().getGivenAsSingleString());
+  }
+
+  @Test
+  void anonymousBackboneSupplementShouldPopulateExtensionValueReference() throws Exception {
+    SimpleWorkerContext delegate = (SimpleWorkerContext) TestingUtilities.context();
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/TopAnonymous\" = \"TopAnonymous\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "group TopAnonymous(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.organization as s -> tgt.extension = create('Extension') as t then SetRelatedPersonExtension(s, t) \"copy-related-person\";\n"
+            + "}\n"
+            + "\n"
+            + "group SetRelatedPersonExtension(source src : Reference, target tgt : Extension) {\n"
+            + "  src -> tgt.url = 'http://example.org/StructureDefinition/patient-relatedPerson' \"set-url\";\n"
+            + "  src -> tgt.value = create('Reference') as t then CopyReference(src, t) \"set-value\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyReference(source src : Reference, target tgt : Reference) {\n"
+            + "  src.reference as s -> tgt.reference = s \"copy-reference\";\n"
+            + "  src.display as s -> tgt.display = s \"copy-display\";\n"
+            + "}\n",
+        "TopAnonymous.map");
+
+    Patient source = new Patient();
+    source.addContact(
+        new Patient.ContactComponent().setOrganization(new Reference("Organization/123").setDisplay("St. Antonius")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertNotNull(patientDefinition);
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    StructureMap supplementMap = buildAnonymousBackboneSupplementMap(topMap, "contact", "CopyContact");
+    mapUtilities.transform(null, source.getContactFirstRep(), supplementMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertEquals(1, result.getContact().size());
+    assertEquals(1, result.getContactFirstRep().getExtension().size());
+    assertEquals("http://example.org/StructureDefinition/patient-relatedPerson",
+        result.getContactFirstRep().getExtensionFirstRep().getUrl());
+    Reference value = assertInstanceOf(Reference.class, result.getContactFirstRep().getExtensionFirstRep().getValue());
+    assertEquals("Organization/123", value.getReference());
+    assertEquals("St. Antonius", value.getDisplay());
+  }
+
+  private static StructureMap buildAnonymousBackboneSupplementMap(StructureMap theMap, String theTargetElementName,
+      String theSubgroupName) {
+    StructureMap copied = theMap.copy();
+    StructureMap.StructureMapGroupComponent subgroup = copied.getGroup().stream()
+        .filter(group -> theSubgroupName.equals(group.getName()))
+        .findFirst()
+        .orElseThrow(IllegalStateException::new);
+    subgroup.getInput().stream()
+        .filter(input -> input.getMode() == StructureMap.StructureMapInputMode.TARGET)
+        .findFirst()
+        .ifPresent(input -> input.setType(null));
+
+    StructureMap.StructureMapGroupComponent rootGroup = new StructureMap.StructureMapGroupComponent();
+    rootGroup.setName("SupplementContact");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setName("src");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.TARGET).setName("tgt").setType("Patient");
+    rootGroup.addRule()
+        .setName("supplement-contact")
+        .addSource(new StructureMap.StructureMapGroupRuleSourceComponent().setContext("src").setVariable("s"))
+        .addTarget(new StructureMap.StructureMapGroupRuleTargetComponent().setContext("tgt")
+            .setElement(theTargetElementName).setVariable("t"))
+        .addDependent(new StructureMap.StructureMapGroupRuleDependentComponent().setName(theSubgroupName)
+            .addVariable("s").addVariable("t"));
+
+    copied.getGroup().add(0, rootGroup);
+    copied.setName(rootGroup.getName());
+    copied.setId(rootGroup.getName());
+    copied.setUrl(theMap.getUrl() + "#" + rootGroup.getName());
+    return copied;
+  }
+
+  private static StructureMap parseAndRegister(StructureMapUtilities theMapUtilities, Map<String, StructureMap> theMapsByUrl,
+      String theMapText, String theName) throws Exception {
+    StructureMap map = (StructureMap) theMapUtilities.parse(theMapText, theName);
+    theMapsByUrl.put(map.getUrl(), map);
+    return map;
+  }
+
+  private static IWorkerContext mapAwareWorkerContext(IWorkerContext theDelegate, Map<String, StructureMap> theMapsByUrl) {
+    InvocationHandler handler = (theProxy, theMethod, theArgs) -> {
+      String name = theMethod.getName();
+      if ("getTransform".equals(name)) {
+        String url = (String) theArgs[0];
+        StructureMap fromRegistry = theMapsByUrl.get(url);
+        return fromRegistry != null ? fromRegistry : theMethod.invoke(theDelegate, theArgs);
+      }
+      if ("listTransforms".equals(name)) {
+        Map<String, StructureMap> combined = new LinkedHashMap<String, StructureMap>();
+        for (StructureMap next : theDelegate.listTransforms()) {
+          combined.put(next.getUrl(), next);
+        }
+        combined.putAll(theMapsByUrl);
+        return List.copyOf(combined.values());
+      }
+      if ("getTypeNames".equals(name)) {
+        List<String> typeNames = new ArrayList<String>(theDelegate.getTypeNames());
+        typeNames.addAll(List.of("Address", "BackboneElement", "CodeableConcept", "Coding", "ContactPoint",
+            "Extension", "HumanName", "Meta", "Period", "Reference"));
+        return typeNames;
+      }
+      return theMethod.invoke(theDelegate, theArgs);
+    };
+    return (IWorkerContext) Proxy.newProxyInstance(IWorkerContext.class.getClassLoader(),
+        new Class<?>[] { IWorkerContext.class }, handler);
+  }
+
+  private static class TestTransformerServices implements ITransformerServices {
+    private final IWorkerContext myWorkerContext;
+
+    private TestTransformerServices(IWorkerContext theWorkerContext) {
+      myWorkerContext = theWorkerContext;
+    }
+
+    @Override
+    public void log(String message) {
+      // nothing
+    }
+
+    @Override
+    public Base createType(Object appInfo, String name) {
+      if (name == null || name.isBlank()) {
+        return new StringType();
+      }
+      try {
+        return ResourceFactory.createType(name);
+      } catch (Exception e) {
+        try {
+          return new Factory().create(name);
+        } catch (Exception ignored) {
+          StructureDefinition definition = myWorkerContext.fetchTypeDefinition(name);
+          if (definition == null) {
+            definition = myWorkerContext.fetchResource(StructureDefinition.class, name);
+          }
+          if (definition == null) {
+            throw new IllegalArgumentException("Unknown data type " + name, e);
+          }
+          return Manager.build(myWorkerContext, definition);
+        }
+      }
+    }
+
+    @Override
+    public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+      return res;
+    }
+
+    @Override
+    public Coding translate(Object appInfo, Coding source, String conceptMapUrl) {
+      return source;
+    }
+
+    @Override
+    public Base resolveReference(Object appContext, String url) {
+      return null;
+    }
+
+    @Override
+    public List<Base> performSearch(Object appContext, String url) {
+      return List.of();
+    }
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/StructureMapUtilities.java
@@ -43,6 +43,7 @@ import org.hl7.fhir.r5.context.ContextUtilities;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.elementmodel.ObjectConverter;
 import org.hl7.fhir.r5.elementmodel.Property;
 import org.hl7.fhir.r5.extensions.ExtensionDefinitions;
 import org.hl7.fhir.r5.extensions.ExtensionUtilities;
@@ -1575,30 +1576,45 @@ public class StructureMapUtilities {
       return res;
     }
 
+    Set<String> visitedMapUrls = new HashSet<String>();
+    visitedMapUrls.add(getMapVisitKey(map));
+    resolveGroupReferenceInImports(map, name, res, visitedMapUrls);
+    if (res.getTargetGroup() == null)
+      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
+    source.setUserData(kn, res);
+    return res;
+  }
+
+  private void resolveGroupReferenceInImports(StructureMap map, String name, ResolvedGroup res,
+      Set<String> visitedMapUrls) throws FHIRException {
     for (UriType imp : map.getImport()) {
       List<StructureMap> impMapList = findMatchingMaps(imp.getValue());
       if (impMapList.size() == 0)
         throw new FHIRException("Unable to find map(s) for " + imp.getValue());
       for (StructureMap impMap : impMapList) {
-        if (!impMap.getUrl().equals(map.getUrl())) {
-          for (StructureMapGroupComponent grp : impMap.getGroup()) {
-            if (grp.getName().equals(name)) {
-              if (res.getTargetMap() == null) {
-                res.setTargetMap(impMap);
-                res.setTargetGroup(grp);
-              } else
-                throw new FHIRException("Multiple possible matches for rule group '" + name + "' in " +
+        String visitKey = getMapVisitKey(impMap);
+        if (visitedMapUrls.contains(visitKey))
+          continue;
+
+        visitedMapUrls.add(visitKey);
+        for (StructureMapGroupComponent grp : impMap.getGroup()) {
+          if (grp.getName().equals(name)) {
+            if (res.getTargetMap() == null) {
+              res.setTargetMap(impMap);
+              res.setTargetGroup(grp);
+            } else
+              throw new FHIRException("Multiple possible matches for rule group '" + name + "' in " +
                   res.getTargetMap().getUrl() + "#" + res.getTargetGroup().getName() + " and " +
                   impMap.getUrl() + "#" + grp.getName());
-            }
           }
         }
+        resolveGroupReferenceInImports(impMap, name, res, visitedMapUrls);
       }
     }
-    if (res.getTargetGroup() == null)
-      throw new FHIRException("No matches found for rule '" + name + "'. Reference found in " + map.getUrl());
-    source.setUserData(kn, res);
-    return res;
+  }
+
+  private String getMapVisitKey(StructureMap map) {
+    return map.getUrl() == null ? Integer.toHexString(System.identityHashCode(map)) : map.getUrl();
   }
 
   private List<Variables> processSource(String ruleId, TransformContext context, Variables vars, StructureMapGroupRuleSourceComponent src, String pathForErrors, String indent) throws FHIRException {
@@ -1747,6 +1763,14 @@ public class StructureMapUtilities {
       v = runTransform(rulePath, context, map, group, tgt, vars, dest, tgt.getElement(), srcVar, atRoot);
       if (v != null && dest != null) {
         try {
+          if (dest instanceof Element && v instanceof DataType && !v.isPrimitive() && !(v instanceof Element)) {
+            DataType typedValue = (DataType) v;
+            Property childProperty = resolveTargetChildProperty((Element) dest, tgt.getElement());
+            if (childProperty != null) {
+              v = normalizeConvertedTypeValue(childProperty, typedValue,
+                  new ObjectConverter(worker).convert(childProperty, typedValue));
+            }
+          }
           v = dest.setProperty(tgt.getElement().hashCode(), tgt.getElement(), v); // reset v because some implementations may have to rewrite v when setting the value
         } catch (Exception e) {
           throw new FHIRException("Error setting "+tgt.getElement()+" on "+dest.fhirType()+" for rule "+rulePath+" to value "+v.toString()+": "+e.getMessage(), e);
@@ -1767,6 +1791,40 @@ public class StructureMapUtilities {
     }
     if (tgt.hasVariable() && v != null)
       vars.add(VariableMode.OUTPUT, tgt.getVariable(), v);
+  }
+
+  private Property resolveTargetChildProperty(Element theDestination, String theChildName) throws FHIRException {
+    if (theDestination.getProperty() == null) {
+      return null;
+    }
+    Property child = theDestination.getProperty().getChild(theDestination.getType(), theChildName);
+    if (child == null) {
+      child = theDestination.getProperty().getChildSimpleName(theDestination.getType(), theChildName);
+    }
+    if (child == null) {
+      child = theDestination.getProperty().getChild(theChildName);
+    }
+    return child;
+  }
+
+  private Element normalizeConvertedTypeValue(Property theChildProperty, DataType theSourceValue,
+      Element theConvertedValue) {
+    if (theConvertedValue == null) {
+      return null;
+    }
+    String actualType = theSourceValue.fhirType();
+    if (Utilities.noString(actualType)) {
+      return theConvertedValue;
+    }
+    Element normalized = new Element(theConvertedValue.getName(), theChildProperty, actualType,
+        theConvertedValue.getValue());
+    if (theConvertedValue.hasChildren()) {
+      normalized.getChildren().addAll(theConvertedValue.getChildren());
+    }
+    if (theConvertedValue.hasComments()) {
+      normalized.getComments().addAll(theConvertedValue.getComments());
+    }
+    return normalized;
   }
   
   private Base runTransform(String rulePath, TransformContext context, StructureMap map, StructureMapGroupComponent group, StructureMapGroupRuleTargetComponent tgt, Variables vars, Base dest, String element, String srcVar, boolean root) throws FHIRException {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesRegressionTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/StructureMapUtilitiesRegressionTest.java
@@ -1,0 +1,276 @@
+package org.hl7.fhir.r5.test;
+
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.elementmodel.Element;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.elementmodel.ObjectConverter;
+import org.hl7.fhir.r5.model.Base;
+import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.Factory;
+import org.hl7.fhir.r5.model.HumanName;
+import org.hl7.fhir.r5.model.IdType;
+import org.hl7.fhir.r5.model.Patient;
+import org.hl7.fhir.r5.model.Reference;
+import org.hl7.fhir.r5.model.ResourceFactory;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.model.StructureMap;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.structuremap.ITransformerServices;
+import org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StructureMapUtilitiesRegressionTest {
+
+  @Test
+  void transitiveImportsShouldResolveNamedGroups() throws Exception {
+    SimpleWorkerContext delegate = TestingUtilities.getWorkerContext("4.0.1");
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/shared/FhirDatatypeCopies\" = \"FhirDatatypeCopies\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Resource\" as target\n"
+            + "\n"
+            + "group CopyHumanName(source src : HumanName, target tgt : HumanName) {\n"
+            + "  src.family as s -> tgt.family = s \"copy-family\";\n"
+            + "  src.given as s -> tgt.given = s \"copy-given\";\n"
+            + "}\n",
+        "FhirDatatypeCopies.map");
+
+    parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/mid/Mid\" = \"Mid\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/shared/FhirDatatypeCopies\"\n"
+            + "\n"
+            + "group Mid(source src : Patient, target tgt : Patient) {\n"
+            + "  src -> tgt \"noop\";\n"
+            + "}\n",
+        "Mid.map");
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/Top\" = \"Top\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "imports \"http://example.org/StructureMap/mid/Mid\"\n"
+            + "\n"
+            + "group Top(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact = create('BackboneElement') as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.name as s -> tgt.name as t then CopyHumanName(s, t) \"copy-name\";\n"
+            + "}\n",
+        "Top.map");
+
+    Patient source = new Patient();
+    source.addContact(new Patient.ContactComponent().setName(new HumanName().setFamily("Jansen").addGiven("Anja")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertNotNull(patientDefinition);
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    mapUtilities.transform(null, source, topMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertEquals(1, result.getContact().size());
+    assertEquals("Jansen", result.getContactFirstRep().getName().getFamily());
+    assertEquals("Anja", result.getContactFirstRep().getName().getGivenAsSingleString());
+  }
+
+  @Test
+  void anonymousBackboneSupplementShouldPopulateExtensionValueReference() throws Exception {
+    SimpleWorkerContext delegate = TestingUtilities.getWorkerContext("4.0.1");
+    Map<String, StructureMap> mapsByUrl = new LinkedHashMap<String, StructureMap>();
+    IWorkerContext workerContext = mapAwareWorkerContext(delegate, mapsByUrl);
+    StructureMapUtilities mapUtilities = new StructureMapUtilities(workerContext, new TestTransformerServices(workerContext));
+
+    StructureMap topMap = parseAndRegister(mapUtilities, mapsByUrl,
+        "map \"http://example.org/StructureMap/top/TopAnonymous\" = \"TopAnonymous\"\n"
+            + "\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as source\n"
+            + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" as target\n"
+            + "\n"
+            + "group TopAnonymous(source src : Patient, target tgt : Patient) {\n"
+            + "  src.contact as s -> tgt.contact as t then CopyContact(s, t) \"copy-contact\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyContact(source src, target tgt : BackboneElement) {\n"
+            + "  src.organization as s -> tgt.extension = create('Extension') as t then SetRelatedPersonExtension(s, t) \"copy-related-person\";\n"
+            + "}\n"
+            + "\n"
+            + "group SetRelatedPersonExtension(source src : Reference, target tgt : Extension) {\n"
+            + "  src -> tgt.url = 'http://example.org/StructureDefinition/patient-relatedPerson' \"set-url\";\n"
+            + "  src -> tgt.value = create('Reference') as t then CopyReference(src, t) \"set-value\";\n"
+            + "}\n"
+            + "\n"
+            + "group CopyReference(source src : Reference, target tgt : Reference) {\n"
+            + "  src.reference as s -> tgt.reference = s \"copy-reference\";\n"
+            + "  src.display as s -> tgt.display = s \"copy-display\";\n"
+            + "}\n",
+        "TopAnonymous.map");
+
+    Patient source = new Patient();
+    source.addContact(
+        new Patient.ContactComponent().setOrganization(new Reference("Organization/123").setDisplay("St. Antonius")));
+
+    StructureDefinition patientDefinition = workerContext.fetchTypeDefinition("Patient");
+    assertNotNull(patientDefinition);
+
+    Element target = Manager.build(workerContext, patientDefinition);
+    StructureMap supplementMap = buildAnonymousBackboneSupplementMap(topMap, "contact", "CopyContact");
+    mapUtilities.transform(null, source.getContactFirstRep(), supplementMap, target);
+
+    Patient result = (Patient) new ObjectConverter(workerContext).convert(target);
+    assertEquals(1, result.getContact().size());
+    assertEquals(1, result.getContactFirstRep().getExtension().size());
+    assertEquals("http://example.org/StructureDefinition/patient-relatedPerson",
+        result.getContactFirstRep().getExtensionFirstRep().getUrl());
+    Reference value = assertInstanceOf(Reference.class, result.getContactFirstRep().getExtensionFirstRep().getValue());
+    assertEquals("Organization/123", value.getReference());
+    assertEquals("St. Antonius", value.getDisplay());
+  }
+
+  private static StructureMap buildAnonymousBackboneSupplementMap(StructureMap theMap, String theTargetElementName,
+      String theSubgroupName) {
+    StructureMap copied = theMap.copy();
+    StructureMap.StructureMapGroupComponent subgroup = copied.getGroup().stream()
+        .filter(group -> theSubgroupName.equals(group.getName()))
+        .findFirst()
+        .orElseThrow(IllegalStateException::new);
+    subgroup.getInput().stream()
+        .filter(input -> input.getMode() == StructureMap.StructureMapInputMode.TARGET)
+        .findFirst()
+        .ifPresent(input -> input.setType(null));
+
+    StructureMap.StructureMapGroupComponent rootGroup = new StructureMap.StructureMapGroupComponent();
+    rootGroup.setName("SupplementContact");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.SOURCE).setName("src");
+    rootGroup.addInput().setMode(StructureMap.StructureMapInputMode.TARGET).setName("tgt").setType("Patient");
+    rootGroup.addRule()
+        .setName("supplement-contact")
+        .addSource(new StructureMap.StructureMapGroupRuleSourceComponent().setContext("src").setVariable("s"))
+        .addTarget(new StructureMap.StructureMapGroupRuleTargetComponent().setContext("tgt")
+            .setElement(theTargetElementName).setVariable("t"))
+        .addDependent(new StructureMap.StructureMapGroupRuleDependentComponent().setName(theSubgroupName)
+            .addParameter(new StructureMap.StructureMapGroupRuleTargetParameterComponent().setValue(new IdType("s")))
+            .addParameter(new StructureMap.StructureMapGroupRuleTargetParameterComponent().setValue(new IdType("t"))));
+
+    copied.getGroup().add(0, rootGroup);
+    copied.setName(rootGroup.getName());
+    copied.setId(rootGroup.getName());
+    copied.setUrl(theMap.getUrl() + "#" + rootGroup.getName());
+    return copied;
+  }
+
+  private static StructureMap parseAndRegister(StructureMapUtilities theMapUtilities, Map<String, StructureMap> theMapsByUrl,
+      String theMapText, String theName) throws Exception {
+    StructureMap map = (StructureMap) theMapUtilities.parse(theMapText, theName);
+    theMapsByUrl.put(map.getUrl(), map);
+    return map;
+  }
+
+  private static IWorkerContext mapAwareWorkerContext(IWorkerContext theDelegate, Map<String, StructureMap> theMapsByUrl) {
+    InvocationHandler handler = (theProxy, theMethod, theArgs) -> {
+      String name = theMethod.getName();
+      if ("getTransform".equals(name)) {
+        String url = (String) theArgs[0];
+        StructureMap fromRegistry = theMapsByUrl.get(url);
+        return fromRegistry != null ? fromRegistry : theMethod.invoke(theDelegate, theArgs);
+      }
+      if ("fetchResource".equals(name) && theArgs.length >= 2 && theArgs[0] == StructureMap.class) {
+        String url = (String) theArgs[1];
+        StructureMap fromRegistry = theMapsByUrl.get(url);
+        return fromRegistry != null ? fromRegistry : theMethod.invoke(theDelegate, theArgs);
+      }
+      if ("fetchResourcesByType".equals(name) && theArgs.length == 1 && theArgs[0] == StructureMap.class) {
+        Map<String, StructureMap> combined = new LinkedHashMap<String, StructureMap>();
+        for (StructureMap next : theDelegate.fetchResourcesByType(StructureMap.class)) {
+          combined.put(next.getUrl(), next);
+        }
+        combined.putAll(theMapsByUrl);
+        return List.copyOf(combined.values());
+      }
+      return theMethod.invoke(theDelegate, theArgs);
+    };
+    return (IWorkerContext) Proxy.newProxyInstance(IWorkerContext.class.getClassLoader(),
+        new Class<?>[] { IWorkerContext.class }, handler);
+  }
+
+  private static class TestTransformerServices implements ITransformerServices {
+    private final IWorkerContext myWorkerContext;
+
+    private TestTransformerServices(IWorkerContext theWorkerContext) {
+      myWorkerContext = theWorkerContext;
+    }
+
+    @Override
+    public void log(String message) {
+      // nothing
+    }
+
+    @Override
+    public Base createType(Object appInfo, String name, ProfileUtilities profileUtilities) {
+      if (name == null || name.isBlank()) {
+        return new StringType();
+      }
+      try {
+        return ResourceFactory.createType(name);
+      } catch (Exception e) {
+        try {
+          return new Factory().create(name);
+        } catch (Exception ignored) {
+          StructureDefinition definition = myWorkerContext.fetchTypeDefinition(name);
+          if (definition == null) {
+            definition = myWorkerContext.fetchResource(StructureDefinition.class, name);
+          }
+          if (definition == null) {
+            throw new IllegalArgumentException("Unknown data type " + name, e);
+          }
+          return Manager.build(myWorkerContext, definition);
+        }
+      }
+    }
+
+    @Override
+    public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+      return res;
+    }
+
+    @Override
+    public Coding translate(Object appInfo, Coding source, String conceptMapUrl) {
+      return source;
+    }
+
+    @Override
+    public Base resolveReference(Object appContext, String url) {
+      return null;
+    }
+
+    @Override
+    public List<Base> performSearch(Object appContext, String url) {
+      return List.of();
+    }
+  }
+}


### PR DESCRIPTION
This addresses two related runtime problems:
- named groups were only resolved from direct imports, not through transitive imports
- element-model targets could fail when assigning a non-primitive datatype into a choice element such as `Extension.value[x]` during anonymous backbone supplementation

This issue was identified while investigating the downstream HAPI report `hapifhir/hapi-fhir#7690`.

## Problem
`StructureMapUtilities.resolveGroupReference(...)` stopped at the first import layer. That meant a map could not invoke a group that existed only in an imported map of an imported map.

`StructureMapUtilities.processTarget(...)` also mishandled some element-model assignments when the produced value was a non-primitive datatype. In practice this broke cases such as assigning a `Reference` into `Extension.value[x]` while materializing an extension under an anonymously supplemented backbone element.

## Changes
- add recursive group lookup across the full import graph, with cycle protection and duplicate-match detection preserved
- normalize converted non-primitive datatype values before calling `setProperty(...)` on element-model targets
- apply the fix consistently in:
  - `org.hl7.fhir.r4`
  - `org.hl7.fhir.r4b`
  - `org.hl7.fhir.r5`
- add regression tests for:
  - transitive imported group resolution
  - anonymous backbone supplementation with `Extension.valueReference`

## Impact
After this change:
- dependent groups such as `CopyHumanName` resolve correctly through transitive imports
- assignments like `src -> tgt.value = create('Reference') as t then CopyReference(src, t)` materialize correctly in the element model for anonymous backbone supplementation scenarios

## Testing
Added focused regression coverage for R4, R4B, and R5.

## References
- `hapifhir/org.hl7.fhir.core#2360`
- `hapifhir/hapi-fhir#7690`