### PR TITLE
Fix illegal windows filenames in TestDataFactory / TestDataProvider 

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/testfactory/TestDataFactory.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/testfactory/TestDataFactory.java
@@ -264,8 +264,14 @@ public class TestDataFactory {
   private void executeProfile() throws IOException {
     try {
       checkDownloadBaseData();
-      
-      TableDataProvider tbl = loadTable(Utilities.path(rootFolder, details.asString( "data")));
+
+      //FIXME trim additional details
+      String dataWithSheetInfo = details.asString("data");
+      String[] split = splitDataWithSheetInfo(dataWithSheetInfo);
+      TableDataProvider.SheetInfo sheetInfo = split[1] == null ? new TableDataProvider.SheetInfo(null, null) :
+          TableDataProvider.SheetInfo.fromString(split[1]);
+
+      TableDataProvider tbl = loadTable(Utilities.path(rootFolder, split[0]), sheetInfo);
       Map<String, DataTable> tables = new HashMap<>();
       if (details.has("tables")) {
         JsonObject tablesJ = details.getJsonObject("tables");
@@ -308,6 +314,18 @@ public class TestDataFactory {
       e.printStackTrace(testLog);
       throw new FHIRException(e);
     }
+  }
+
+  private String[] splitDataWithSheetInfo(String dataWithSheetInfo) {
+    if (dataWithSheetInfo.contains(";")) {
+      int splitIndex = dataWithSheetInfo.lastIndexOf(";");
+      if (splitIndex + 1 < dataWithSheetInfo.length()) {
+        final String path = dataWithSheetInfo.substring(0, splitIndex);
+        final String sheetInfo = dataWithSheetInfo.substring(splitIndex + 1);
+        return new String[]{path, sheetInfo};
+      }
+    }
+    return new String[]{dataWithSheetInfo, null};
   }
 
   private void checkDownloadBaseData() throws IOException {
@@ -374,9 +392,9 @@ public class TestDataFactory {
     }
   }
 
-  private TableDataProvider loadTable(String path) throws IOException, InvalidFormatException {
-    log("Load Data From "+path);
-    return loadTableProvider(path, locale);
+  private TableDataProvider loadTable(String path, TableDataProvider.SheetInfo sheetInfo) throws IOException, InvalidFormatException {
+    log("Load Data From "+ path + " with sheet info: " + sheetInfo);
+    return loadTableProvider(path, sheetInfo, locale);
   }
 
   private void error(String msg) throws IOException {
@@ -470,9 +488,14 @@ public class TestDataFactory {
     return new ByteArrayInputStream(FileUtilities.stringToBytes(bundle));
   }
 
-  private DataTable loadData(String path) throws FHIRException, IOException, InvalidFormatException {
-    log("Load Data From "+path);
-    TableDataProvider tbl = loadTableProvider(path, locale);
+  private DataTable loadData(String pathWithSheetInfo) throws FHIRException, IOException {
+    log("Load Data From "+pathWithSheetInfo);
+
+    String[] split = splitDataWithSheetInfo(pathWithSheetInfo);
+    TableDataProvider.SheetInfo sheetInfo = split[1] == null ? new TableDataProvider.SheetInfo(null, null) :
+      TableDataProvider.SheetInfo.fromString(split[1]);
+
+    TableDataProvider tbl = loadTableProvider(split[0], sheetInfo, locale);
 
     DataTable dt = new DataTable();
     for (String n : tbl.columns()) {
@@ -495,7 +518,7 @@ public class TestDataFactory {
     return dt;
   }
 
-  public TableDataProvider loadTableProvider(String path, Locale locale) {
+  public TableDataProvider loadTableProvider(String path, TableDataProvider.SheetInfo sheetInfo, Locale locale) {
     TableDataProvider tbl;
     if (Utilities.isAbsoluteUrl(path)) {
       ValueSet vs = context.findTxResource(ValueSet.class, path, IWorkerContext.VersionResolutionRules.defaultRule());
@@ -510,7 +533,7 @@ public class TestDataFactory {
         }
       }
     } else {
-      tbl = TableDataProvider.forFile(path, locale);
+      tbl = TableDataProvider.forFile(path, sheetInfo, locale);
     }
     return tbl;
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/testfactory/dataprovider/TableDataProvider.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/testfactory/dataprovider/TableDataProvider.java
@@ -17,30 +17,31 @@ public abstract class TableDataProvider {
   public abstract String cell(String name) throws FHIRException;
   public abstract void reset() throws FHIRException;
 
-
-  public static TableDataProvider forFile(String path, Locale locale) throws FHIRException {
-    try {
-      String filename = path;
-      String sheetname = null;
-      String range = null;
-
-      if (path.contains("!")) {
-          range = path.substring(path.indexOf("!")+1);
-          path = path.substring(0, path.indexOf("!"));
+  public record SheetInfo(String sheet, String range){
+    public static SheetInfo fromString(String string) {
+      if (string.contains("!")) {
+        final int splitIndex = string.indexOf("!");
+        if (splitIndex + 1 < string.length()) {
+          final String sheetName = string.substring(0, splitIndex);
+          final String range = string.substring(splitIndex + 1);
+          return new SheetInfo(sheetName, range);
         }
-      if (path.contains(";")) {
-        filename = path.substring(0, path.indexOf(";"));
-        sheetname = path.substring(path.indexOf(";")+1);
       }
-      String extension = Utilities.getFileExtension(filename);
+      return new SheetInfo(string, null);
+    }
+  }
+
+  public static TableDataProvider forFile(String path, SheetInfo sheetInfo, Locale locale) throws FHIRException {
+    try {
+      String extension = Utilities.getFileExtension(path);
       if (Utilities.existsInList(extension, "csv", "txt")) {
-        return new CSVDataProvider(filename);
+        return new CSVDataProvider(path);
       } else if (Utilities.existsInList(extension, "xlsx")) {
-        return new ExcelDataProvider(filename, sheetname, range, locale);
+        return new ExcelDataProvider(path, sheetInfo.sheet, sheetInfo.range, locale);
       } else if (Utilities.existsInList(extension, "db")) {
-        return new SQLDataProvider(DriverManager.getConnection("jdbc:sqlite:"+filename), sheetname);
+        return new SQLDataProvider(DriverManager.getConnection("jdbc:sqlite:"+ path), sheetInfo.sheet);
       } else {
-        throw new FHIRException("Unknown File Type "+path);
+        throw new FHIRException("Unknown File Type "+ path);
       }
     } catch (Exception e) {
       throw new FHIRException(e);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/generation/tests/TestInstanceGenerationTester.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/generation/tests/TestInstanceGenerationTester.java
@@ -2,7 +2,6 @@ package org.hl7.fhir.generation.tests;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Locale;
 


### PR DESCRIPTION
File paths generated by processing test data names containing cell ranges (A1:B5, etc) would crash in Windows environments.

This parses the test data beforehand to only handle the path portion of the test as a filename.