### PR TITLE
Fix "the the" typo in cardinality tooltip text

### DIFF
--- a/org.hl7.fhir.dstu3.support/src/main/java/org/hl7/fhir/dstu3/support/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.dstu3.support/src/main/java/org/hl7/fhir/dstu3/support/conformance/ProfileUtilities.java
@@ -3577,7 +3577,7 @@ public class ProfileUtilities extends TranslatingUtilities {
     model.setDocoImg(prefix+"help16.png");
     model.setDocoRef(prefix+"formats.html#table"); // todo: change to graph definition
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Property", "A profiled resource", null, 0));
-    model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Card.", "Minimum and Maximum # of times the the element can appear in the instance", null, 0));
+    model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Card.", "Minimum and Maximum # of times the element can appear in the instance", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Content", "What goes here", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Description", "Description of the profile", null, 0));
     return model;

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/conformance/ProfileUtilities.java
@@ -5094,7 +5094,7 @@ public class ProfileUtilities extends TranslatingUtilities {
     model.setDocoRef(prefix + "formats.html#table"); // todo: change to graph definition
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Property", "A profiled resource", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Card.",
-        "Minimum and Maximum # of times the the element can appear in the instance", null, 0));
+        "Minimum and Maximum # of times the element can appear in the instance", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Content", "What goes here", null, 0));
     model.getTitles()
         .add(gen.new Title(null, model.getDocoRef(), "Description", "Description of the profile", null, 0));

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/conformance/ProfileUtilities.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/conformance/ProfileUtilities.java
@@ -7301,7 +7301,7 @@ public class ProfileUtilities extends TranslatingUtilities {
     model.setDocoRef(Utilities.pathURL(prefix, "formats.html#table")); // todo: change to graph definition
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Property", "A profiled resource", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Card.",
-        "Minimum and Maximum # of times the the element can appear in the instance", null, 0));
+        "Minimum and Maximum # of times the element can appear in the instance", null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), "Content", "What goes here", null, 0));
     model.getTitles()
         .add(gen.new Title(null, model.getDocoRef(), "Description", "Description of the profile", null, 0));

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/QuestionnaireRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/QuestionnaireRenderer.java
@@ -93,7 +93,7 @@ public class QuestionnaireRenderer extends TerminologyRenderer {
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Text"),
         translate("sd.hint", "Text for the item"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Cardinality"),
-        translate("sd.hint", "Minimum and Maximum # of times the the itemcan appear in the instance"), null, 0));
+        translate("sd.hint", "Minimum and Maximum # of times the item can appear in the instance"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Type"),
         translate("sd.hint", "The type of the item"), null, 0));
     if (hasFlags) {

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/QuestionnaireResponseRenderer.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/renderers/QuestionnaireResponseRenderer.java
@@ -98,7 +98,7 @@ public class QuestionnaireResponseRenderer extends ResourceRenderer {
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Text"),
         translate("sd.hint", "Text for the item"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Definition"),
-        translate("sd.hint", "Minimum and Maximum # of times the the itemcan appear in the instance"), null, 0));
+        translate("sd.hint", "Minimum and Maximum # of times the item can appear in the instance"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Answer"),
         translate("sd.hint", "The type of the item"), null, 0));
 
@@ -126,7 +126,7 @@ public class QuestionnaireResponseRenderer extends ResourceRenderer {
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Text"),
         translate("sd.hint", "Text for the item"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Definition"),
-        translate("sd.hint", "Minimum and Maximum # of times the the itemcan appear in the instance"), null, 0));
+        translate("sd.hint", "Minimum and Maximum # of times the item can appear in the instance"), null, 0));
     model.getTitles().add(gen.new Title(null, model.getDocoRef(), translate("sd.head", "Answer"),
         translate("sd.hint", "The type of the item"), null, 0));
 


### PR DESCRIPTION
The "Card." column tooltip had "the the" in the text across R4, R4B, and R3. 
Also fixed a missing space ("itemcan") in the same string in the Questionnaire renderers.