### PR TITLE
Fix sqlite native access warnings

### DIFF
--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -33,3 +33,5 @@
 (Eclipse Public License 2.0) (GNU General Public License, version 2 with the GNU Classpath Exception) JSON-P Default Provider (org.glassfish:jakarta.json:2.0.1 - https://github.com/eclipse-ee4j/jsonp)
 # License string includes includes brackets around Aggregator, treating it as separate license.
 (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.14.0 - https://junit.org/)
+# License string includes brackets, but is a valid Apache License
+(Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.18.8 - https://bytebuddy.net/byte-buddy)

--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/misc/SQLiteLoadWarningTest.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/misc/SQLiteLoadWarningTest.java
@@ -1,0 +1,21 @@
+package org.hl7.fhir.convertors.misc;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+class SQLiteLoadWarningTest {
+
+  @Test
+  void sqliteNativeLibraryIsLoadedFromUnnamedModule() throws Exception {
+    // Opening any sqlite connection causes SQLiteJDBCLoader to call
+    // System.load() from an unnamed module.
+    // On JDK 22+ this prints to stderr:
+    //   WARNING: java.lang.System::load has been called by
+    //   org.sqlite.SQLiteJDBCLoader in an unnamed module
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+      // connection is enough — no queries needed
+    }
+  }
+}

--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -178,6 +178,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!--
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/DateTimeUtilTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/DateTimeUtilTests.java
@@ -51,9 +51,9 @@ public class DateTimeUtilTests {
       Arguments.of(TemporalPrecisionEnum.YEAR, new Date("2002/02/04"), "dummyValueAsString"),
       Arguments.of(TemporalPrecisionEnum.MONTH, new Date("2002/02/04"), "dummyValueAsString"),
       Arguments.of(TemporalPrecisionEnum.DAY, new Date("2002/02/04"), "dummyValueAsString"),
-      Arguments.of(TemporalPrecisionEnum.MILLI, new Date("2002/02/04"), "04-Feb-2002 00:00:00"),
-      Arguments.of(TemporalPrecisionEnum.SECOND, new Date("2002/02/04"), "04-Feb-2002 00:00:00"),
-      Arguments.of(TemporalPrecisionEnum.MINUTE, new Date("2002/02/04"), "04-Feb-2002 00:00:00")
+      Arguments.of(TemporalPrecisionEnum.MILLI, new Date("2002/02/04"), "4 Feb 2002, 00:00:00"),
+      Arguments.of(TemporalPrecisionEnum.SECOND, new Date("2002/02/04"), "4 Feb 2002, 00:00:00"),
+      Arguments.of(TemporalPrecisionEnum.MINUTE, new Date("2002/02/04"), "4 Feb 2002, 00:00:00")
 
     );
   }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/DateTimeUtilTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/DateTimeUtilTests.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.utilities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.condition.JRE.*;
 
 import java.util.Date;
 import java.util.Locale;
@@ -9,6 +10,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,21 +43,37 @@ public class DateTimeUtilTests {
   @Disabled
   @ParameterizedTest
   @MethodSource("getToHumanDisplayParams")
-  public void testToHumanDisplay(TimeZone theTimeZone, TemporalPrecisionEnum thePrecision, Date theValue, String expected) {
+  void testToHumanDisplay(TimeZone theTimeZone, TemporalPrecisionEnum thePrecision, Date theValue, String expected) {
     final String humanDisplay = DateTimeUtil.toHumanDisplay(theTimeZone, thePrecision, theValue, "dummyValueAsString");
     assertEquals(expected, humanDisplay);
   }
 
-  private static Stream<Arguments> getToHumanDisplayLocalTimezoneParams() {
+  private static Stream<Arguments> getToHumanDisplayLocalTimezoneDummyParams() {
     return Stream.of(
       Arguments.of(TemporalPrecisionEnum.YEAR, new Date("2002/02/04"), "dummyValueAsString"),
       Arguments.of(TemporalPrecisionEnum.MONTH, new Date("2002/02/04"), "dummyValueAsString"),
-      Arguments.of(TemporalPrecisionEnum.DAY, new Date("2002/02/04"), "dummyValueAsString"),
+      Arguments.of(TemporalPrecisionEnum.DAY, new Date("2002/02/04"), "dummyValueAsString")
+    );
+  }
+
+  private static Stream<Arguments> getToHumanDisplayLocalTimezoneParams_Java25() {
+    return Stream.concat(
+      getToHumanDisplayLocalTimezoneDummyParams(),
+      Stream.of(
       Arguments.of(TemporalPrecisionEnum.MILLI, new Date("2002/02/04"), "4 Feb 2002, 00:00:00"),
       Arguments.of(TemporalPrecisionEnum.SECOND, new Date("2002/02/04"), "4 Feb 2002, 00:00:00"),
       Arguments.of(TemporalPrecisionEnum.MINUTE, new Date("2002/02/04"), "4 Feb 2002, 00:00:00")
+    ));
+  }
 
-    );
+  private static Stream<Arguments> getToHumanDisplayLocalTimezoneParams_Java17_24() {
+    return Stream.concat(
+      getToHumanDisplayLocalTimezoneDummyParams(),
+      Stream.of(
+        Arguments.of(TemporalPrecisionEnum.MILLI, new Date("2002/02/04"), "04-Feb-2002 00:00:00"),
+        Arguments.of(TemporalPrecisionEnum.SECOND, new Date("2002/02/04"), "04-Feb-2002 00:00:00"),
+        Arguments.of(TemporalPrecisionEnum.MINUTE, new Date("2002/02/04"), "04-Feb-2002 00:00:00")
+      ));
   }
 
   private static Locale defaultLocale;
@@ -64,24 +82,38 @@ public class DateTimeUtilTests {
   public static void beforeAll() {
     defaultLocale = Locale.getDefault();
     ourLog.info("Test setup: getting current default locale");
-    ourLog.info("Locale.getDefault(): " + defaultLocale);
+    ourLog.info("Locale.getDefault() = {} ", defaultLocale);
     ourLog.info("Test setup: setting default locale to UK for tests");
     Locale.setDefault(Locale.UK);
-    ourLog.info("Locale.getDefault(): " + Locale.getDefault());
-    ourLog.info("DateTime format: " + FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM));
+    ourLog.info("Locale.getDefault() = {}", Locale.getDefault());
+    ourLog.info("DateTime format = {}", FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM));
   }
 
   @AfterAll
-  public static void afterAll() {
+  static void afterAll() {
     ourLog.info("Test teardown: setting default locale back to default");
     Locale.setDefault(defaultLocale);
-    ourLog.info("Locale.getDefault(): " + Locale.getDefault());
-    ourLog.info("DateTime format: " + FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM));
+    ourLog.info("Locale.getDefault() = {} ", Locale.getDefault());
+    ourLog.info("DateTime format =  {}", FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM));
+  }
+
+
+
+  @ParameterizedTest
+  @MethodSource("getToHumanDisplayLocalTimezoneParams_Java25")
+  @EnabledForJreRange(min = JAVA_25)
+  void testToHumanDisplayLocalTimezone_Java25(TemporalPrecisionEnum thePrecision, Date theValue, String expected) {
+    testToHumanDisplayLocalTimezone(thePrecision,theValue,  expected);
   }
 
   @ParameterizedTest
-  @MethodSource("getToHumanDisplayLocalTimezoneParams")
-  public void testToHumanDisplayLocalTimezone(TemporalPrecisionEnum thePrecision, Date theValue, String expected){
+  @MethodSource("getToHumanDisplayLocalTimezoneParams_Java17_24")
+  @EnabledForJreRange(min = JAVA_17, max = JAVA_24)
+  void testToHumanDisplayLocalTimezone_Java17_24(TemporalPrecisionEnum thePrecision, Date theValue, String expected) {
+    testToHumanDisplayLocalTimezone(thePrecision,theValue,  expected);
+  }
+
+  void testToHumanDisplayLocalTimezone(TemporalPrecisionEnum thePrecision, Date theValue, String expected){
     final String humanDisplay = DateTimeUtil.toHumanDisplayLocalTimezone(thePrecision, theValue, "dummyValueAsString");
     assertEquals(expected, humanDisplay);
   }
@@ -89,24 +121,6 @@ public class DateTimeUtilTests {
   @Test
   @DisplayName("Date Reasoning Tests")
   void testDateRoutines() {
-//    Assertions.assertEquals("2021-01-01T00:00:00.000", Utilities.lowBoundaryForDate("2021"));
-//    Assertions.assertEquals("2021-04-01T00:00:00.000", Utilities.lowBoundaryForDate("2021-04"));
-//    Assertions.assertEquals("2020-02-01T00:00:00.000", Utilities.lowBoundaryForDate("2020-02"));
-//    Assertions.assertEquals("2021-04-04T00:00:00.000", Utilities.lowBoundaryForDate("2021-04-04"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.000", Utilities.lowBoundaryForDate("2021-04-04T21:22:23"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.245", Utilities.lowBoundaryForDate("2021-04-04T21:22:23.245"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.000Z", Utilities.lowBoundaryForDate("2021-04-04T21:22:23Z"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.245+10:00", Utilities.lowBoundaryForDate("2021-04-04T21:22:23.245+10:00"));
-//
-//    Assertions.assertEquals("2021-12-31T23:23:59.999", Utilities.highBoundaryForDate("2021"));
-//    Assertions.assertEquals("2021-04-30T23:23:59.999", Utilities.highBoundaryForDate("2021-04"));
-//    Assertions.assertEquals("2020-02-29T23:23:59.999", Utilities.highBoundaryForDate("2020-02"));
-//    Assertions.assertEquals("2021-04-04T23:23:59.999", Utilities.highBoundaryForDate("2021-04-04"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.999", Utilities.highBoundaryForDate("2021-04-04T21:22:23"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.245", Utilities.highBoundaryForDate("2021-04-04T21:22:23.245"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.999Z", Utilities.highBoundaryForDate("2021-04-04T21:22:23Z"));
-//    Assertions.assertEquals("2021-04-04T21:22:23.245+10:00", Utilities.highBoundaryForDate("2021-04-04T21:22:23.245+10:00"));
-
     assertEquals(8, DateTimeUtil.getDatePrecision("1900-01-01"));
     assertEquals(4, DateTimeUtil.getDatePrecision("1900"));
     assertEquals(6, DateTimeUtil.getDatePrecision("1900-06"));

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
@@ -2,8 +2,12 @@ package org.hl7.fhir.utilities;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SQLiteLoadWarningTest {
 
@@ -11,11 +15,20 @@ class SQLiteLoadWarningTest {
   void sqliteNativeLibraryIsLoadedFromUnnamedModule() throws Exception {
     // Opening any sqlite connection causes SQLiteJDBCLoader to call
     // System.load() from an unnamed module.
-    // On JDK 22+ this prints to stderr:
+    // On JDK 22+ without --enable-native-access=ALL-UNNAMED this prints to stderr:
     //   WARNING: java.lang.System::load has been called by
     //   org.sqlite.SQLiteJDBCLoader in an unnamed module
-    try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
-      // connection is enough — no queries needed
+    PrintStream originalErr = System.err;
+    ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+    try {
+      System.setErr(new PrintStream(capturedErr));
+      try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+        // connection is enough — no queries needed
+      }
+      capturedErr.flush();
+    } finally {
+      System.setErr(originalErr);
     }
+    assertEquals("", capturedErr.toString());
   }
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
@@ -2,12 +2,11 @@ package org.hl7.fhir.utilities;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SQLiteLoadWarningTest {
 
@@ -18,17 +17,26 @@ class SQLiteLoadWarningTest {
     // On JDK 22+ without --enable-native-access=ALL-UNNAMED this prints to stderr:
     //   WARNING: java.lang.System::load has been called by
     //   org.sqlite.SQLiteJDBCLoader in an unnamed module
-    PrintStream originalErr = System.err;
-    ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
-    try {
-      System.setErr(new PrintStream(capturedErr));
-      try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
-        // connection is enough — no queries needed
+    //
+    // Module.isNativeAccessEnabled() was added in JDK 22. On older runtimes the
+    // warning is never emitted, so no assertion is needed.
+    if (Runtime.version().feature() >= 22) {
+      try {
+        Method isNativeAccessEnabled = Module.class.getMethod("isNativeAccessEnabled");
+        boolean enabled = (boolean) isNativeAccessEnabled.invoke(
+          SQLiteLoadWarningTest.class.getModule());
+        assertThat(enabled)
+          .as("Native access must be enabled for the unnamed module " +
+              "(--enable-native-access=ALL-UNNAMED) to suppress the " +
+              "SQLiteJDBCLoader warning on JDK 22+")
+          .isTrue();
+      } catch (NoSuchMethodException e) {
+        // safety net — should not occur on JDK 22+
       }
-      capturedErr.flush();
-    } finally {
-      System.setErr(originalErr);
     }
-    assertEquals("", capturedErr.toString());
+
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+      // connection is enough — no queries needed
+    }
   }
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/SQLiteLoadWarningTest.java
@@ -1,4 +1,4 @@
-package org.hl7.fhir.convertors.misc;
+package org.hl7.fhir.utilities;
 
 import org.junit.jupiter.api.Test;
 

--- a/org.hl7.fhir.validation.cli/pom.xml
+++ b/org.hl7.fhir.validation.cli/pom.xml
@@ -359,6 +359,9 @@
                             <classpathLayoutType>repository</classpathLayoutType>
                             <mainClass>org.hl7.fhir.validation.cli.ValidatorCli</mainClass>
                         </manifest>
+                        <manifestEntries>
+                            <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,7 @@
                         -->
                         <argLine>@{argLine} -Xmx3500m -XX:MaxRAMPercentage=50.0 ${surefire.native.access.arg}</argLine>
                         <systemPropertyVariables>
+                            <java.locale.providers>COMPAT</java.locale.providers>
                             <!--    For JUnit4 use TestUtilities.runningAsSurefire() or
                                     TestingUtilities.runningAsSurefire() to exclude a test from surefire executions-->
                             <runningAsSurefire>true</runningAsSurefire>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <okhttp.version>5.3.2</okhttp.version>
         <jacoco_version>0.8.12</jacoco_version>
         <lombok_version>1.18.38</lombok_version>
+        <mockito_version>5.23.0</mockito_version>
         <byte_buddy_version>1.14.8</byte_buddy_version>
         <apache_poi_version>5.4.1</apache_poi_version>
         <saxon_he_version>11.6</saxon_he_version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <log4jVersion>2.25.3</log4jVersion>
         <okio.version>3.16.4</okio.version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
+        <surefire.native.access.arg/>
     </properties>
 
     <name>HL7 Core Artifacts</name>
@@ -447,9 +448,8 @@
                         <!-- We need to include the ${argLine} here so the Jacoco test arguments are included in the
                          Surefire testing run. This may appear as an error in some IDEs, but it will run regardless.
                         -->
-                        <argLine>@{argLine} -Xmx3500m -XX:MaxRAMPercentage=50.0</argLine>
+                        <argLine>@{argLine} -Xmx3500m -XX:MaxRAMPercentage=50.0 ${surefire.native.access.arg}</argLine>
                         <systemPropertyVariables>
-                            <java.locale.providers>COMPAT</java.locale.providers>
                             <!--    For JUnit4 use TestUtilities.runningAsSurefire() or
                                     TestingUtilities.runningAsSurefire() to exclude a test from surefire executions-->
                             <runningAsSurefire>true</runningAsSurefire>
@@ -700,20 +700,14 @@
             </build>
         </profile>
     <profile>
-        <id>surefire-java-9-plus</id>
+        <id>surefire-java-22-plus</id>
         <activation>
-            <jdk>[9,)</jdk>
+            <jdk>[22,)</jdk>
         </activation>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                </plugin>
-
-                </plugins>
-            </build>
-        </profile>
+        <properties>
+            <surefire.native.access.arg>--enable-native-access=ALL-UNNAMED</surefire.native.access.arg>
+        </properties>
+    </profile>
         <profile>
             <id>github-repo</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
                         -->
                         <argLine>@{argLine} -Xmx3500m -XX:MaxRAMPercentage=50.0 ${surefire.native.access.arg}</argLine>
                         <systemPropertyVariables>
-                            <java.locale.providers>COMPAT</java.locale.providers>
+                            <java.locale.providers>COMPAT,CLDR,SPI</java.locale.providers>
                             <!--    For JUnit4 use TestUtilities.runningAsSurefire() or
                                     TestingUtilities.runningAsSurefire() to exclude a test from surefire executions-->
                             <runningAsSurefire>true</runningAsSurefire>
@@ -707,7 +707,7 @@
         </activation>
         <properties>
             <surefire.native.access.arg>--enable-native-access=ALL-UNNAMED</surefire.native.access.arg>
-        </properties>
+         </properties>
     </profile>
         <profile>
             <id>github-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <jacoco_version>0.8.12</jacoco_version>
         <lombok_version>1.18.38</lombok_version>
         <mockito_version>5.23.0</mockito_version>
-        <byte_buddy_version>1.14.8</byte_buddy_version>
+        <byte_buddy_version>1.18.8</byte_buddy_version>
         <apache_poi_version>5.4.1</apache_poi_version>
         <saxon_he_version>11.6</saxon_he_version>
         <maven.compiler.release>17</maven.compiler.release>

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -77,6 +77,10 @@ parameters:
           image: macos-latest
           jdk: 1.21
           javaToolOptions:
+        - name: ubuntu_java_25
+          image: ubuntu-latest
+          jdk: 1.25
+          javaToolOptions:
   - name: jdksToTest
     displayName: JDKs to Test Against
     type: object


### PR DESCRIPTION
When run in later Java versions, sqlite will produce warnings regarding native access.

The following thread includes instructions from xerial on how to rectify this in the config, which will be applied here: https://github.com/xerial/sqlite-jdbc/issues/1289

Additional note:

These changes also introduce new testing for Java 25. This revealed that DateTimeUtil.toHumanDisplay no longer functions with the deprecated COMPAT provider for Java locale and now produces different output for different versions of Java. Since 'toHumanDisplay' is defined in the API as "using the system local format" this is expected, and the tests are now Java version specific.
