### PR TITLE
Whitelist all valid fields within ViewDefinition validation

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/sql/Validator.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/sql/Validator.java
@@ -88,7 +88,7 @@ public class Validator {
 
 
   public void checkViewDefinition(String path, JsonObject viewDefinition) {    
-    checkProperties(viewDefinition, path, "resourceType", "url", "identifier", "name", "version", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "copyright", "resource", "constant", "select", "where");
+    checkProperties(viewDefinition, path, "resourceType", "id", "meta", "implicitRules", "language", "text", "contained", "modifierExtension", "url", "identifier", "version", "versionAlgorithmString", "versionAlgorithmCoding", "name", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "jurisdiction", "purpose", "copyright", "copyrightLabel", "resource", "profile", "fhirVersion", "constant", "select", "where");
     
     JsonElement nameJ = viewDefinition.get("name");
     if (nameJ == null) {
@@ -155,7 +155,7 @@ public class Validator {
   private List<Column> checkSelect(JsonObject vd, String path, JsonObject select, TypeDetails t) {
     List<Column> columns = new ArrayList<>();
     select.setUserData("columns", columns);
-    checkProperties(select, path, "column", "select", "forEach", "forEachOrNull", "unionAll");
+    checkProperties(select, path, "id", "modifierExtension", "column", "select", "forEach", "forEachOrNull", "repeat", "unionAll");
 
     if (select.has("forEach")) {
       t = checkForEach(vd, path, select, select.get("forEach"), t);
@@ -276,7 +276,7 @@ public class Validator {
   }
 
   private Column checkColumn(JsonObject vd, String path, JsonObject column, TypeDetails t) {
-    checkProperties(column, path, "path", "name", "description", "collection", "type", "tag");
+    checkProperties(column, path, "id", "modifierExtension", "path", "name", "description", "collection", "type", "tag");
 
     if (!column.has("path")) {
       error(path, column, "no path found", IssueType.INVALID);      
@@ -514,7 +514,7 @@ public class Validator {
   }
 
   private void checkConstant(String path, JsonObject constant) {
-    checkProperties(constant, path, "name", "valueBase64Binary", "valueBoolean", "valueCanonical", "valueCode", "valueDate", "valueDateTime", "valueDecimal", "valueId", "valueInstant", "valueInteger", "valueInteger64", "valueOid", "valueString", "valuePositiveInt", "valueTime", "valueUnsignedInt", "valueUri", "valueUrl", "valueUuid");
+    checkProperties(constant, path, "id", "modifierExtension", "name", "valueBase64Binary", "valueBoolean", "valueCanonical", "valueCode", "valueDate", "valueDateTime", "valueDecimal", "valueId", "valueInstant", "valueInteger", "valueInteger64", "valueOid", "valueString", "valuePositiveInt", "valueTime", "valueUnsignedInt", "valueUri", "valueUrl", "valueUuid");
     JsonElement nameJ = constant.get("name");
     if (nameJ == null) {
       error(path, constant, "No name provided", IssueType.REQUIRED);      
@@ -598,7 +598,7 @@ public class Validator {
   }
   
   private void checkWhere(JsonObject vd, String path, JsonObject where) {
-    checkProperties(where, path, "path", "description");
+    checkProperties(where, path, "id", "modifierExtension", "path", "description");
 
     String expr = where.asString("path");
     if (expr == null) {

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/ValidatorTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/ValidatorTests.java
@@ -1,0 +1,210 @@
+package org.hl7.fhir.r4.utils.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.r4.context.IWorkerContext;
+import org.hl7.fhir.r4.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r4.test.utils.TestingUtilities;
+import org.hl7.fhir.r4.utils.sql.Validator.TrueFalseOrUnknown;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.hl7.fhir.utilities.json.parser.JsonParser;
+import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests that the SQL on FHIR Validator's property allow-lists accept the fields declared on the
+ * ViewDefinition logical model in the spec (including inherited Resource/DomainResource/
+ * CanonicalResource fields and backbone Element fields), while still rejecting genuinely unknown
+ * properties.
+ *
+ * @author John Grimes
+ */
+class ValidatorTests {
+
+  private static IWorkerContext context;
+  private static FHIRPathEngine fpe;
+
+  @BeforeAll
+  static void setUpAll() {
+    context = TestingUtilities.context();
+    fpe = new FHIRPathEngine(context);
+  }
+
+  /**
+   * Returns a fresh minimal-but-valid ViewDefinition with one select and one column, on which
+   * individual tests can layer extra properties.
+   */
+  private static JsonObject minimalViewDefinition() {
+    JsonObject vd = new JsonObject();
+    vd.add("resourceType", "ViewDefinition");
+    vd.add("name", "vt_test");
+    vd.add("status", "active");
+    vd.add("resource", "Patient");
+    JsonObject select = vd.forceArray("select").addObject();
+    JsonObject column = select.forceArray("column").addObject();
+    column.add("name", "id");
+    column.add("path", "id");
+    return vd;
+  }
+
+  private static Validator newValidator() {
+    return new Validator(context, fpe, new ArrayList<>(), TrueFalseOrUnknown.UNKNOWN, TrueFalseOrUnknown.UNKNOWN, TrueFalseOrUnknown.UNKNOWN);
+  }
+
+  /**
+   * Round-trips the in-memory JsonObject through the JSON parser so each element carries the
+   * source-location data that Validator.error() requires, then invokes the validator. Without this,
+   * programmatically constructed JsonObjects produce a NullPointerException in error reporting
+   * rather than the expected validation issues.
+   */
+  private static void check(Validator v, JsonObject vd) {
+    JsonObject parsed;
+    try {
+      parsed = JsonParser.parseObject(JsonParser.compose(vd));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to round-trip ViewDefinition fixture", e);
+    }
+    v.checkViewDefinition("ViewDefinition", parsed);
+  }
+
+  /**
+   * Filters validation issues down to the unknown-property errors emitted by checkProperties so the
+   * test failure messages are pinpointed at this bug.
+   */
+  private static List<ValidationMessage> unknownPropertyIssues(Validator v) {
+    return v.getIssues().stream()
+        .filter(m -> m.getMessage() != null && m.getMessage().startsWith("Unknown JSON property "))
+        .collect(Collectors.toList());
+  }
+
+  private static void assertNoUnknownPropertyIssues(Validator v) {
+    List<ValidationMessage> unknown = unknownPropertyIssues(v);
+    if (!unknown.isEmpty()) {
+      String detail = unknown.stream()
+          .map(m -> m.getLocation() + ": " + m.getMessage())
+          .collect(Collectors.joining("\n  "));
+      fail("Expected no 'Unknown JSON property' issues but got:\n  " + detail);
+    }
+  }
+
+  // ViewDefinition logical-model fields and inherited Resource fields that SUSHI emits on
+  // Instances generated from the logical model. The spec's edge build snapshot at
+  // https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-ViewDefinition.json
+  // is the authoritative source for this list.
+  static Stream<String> topLevelInheritedFields() {
+    return Stream.of("id", "meta", "text", "language", "implicitRules", "contained",
+        "modifierExtension", "profile", "fhirVersion", "jurisdiction", "purpose", "copyrightLabel",
+        "versionAlgorithmString", "versionAlgorithmCoding");
+  }
+
+  @ParameterizedTest(name = "top-level field {0} is accepted")
+  @MethodSource("topLevelInheritedFields")
+  void topLevelInheritedPropertiesAreAccepted(String field) {
+    JsonObject vd = minimalViewDefinition();
+    // Use an array or object value where the model expects one, otherwise a simple string. The
+    // specific value does not matter for property-name checking - we only care that the allow-list
+    // accepts the property name.
+    if ("contained".equals(field) || "jurisdiction".equals(field)
+        || "modifierExtension".equals(field) || "profile".equals(field)
+        || "fhirVersion".equals(field)) {
+      vd.forceArray(field);
+    } else if ("meta".equals(field) || "text".equals(field)
+        || "versionAlgorithmCoding".equals(field)) {
+      vd.forceObject(field);
+    } else {
+      vd.add(field, "x");
+    }
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("select.repeat is accepted")
+  void selectRepeatIsAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject select = vd.getJsonArray("select").asJsonObjects().get(0);
+    select.forceArray("repeat").add("contained");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("select backbone-inherited id/modifierExtension are accepted")
+  void selectBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject select = vd.getJsonArray("select").asJsonObjects().get(0);
+    select.add("id", "s1");
+    select.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("column backbone-inherited id/modifierExtension are accepted")
+  void columnBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject column = vd.getJsonArray("select").asJsonObjects().get(0)
+        .getJsonArray("column").asJsonObjects().get(0);
+    column.add("id", "c1");
+    column.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("constant backbone-inherited id/modifierExtension are accepted")
+  void constantBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject constant = vd.forceArray("constant").addObject();
+    constant.add("name", "k1");
+    constant.add("valueString", "v");
+    constant.add("id", "k1id");
+    constant.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("where backbone-inherited id/modifierExtension are accepted")
+  void whereBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject where = vd.forceArray("where").addObject();
+    where.add("path", "active");
+    where.add("id", "w1");
+    where.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  // Negative case: the broader allow-lists must not weaken the spirit of checkProperties - a
+  // genuinely unknown property should still be reported.
+  @Test
+  @DisplayName("genuinely unknown property is still rejected")
+  void genuinelyUnknownPropertyIsStillRejected() {
+    JsonObject vd = minimalViewDefinition();
+    vd.add("foo", "bar");
+    Validator v = newValidator();
+    check(v, vd);
+    List<ValidationMessage> unknown = unknownPropertyIssues(v);
+    assertEquals(1, unknown.size(), "expected exactly one unknown-property issue");
+    assertTrue(unknown.get(0).getMessage().contains("foo"),
+        "expected the unknown-property issue to name 'foo' but was: " + unknown.get(0).getMessage());
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/sql/Validator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/sql/Validator.java
@@ -90,7 +90,7 @@ public class Validator {
 
 
   public void checkViewDefinition(String path, JsonObject viewDefinition) {    
-    checkProperties(viewDefinition, path, "resourceType", "url", "identifier", "name", "version", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "copyright", "resource", "constant", "select", "where");
+    checkProperties(viewDefinition, path, "resourceType", "id", "meta", "implicitRules", "language", "text", "contained", "modifierExtension", "url", "identifier", "version", "versionAlgorithmString", "versionAlgorithmCoding", "name", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "jurisdiction", "purpose", "copyright", "copyrightLabel", "resource", "profile", "fhirVersion", "constant", "select", "where");
     
     JsonElement nameJ = viewDefinition.get("name");
     if (nameJ == null) {
@@ -157,7 +157,7 @@ public class Validator {
   private List<Column> checkSelect(JsonObject vd, String path, JsonObject select, TypeDetails t) {
     List<Column> columns = new ArrayList<>();
     select.setUserData(UserDataNames.db_columns, columns);
-    checkProperties(select, path, "column", "select", "forEach", "forEachOrNull", "unionAll");
+    checkProperties(select, path, "id", "modifierExtension", "column", "select", "forEach", "forEachOrNull", "repeat", "unionAll");
 
     if (select.has("forEach")) {
       t = checkForEach(vd, path, select, select.get("forEach"), t);
@@ -278,7 +278,7 @@ public class Validator {
   }
 
   private Column checkColumn(JsonObject vd, String path, JsonObject column, TypeDetails t) {
-    checkProperties(column, path, "path", "name", "description", "collection", "type", "tag");
+    checkProperties(column, path, "id", "modifierExtension", "path", "name", "description", "collection", "type", "tag");
 
     if (!column.has("path")) {
       error(path, column, "no path found", IssueType.INVALID);      
@@ -516,7 +516,7 @@ public class Validator {
   }
 
   private void checkConstant(String path, JsonObject constant) {
-    checkProperties(constant, path, "name", "valueBase64Binary", "valueBoolean", "valueCanonical", "valueCode", "valueDate", "valueDateTime", "valueDecimal", "valueId", "valueInstant", "valueInteger", "valueInteger64", "valueOid", "valueString", "valuePositiveInt", "valueTime", "valueUnsignedInt", "valueUri", "valueUrl", "valueUuid");
+    checkProperties(constant, path, "id", "modifierExtension", "name", "valueBase64Binary", "valueBoolean", "valueCanonical", "valueCode", "valueDate", "valueDateTime", "valueDecimal", "valueId", "valueInstant", "valueInteger", "valueInteger64", "valueOid", "valueString", "valuePositiveInt", "valueTime", "valueUnsignedInt", "valueUri", "valueUrl", "valueUuid");
     JsonElement nameJ = constant.get("name");
     if (nameJ == null) {
       error(path, constant, "No name provided", IssueType.REQUIRED);      
@@ -602,7 +602,7 @@ public class Validator {
   }
   
   private void checkWhere(JsonObject vd, String path, JsonObject where) {
-    checkProperties(where, path, "path", "description");
+    checkProperties(where, path, "id", "modifierExtension", "path", "description");
 
     String expr = where.asString("path");
     if (expr == null) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/ValidatorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/sql/ValidatorTests.java
@@ -1,0 +1,210 @@
+package org.hl7.fhir.r5.utils.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.sql.Validator.TrueFalseOrUnknown;
+import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.hl7.fhir.utilities.json.parser.JsonParser;
+import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests that the SQL on FHIR Validator's property allow-lists accept the fields declared on the
+ * ViewDefinition logical model in the spec (including inherited Resource/DomainResource/
+ * CanonicalResource fields and backbone Element fields), while still rejecting genuinely unknown
+ * properties.
+ *
+ * @author John Grimes
+ */
+class ValidatorTests {
+
+  private static IWorkerContext context;
+  private static FHIRPathEngine fpe;
+
+  @BeforeAll
+  static void setUpAll() {
+    context = TestingUtilities.getSharedWorkerContext();
+    fpe = new FHIRPathEngine(context);
+  }
+
+  /**
+   * Returns a fresh minimal-but-valid ViewDefinition with one select and one column, on which
+   * individual tests can layer extra properties.
+   */
+  private static JsonObject minimalViewDefinition() {
+    JsonObject vd = new JsonObject();
+    vd.add("resourceType", "ViewDefinition");
+    vd.add("name", "vt_test");
+    vd.add("status", "active");
+    vd.add("resource", "Patient");
+    JsonObject select = vd.forceArray("select").addObject();
+    JsonObject column = select.forceArray("column").addObject();
+    column.add("name", "id");
+    column.add("path", "id");
+    return vd;
+  }
+
+  private static Validator newValidator() {
+    return new Validator(context, fpe, new ArrayList<>(), TrueFalseOrUnknown.UNKNOWN, TrueFalseOrUnknown.UNKNOWN, TrueFalseOrUnknown.UNKNOWN);
+  }
+
+  /**
+   * Round-trips the in-memory JsonObject through the JSON parser so each element carries the
+   * source-location data that Validator.error() requires, then invokes the validator. Without this,
+   * programmatically constructed JsonObjects produce a NullPointerException in error reporting
+   * rather than the expected validation issues.
+   */
+  private static void check(Validator v, JsonObject vd) {
+    JsonObject parsed;
+    try {
+      parsed = JsonParser.parseObject(JsonParser.compose(vd));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to round-trip ViewDefinition fixture", e);
+    }
+    v.checkViewDefinition("ViewDefinition", parsed);
+  }
+
+  /**
+   * Filters validation issues down to the unknown-property errors emitted by checkProperties so the
+   * test failure messages are pinpointed at this bug.
+   */
+  private static List<ValidationMessage> unknownPropertyIssues(Validator v) {
+    return v.getIssues().stream()
+        .filter(m -> m.getMessage() != null && m.getMessage().startsWith("Unknown JSON property "))
+        .collect(Collectors.toList());
+  }
+
+  private static void assertNoUnknownPropertyIssues(Validator v) {
+    List<ValidationMessage> unknown = unknownPropertyIssues(v);
+    if (!unknown.isEmpty()) {
+      String detail = unknown.stream()
+          .map(m -> m.getLocation() + ": " + m.getMessage())
+          .collect(Collectors.joining("\n  "));
+      fail("Expected no 'Unknown JSON property' issues but got:\n  " + detail);
+    }
+  }
+
+  // ViewDefinition logical-model fields and inherited Resource fields that SUSHI emits on
+  // Instances generated from the logical model. The spec's edge build snapshot at
+  // https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-ViewDefinition.json
+  // is the authoritative source for this list.
+  static Stream<String> topLevelInheritedFields() {
+    return Stream.of("id", "meta", "text", "language", "implicitRules", "contained",
+        "modifierExtension", "profile", "fhirVersion", "jurisdiction", "purpose", "copyrightLabel",
+        "versionAlgorithmString", "versionAlgorithmCoding");
+  }
+
+  @ParameterizedTest(name = "top-level field {0} is accepted")
+  @MethodSource("topLevelInheritedFields")
+  void topLevelInheritedPropertiesAreAccepted(String field) {
+    JsonObject vd = minimalViewDefinition();
+    // Use an array or object value where the model expects one, otherwise a simple string. The
+    // specific value does not matter for property-name checking - we only care that the allow-list
+    // accepts the property name.
+    if ("contained".equals(field) || "jurisdiction".equals(field)
+        || "modifierExtension".equals(field) || "profile".equals(field)
+        || "fhirVersion".equals(field)) {
+      vd.forceArray(field);
+    } else if ("meta".equals(field) || "text".equals(field)
+        || "versionAlgorithmCoding".equals(field)) {
+      vd.forceObject(field);
+    } else {
+      vd.add(field, "x");
+    }
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("select.repeat is accepted")
+  void selectRepeatIsAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject select = vd.getJsonArray("select").asJsonObjects().get(0);
+    select.forceArray("repeat").add("contained");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("select backbone-inherited id/modifierExtension are accepted")
+  void selectBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject select = vd.getJsonArray("select").asJsonObjects().get(0);
+    select.add("id", "s1");
+    select.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("column backbone-inherited id/modifierExtension are accepted")
+  void columnBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject column = vd.getJsonArray("select").asJsonObjects().get(0)
+        .getJsonArray("column").asJsonObjects().get(0);
+    column.add("id", "c1");
+    column.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("constant backbone-inherited id/modifierExtension are accepted")
+  void constantBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject constant = vd.forceArray("constant").addObject();
+    constant.add("name", "k1");
+    constant.add("valueString", "v");
+    constant.add("id", "k1id");
+    constant.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  @Test
+  @DisplayName("where backbone-inherited id/modifierExtension are accepted")
+  void whereBackboneInheritedPropertiesAreAccepted() {
+    JsonObject vd = minimalViewDefinition();
+    JsonObject where = vd.forceArray("where").addObject();
+    where.add("path", "active");
+    where.add("id", "w1");
+    where.forceArray("modifierExtension");
+    Validator v = newValidator();
+    check(v, vd);
+    assertNoUnknownPropertyIssues(v);
+  }
+
+  // Negative case: the broader allow-lists must not weaken the spirit of checkProperties - a
+  // genuinely unknown property should still be reported.
+  @Test
+  @DisplayName("genuinely unknown property is still rejected")
+  void genuinelyUnknownPropertyIsStillRejected() {
+    JsonObject vd = minimalViewDefinition();
+    vd.add("foo", "bar");
+    Validator v = newValidator();
+    check(v, vd);
+    List<ValidationMessage> unknown = unknownPropertyIssues(v);
+    assertEquals(1, unknown.size(), "expected exactly one unknown-property issue");
+    assertTrue(unknown.get(0).getMessage().contains("foo"),
+        "expected the unknown-property issue to name 'foo' but was: " + unknown.get(0).getMessage());
+  }
+}


### PR DESCRIPTION
The SQL on FHIR Validator's `checkProperties` allow-lists (r4 and r5) were rejecting valid ViewDefinition fields declared by the spec's logical model - including `profile`, `fhirVersion`, `repeat`, and the Resource/DomainResource/CanonicalResource inheritance SUSHI emits on every Instance. IGs built from the SQL on FHIR v2 examples failed with `Unknown JSON property ...`, leaving `{% sql %}` queries running against an empty database.

Each of the five `checkProperties` calls is now aligned with the [edge ViewDefinition StructureDefinition](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-ViewDefinition.json). New `ValidatorTests` cover each newly-allowed property plus a negative case for genuinely unknown ones.

Fixes #2440