### PR TITLE
Fix: restore binary compatibility of IValidationPolicyAdvisor

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
@@ -284,5 +284,7 @@ public interface IValidationPolicyAdvisor {
    * or replaced by some arbitrary placeholder (e.g. "XXX") to allow for automated tested frameworks
    * @return a value to use, or null to use the real value
    */
-  String relativeDatePlaceHolder();
+  default String relativeDatePlaceHolder() {
+    return null;
+  }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
@@ -75,6 +75,16 @@ public interface IValidationPolicyAdvisor {
   boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments);
 
   /**
+   * @deprecated implement {@link #isSuppressMessageId(String, String, Object...)} instead.
+   *   This bridge method exists for binary compatibility with implementations that predate
+   *   the addition of {@code theMessageArguments} and will be removed in a future release.
+   */
+  @Deprecated
+  default boolean isSuppressMessageId(String path, String messageId) {
+    return isSuppressMessageId(path, messageId, new Object[0]);
+  }
+
+  /**
    * Whether to try validating a reference, and if so, how much validation to apply
    * 
    * @param validator

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
@@ -72,7 +72,9 @@ public interface IValidationPolicyAdvisor {
    * @param messageId - the message id (from messages.properties)
    * @return true if the validator should ignore the message
    */
-  boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments);
+  default boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments) {
+    return isSuppressMessageId(path, messageId);
+  }
 
   /**
    * @deprecated implement {@link #isSuppressMessageId(String, String, Object...)} instead.
@@ -80,9 +82,7 @@ public interface IValidationPolicyAdvisor {
    *   the addition of {@code theMessageArguments} and will be removed in a future release.
    */
   @Deprecated
-  default boolean isSuppressMessageId(String path, String messageId) {
-    return isSuppressMessageId(path, messageId, new Object[0]);
-  }
+   boolean isSuppressMessageId(String path, String messageId) ;
 
   /**
    * Whether to try validating a reference, and if so, how much validation to apply


### PR DESCRIPTION
### Problem

PR #2407 changed the signature of IValidationPolicyAdvisor.isSuppressMessageId from

```
boolean isSuppressMessageId(String path, String messageId);
```
to

```
boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments);
```

In Java, varargs produce a distinct method descriptor. This removes the original method from the interface contract, breaking all existing implementations — they either fail to compile or throw `AbstractMethodError` at runtime.

This is a confirmed cause of the incompatibility between `hl7.fhir.core 6.9.9` and `hapi-fhir 8.10.0`. Affected classes include `ValidatorPolicyAdvisor`, `FhirDefaultPolicyAdvisor`, and `BaseJpaR4Test.ValidationPolicyAdvisor.`

### Fix

Add a `default` bridge method with the old signature that delegates to the new one. Existing implementations continue to work without modification; implementations that want access to `theMessageArguments` can override the new method.

Related to #2407