### PR TITLE
Increase testCachedCanonicalResourceGetWithMultiThread timeout

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/CanonicalResourceManager.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/CanonicalResourceManager.java
@@ -24,14 +24,14 @@ import org.hl7.fhir.utilities.*;
 @MarkedToMoveToAdjunctPackage
 public class CanonicalResourceManager<T extends CanonicalResource> {
 
-  private final String[] INVALID_TERMINOLOGY_URLS = {
+  private static final String[] INVALID_TERMINOLOGY_URLS = {
     "http://snomed.info/sct",
     "http://dicom.nema.org/resources/ontology/DCM",
     "http://nucc.org/provider-taxonomy"
   };
   private int loadCount = 0;
 
-  public static abstract class CanonicalResourceProxy {
+  public abstract static class CanonicalResourceProxy {
     private String type;
     private String id;
     private String url;

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -1366,9 +1366,8 @@ public class CanonicalResourceManagerTests {
      */
   @Test
   // This timeout value was evaluated based on an observed time of 1400 ms for a single run, with a tolerance of 20%.
-  @Timeout(value = 1680, unit = TimeUnit.MILLISECONDS)
-  @Disabled
-  public void testCachedCanonicalResourceGetWithMultiThread() {
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
+  void testCachedCanonicalResourceGetWithMultiThread() {
     //Create a single resource and then try to get it with multiple threads.
     CanonicalResourceManager<ValueSet> resourceManager = new CanonicalResourceManager<>(true, false);
     ValueSet vs = new ValueSet();

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -1368,6 +1368,7 @@ public class CanonicalResourceManagerTests {
   // This timeout value was evaluated based on an observed time of 1400 ms for a single run, with a tolerance of 20%.
   @Timeout(value = 4000, unit = TimeUnit.MILLISECONDS)
   void testCachedCanonicalResourceGetWithMultiThread() {
+    long testStart = System.currentTimeMillis();
     //Create a single resource and then try to get it with multiple threads.
     CanonicalResourceManager<ValueSet> resourceManager = new CanonicalResourceManager<>(true, false);
     ValueSet vs = new ValueSet();
@@ -1399,6 +1400,7 @@ public class CanonicalResourceManagerTests {
 
     //Check that loadResource, which can be an expensive operation, is only called once
     verify(testResource, times(1)).loadResource();
+    System.out.println("Total test time: " + (System.currentTimeMillis() - testStart));
   }
 
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -1365,8 +1365,8 @@ public class CanonicalResourceManagerTests {
       Multithread Test
      */
   @Test
-  // This timeout value was evaluated based on an observed time of 1400 ms for a single run, with a tolerance of 20%.
-  @Timeout(value = 4000, unit = TimeUnit.MILLISECONDS)
+  // This timeout value was evaluated based on an observed time of 2182 ms for a single run, with a tolerance of 20%.
+  @Timeout(value = 2600, unit = TimeUnit.MILLISECONDS)
   void testCachedCanonicalResourceGetWithMultiThread() {
     long testStart = System.currentTimeMillis();
     //Create a single resource and then try to get it with multiple threads.

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -1366,7 +1366,7 @@ public class CanonicalResourceManagerTests {
      */
   @Test
   // This timeout value was evaluated based on an observed time of 1400 ms for a single run, with a tolerance of 20%.
-  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
+  @Timeout(value = 4000, unit = TimeUnit.MILLISECONDS)
   void testCachedCanonicalResourceGetWithMultiThread() {
     //Create a single resource and then try to get it with multiple threads.
     CanonicalResourceManager<ValueSet> resourceManager = new CanonicalResourceManager<>(true, false);


### PR DESCRIPTION
The timeout on testCachedCanonicalResourceGetWithMultiThread is currently being hit on our pipelines and causing test failures. It still executes in a reasonable timespan on local machines (1.0s in most cases), so this seems likely to be a Azure VM issue.