### PR TITLE
Fix missing assets and malformed icon URLs in comparison output

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/Utilities.java
@@ -166,7 +166,7 @@ public class Utilities {
 
   // work around bad practices in past binary handling
   public static boolean isProhibitedBinaryFile(String k) {
-    return !EXCLUDED_FILES.contains(k);
+    return EXCLUDED_FILES.contains(k);
   }
 
   public static String insertBreakingSpaces(String text, Set<Character> breakingChars) {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/HierarchicalTableGenerator.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/HierarchicalTableGenerator.java
@@ -1313,7 +1313,7 @@ public class HierarchicalTableGenerator {
       //      files.put(filename, b.toString());
       return b.toString();
     } else {
-      return corePrefix+filename;
+      return Utilities.pathURL(corePrefix, filename);
     }
   }
 


### PR DESCRIPTION
Two independent one-liners in the comparison/hierarchical-table path that together caused broken icons and 404s in the ig-comparison output of the validator's `compare` command:

- HierarchicalTableGenerator.srcFor: use Utilities.pathURL instead of raw string concat so an imagePath without a trailing slash (as passed by the comparison renderers) does not yield `ig-comparisonicon.gif`.

- Utilities.isProhibitedBinaryFile: predicate was inverted. It returned true for everything NOT in EXCLUDED_FILES, so ComparisonRenderer.dumpBinaries skipped every binary except the ones meant to be excluded (fhir.css, tbl_*.png, icon_*.png were dropped while togaf.png / xver-paths-*.json were the only files copied).

Before: 
<img width="609" height="809" alt="image" src="https://github.com/user-attachments/assets/792b8733-0dea-401d-9b11-88a79f4cfaa2" />

after:
<img width="624" height="981" alt="image" src="https://github.com/user-attachments/assets/b5f5f400-f40b-4df7-9d59-4431567cb09b" />
