### PR TITLE
Fix test inclusion for rX/narrative

### DIFF
--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/OpenApiGeneratorTest.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/OpenApiGeneratorTest.java
@@ -1,7 +1,5 @@
 package org.hl7.fhir.r5.test;
 
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -10,14 +8,13 @@ import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.CapabilityStatement;
 import org.hl7.fhir.r5.openapi.OpenApiGenerator;
 import org.hl7.fhir.r5.openapi.Writer;
-import org.hl7.fhir.r5.test.utils.CompareUtilities;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-public class OpenApiGeneratorTest {
+class OpenApiGeneratorTest {
 
   @Test
   void testBase1() {
@@ -46,7 +43,7 @@ public class OpenApiGeneratorTest {
     });
   }
 
-  public void run(InputStream sfn, String dfn) throws IOException, FHIRFormatError, FileNotFoundException {
+  public void run(InputStream sfn, String dfn) throws IOException, FHIRFormatError {
     CapabilityStatement cs = (CapabilityStatement) new JsonParser().parse(sfn);
     Writer oa = new Writer(ManagedFileAccess.outStream(dfn));
     OpenApiGenerator gen = new OpenApiGenerator(TestingUtilities.getSharedWorkerContext(), cs, oa);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/narrative/tests/NarrativeGenerationXTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/narrative/tests/NarrativeGenerationXTests.java
@@ -28,7 +28,6 @@ import org.hl7.fhir.r5.terminologies.client.TerminologyClientR5;
 import org.hl7.fhir.r5.test.utils.CompareUtilities;
 import org.hl7.fhir.r5.test.utils.TestPackageLoader;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
-import org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities;
 import org.hl7.fhir.utilities.FileUtilities;
 import org.hl7.fhir.utilities.TerminologyServiceOptions;
 import org.hl7.fhir.utilities.Utilities;
@@ -56,7 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public class NarrativeGenerationTestsX {
+public class NarrativeGenerationXTests {
 
   public static class TestProfileKnowledgeProvider implements ProfileKnowledgeProvider {
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <guava_version>32.0.1-jre</guava_version>
         <gson_version>2.13.1</gson_version>
         <hapi_fhir_version>8.4.0</hapi_fhir_version>
-        <validator_test_case_version>1.7.62</validator_test_case_version>
+        <validator_test_case_version>1.7.63-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.21.3</jackson_version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
         <junit_jupiter_version>5.14.0</junit_jupiter_version>


### PR DESCRIPTION
rX/narrative test cases weren't being included in maven test runs.

The test will fail until https://github.com/FHIR/fhir-test-cases/pull/268 is merged to address changes in an expected outcome.