### PR TITLE
Don't overwrite the persisted terminology cache after unload()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,4 +4,4 @@
 
 ## Other code changes
 
-* no changes
+* TerminologyCache: don't overwrite the complete on-disk cache with a partial one after unload() (terminology work performed after the final flush was clobbering the saved cache, so warm/subsequent builds re-queried the tx server for results already computed)

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -171,6 +171,11 @@ public class TerminologyCache {
 
   private SystemNameKeyGenerator systemNameKeyGenerator = new SystemNameKeyGenerator();
 
+  // Set once unload() has performed its final flush. After that, save() is a no-op so that any
+  // late terminology work cannot overwrite the just-flushed, complete on-disk cache with a
+  // freshly-repopulated partial one (see unload()).
+  private boolean unloaded = false;
+
   public class CacheToken {
     @Getter
     private String name;
@@ -386,6 +391,7 @@ public class TerminologyCache {
     // not useable after this is called — flush any pending writes first so we don't lose
     // entries that were waiting out the SAVE_DELAY_MS coalescing window.
     save();
+    unloaded = true;
     caches.clear();
     vsCache.clear();
     csCache.clear();
@@ -738,6 +744,8 @@ public class TerminologyCache {
 
   private void save(NamedCache nc) {
     if (folder == null)
+      return;
+    if (unloaded) // unload() already wrote the complete cache; don't overwrite it with later partial state
       return;
 
     try {


### PR DESCRIPTION
## Problem

`TerminologyCache.unload()` flushes the complete cache to disk (`save()`) and then clears the in-memory caches. But terminology operations that run **after** a caller invokes `unload()` repopulate fresh, *partial* `NamedCache`s, and the `SAVE_DELAY_MS`-coalesced `save(NamedCache)` then writes those partial caches back — **overwriting the complete cache files `unload()` had just written.**

This happens in normal IG Publisher builds: the publisher calls `context.unload()` at the end of the generate phase, but the QA/rendering phase afterward still validates/expands codes, which re-creates and re-saves partial caches over the complete ones.

The net effect is that most persisted terminology results are lost at the end of every build. Measured on US mCODE: a cold build performs ~2,600 persistent stores, but only ~230 survive on disk. The SNOMED bucket grows to ~1,029 entries, is flushed in full by `unload()`, then overwritten down to ~86. Subsequent ("warm") builds load the partial cache, miss the rest, and re-query the terminology server for answers already computed.

## Fix

Once `unload()` has performed its final flush, set an `unloaded` flag and make `save(NamedCache)` a no-op so later writes can't clobber the complete on-disk cache. Three lines; no behavior change before `unload()`.

## Impact (measured)

We profiled cold-vs-warm terminology traffic across a random sample of published HL7 IGs. Warm-cache effectiveness (the fraction of cold tx round-trips a warm build avoids) varied widely and was poor precisely for terminology-heavy clinical IGs:

- light terminology: registry-protocols 100%, smart-scheduling-links 97%, smart-app-launch 89%
- heavy terminology: US-Core 50%, physical-activity 44%, CARIN-BB 36%, IPS 30%, PQ-CMC-FDA 28%, mCODE 21%, ICHOM-breast-cancer 18%

The low numbers are explained by this bug — warm builds re-ask the server for results the previous build already computed but failed to keep on disk.

Demonstration on mCODE, baseline vs this fix (cold then warm, identical inputs, requests captured via a logging proxy):

| | warm tx calls | on-disk cache entries (after cold) | QA result |
|---|--:|--:|---|
| baseline | 2,169 | 234 | 8 errors / 117 warnings |
| **with this fix** | **220** | **2,456** | 8 errors / 117 warnings |

Warm terminology-server calls drop ~90%, the complete cache persists (~10× more entries on disk), and the build's validation output is unchanged (same error/warning counts) — i.e. the change is output-preserving.

## Notes

- Minimal, defensive core-side change. The underlying trigger is callers doing terminology work after `unload()`; the IG Publisher could additionally defer `context.unload()` until after QA, which would also let those late lookups be cached (the ~220 residual warm calls above). Happy to follow up on that separately.
- Marked **draft** pending maintainer review and a regression test for the unload-then-save path.
