### PR TITLE
Fix timeout logic in RegexTimeout

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
@@ -33,145 +33,181 @@ public final class RegexTimeout {
 
   /**
    * Wrapper around {@link String#matches(String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
-   * @return true if, and only if, the string matches the given regular expression
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
+   * @return true if, and only if, the charSequence matches the given regular expression
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static boolean matches(String string, String regex) throws TimeoutException {
-    return matches(string, regex, DEFAULT_TIMEOUT);
+  public static boolean matches(CharSequence charSequence, String regex) throws TimeoutException {
+    return matches(charSequence, regex, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link String#matches(String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
    * @param timeoutMillis the timeout in milliseconds
-   * @return true if, and only if, the string matches the given regular expression
+   * @return true if, and only if, the charSequence matches the given regular expression
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static boolean matches(String string, String regex, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(()->Pattern.matches(regex, string), timeoutMillis);
+  public static boolean matches(CharSequence charSequence, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(()->Pattern.matches(regex, new InterruptibleCharSequence(charSequence)), timeoutMillis);
   }
 
   /**
    * Wrapper around {@link java.util.regex.Matcher#find()} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to search for within the string
+   * @param charSequence the charSequence
+   * @param regex the regular expression to search for within the charSequence
    * @return true if a subsequence of the input sequence matches the pattern
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static boolean find(String string, String regex) throws TimeoutException {
-    return find(string, regex, DEFAULT_TIMEOUT);
+  public static boolean find(CharSequence charSequence, String regex) throws TimeoutException {
+    return find(charSequence, regex, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link java.util.regex.Matcher#find()} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to search for within the string
+   * @param charSequence the charSequence
+   * @param regex the regular expression to search for within the charSequence
    * @param timeoutMillis the timeout in milliseconds
    * @return true if a subsequence of the input sequence matches the pattern
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static boolean find(String string, String regex, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).find(), timeoutMillis);
+  public static boolean find(CharSequence charSequence, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(new InterruptibleCharSequence(charSequence)).find(), timeoutMillis);
   }
 
   /**
    * Wrapper around {@link String#replaceAll(String, String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
    * @param replacement the string to be substituted for each match
    * @return the resulting string
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static String replaceAll(String string, String regex, String replacement) throws TimeoutException {
-    return replaceAll(string, regex, replacement, DEFAULT_TIMEOUT);
+  public static String replaceAll(CharSequence charSequence, String regex, String replacement) throws TimeoutException {
+    return replaceAll(charSequence, regex, replacement, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link String#replaceAll(String, String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
    * @param replacement the string to be substituted for each match
    * @param timeoutMillis the timeout in milliseconds
    * @return the resulting string
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static String replaceAll(String string, String regex, String replacement, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).replaceAll(replacement), timeoutMillis);
+  public static String replaceAll(CharSequence charSequence, String regex, String replacement, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(new InterruptibleCharSequence(charSequence)).replaceAll(replacement), timeoutMillis);
   }
 
   /**
    * Wrapper around {@link String#replaceFirst(String, String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
    * @param replacement the string to be substituted for the first match
    * @return the resulting string
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static String replaceFirst(String string, String regex, String replacement) throws TimeoutException {
-    return replaceFirst(string, regex, replacement, DEFAULT_TIMEOUT);
+  public static String replaceFirst(CharSequence charSequence, String regex, String replacement) throws TimeoutException {
+    return replaceFirst(charSequence, regex, replacement, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link String#replaceFirst(String, String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
-   * @param regex the regular expression to which the string is to be matched
+   * @param charSequence the charSequence
+   * @param regex the regular expression to which the charSequence is to be matched
    * @param replacement the string to be substituted for the first match
    * @param timeoutMillis the timeout in milliseconds
    * @return the resulting string
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static String replaceFirst(String string, String regex, String replacement, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(() -> Pattern.compile(regex).matcher(string).replaceFirst(replacement), timeoutMillis);
+  public static String replaceFirst(CharSequence charSequence, String regex, String replacement, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).matcher(new InterruptibleCharSequence(charSequence)).replaceFirst(replacement), timeoutMillis);
   }
 
   /**
    * Wrapper around {@link String#split(String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
+   * @param charSequence the charSequence
    * @param regex the delimiting regular expression
-   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @return the array of strings computed by splitting the charSequence around matches of the given regular expression
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static String[] split(String string, String regex) throws TimeoutException {
-    return split(string, regex, DEFAULT_TIMEOUT);
+  public static String[] split(CharSequence charSequence, String regex) throws TimeoutException {
+    return split(charSequence, regex, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link String#split(String)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
+   * @param charSequence the charSequence
    * @param regex the delimiting regular expression
    * @param timeoutMillis the timeout in milliseconds
-   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @return the array of strings computed by splitting the charSequence around matches of the given regular expression
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static String[] split(String string, String regex, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(() -> Pattern.compile(regex).split(string), timeoutMillis);
+  public static String[] split(CharSequence charSequence, String regex, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).split(new InterruptibleCharSequence(charSequence)), timeoutMillis);
   }
 
   /**
    * Wrapper around {@link String#split(String, int)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
+   * @param charSequence the charSequence
    * @param regex the delimiting regular expression
    * @param limit the result threshold
-   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @return the array of strings computed by splitting the charSequence around matches of the given regular expression
    * @throws TimeoutException if processing runs longer than the default timeout in milliseconds
    */
-  public static String[] split(String string, String regex, int limit) throws TimeoutException {
-    return split(string, regex, limit, DEFAULT_TIMEOUT);
+  public static String[] split(CharSequence charSequence, String regex, int limit) throws TimeoutException {
+    return split(charSequence, regex, limit, DEFAULT_TIMEOUT);
   }
 
   /**
    * Wrapper around {@link String#split(String, int)} which will throw an exception if processing runs longer than expected.
-   * @param string the string
+   * @param charSequence the charSequence
    * @param regex the delimiting regular expression
    * @param limit the result threshold
    * @param timeoutMillis the timeout in milliseconds
-   * @return the array of strings computed by splitting the string around matches of the given regular expression
+   * @return the array of strings computed by splitting the charSequence around matches of the given regular expression
    * @throws TimeoutException if processing runs longer than timeoutMillis milliseconds
    */
-  public static String[] split(String string, String regex, int limit, long timeoutMillis) throws TimeoutException {
-    return executeWithTimeout(() -> Pattern.compile(regex).split(string, limit), timeoutMillis);
+  public static String[] split(CharSequence charSequence, String regex, int limit, long timeoutMillis) throws TimeoutException {
+    return executeWithTimeout(() -> Pattern.compile(regex).split(new InterruptibleCharSequence(charSequence), limit), timeoutMillis);
+  }
+
+  /**
+   * CharSequence that noticed thread interrupts -- as might be necessary
+   * to recover from a loose regex on unexpected challenging input.
+   *
+   * @author gojomo
+   */
+  static class InterruptibleCharSequence implements CharSequence {
+      CharSequence inner;
+
+      public InterruptibleCharSequence(CharSequence inner) {
+          super();
+          this.inner = inner;
+      }
+
+      public char charAt(int index) {
+          if (Thread.interrupted()) { // clears flag if set
+              throw new RuntimeException(new InterruptedException());
+          }
+          return inner.charAt(index);
+      }
+
+      public int length() {
+          return inner.length();
+      }
+
+
+      public CharSequence subSequence(int start, int end) {
+          return new InterruptibleCharSequence(inner.subSequence(start, end));
+      }
+
+      @Override
+      public String toString() {
+          return inner.toString();
+      }
   }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/regex/RegexTimeout.java
@@ -176,10 +176,15 @@ public final class RegexTimeout {
   }
 
   /**
+   * <p>
    * CharSequence that noticed thread interrupts -- as might be necessary
    * to recover from a loose regex on unexpected challenging input.
-   *
+   * </p>
+   * <p>
+   * This solution is sourced from <a href="https://stackoverflow.com/a/910798">this StackOverflow answer</a>
+   * </p>
    * @author gojomo
+   *
    */
   static class InterruptibleCharSequence implements CharSequence {
       CharSequence inner;

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
@@ -1,8 +1,10 @@
 package org.hl7.fhir.utilities.regex;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeoutException;
+import java.util.Collections;import java.util.Set;import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +24,28 @@ class RegexTimeoutTests {
   static final String BAD_SUFFIX_REGEX = "((a+)+)+b";
   static final String EVIL_NO_SUFFIX = "a".repeat(50);
 
+   private static Set<Thread> threadsBefore;
+
+      @BeforeAll
+      static void beforeAll()
+      {
+          threadsBefore = Collections.unmodifiableSet(Thread.getAllStackTraces().keySet());
+      }
+
+      @AfterAll
+      static void afterAll() throws InterruptedException {
+        // We need a tiny amount of delay here, the interruption is intruduced as regexs process chars, which is fast,
+        // but not instantaneous.
+        Thread.sleep(10);
+        Set<Thread> threadsAfter = Thread.getAllStackTraces().keySet();
+        if (threadsAfter.size() != threadsBefore.size())
+        {
+          threadsAfter.removeAll(threadsBefore);
+          throw new IllegalStateException("Lingering threads in test: " + threadsAfter);
+        }
+      }
+
+
   @Test
   void test_BadRegex_Matches_EvilString() {
     assertThrows( TimeoutException.class, () -> RegexTimeout.matches(EVIL_STRING, BAD_REGEX));
@@ -35,7 +59,6 @@ class RegexTimeoutTests {
   }
 
   // find()
-
   @Test
   void test_BadRegex_Find_EvilString() {
     assertThrows(TimeoutException.class, () -> RegexTimeout.find(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX));
@@ -54,7 +77,6 @@ class RegexTimeoutTests {
   }
 
   // replaceAll()
-
   @Test
   void test_BadRegex_ReplaceAll_EvilString() {
     assertThrows(TimeoutException.class, () -> RegexTimeout.replaceAll(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, "X"));
@@ -66,7 +88,6 @@ class RegexTimeoutTests {
   }
 
   // replaceFirst()
-
   @Test
   void test_BadRegex_ReplaceFirst_EvilString() {
     assertThrows(TimeoutException.class, () -> RegexTimeout.replaceFirst(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, "X"));
@@ -78,7 +99,6 @@ class RegexTimeoutTests {
   }
 
   // split()
-
   @Test
   void test_BadRegex_Split_EvilString() {
     assertThrows(TimeoutException.class, () -> RegexTimeout.split(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX));
@@ -90,7 +110,6 @@ class RegexTimeoutTests {
   }
 
   // split(limit)
-
   @Test
   void test_BadRegex_SplitWithLimit_EvilString() {
     assertThrows(TimeoutException.class, () -> RegexTimeout.split(EVIL_NO_SUFFIX, BAD_SUFFIX_REGEX, 2));

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/regex/RegexTimeoutTests.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;import java.util.Set;import java.util.concurrent.TimeoutException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,8 +36,8 @@ class RegexTimeoutTests {
 
       @AfterAll
       static void afterAll() throws InterruptedException {
-        // We need a tiny amount of delay here, the interruption is intruduced as regexs process chars, which is fast,
-        // but not instantaneous.
+        // We need a tiny amount of delay here. Interruption is introduced as regexs process chars, which is fast, but
+        // not instantaneous.
         Thread.sleep(10);
         Set<Thread> threadsAfter = Thread.getAllStackTraces().keySet();
         if (threadsAfter.size() != threadsBefore.size())


### PR DESCRIPTION
Adds an interrupt point to regular expression processing via a CharSequence wrapper.