### PR TITLE
Add -suite filter to txTests command

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/TxTestsCommand.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/TxTestsCommand.java
@@ -66,6 +66,12 @@ public class TxTestsCommand extends ValidationServiceCommand implements Callable
   private String filter;
 
   @CommandLine.Option(
+    names = {"-suite"},
+    description = "Run only tests belonging to the named suite"
+  )
+  private String suite;
+
+  @CommandLine.Option(
     names = {"-externals"},
     description = "Path to JSON file with external test definitions"
   )
@@ -123,7 +129,7 @@ public class TxTestsCommand extends ValidationServiceCommand implements Callable
         CommaSeparatedStringBuilder.join(" | ", Utilities.sorted(modeSet)));
 
       // Execute tests
-      boolean ok = txTester.setOutput(outputDir).execute(modeSet, filter);
+      boolean ok = txTester.setOutput(outputDir).execute(modeSet, filter, suite);
 
       // Write report
       new org.hl7.fhir.r5.formats.JsonParser()

--- a/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/picocli/TxTestsCommandTest.java
+++ b/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/picocli/TxTestsCommandTest.java
@@ -53,6 +53,14 @@ public class TxTestsCommandTest {
   }
 
   @Test
+  public void testCommandHasSuiteOption() {
+    CommandLine commandLine = new CommandLine(new TxTestsCommand());
+    boolean hasOption = commandLine.getCommandSpec()
+      .optionsMap().containsKey("-suite");
+    assertThat(hasOption).isTrue();
+  }
+
+  @Test
   public void testCommandHasExternalsOption() {
     CommandLine commandLine = new CommandLine(new TxTestsCommand());
     boolean hasOption = commandLine.getCommandSpec()

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
@@ -165,6 +165,10 @@ public class TxTester implements ITerminologyRequestIdProvider {
   }
 
   public boolean execute(Set<String> modes, String filter) throws IOException, URISyntaxException {
+    return execute(modes, filter, null);
+  }
+
+  public boolean execute(Set<String> modes, String filter, String suite) throws IOException, URISyntaxException {
     if (outputDir == null) {
       outputDir = Utilities.path("[tmp]", serverId());
     }
@@ -193,6 +197,9 @@ public class TxTester implements ITerminologyRequestIdProvider {
     if (filter != null) {
       log.info("  Filter Parameter: "+filter);
     }
+    if (suite != null) {
+      log.info("  Suite Parameter: "+suite);
+    }
 
     AtomicInteger counter = new AtomicInteger();
     AtomicInteger errCount = new AtomicInteger();
@@ -209,12 +216,12 @@ public class TxTester implements ITerminologyRequestIdProvider {
         JsonObject tests = loadTests(loader);
         readTests(tests, loader.version());
         versions.add(new StringPair(loader.code(), loader.version()));
-        for (JsonObject suite : tests.getJsonObjects("suites")) {
-          if ((!suite.has("mode") || modes.contains(suite.asString("mode"))) && passesVersion(suite)) {
-            if (suite.asBoolean("disabled")) {
+        for (JsonObject suiteObj : tests.getJsonObjects("suites")) {
+          if ((!suiteObj.has("mode") || modes.contains(suiteObj.asString("mode"))) && passesVersion(suiteObj)) {
+            if (suiteObj.asBoolean("disabled")) {
               // ok = true;
-            } else {
-              ok = runSuite(loader, suite, modes, filter, json.forceArray("suites"), counter, errCount) && ok;
+            } else if (suite == null || suite.equals(suiteObj.asString("name"))) {
+              ok = runSuite(loader, suiteObj, modes, filter, json.forceArray("suites"), counter, errCount) && ok;
             }
           }
         }
@@ -228,7 +235,7 @@ public class TxTester implements ITerminologyRequestIdProvider {
       testReport.setScore(s / 100);
       testReport.setResult(errCount.intValue() == 0 ? TestReportResult.PASS : TestReportResult.FAIL);
 
-      if (filter == null) {
+      if (filter == null && suite == null) {
         String m = modes.isEmpty() ? "[none]" : CommaSeparatedStringBuilder.join("+", modes);
         if (ok) {
           log.info(software+" passed all "+counter.intValue()+" HL7 terminology service tests ("+Utilities.pluralize("mode", modes.size())+" "+m+", tests v"+vString(versions)+", runner v"+VersionUtil.getBaseVersion()+")");
@@ -238,6 +245,16 @@ public class TxTester implements ITerminologyRequestIdProvider {
           log.info("Failed Tests: "+ CommaSeparatedStringBuilder.join(",", fails ));
           return false;
         }
+      } else if (suite != null) {
+        String m = modes.isEmpty() ? "[none]" : CommaSeparatedStringBuilder.join("+", modes);
+        int passed = counter.intValue() - errCount.intValue();
+        if (ok) {
+          log.info(software+" passed all "+counter.intValue()+" tests for suite '"+suite+"' ("+passed+" passed, 0 failed, "+Utilities.pluralize("mode", modes.size())+" "+m+", tests v"+vString(versions)+", runner v"+VersionUtil.getBaseVersion()+")");
+        } else {
+          log.info(software+" did not pass tests for suite '"+suite+"' ("+passed+" passed, "+errCount.intValue()+" failed of "+counter.intValue()+", "+Utilities.pluralize("mode", modes.size())+" "+m+", tests v"+vString(versions)+", runner v"+VersionUtil.getBaseVersion()+")");
+          log.info("Failed Tests: "+ CommaSeparatedStringBuilder.join(",", fails));
+        }
+        return ok;
       } else {
         log.info(software+" "+(ok ? "Passed the tests" : "did not pass the tests")+" '"+filter+"'");
         return ok;
@@ -638,7 +655,7 @@ public class TxTester implements ITerminologyRequestIdProvider {
           outputT.add("message", msg);
         }
         tr.getActionFirstRep().getOperation().setResult(msg == null ? TestReportActionResult.PASS : TestReportActionResult.FAIL).setMessage(msg);
-        return new ResultInformation(msg);
+        return msg == null ? new ResultInformation(true) : new ResultInformation(msg);
       } catch (Exception e) {
         log.error("  Tested "+ testName +": "+ "  ... Exception: "+e.getMessage());
 


### PR DESCRIPTION
Summary

  Adds a -suite option to the txTests command to allow running only the tests belonging to a named suite, without having to run the full test set.

  Changes

  New -suite option (TxTestsCommand, TxTester)
  - -suite <name> filters test execution to a single named suite
  - Backward compatible: the existing execute(modes, filter) overload is preserved and delegates to the new execute(modes, filter, suite)
  - Suite-specific summary logging is shown on completion (pass/fail counts)
  
  Fix -h / -help for txTests (TxTestsCommand)
  - The help option was only defined on the parent ValidateCommand and was not inherited by subcommands
  - Added -h, -help, -? to TxTestsCommand so txTests -h now works
  - Note: other subcommands have the same gap and can be addressed as a follow-up
  
  Remove picocli stdout/stderr SLF4J redirect (CLI.java)
  - Removed the setOut/setErr wiring that routed picocli output through CLIToSlf4jLoggerWriter
  - This was suppressing picocli's built-in help output, causing -h to appear broken
  
  Build: animal-sniffer ignore for http package (pom.xml)
  - Suppresses API compatibility check failures for org.hl7.fhir.validation.http.*
  
  Test coverage (TxTestsCommandTest)
  - Added testCommandHasSuiteOption to match the existing pattern for all other options
  