### PR TITLE
BaseWorkerContext: fall back to per-code when vs is null in validateC…

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -1263,20 +1263,34 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
 
     if (items.size() > 0) {
-      TerminologyClientContext tc = terminologyClientManager.chooseServer(vs, systems, false);
-      Parameters resp = processBatch(tc, batch, systems, items.size());
-      List<ParametersParameterComponent> validations = resp.getParameters("validation");
-      for (int i = 0; i < items.size(); i++) {
-        CodingValidationRequest t = items.get(i);
-        ParametersParameterComponent r = validations.get(i);
-
-        if (r.getResource() instanceof Parameters) {
-          t.setResult(processValidationResult((Parameters) r.getResource(), null, tc.getAddress()));
+      if (vs == null) {
+        // No target ValueSet — sending /ValueSet/$batch-validate-code without
+        // url or tx-resource is malformed per FHIR spec; spec-strict servers
+        // (Ontoserver/HAPI) reject every slot. Fall back to per-code validation
+        // up-front rather than incurring the noisy round-trip.
+        for (CodingValidationRequest t : items) {
+          ValidationResult res = validateCode(options, t.getCoding(), null);
+          t.setResult(res);
           if (txCache != null) {
-            txCache.cacheValidation(t.getCacheToken(), t.getResult(), TerminologyCache.PERMANENT);
+            txCache.cacheValidation(t.getCacheToken(), res, TerminologyCache.PERMANENT);
           }
-        } else {
-          t.setResult(new ValidationResult(IssueSeverity.ERROR, getResponseText(r.getResource()), null).setTxLink(txLog == null ? null : txLog.getLastId()));
+        }
+      } else {
+        TerminologyClientContext tc = terminologyClientManager.chooseServer(vs, systems, false);
+        Parameters resp = processBatch(tc, batch, systems, items.size());
+        List<ParametersParameterComponent> validations = resp.getParameters("validation");
+        for (int i = 0; i < items.size(); i++) {
+          CodingValidationRequest t = items.get(i);
+          ParametersParameterComponent r = validations.get(i);
+    
+          if (r.getResource() instanceof Parameters) {
+            t.setResult(processValidationResult((Parameters) r.getResource(), null, tc.getAddress()));
+            if (txCache != null) {
+              txCache.cacheValidation(t.getCacheToken(), t.getResult(), TerminologyCache.PERMANENT);
+            }
+          } else {
+            t.setResult(new ValidationResult(IssueSeverity.ERROR, getResponseText(r.getResource()), null).setTxLink(txLog == null ? null : txLog.getLastId()));
+          }
         }
       }
     }


### PR DESCRIPTION
…odeBatch

When validateCodeBatch was called with vs=null — as ValueSetValidator does when validating ValueSet.compose.include.concept codes against their CodeSystem — the constructed batch was sent to /ValueSet/$batch-validate-code with neither a top-level "url" nor a "tx-resource" parameter, which is malformed per the FHIR R4 spec. Spec-strict servers (Ontoserver/HAPI) returned HTTP 200 with an OperationOutcome rejecting every slot; behaviour then relied on downstream per-code retries to recover.

Detect vs==null up-front and validate per code via validateCode(). Net wire traffic is identical or smaller (no rejected batch round-trip), and the misleading per-slot OperationOutcomes disappear from server logs.


## Bug

`/ValueSet/$batch-validate-code` requests sent by the IG publisher (and any caller of `BaseWorkerContext.validateCodeBatch` with `vs == null`) are malformed per FHIR R4 spec — the batch carries neither a top-level `url` nor a `tx-resource` parameter. Spec-strict servers (Ontoserver/HAPI) return HTTP 200 with an `OperationOutcome` rejecting every slot. The publisher recovers via per-code fallback, so the build still passes, but each batch attempt produces a round-trip of noisy errors.

## Chain

1. **`ValueSetValidator.executeValidationBatch`** ([validation/instance/type/ValueSetValidator.java](https://github.com/hapifhir/org.hl7.fhir.core/blob/master/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/ValueSetValidator.java)) calls `context.validateCodeBatch(opts, batch, **null**, false)` — passes `null` for `vs` because the codes are being validated against a CodeSystem, not a target ValueSet.

2. **`BaseWorkerContext.validateCodeBatch`** ([r5/context/BaseWorkerContext.java](https://github.com/hapifhir/org.hl7.fhir.core/blob/master/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java)) builds the batch `Parameters`. The block `if (vs != null) { ... batch.addParameter("url", vs.getUrl()); }` is skipped — no `url`, no `tx-resource`.

3. **`BaseWorkerContext.processBatch`** unconditionally calls `tc.getClient().batchValidateVS(batch)`.

4. **`TerminologyClientR5.batchValidateVS`** issues `POST /ValueSet/$batch-validate-code` with the malformed body → strict servers reject every slot.

## Reproducer

Captured in an IG publisher `qa-tx.log` against the Belgian Ontoserver (Ontoserver 6.25.1, HAPI 8.8.2-SNAPSHOT) on 2026-05-20. Five SNOMED codes from a `ValueSet.compose.include.concept` list in an R4 IG. Server response:

```json
{"resourceType":"Parameters","parameter":[
  {"name":"validation","resource":{"resourceType":"OperationOutcome","issue":[
    {"severity":"error","code":"invalid",
     "diagnostics":"Type-level request to $validate-code must specify either valueSet or url parameter."}
  ]}},
  ... (one per code)
]}

https://hl7-be.github.io/core-clinical/branches/release-candidate/en/