### PR TITLE
FHIRPath execution limits

### DIFF
--- a/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2/src/main/java/org/hl7/fhir/dstu2/utils/FHIRPathEngine.java
@@ -87,6 +87,14 @@ public class FHIRPathEngine {
   @Getter @Setter
   private long regexTimeoutMillis = 500;
 
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
+  @Getter @Setter
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
+  @Getter @Setter
+  private int repeatMaxIterations = DEFAULT_REPEAT_MAX_ITERATIONS;
+
   /**
    * @param worker - used when validating paths (@check), and used doing value set
    *               membership when executing tests (once that's defined)
@@ -431,12 +439,18 @@ public class FHIRPathEngine {
     private Base resource;
     private Base context;
     private Base thisItem;
+    private int executeCount;
 
     public ExecutionContext(Object appInfo, Base resource, Base context, Base thisItem) {
+      this(appInfo, resource, context, thisItem, 0);
+    }
+
+    public ExecutionContext(Object appInfo, Base resource, Base context, Base thisItem, int executeCount) {
       this.appInfo = appInfo;
       this.resource = resource;
       this.context = context;
       this.thisItem = thisItem;
+      this.executeCount = executeCount;
     }
 
     public Base getResource() {
@@ -445,6 +459,14 @@ public class FHIRPathEngine {
 
     public Base getThisItem() {
       return thisItem;
+    }
+
+    public int getExecuteCount() {
+      return executeCount;
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
     }
   }
 
@@ -806,6 +828,10 @@ public class FHIRPathEngine {
 
   private List<Base> execute(ExecutionContext context, List<Base> focus, ExpressionNode exp, boolean atEntry)
       throws PathEngineException {
+    context.incrementExecuteCount();
+    if (context.getExecuteCount() > executionMaxCalls) {
+      throw new PathEngineException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls + ")");
+    }
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
     case Name:
@@ -2162,7 +2188,7 @@ public class FHIRPathEngine {
   }
 
   private ExecutionContext changeThis(ExecutionContext context, Base newThis) {
-    return new ExecutionContext(context.appInfo, context.resource, context.context, newThis);
+    return new ExecutionContext(context.appInfo, context.resource, context.context, newThis, context.getExecuteCount());
   }
 
   private ExecutionTypeContext changeThis(ExecutionTypeContext context, TypeDetails newThis) {
@@ -2317,7 +2343,9 @@ public class FHIRPathEngine {
     current.addAll(focus);
     List<Base> added = new ArrayList<Base>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
       List<Base> pc = new ArrayList<Base>();
       for (Base item : current) {
@@ -2329,6 +2357,9 @@ public class FHIRPathEngine {
       result.addAll(added);
       current.clear();
       current.addAll(added);
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new PathEngineException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" + repeatMaxIterations + ")");
     }
     return result;
   }

--- a/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu2/src/test/java/org/hl7/fhir/dstu2/utils/FhirPathTests.java
@@ -1,0 +1,65 @@
+package org.hl7.fhir.dstu2.utils;
+
+import org.hl7.fhir.dstu2.model.Patient;
+import org.hl7.fhir.dstu2.model.Questionnaire;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FhirPathTests {
+
+  @Mock
+  IWorkerContext iWorkerContext;
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Patient input = new Patient();
+    input.addName().addGiven("John");
+    engine.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Patient.name.given"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Patient.name.given"));
+      }
+    } finally {
+      engine.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Questionnaire input = new Questionnaire();
+    Questionnaire.GroupComponent mainGroup = input.getGroup();
+    mainGroup.setLinkId("main");
+    mainGroup.addGroup().setLinkId("subgroup1");
+    mainGroup.addGroup().setLinkId("subgroup2");
+    engine.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Questionnaire.repeat(group)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Questionnaire.repeat(group)"));
+      }
+    } finally {
+      engine.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
+  }
+}

--- a/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu2016may/src/main/java/org/hl7/fhir/dstu2016may/utils/FHIRPathEngine.java
@@ -90,6 +90,14 @@ public class FHIRPathEngine {
   @Getter @Setter
   private long regexTimeoutMillis = 500;
 
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
+  @Getter @Setter
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
+  @Getter @Setter
+  private int repeatMaxIterations = DEFAULT_REPEAT_MAX_ITERATIONS;
+
   /**
    * @param worker - used when validating paths (@check), and used doing value set
    *               membership when executing tests (once that's defined)
@@ -421,11 +429,17 @@ public class FHIRPathEngine {
     private Object appInfo;
     private Base resource;
     private Base thisItem;
+    private int executeCount;
 
     public ExecutionContext(Object appInfo, Base resource, Base thisItem) {
+      this(appInfo, resource, thisItem, 0);
+    }
+
+    public ExecutionContext(Object appInfo, Base resource, Base thisItem, int executeCount) {
       this.appInfo = appInfo;
       this.resource = resource;
       this.thisItem = thisItem;
+      this.executeCount = executeCount;
     }
 
     public Base getResource() {
@@ -434,6 +448,14 @@ public class FHIRPathEngine {
 
     public Base getThisItem() {
       return thisItem;
+    }
+
+    public int getExecuteCount() {
+      return executeCount;
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
     }
   }
 
@@ -789,6 +811,10 @@ public class FHIRPathEngine {
 
   private List<Base> execute(ExecutionContext context, List<Base> focus, ExpressionNode exp, boolean atEntry)
       throws FHIRException {
+    context.incrementExecuteCount();
+    if (context.getExecuteCount() > executionMaxCalls) {
+      throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls + ")");
+    }
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
     case Name:
@@ -2136,7 +2162,7 @@ public class FHIRPathEngine {
   }
 
   private ExecutionContext changeThis(ExecutionContext context, Base newThis) {
-    return new ExecutionContext(context.appInfo, context.resource, newThis);
+    return new ExecutionContext(context.appInfo, context.resource, newThis, context.getExecuteCount());
   }
 
   private ExecutionTypeContext changeThis(ExecutionTypeContext context, TypeDetails newThis) {
@@ -2282,7 +2308,9 @@ public class FHIRPathEngine {
     current.addAll(focus);
     List<Base> added = new ArrayList<Base>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
       List<Base> pc = new ArrayList<Base>();
       for (Base item : current) {
@@ -2294,6 +2322,9 @@ public class FHIRPathEngine {
       result.addAll(added);
       current.clear();
       current.addAll(added);
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new FHIRException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" + repeatMaxIterations + ")");
     }
     return result;
   }

--- a/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu2016may/src/test/java/org/hl7/fhir/dstu2016may/utils/FhirPathTests.java
@@ -1,0 +1,63 @@
+package org.hl7.fhir.dstu2016may.utils;
+
+import org.hl7.fhir.dstu2016may.model.Patient;
+import org.hl7.fhir.dstu2016may.model.Questionnaire;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FhirPathTests {
+
+  @Mock
+  IWorkerContext iWorkerContext;
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Patient input = new Patient();
+    input.addName().addGiven("John");
+    engine.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Patient.name.given"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Patient.name.given"));
+      }
+    } finally {
+      engine.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Questionnaire input = new Questionnaire();
+    input.addItem().setLinkId("item1").addItem().setLinkId("subitem1");
+    input.addItem().setLinkId("item2").addItem().setLinkId("subitem2");
+    engine.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Questionnaire.repeat(item)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Questionnaire.repeat(item)"));
+      }
+    } finally {
+      engine.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
+  }
+}

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathEngine.java
@@ -86,6 +86,14 @@ public class FHIRPathEngine {
   @Getter @Setter
   private long regexTimeoutMillis = 500;
 
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
+  @Getter @Setter
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
+  @Getter @Setter
+  private int repeatMaxIterations = DEFAULT_REPEAT_MAX_ITERATIONS;
+
 
   /**
    * @param worker - used when validating paths (@check), and used doing value set membership when executing tests (once that's defined)
@@ -760,6 +768,10 @@ public class FHIRPathEngine {
   }
 
 	private List<Base> execute(ExecutionContext context, List<Base> focus, ExpressionNode exp, boolean atEntry) throws FHIRException {
+    context.incrementExecuteCount();
+    if (context.getExecuteCount() > executionMaxCalls) {
+      throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls + ")");
+    }
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
     case Name:
@@ -2049,7 +2061,7 @@ public class FHIRPathEngine {
 
 
   private ExecutionContext changeThis(ExecutionContext context, Base newThis) {
-    return new ExecutionContext(context.getAppInfo(), context.getResource(), context.getContext(), context.getAliases(), newThis);
+    return new ExecutionContext(context.getAppInfo(), context.getResource(), context.getContext(), context.getAliases(), newThis, context.getExecuteCount());
   }
 
   private ExecutionTypeContext changeThis(ExecutionTypeContext context, TypeDetails newThis) {
@@ -2240,7 +2252,9 @@ public class FHIRPathEngine {
     current.addAll(focus);
     List<Base> added = new ArrayList<Base>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
       List<Base> pc = new ArrayList<Base>();
       for (Base item : current) {
@@ -2252,6 +2266,9 @@ public class FHIRPathEngine {
       result.addAll(added);
       current.clear();
       current.addAll(added);
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new FHIRException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" + repeatMaxIterations + ")");
     }
     return result;
   }

--- a/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathUtilityClasses.java
+++ b/org.hl7.fhir.dstu3/src/main/java/org/hl7/fhir/dstu3/fhirpath/FHIRPathUtilityClasses.java
@@ -18,11 +18,16 @@ public class FHIRPathUtilityClasses {
     private Map<String, Base> aliases;
 
     public ExecutionContext(Object appInfo, Base resource, Base context, Map<String, Base> aliases, Base thisItem) {
+      this(appInfo, resource, context, aliases, thisItem, 0);
+    }
+
+    public ExecutionContext(Object appInfo, Base resource, Base context, Map<String, Base> aliases, Base thisItem, int executeCount) {
       this.appInfo = appInfo;
       this.context = context;
       this.resource = resource;
       this.aliases = aliases;
       this.thisItem = thisItem;
+      this.executeCount = executeCount;
     }
     public Base getResource() {
       return resource;
@@ -51,7 +56,16 @@ public class FHIRPathUtilityClasses {
     public Map<String, Base> getAliases() {
       return aliases;
     }
-    
+
+    private int executeCount;
+
+    public int getExecuteCount() {
+      return executeCount;
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
+    }
   }
 
   public static class ExecutionTypeContext {

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
@@ -11,9 +11,15 @@ import org.hl7.fhir.dstu3.context.IWorkerContext;
 import org.hl7.fhir.dstu3.fhirpath.ExpressionNode;
 import org.hl7.fhir.dstu3.fhirpath.FHIRPathEngine;
 import org.hl7.fhir.dstu3.model.Base;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Questionnaire;
 import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -58,5 +64,50 @@ public class FhirPathTests {
     assertTrue(onlyResult instanceof StringType);
     assertEquals("base", ((StringType)result.get(0)).asStringValue());
     Mockito.verify(engine, times(2)).convertToString(any());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Patient input = new Patient();
+    input.addName().setFamily("Smith").addGiven("John");
+    engine.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Patient.name.family"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Patient.name.family"));
+      }
+    } finally {
+      engine.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    FHIRPathEngine engine = new FHIRPathEngine(iWorkerContext);
+    Questionnaire input = new Questionnaire();
+    input.addItem().setLinkId("item1").addItem().setLinkId("subitem1");
+    input.addItem().setLinkId("item2").addItem().setLinkId("subitem2");
+    engine.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> engine.evaluate(input, "Questionnaire.repeat(item)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> engine.evaluate(input, "Questionnaire.repeat(item)"));
+      }
+    } finally {
+      engine.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
   }
 }

--- a/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
+++ b/org.hl7.fhir.dstu3/src/test/java/org/hl7/fhir/dstu3/utils/FhirPathTests.java
@@ -25,7 +25,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class FhirPathTests {
+class FhirPathTests {
 
   @Mock
   IWorkerContext iWorkerContext;
@@ -40,7 +40,7 @@ public class FhirPathTests {
   Base base;
 
   @Test
-  public void testFuncReplaceParamSize() {
+  void testFuncReplaceParamSize() {
     FHIRPathEngine engine = Mockito.spy(new FHIRPathEngine(iWorkerContext));
 
     ExpressionNode expressionNode = new ExpressionNode(0);

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/fhirpath/FHIRPathEngine.java
@@ -183,6 +183,14 @@ public class FHIRPathEngine {
   @Getter @Setter
   private long regexTimeoutMillis = 500;
 
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
+  @Getter @Setter
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
+  @Getter @Setter
+  private int repeatMaxIterations = DEFAULT_REPEAT_MAX_ITERATIONS;
+
   /**
    * @param worker - used when validating paths (@check), and used doing value set membership when executing tests (once that's defined)
    */
@@ -1015,6 +1023,16 @@ public class FHIRPathEngine {
 
       definedVariables.put(name, value);
     }
+
+    private int executeCount = 0;
+
+    public int getExecuteCount() {
+      return executeCount;
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
+    }
   }
 
   private static class ExecutionTypeContext {
@@ -1463,6 +1481,10 @@ public class FHIRPathEngine {
   }
 
   private List<Base> execute(ExecutionContext inContext, List<Base> focus, ExpressionNode exp, boolean atEntry) throws FHIRException {
+    inContext.incrementExecuteCount();
+    if (inContext.getExecuteCount() > executionMaxCalls) {
+      throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls + ")");
+    }
     ExecutionContext context = contextForParameter(inContext);
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
@@ -4728,6 +4750,7 @@ public class FHIRPathEngine {
 
   private ExecutionContext contextForParameter(ExecutionContext context) {
     ExecutionContext newContext = new ExecutionContext(context.appInfo, context.focusResource, context.rootResource, context.context, context.thisItem);
+    newContext.executeCount = context.executeCount;
     newContext.total = context.total;
     newContext.index = context.index;
     // append all of the defined variables from the context into the new context
@@ -5249,7 +5272,9 @@ public class FHIRPathEngine {
     current.addAll(focus);
     List<Base> added = new ArrayList<Base>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
       List<Base> pc = new ArrayList<Base>();
       for (Base item : current) {
@@ -5272,6 +5297,9 @@ public class FHIRPathEngine {
           more = true;
         }
       }
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new FHIRException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" + repeatMaxIterations + ")");
     }
     return result;
   }

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/FHIRPathTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -352,5 +353,48 @@ public class FHIRPathTests {
     List<Base> results = fp.evaluate(input, "Patient.id");
     assertEquals(1, results.size());
     assertEquals("123", results.get(0).toString());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    Patient input = new Patient();
+    input.addName().setFamily("Smith").addGiven("John");
+    fp.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Patient.name.family"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Patient.name.family"));
+      }
+    } finally {
+      fp.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    Questionnaire input = new Questionnaire();
+    input.addItem().setLinkId("item1").addItem().setLinkId("subitem1");
+    input.addItem().setLinkId("item2").addItem().setLinkId("subitem2");
+    fp.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      }
+    } finally {
+      fp.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
   }
 }

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/fhirpath/FHIRPathEngine.java
@@ -116,6 +116,14 @@ public class FHIRPathEngine {
   @Getter @Setter
   private long regexTimeoutMillis = 500;
 
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
+  @Getter @Setter
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
+  @Getter @Setter
+  private int repeatMaxIterations = DEFAULT_REPEAT_MAX_ITERATIONS;
+
   /**
    * @param worker - used when validating paths (@check), and used doing value set
    *               membership when executing tests (once that's defined)
@@ -818,6 +826,16 @@ public class FHIRPathEngine {
 
       definedVariables.put(name, value);
     }
+
+    private int executeCount = 0;
+
+    public int getExecuteCount() {
+      return executeCount;
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
+    }
   }
 
   private class ExecutionTypeContext {
@@ -1377,6 +1395,10 @@ public class FHIRPathEngine {
 
   private List<Base> execute(ExecutionContext inContext, List<Base> focus, ExpressionNode exp, boolean atEntry)
       throws FHIRException {
+    inContext.incrementExecuteCount();
+    if (inContext.getExecuteCount() > executionMaxCalls) {
+      throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls + ")");
+    }
     ExecutionContext context = contextForParameter(inContext);
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
@@ -4554,6 +4576,7 @@ public class FHIRPathEngine {
 
   private ExecutionContext contextForParameter(ExecutionContext context) {
     ExecutionContext newContext = new ExecutionContext(context.appInfo, context.focusResource, context.rootResource, context.context, context.thisItem);
+    newContext.executeCount = context.executeCount;
     newContext.total = context.total;
     newContext.index = context.index;
     // append all of the defined variables from the context into the new context
@@ -5057,7 +5080,9 @@ public class FHIRPathEngine {
     current.addAll(focus);
     List<Base> added = new ArrayList<Base>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
       List<Base> pc = new ArrayList<Base>();
       for (Base item : current) {
@@ -5080,6 +5105,9 @@ public class FHIRPathEngine {
           more = true;
         }
       }
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new FHIRException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" + repeatMaxIterations + ")");
     }
     return result;
   }

--- a/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r4b/src/test/java/org/hl7/fhir/r4b/test/FHIRPathTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -359,5 +360,48 @@ public class FHIRPathTests {
     input.setBirthDateElement(dtv);
     List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
     assertEquals(0, results.size());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    Patient input = new Patient();
+    input.addName().setFamily("Smith").addGiven("John");
+    fp.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Patient.name.family"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Patient.name.family"));
+      }
+    } finally {
+      fp.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    Questionnaire input = new Questionnaire();
+    input.addItem().setLinkId("item1").addItem().setLinkId("subitem1");
+    input.addItem().setLinkId("item2").addItem().setLinkId("subitem2");
+    fp.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      }
+    } finally {
+      fp.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
   }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -4809,15 +4809,15 @@ public class ProfileUtilities {
     if (!c.hasExpression()) {
       return null;
     }
-    fpe.setAllowUknownFunctions(true);
+    fpe.setAllowUnknownFunctions(true);
     ExpressionNode expr = null;
     try {
       expr = fpe.parse(c.getExpression());
     } catch (Exception e) {
-      fpe.setAllowUknownFunctions(false);
+      fpe.setAllowUnknownFunctions(false);
       return null;
     }
-    fpe.setAllowUknownFunctions(false);
+    fpe.setAllowUnknownFunctions(false);
     if (expr.getKind() != Kind.Group || expr.getOpNext() == null || !(expr.getOperation() == Operation.Equals || expr.getOperation() == Operation.LessOrEqual)) {
       return null;      
     }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -178,14 +178,18 @@ public class FHIRPathEngine {
    */
   private boolean checkWithHostServicesBeforeHand;
   private boolean allowDoubleQuotes;
-  private List<IssueMessage> typeWarnings = new ArrayList<>();
+  private final List<IssueMessage> typeWarnings = new ArrayList<>();
   private boolean emitSQLonFHIRWarning;
   @Getter @Setter
-  private long regexTimeoutMillis = 500;
+  private long regexTimeoutMillis = RegexTimeout.DEFAULT_TIMEOUT;
+
+  public static final int DEFAULT_EXECUTION_MAX_CALLS = 50;
   @Getter @Setter
-  private long executionMaxCalls = 50;
+  private int executionMaxCalls = DEFAULT_EXECUTION_MAX_CALLS;
+
+  public static final int DEFAULT_REPEAT_MAX_ITERATIONS = 50;
   @Getter @Setter
-  private long repeatMaxIterations = 50;
+  private int repeatMaxIterations = 50;
 
   public interface IDebugTracer {
 
@@ -514,7 +518,7 @@ public class FHIRPathEngine {
    * 
    * returns a list of the possible types that might be returned by executing the ExpressionNode against a particular context
    * 
-   * @param context - the logical type against which this path is applied
+   the logical type against which this path is applied
    * @throws DefinitionException
    * @throws PathEngineException 
    * @if the path is not valid
@@ -1522,10 +1526,11 @@ public class FHIRPathEngine {
   }
 
   private List<Base> execute(ExecutionContext inContext, List<Base> focus, ExpressionNode exp, boolean atEntry) throws FHIRException {
+    inContext.incrementExecuteCount();
     if (inContext.getExecuteCount() > this.executionMaxCalls) {
       throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls +")");
     }
-    inContext.incrementExecuteCount();
+
     ExecutionContext context = contextForParameter(inContext);
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
@@ -4993,6 +4998,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
   private ExecutionContext contextForParameter(ExecutionContext context) {
     ExecutionContext newContext = new ExecutionContext(context.appInfo, context.focusResource, context.rootResource, context.context, context.thisItem);
+    newContext.executeCount = context.executeCount;
     newContext.total = context.total;
     newContext.index = context.index;
     // append all of the defined variables from the context into the new context

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -154,7 +154,7 @@ public class FHIRPathEngine {
 
   private enum Equality { Null, True, False }
   
-  private IWorkerContext worker;
+  private final IWorkerContext worker;
   private IHostApplicationServices hostServices;
   private IDebugTracer tracer;
   private StringBuilder traceLog = new StringBuilder();
@@ -168,7 +168,7 @@ public class FHIRPathEngine {
   private boolean doNotEnforceAsCaseSensitive;
   private FHIRPathAnalysis analysis;
   private ProfileUtilities profileUtilities;
-  @Getter @Setter private boolean allowUknownFunctions;
+  @Getter @Setter private boolean allowUnknownFunctions;
 
   /*
    * The FHIRPath engine consults with the HostApplicationServices when an element fails to
@@ -182,26 +182,26 @@ public class FHIRPathEngine {
   private boolean emitSQLonFHIRWarning;
   @Getter @Setter
   private long regexTimeoutMillis = 500;
+  @Getter @Setter
+  private long executionMaxCalls = 50;
+  @Getter @Setter
+  private long repeatMaxIterations = 50;
 
   public interface IDebugTracer {
 
     /**
      * When an expression node is evaluated during execution
-     * 
-     * @param argument
+     *
      * @param focus
-     * @return
      */
-    public void traceExpression(ExecutionContext context, List<Base> focus, List<Base> result, ExpressionNode exp);
+    void traceExpression(ExecutionContext context, List<Base> focus, List<Base> result, ExpressionNode exp);
 
     /**
      * When an Operation expression node is evaluated during execution
-     * 
-     * @param argument
+     *
      * @param focus
-     * @return
      */
-    public void traceOperationExpression(ExecutionContext context, List<Base> focus, List<Base> result, ExpressionNode exp);
+    void traceOperationExpression(ExecutionContext context, List<Base> focus, List<Base> result, ExpressionNode exp);
   }
 
   /**
@@ -997,14 +997,24 @@ public class FHIRPathEngine {
   }
 
   public class ExecutionContext {
-    private Object appInfo;
+    private final Object appInfo;
+    @Getter
     private Base focusResource;
+    @Getter
     private Base rootResource;
     private Base context;
+    @Getter
     private Base thisItem;
+    @Getter
     private List<Base> total;
     private int index;
     private Map<String, List<Base>> definedVariables;
+
+    /**
+     * A count of times that this context has entered the execute method.
+     */
+    @Getter
+    private int executeCount = 0;
 
     public ExecutionContext(Object appInfo, Base resource, Base rootResource, Base context, Base thisItem) {
       this.appInfo = appInfo;
@@ -1013,18 +1023,6 @@ public class FHIRPathEngine {
       this.rootResource = rootResource; 
       this.thisItem = thisItem;
       this.index = 0;
-    }
-    public Base getFocusResource() {
-      return focusResource;
-    }
-    public Base getRootResource() {
-      return rootResource;
-    }
-    public Base getThisItem() {
-      return thisItem;
-    }
-    public List<Base> getTotal() {
-      return total;
     }
 
     public void next() {
@@ -1052,7 +1050,7 @@ public class FHIRPathEngine {
         throw new PathEngineException(worker.formatMessage(I18nConstants.FHIRPATH_REDEFINE_VARIABLE, name), I18nConstants.FHIRPATH_REDEFINE_VARIABLE);
 
       if (definedVariables == null) {
-        definedVariables = new HashMap<String, List<Base>>();
+        definedVariables = new HashMap<>();
       } else {
         if (definedVariables.containsKey(name)) {
           // Can't do this, so throw an error
@@ -1061,6 +1059,10 @@ public class FHIRPathEngine {
       }
 
       definedVariables.put(name, value);
+    }
+
+    public void incrementExecuteCount() {
+      executeCount++;
     }
   }
 
@@ -1208,7 +1210,7 @@ public class FHIRPathEngine {
           if (hostServices != null) {
             details = hostServices.resolveFunction(this, result.getName());
           }
-          if (details == null && !allowUknownFunctions) {
+          if (details == null && !allowUnknownFunctions) {
             throw lexer.error("The name "+result.getName()+" is not a known function name");
           }
           f = Function.Custom;
@@ -1520,6 +1522,10 @@ public class FHIRPathEngine {
   }
 
   private List<Base> execute(ExecutionContext inContext, List<Base> focus, ExpressionNode exp, boolean atEntry) throws FHIRException {
+    if (inContext.getExecuteCount() > this.executionMaxCalls) {
+      throw new FHIRException("Exceeded maximum allowed recursion in FHIRPath evaluation (" + executionMaxCalls +")");
+    }
+    inContext.incrementExecuteCount();
     ExecutionContext context = contextForParameter(inContext);
     List<Base> work = new ArrayList<Base>();
     switch (exp.getKind()) {
@@ -1849,10 +1855,10 @@ public class FHIRPathEngine {
     } else if (s.equals("%ucum")) {
       return new ArrayList<Base>(Arrays.asList(new StringType("http://unitsofmeasure.org").noExtensions()));
     } else if (s.equals("%resource")) {
-      if (context.focusResource == null) {
+      if (context.getFocusResource() == null) {
         throw makeException(expr, I18nConstants.FHIRPATH_CANNOT_USE, "%resource", "no focus resource");
       }
-      return new ArrayList<Base>(Arrays.asList(context.focusResource));
+      return new ArrayList<Base>(Arrays.asList(context.getFocusResource()));
     } else if (s.equals("%rootResource")) {
       if (context.rootResource == null) {
         throw makeException(expr, I18nConstants.FHIRPATH_CANNOT_USE, "%rootResource", "no focus rootResource");
@@ -5505,14 +5511,15 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
 
   private List<Base> funcRepeat(ExecutionContext context, List<Base> focus, ExpressionNode exp) throws FHIRException {
-    List<Base> result = new ArrayList<Base>();
-    List<Base> current = new ArrayList<Base>();
-    current.addAll(focus);
-    List<Base> added = new ArrayList<Base>();
+    List<Base> result = new ArrayList<>();
+    List<Base> current = new ArrayList<>(focus);
+    List<Base> added = new ArrayList<>();
     boolean more = true;
-    while (more) {
+    int repeatCount = 0;
+    while (more && repeatCount <= repeatMaxIterations) {
+      repeatCount++;
       added.clear();
-      List<Base> pc = new ArrayList<Base>();
+      List<Base> pc = new ArrayList<>();
       for (Base item : current) {
         pc.clear();
         pc.add(item);
@@ -5533,6 +5540,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
           more = true;
         }
       }
+    }
+    if (repeatCount > repeatMaxIterations) {
+      throw new FHIRException("Exceeded maximum allowed repeats in FHIRPath repeat evaluation (" +repeatMaxIterations+")");
     }
     return result;
   }
@@ -5925,7 +5935,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     List<Base> swb = execute(context, baseToList(context.thisItem), exp.getParameters().get(0), true);
     String sw = convertToString(swb);
 
-    if (focus.size() == 0 || swb.size() == 0) {
+    if (focus.isEmpty() || swb.isEmpty()) {
       //
     } else if (focus.size() == 1 && !Utilities.noString(sw)) {
       if (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -378,4 +378,26 @@ public class FHIRPathTests {
       fp.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
     }
   }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testRepeatMaxIterationsExceededThrowsException(int maxIterations, boolean shouldThrow) {
+    Questionnaire input = new Questionnaire();
+    input.addItem().setLinkId("item1").addItem().setLinkId("subitem1");
+    input.addItem().setLinkId("item2").addItem().setLinkId("subitem2");
+    fp.setRepeatMaxIterations(maxIterations);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Questionnaire.repeat(item)"));
+      }
+    } finally {
+      fp.setRepeatMaxIterations(FHIRPathEngine.DEFAULT_REPEAT_MAX_ITERATIONS);
+    }
+  }
 }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/FHIRPathTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -110,7 +111,7 @@ public class FHIRPathTests {
   private static SimpleWorkerContext context;
 
   @BeforeAll
-  public static void setUp() throws FileNotFoundException, FHIRException, IOException {
+  static void setUp() throws FHIRException, IOException {
     context = new SimpleWorkerContext(TestingUtilities.getSharedWorkerContext());
     if (!context.hasPackage("hl7.cda.us.ccda", null)) {
       FilesystemPackageCacheManager pcm = new FilesystemPackageCacheManager.Builder().build();
@@ -166,12 +167,12 @@ public class FHIRPathTests {
   @SuppressWarnings("deprecation")
   @ParameterizedTest(name = "{index}: file {0}")
   @MethodSource("data")
-  public void test(String name, Element test) throws FileNotFoundException, IOException, FHIRException, org.hl7.fhir.exceptions.FHIRException, UcumException {
+  void test(String name, Element test) throws IOException, org.hl7.fhir.exceptions.FHIRException, UcumException {
     // Setting timezone for this test. Grahame is in UTC+11, Travis is in GMT, and I'm here in Toronto, Canada with
     // all my time based tests failing locally...
     TimeZone.setDefault(TimeZone.getTimeZone("UTC+1100"));
 
-    fp.setHostServices(new FHIRPathTestEvaluationServices(this.context));
+    fp.setHostServices(new FHIRPathTestEvaluationServices(context));
     String input = test.getAttribute("inputfile");
     String expression = XMLUtil.getNamedChild(test, "expression").getTextContent();
     TestResultType fail = TestResultType.OK;
@@ -181,7 +182,7 @@ public class FHIRPathTests {
       fail = TestResultType.SEMANTICS;      
     } else if ("execution".equals(XMLUtil.getNamedChild(test, "expression").getAttribute("invalid"))) {
       fail = TestResultType.EXECUTION;      
-    };
+    }
     fp.setAllowPolymorphicNames("lenient/polymorphics".equals(test.getAttribute("mode")));
     boolean skipStaticCheck = false;
     if ("true".equals(test.getAttribute("skipStaticCheck")))
@@ -198,7 +199,7 @@ public class FHIRPathTests {
       Assertions.assertTrue(fail != TestResultType.SYNTAX, String.format("Expected exception didn't occur parsing %s", expression));
     } catch (Exception e) {
       System.out.println("Parsing Error: "+e.getMessage());
-      Assertions.assertTrue(fail == TestResultType.SYNTAX, String.format("Unexpected exception parsing %s: " + e.getMessage(), expression));
+      Assertions.assertSame(TestResultType.SYNTAX, fail, String.format("Unexpected exception parsing %s: %s", expression, e.getMessage()));
     }
     
     if (node != null) {
@@ -223,10 +224,10 @@ public class FHIRPathTests {
           } else {
             fp.check(res, res.fhirType(), res.fhirType(), res.fhirType(), node);
           }
-          Assertions.assertTrue(fail != TestResultType.SEMANTICS, String.format("Expected exception didn't occur checking %s", expression));
+          Assertions.assertNotSame(TestResultType.SEMANTICS, fail, String.format("Expected exception didn't occur checking %s", expression));
         } catch (Exception e) {
           System.out.println("Checking Error: "+e.getMessage());
-          Assertions.assertTrue(fail == TestResultType.SEMANTICS, "Unexpected exception checking '"+expression+"': " + e.getMessage());
+          Assertions.assertSame(TestResultType.SEMANTICS, fail, "Unexpected exception checking '" + expression + "': " + e.getMessage());
           node = null;
         }
       }
@@ -308,7 +309,7 @@ public class FHIRPathTests {
 
   @Test
   @DisplayName("resolveConstant returns a list of Base")
-  public void resolveConstantReturnsList() throws IOException {
+  void resolveConstantReturnsList() throws IOException {
     final String DUMMY_CONSTANT_1 = "dummyConstant1";
     final String DUMMY_CONSTANT_2 = "dummyConstant2";
     fp.setHostServices(new FHIRPathTestEvaluationServices(context) {
@@ -330,7 +331,7 @@ public class FHIRPathTests {
   }
 
   @Test
-  public void testEvaluate_Id() {
+  void testEvaluate_Id() {
     Patient input = new Patient();
     input.setId(new IdType("http://base/Patient/123/_history/222"));
     List<Base> results = fp.evaluate(input, "Patient.id");
@@ -355,5 +356,26 @@ public class FHIRPathTests {
     input.setBirthDateElement(dtv);
     List<Base> results = fp.evaluate(input, "Patient.birthDate.toString()");
     assertEquals(0, results.size());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1, true",
+    "2, true",
+    "3, false",
+    "4, false"})
+  void testExecutionLimitExceededThrowsException(int maxCalls, boolean shouldThrow) {
+    Patient input = new Patient();
+    input.addName().setFamily("Smith").addGiven("John");
+    fp.setExecutionMaxCalls(maxCalls);
+    try {
+      if (shouldThrow) {
+        Assertions.assertThrows(FHIRException.class, () -> fp.evaluate(input, "Patient.name.family"));
+      } else {
+        Assertions.assertDoesNotThrow(() -> fp.evaluate(input, "Patient.name.family"));
+      }
+    } finally {
+      fp.setExecutionMaxCalls(FHIRPathEngine.DEFAULT_EXECUTION_MAX_CALLS);
+    }
   }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
@@ -13,7 +13,7 @@ public final class RegexTimeout {
     throw new UnsupportedOperationException("This utility class should not be instantiated");
   }
 
-  static final long DEFAULT_TIMEOUT = 500;
+  public static final long DEFAULT_TIMEOUT = 500;
 
   private static <T> T executeWithTimeout(Callable<T> callable, long timeoutMillis) throws TimeoutException {
     ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/PackageReGenerator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/PackageReGenerator.java
@@ -444,7 +444,7 @@ public class PackageReGenerator {
       }
       if (includeConformsTo) {
         for (ElementDefinition.ElementDefinitionConstraintComponent inv : ed.getConstraint()) {
-          pathEngine.setAllowUknownFunctions(true);
+          pathEngine.setAllowUnknownFunctions(true);
           if (inv.hasExpression()) {
             try {
               ExpressionNode node = pathEngine.parse(inv.getExpression());
@@ -453,7 +453,7 @@ public class PackageReGenerator {
               log.error("Error in FHIRPath expression: "+inv.getExpression()+" ("+e.getMessage()+")");
             }
           }
-          pathEngine.setAllowUknownFunctions(false);
+          pathEngine.setAllowUnknownFunctions(false);
         }
       }
     }


### PR DESCRIPTION
This adds execution/iteration limits to two methods in FHIRPathEngine across all modules: `execute` and `funcRepeat`.

These are set to defaults of 50 in this PR. This limit should be evaluated in review.

