### PR TITLE
Check for terminologyClientManager being null in CompliesWithChecker

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/CompliesWithChecker.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/CompliesWithChecker.java
@@ -20,7 +20,7 @@ import org.hl7.fhir.r5.model.Enumerations.BindingStrength;
 import org.hl7.fhir.r5.terminologies.TerminologyUtilities;
 import org.hl7.fhir.r5.terminologies.ValueSetUtilities;
 import org.hl7.fhir.r5.terminologies.client.ITerminologyClient;
-import org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome;
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientManager;import org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome;
 import org.hl7.fhir.r5.utils.DefinitionNavigator;
 import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
 import org.hl7.fhir.utilities.TranslatorXml;
@@ -484,8 +484,9 @@ public class CompliesWithChecker {
           if (sameValueSets(cVS, aVS)) {
             // no message
           } else {
-            ITerminologyClient client = context.getTerminologyClientManager().getMasterClient();
-            if (TerminologyUtilities.supportsOperation(client.getCapabilitiesStatement(), "ValueSet", "$related")) {
+            TerminologyClientManager terminologyClientManager = context.getTerminologyClientManager();
+            ITerminologyClient client = terminologyClientManager != null ? terminologyClientManager.getMasterClient() : null;
+            if (client != null && TerminologyUtilities.supportsOperation(client.getCapabilitiesStatement(), "ValueSet", "$related")) {
               Parameters params = client.getValueSetRelationship(cVS, aVS);
               throw new Error("not done yet");
             } else {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
@@ -880,8 +880,10 @@ public interface IWorkerContext {
 
   //endregion
 
-
-  // todo: figure these out
+  /**
+  * Note: This currently returns an implementation, not an interface, and will likely be changed at a later time.
+  * @return null if you do not want to use TerminologyClientManager (recommended)
+  */
   TerminologyClientManager getTerminologyClientManager();
 
   @Deprecated

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/client/TerminologyClientManager.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/client/TerminologyClientManager.java
@@ -24,7 +24,6 @@ import org.hl7.fhir.r5.utils.UserDataNames;
 import org.hl7.fhir.utilities.*;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.utilities.http.ManagedWebAccess;
-import org.hl7.fhir.utilities.http.ManagedWebAccessUtils;
 import org.hl7.fhir.utilities.json.model.JsonObject;
 import org.hl7.fhir.utilities.json.parser.JsonParser;
 import org.hl7.fhir.utilities.settings.FhirSettings;


### PR DESCRIPTION
The new getTerminologyClientManager() method forces IWorkerContext implementations to use or extend TerminologyClientManager, which is our own implementation.

The only use of getTerminologyClientManager() is in code that explicitly fails with an Error().

Until this is better thought out, we should allow a `null` value provided by `getTerminologyClientManager()` to skip the unimplemented code, and note its incompleteness.