### PR TITLE
Make using the TerminologyCache after unload() a hard error

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCache.java
@@ -382,13 +382,28 @@ public class TerminologyCache {
     return id;
   }
   
+  private boolean unloaded = false;
+
   public void unload() {
     // not useable after this is called — flush any pending writes first so we don't lose
     // entries that were waiting out the SAVE_DELAY_MS coalescing window.
     save();
+    unloaded = true;
     caches.clear();
     vsCache.clear();
     csCache.clear();
+  }
+
+  // Using the terminology cache after unload() is a programming error in the caller: unload()
+  // has already persisted the complete cache, so any later entry would overwrite it on disk with
+  // partial state. This is an invariant on the *code* (no IG content can trigger it — callers must
+  // finish all terminology work before unload()), so fail hard with an AssertionError that is not
+  // caught by the publisher's per-operation `catch (Exception)`, rather than silently corrupting
+  // the persisted cache or degrading output.
+  private void checkLoaded() {
+    if (unloaded) {
+      throw new AssertionError("Terminology cache used after unload(): unload() persists the complete cache and must be the last terminology operation; later use overwrites the on-disk cache with partial data.");
+    }
   }
   
   public void clear() throws IOException {
@@ -607,6 +622,7 @@ public class TerminologyCache {
   }
 
   public ValueSetExpansionOutcome getExpansion(CacheToken cacheToken) {
+    checkLoaded();
     synchronized (lock) {
       NamedCache nc = getNamedCache(cacheToken);
       CacheEntry e = nc.map.get(cacheToken.key);
@@ -618,7 +634,8 @@ public class TerminologyCache {
   }
 
   public void cacheExpansion(CacheToken cacheToken, ValueSetExpansionOutcome res, boolean persistent) {
-    synchronized (lock) {      
+    checkLoaded();
+    synchronized (lock) {
       NamedCache nc = getNamedCache(cacheToken);
       CacheEntry e = new CacheEntry();
       e.request = cacheToken.request;
@@ -665,6 +682,7 @@ public class TerminologyCache {
   }
 
   public ValidationResult getValidation(CacheToken cacheToken) {
+    checkLoaded();
     if (cacheToken.key == null) {
       return null;
     }
@@ -683,6 +701,7 @@ public class TerminologyCache {
   }
 
   public void cacheValidation(CacheToken cacheToken, ValidationResult res, boolean persistent) {
+    checkLoaded();
     if (cacheToken.key != null) {
       synchronized (lock) {      
         NamedCache nc = getNamedCache(cacheToken);

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCacheTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/terminologies/utilities/TerminologyCacheTests.java
@@ -259,6 +259,42 @@ public class TerminologyCacheTests implements ResourceLoaderTests {
     assertEquals("dummyInfo", retrievedCodeableConceptResult.getMessage());
   }
 
+  @Test
+  public void testCacheUseAfterUnloadThrows() throws IOException {
+    Object lock = new Object();
+    Path tempCacheDirectory = createTempCacheDirectory();
+    TerminologyCache cache = new TerminologyCache(lock, tempCacheDirectory.toString());
+
+    ValueSet valueSet = new ValueSet();
+    valueSet.setUrl("dummyValueSetURL");
+    Coding coding = new Coding();
+    coding.setCode("dummyCode");
+
+    TerminologyCache.CacheToken validationToken = cache.generateValidationToken(CacheTestUtils.validationOptions,
+      coding, valueSet, new Parameters());
+    TerminologyCache.CacheToken expansionToken = cache.generateExpandToken(valueSet,
+      new ExpansionOptions().withHierarchical(true));
+
+    // Before unload(): normal use works.
+    cache.cacheValidation(validationToken,
+      new ValidationResult(ValidationMessage.IssueSeverity.INFORMATION, "dummyInfo", null), true);
+    assertNotNull(cache.getValidation(validationToken));
+
+    // unload() persists the complete cache and must be the last terminology operation.
+    cache.unload();
+
+    // Any subsequent use is a programming error (it would overwrite the persisted cache with
+    // partial state), so it must fail loudly rather than silently corrupt the on-disk cache.
+    assertThrows(AssertionError.class, () -> cache.getValidation(validationToken));
+    assertThrows(AssertionError.class, () -> cache.cacheValidation(validationToken,
+      new ValidationResult(ValidationMessage.IssueSeverity.INFORMATION, "dummyInfo", null), true));
+    assertThrows(AssertionError.class, () -> cache.getExpansion(expansionToken));
+    assertThrows(AssertionError.class, () -> cache.cacheExpansion(expansionToken,
+      new ValueSetExpansionOutcome(valueSet), true));
+
+    deleteTempCacheDirectory(tempCacheDirectory);
+  }
+
   private void assertCanonicalResourceEquals(CanonicalResource a, CanonicalResource b) {
     assertTrue(a.equalsDeep(b));
   }


### PR DESCRIPTION
## What

`TerminologyCache.unload()` flushes the complete cache to disk and then clears it — it is meant to be the **last** terminology operation. Nothing currently enforces that. If a caller uses the cache after `unload()`, the later (partial) entries get written back over the complete `.cache` files, silently corrupting the persisted cache.

This adds the guard @grahamegrieve asked for: `unload()` sets an `unloaded` flag, and the four cache entry points (`getExpansion`, `cacheExpansion`, `getValidation`, `cacheValidation`) throw if used afterward. Plus a unit test.

## Why an `AssertionError` (not a `RuntimeException`)

This is a programming-error invariant on the caller's **code ordering** — no IG input/content can trigger it. Downstream consumers (e.g. the IG Publisher) wrap terminology operations in `catch (Exception)`, so a `RuntimeException` gets swallowed there and the misuse continues silently (degraded output, "successful" build). An `AssertionError` escapes `catch (Exception)` and fails the build, surfacing the bug immediately.

## How it was found / companion fix

The IG Publisher called `context.unload()` mid-build and then ran `genCombinedPackage()`, which expands value sets → used the tx cache after `unload()` → overwrote the persisted cache with partial data → warm builds re-queried everything already computed. With this guard, that ordering now hard-fails with a stack that pinpoints the culprit:

```
java.lang.AssertionError: Terminology cache used after unload()...
  at TerminologyCache.getExpansion(...)
  at BaseWorkerContext.expandVS(...)
  at PackageReGenerator.generateExpansionPackageInner(...)
  at PublisherGenerator.genCombinedPackage(...)
  at Publisher.createIg(...)
```

The publisher-side rewrite that satisfies this guard (moves `unload()` to the end of `createIg()`, after all terminology consumers) is **HL7/fhir-ig-publisher#1318**.

**Sequencing:** the publisher should adopt this guard together with HL7/fhir-ig-publisher#1318 — on its own it would hard-fail every terminology-bearing build until the publisher's ordering is corrected. Opening as a draft for that reason.

## Test

`TerminologyCacheTests.testCacheUseAfterUnloadThrows`: pre-`unload()` use works; all four entry points throw after `unload()`. The existing 42 `TerminologyCache` tests still pass (verified on master).
