### PR TITLE
Add RegexTimeout utilities class

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
 import org.hl7.fhir.dstu2.model.Base;
@@ -82,6 +84,8 @@ public class FHIRPathEngine {
   private StringBuilder log = new StringBuilder();
   private Set<String> primitiveTypes = new HashSet<String>();
   private Map<String, StructureDefinition> allTypes = new HashMap<String, StructureDefinition>();
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
   /**
    * @param worker - used when validating paths (@check), and used doing value set
@@ -2219,7 +2223,7 @@ public class FHIRPathEngine {
 
     if (focus.size() == 1 && !Utilities.noString(regex)) {
       try {
-        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl)));
+        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl, regexTimeoutMillis)));
       } catch (TimeoutException e) {
         throw new PathEngineException("Timeout evaluating regex: " + regex, e);
       }

--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
@@ -68,6 +69,7 @@ import org.hl7.fhir.utilities.Utilities;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 
 /**
  * 
@@ -2216,7 +2218,11 @@ public class FHIRPathEngine {
     String repl = convertToString(execute(context, focus, exp.getParameters().get(1), true));
 
     if (focus.size() == 1 && !Utilities.noString(regex)) {
-      result.add(new StringType(convertToString(focus.get(0)).replaceAll(regex, repl)));
+      try {
+        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl)));
+      } catch (TimeoutException e) {
+        throw new PathEngineException("Timeout evaluating regex: " + regex, e);
+      }
     } else {
       result.add(new StringType(convertToString(focus.get(0))));
     }

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
@@ -71,6 +72,7 @@ import org.hl7.fhir.utilities.Utilities;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 
 /**
  * 
@@ -2414,9 +2416,13 @@ public class FHIRPathEngine {
     List<Base> result = new ArrayList<Base>();
     String sw = convertToString(execute(context, focus, exp.getParameters().get(0), true));
 
-    if (focus.size() == 1 && !Utilities.noString(sw))
-      result.add(new BooleanType(convertToString(focus.get(0)).matches(sw)));
-    else
+    if (focus.size() == 1 && !Utilities.noString(sw)) {
+      try {
+        result.add(new BooleanType(RegexTimeout.matches(convertToString(focus.get(0)), sw)));
+      } catch (TimeoutException e) {
+        throw new FHIRException("Timeout evaluating regex: " + sw, e);
+      }
+    } else
       result.add(new BooleanType(false));
     return result;
   }

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
 import org.hl7.fhir.dstu2016may.model.Base;
@@ -85,6 +87,8 @@ public class FHIRPathEngine {
   private StringBuilder log = new StringBuilder();
   private Set<String> primitiveTypes = new HashSet<String>();
   private Map<String, StructureDefinition> allTypes = new HashMap<String, StructureDefinition>();
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
   /**
    * @param worker - used when validating paths (@check), and used doing value set
@@ -2418,7 +2422,7 @@ public class FHIRPathEngine {
 
     if (focus.size() == 1 && !Utilities.noString(sw)) {
       try {
-        result.add(new BooleanType(RegexTimeout.matches(convertToString(focus.get(0)), sw)));
+        result.add(new BooleanType(RegexTimeout.matches(convertToString(focus.get(0)), sw, regexTimeoutMillis)));
       } catch (TimeoutException e) {
         throw new FHIRException("Timeout evaluating regex: " + sw, e);
       }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
 import org.hl7.fhir.dstu3.context.IWorkerContext;
@@ -81,6 +83,8 @@ public class FHIRPathEngine {
   private StringBuilder log = new StringBuilder();
   private Set<String> primitiveTypes = new HashSet<String>();
   private Map<String, StructureDefinition> allTypes = new HashMap<String, StructureDefinition>();
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
 
   /**
@@ -2138,7 +2142,7 @@ public class FHIRPathEngine {
 
     if (focus.size() == 1 && !Utilities.noString(regex)) {
       try {
-        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl)));
+        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl, regexTimeoutMillis)));
       } catch (TimeoutException e) {
         throw new FHIRException("Timeout evaluating regex: " + regex, e);
       }
@@ -2440,7 +2444,7 @@ public class FHIRPathEngine {
         result.add(new BooleanType(false));
       else {
         try {
-          result.add(new BooleanType(RegexTimeout.matches(st, sw)));
+          result.add(new BooleanType(RegexTimeout.matches(st, sw, regexTimeoutMillis)));
         } catch (TimeoutException e) {
           throw new FHIRException("Timeout evaluating regex: " + sw, e);
         }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.UcumException;
@@ -67,6 +68,7 @@ import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.util.ElementUtil;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 
 /**
  *
@@ -2135,7 +2137,11 @@ public class FHIRPathEngine {
     String repl = convertToString(execute(context, focus, exp.getParameters().get(1), true));
 
     if (focus.size() == 1 && !Utilities.noString(regex)) {
-      result.add(new StringType(convertToString(focus.get(0)).replaceAll(regex, repl)));
+      try {
+        result.add(new StringType(RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl)));
+      } catch (TimeoutException e) {
+        throw new FHIRException("Timeout evaluating regex: " + regex, e);
+      }
     } else {
       result.add(new StringType(convertToString(focus.get(0))));
     }
@@ -2432,8 +2438,13 @@ public class FHIRPathEngine {
       String st = convertToString(focus.get(0));
       if (Utilities.noString(st))
         result.add(new BooleanType(false));
-      else
-        result.add(new BooleanType(st.matches(sw)));
+      else {
+        try {
+          result.add(new BooleanType(RegexTimeout.matches(st, sw)));
+        } catch (TimeoutException e) {
+          throw new FHIRException("Timeout evaluating regex: " + sw, e);
+        }
+      }
     } else
       result.add(new BooleanType(false));
     return result;

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.Pair;
 import org.fhir.ucum.UcumException;
@@ -178,6 +180,8 @@ public class FHIRPathEngine {
   private boolean allowDoubleQuotes;
   private List<IssueMessage> typeWarnings = new ArrayList<>();
   private boolean emitSQLonFHIRWarning;
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
   /**
    * @param worker - used when validating paths (@check), and used doing value set membership when executing tests (once that's defined)
@@ -5676,7 +5680,7 @@ public class FHIRPathEngine {
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.find(st, "(?s)" + sw);
+            ok = RegexTimeout.find(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }
@@ -5701,7 +5705,7 @@ public class FHIRPathEngine {
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.matches(st, "(?s)" + sw);
+            ok = RegexTimeout.matches(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
@@ -15,8 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.concurrent.TimeoutException;
 
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.Pair;
@@ -69,6 +68,7 @@ import org.hl7.fhir.utilities.MergedList.MergeNode;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -5674,9 +5674,12 @@ public class FHIRPathEngine {
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.find();
+          boolean ok;
+          try {
+            ok = RegexTimeout.find(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }
@@ -5696,9 +5699,12 @@ public class FHIRPathEngine {
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.matches();
+          boolean ok;
+          try {
+            ok = RegexTimeout.matches(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
@@ -15,8 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.concurrent.TimeoutException;
 
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.Pair;
@@ -48,6 +47,7 @@ import org.hl7.fhir.utilities.MergedList.MergeNode;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -5489,9 +5489,12 @@ public class FHIRPathEngine {
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.find();
+          boolean ok;
+          try {
+            ok = RegexTimeout.find(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }
@@ -5512,9 +5515,12 @@ public class FHIRPathEngine {
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.matches();
+          boolean ok;
+          try {
+            ok = RegexTimeout.matches(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.Pair;
 import org.fhir.ucum.UcumException;
@@ -111,6 +113,8 @@ public class FHIRPathEngine {
   private boolean doNotEnforceAsSingletonRule;
   private boolean doNotEnforceAsCaseSensitive;
   private boolean allowDoubleQuotes;
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
   /**
    * @param worker - used when validating paths (@check), and used doing value set
@@ -5491,7 +5495,7 @@ public class FHIRPathEngine {
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.find(st, "(?s)" + sw);
+            ok = RegexTimeout.find(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }
@@ -5517,7 +5521,7 @@ public class FHIRPathEngine {
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.matches(st, "(?s)" + sw);
+            ok = RegexTimeout.matches(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.fhir.ucum.Decimal;
 import org.fhir.ucum.Pair;
@@ -177,6 +179,8 @@ public class FHIRPathEngine {
   private boolean allowDoubleQuotes;
   private List<IssueMessage> typeWarnings = new ArrayList<>();
   private boolean emitSQLonFHIRWarning;
+  @Getter @Setter
+  private long regexTimeoutMillis = 500;
 
   public interface IDebugTracer {
 
@@ -5928,7 +5932,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.find(st, "(?s)" + sw);
+            ok = RegexTimeout.find(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }
@@ -5953,7 +5957,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         } else {
           boolean ok;
           try {
-            ok = RegexTimeout.matches(st, "(?s)" + sw);
+            ok = RegexTimeout.matches(st, "(?s)" + sw, regexTimeoutMillis);
           } catch (TimeoutException e) {
             throw new FHIRException("Timeout evaluating regex: " + sw, e);
           }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -15,8 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.concurrent.TimeoutException;
 
 import lombok.extern.slf4j.Slf4j;
 import org.fhir.ucum.Decimal;
@@ -53,6 +52,7 @@ import org.hl7.fhir.utilities.MergedList.MergeNode;
 import org.hl7.fhir.utilities.fhirpath.FHIRPathConstantEvaluationMode;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.hl7.fhir.utilities.regex.RegexTimeout;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -5926,9 +5926,12 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.find();
+          boolean ok;
+          try {
+            ok = RegexTimeout.find(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }
@@ -5948,9 +5951,12 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
         if (Utilities.noString(st)) {
           result.add(new BooleanType(false).noExtensions());
         } else {
-          Pattern p = Pattern.compile("(?s)" + sw);
-          Matcher m = p.matcher(st);
-          boolean ok = m.matches();
+          boolean ok;
+          try {
+            ok = RegexTimeout.matches(st, "(?s)" + sw);
+          } catch (TimeoutException e) {
+            throw new FHIRException("Timeout evaluating regex: " + sw, e);
+          }
           result.add(new BooleanType(ok).noExtensions());
         }
       }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -43,7 +43,7 @@ import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
+
 
 public class FHIRPathTests {
 

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
@@ -1,0 +1,177 @@
+package org.hl7.fhir.utilities.regex;
+
+import java.util.concurrent.*;
+import java.util.regex.Pattern;
+
+/**
+ * <p>This utility class executes common regular expression methods and times out if processing takes longer than expected.</p>
+ * <p>500ms is the default timeout.</p>
+ */
+public final class RegexTimeout {
+
+  private RegexTimeout() {
+    throw new UnsupportedOperationException("This utility class should not be instantiated");
+  }
+
+  static final long DEFAULT_TIMEOUT = 500;
+
+  private static <T> T executeWithTimeout(Callable<T> callable, long timeoutMillis) throws TimeoutException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<T> future = executor.submit(callable);
+    try {
+      return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e ) {
+      future.cancel(true);
+      throw new TimeoutException("Regex evaluation timed out after ");
+    } catch (ExecutionException | InterruptedException e) {
+      future.cancel(true);
+      throw new RuntimeException(e);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /**
+   * Wrapper around {@link String#matches(String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @return true if, and only if, the string matches the given regular expression
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static boolean matches(String string, String regex) throws TimeoutException {
+    return matches(string, regex, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link String#matches(String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @param timeoutMillis the timeout in milliseconds
+   * @return true if, and only if, the string matches the given regular expression
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static boolean matches(String string, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(()->Pattern.matches(regex, string), timeoutMillis);
+  }
+
+  /**
+   * Wrapper around {@link java.util.regex.Matcher#find()} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to search for within the string
+   * @return true if a subsequence of the input sequence matches the pattern
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static boolean find(String string, String regex) throws TimeoutException {
+    return find(string, regex, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link java.util.regex.Matcher#find()} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to search for within the string
+   * @param timeoutMillis the timeout in milliseconds
+   * @return true if a subsequence of the input sequence matches the pattern
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static boolean find(String string, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).find(), timeoutMillis);
+  }
+
+  /**
+   * Wrapper around {@link String#replaceAll(String, String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @param replacement the string to be substituted for each match
+   * @return the resulting string
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static String replaceAll(String string, String regex, String replacement) throws TimeoutException {
+    return replaceAll(string, regex, replacement, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link String#replaceAll(String, String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @param replacement the string to be substituted for each match
+   * @param timeoutMillis the timeout in milliseconds
+   * @return the resulting string
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static String replaceAll(String string, String regex, String replacement, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).replaceAll(replacement), timeoutMillis);
+  }
+
+  /**
+   * Wrapper around {@link String#replaceFirst(String, String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @param replacement the string to be substituted for the first match
+   * @return the resulting string
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static String replaceFirst(String string, String regex, String replacement) throws TimeoutException {
+    return replaceFirst(string, regex, replacement, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link String#replaceFirst(String, String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the regular expression to which the string is to be matched
+   * @param replacement the string to be substituted for the first match
+   * @param timeoutMillis the timeout in milliseconds
+   * @return the resulting string
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static String replaceFirst(String string, String regex, String replacement, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).replaceFirst(replacement), timeoutMillis);
+  }
+
+  /**
+   * Wrapper around {@link String#split(String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the delimiting regular expression
+   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static String[] split(String string, String regex) throws TimeoutException {
+    return split(string, regex, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link String#split(String)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the delimiting regular expression
+   * @param timeoutMillis the timeout in milliseconds
+   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static String[] split(String string, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).split(string), timeoutMillis);
+  }
+
+  /**
+   * Wrapper around {@link String#split(String, int)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the delimiting regular expression
+   * @param limit the result threshold
+   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
+   */
+  public static String[] split(String string, String regex, int limit) throws TimeoutException {
+    return split(string, regex, limit, DEFAULT_TIMEOUT);
+  }
+
+  /**
+   * Wrapper around {@link String#split(String, int)} which will throw an exception if processing runs longer than expected.
+   * @param string the string
+   * @param regex the delimiting regular expression
+   * @param limit the result threshold
+   * @param timeoutMillis the timeout in milliseconds
+   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
+   */
+  public static String[] split(String string, String regex, int limit, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).split(string, limit), timeoutMillis);
+  }
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
@@ -1,0 +1,103 @@
+package org.hl7.fhir.utilities.regex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RegexTimeoutTests {
+
+  public static final String NORMAL_STRING = "a".repeat(10) + "!";
+  public static final String EVIL_STRING = "a".repeat(50) + "!";
+
+  public static final String BAD_REGEX = "((a+)+)+";
+
+  // BAD_REGEX causes catastrophic backtracking only for matches() (full-string match).
+  // For find/replace/split, the engine greedily matches the leading a's and returns immediately.
+  // BAD_SUFFIX_REGEX requires a trailing 'b' that never appears, forcing exhaustive backtracking
+  // for find/replace/split as well.
+  static final String BAD_SUFFIX_REGEX = "((a+)+)+b";
+  static final String EVIL_NO_SUFFIX = "a".repeat(50);
+
+  @Test
+  void test_BadRegex_Matches_EvilString() {
+    assertThrows( TimeoutException.class, () -> RegexTimeout.matches(EVIL_STRING, BAD_REGEX));
+  }
+
+  @Test
+  void test_BadRegex_Matches_NormalString() throws TimeoutException {
+    Boolean actual = RegexTimeout.matches(NORMAL_STRING, BAD_REGEX);
+    assertThat(actual).isEqualTo(NORMAL_STRING.matches(BAD_REGEX));
+    assertThat(actual).isFalse();
+  }
+
+  // find()
+
+  @Test
+  void test_BadRegex_Find_EvilString() {
+    assertThrows(TimeoutException.class, () -> RegexTimeout.find(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX));
+  }
+
+  @Test
+  void test_BadRegex_Find_NormalString() throws TimeoutException {
+    boolean actual = RegexTimeout.find(NORMAL_STRING, BAD_REGEX);
+    assertThat(actual).isEqualTo(Pattern.compile(BAD_REGEX).matcher(NORMAL_STRING).find());
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void test_NormalRegex_Find_ReturnsFalse() throws TimeoutException {
+    assertThat(RegexTimeout.find("123", "[a-z]+")).isFalse();
+  }
+
+  // replaceAll()
+
+  @Test
+  void test_BadRegex_ReplaceAll_EvilString() {
+    assertThrows(TimeoutException.class, () -> RegexTimeout.replaceAll(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, "X"));
+  }
+
+  @Test
+  void test_NormalRegex_ReplaceAll() throws TimeoutException {
+    assertThat(RegexTimeout.replaceAll("hello world", "\\w+", "X")).isEqualTo("X X");
+  }
+
+  // replaceFirst()
+
+  @Test
+  void test_BadRegex_ReplaceFirst_EvilString() {
+    assertThrows(TimeoutException.class, () -> RegexTimeout.replaceFirst(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, "X"));
+  }
+
+  @Test
+  void test_NormalRegex_ReplaceFirst() throws TimeoutException {
+    assertThat(RegexTimeout.replaceFirst("hello world", "\\w+", "X")).isEqualTo("X world");
+  }
+
+  // split()
+
+  @Test
+  void test_BadRegex_Split_EvilString() {
+    assertThrows(TimeoutException.class, () -> RegexTimeout.split(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX));
+  }
+
+  @Test
+  void test_NormalRegex_Split() throws TimeoutException {
+    assertThat(RegexTimeout.split("a,b,c", ",")).isEqualTo(new String[]{"a", "b", "c"});
+  }
+
+  // split(limit)
+
+  @Test
+  void test_BadRegex_SplitWithLimit_EvilString() {
+    assertThrows(TimeoutException.class, () -> RegexTimeout.split(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, 2));
+  }
+
+  @Test
+  void test_NormalRegex_SplitWithLimit() throws TimeoutException {
+    assertThat(RegexTimeout.split("a,b,c", ",", 2)).isEqualTo(new String[]{"a", "b,c"});
+  }
+}


### PR DESCRIPTION
This utility class executes common regular expression methods and times out if processing takes longer than expected.

FHIRPathEngine in all versions will now use this with the default timeout.