### PR TITLE
Support granular suppression of compliesWith check reasons (ISSUE-2451)

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/validation/IValidationPolicyAdvisor.java
@@ -75,6 +75,17 @@ public interface IValidationPolicyAdvisor {
   boolean isSuppressMessageId(String path, String messageId, Object... theMessageArguments);
 
   /**
+   * Return true if a specific reason produced by the compliesWith check should not be reported.
+   *
+   * @param claimedProfileUrl URL of the claimed profile
+   * @param elementPath path of the element in the StructureDefinition
+   * @return true if the validator should ignore the reason
+   */
+  default boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    return false;
+  }
+
+  /**
    * Whether to try validating a reference, and if so, how much validation to apply
    * 
    * @param validator

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/BaseValidator.java
@@ -294,6 +294,14 @@ public class BaseValidator implements IValidationContextResourceLoader, IMessagi
     }
   }
 
+  protected boolean isSuppressedCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    if (policyAdvisor == null) {
+      return false;
+    } else {
+      return policyAdvisor.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
+    }
+  }
+
   protected boolean fail(List<ValidationMessage> errors, String ruleDate, IssueType type, int line, int col, String path, boolean thePass, String theMessage, Object... theMessageArguments) {
     if (!thePass && doingErrors() && !isSuppressedValidationMessage(path, theMessage, theMessageArguments)) {
       String msg = context.formatMessage(theMessage, theMessageArguments);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -1541,6 +1541,11 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
   }
 
   @Override
+  public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    return policyAdvisor != null && policyAdvisor.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
+  }
+
+  @Override
   public ReferenceValidationPolicy getReferencePolicy() {
     return ReferenceValidationPolicy.IGNORE;
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/JsonDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/JsonDrivenPolicyAdvisor.java
@@ -46,6 +46,16 @@ public class JsonDrivenPolicyAdvisor extends RulesDrivenPolicyAdvisor {
         addSuppressMessageRule(s);
       }
     }
+    for (JsonElement e : json.forceArray("suppress-complies-with").getItems()) {
+      String s = e.asString();
+      if (s.contains("@")) {
+        String profileUrl = s.substring(0, s.indexOf("@"));
+        String elementPath = s.substring(s.indexOf("@")+1);
+        addCompliesWithReasonRule(profileUrl, elementPath);
+      } else {
+        addCompliesWithReasonRule(s, null);
+      }
+    }
   }
 
 }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
@@ -74,7 +74,7 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
     }
 
     public boolean matches(String url, String path) {
-      return stringMatches(profileUrl, url) && stringMatches(elementPath, path);
+      return stringMatches(profileUrl, url) && compliesWithPathMatches(elementPath, path);
     }
   }
   
@@ -109,6 +109,43 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
     } else {      
       return specifier.equals(actual);
     }
+  }
+
+  boolean compliesWithPathMatches(String specifier, String actual) {
+    if (specifier == null) {
+      return true;
+    } else if (actual == null) {
+      return false;
+    }
+    String[] expected = specifier.split("\\.");
+    String[] found = actual.split("\\.");
+    if (expected.length > found.length) {
+      return false;
+    }
+    for (int i = 0; i < expected.length; i++) {
+      if (!compliesWithPathSegmentMatches(expected[i], found[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean compliesWithPathSegmentMatches(String specifier, String actual) {
+    if ("*".equals(specifier)) {
+      return true;
+    }
+    return normalizeCompliesWithPathSegment(specifier).equals(normalizeCompliesWithPathSegment(actual));
+  }
+
+  private String normalizeCompliesWithPathSegment(String segment) {
+    String normalized = segment;
+    if (normalized.contains(":")) {
+      normalized = normalized.substring(0, normalized.indexOf(":"));
+    }
+    if (normalized.contains("[")) {
+      normalized = normalized.substring(0, normalized.indexOf("["));
+    }
+    return normalized;
   }
 
   boolean stringMatches(String specifier, String actual) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
@@ -81,7 +81,7 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
   // string matching 
 
   boolean pathMatches(String[] specifier, String[] actual) {
-    if (specifier == null) {
+    if (specifier == null || specifier.length == 0) {
       return true;
     }
     for (int i = 0; i < specifier.length; i++) {
@@ -189,7 +189,7 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
     if (base != null) {
       return base.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
     } else {
-      return false;
+      return super.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
     }
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
@@ -62,6 +62,21 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
       }
     }
   }
+
+  private class CompliesWithReasonRule {
+    private String profileUrl;
+    private String elementPath;
+
+    protected CompliesWithReasonRule(String profileUrl, String elementPath) {
+      super();
+      this.profileUrl = profileUrl;
+      this.elementPath = elementPath;
+    }
+
+    public boolean matches(String url, String path) {
+      return stringMatches(profileUrl, url) && stringMatches(elementPath, path);
+    }
+  }
   
   // string matching 
 
@@ -96,9 +111,11 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
     }
   }
 
-  boolean stringMatches(String specifier, @Nonnull String actual) {
+  boolean stringMatches(String specifier, String actual) {
     if (specifier == null) {
       return true;
+    } else if (actual == null) {
+      return false;
     } else if (specifier.endsWith("*")) {
       return specifier.substring(0, specifier.length()-1).equalsIgnoreCase(actual.substring(0, Integer.min(specifier.length()-1, actual.length())));      
     } else {
@@ -115,6 +132,7 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
   }
   
   private List<SuppressMessageRule> suppressMessageRules = new ArrayList<>();
+  private List<CompliesWithReasonRule> compliesWithReasonRules = new ArrayList<>();
   private int suppressed = 0;
 
   protected void addSuppressMessageRule(@Nonnull String id, String path, boolean regex) {
@@ -125,6 +143,11 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
   protected void addSuppressMessageRule(@Nonnull String id) {
     log.debug("SuppressingRule was added for: " + id);
     suppressMessageRules.add(new SuppressMessageRule(id));
+  }
+
+  protected void addCompliesWithReasonRule(String profileUrl, String elementPath) {
+    log.debug("CompliesWithReasonRule was added for: " + profileUrl + " at path " + elementPath);
+    compliesWithReasonRules.add(new CompliesWithReasonRule(profileUrl, elementPath));
   }
   
   @Override
@@ -140,6 +163,21 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
       return base.isSuppressMessageId(path, messageId, theMessageArguments);
     } else {
       return super.isSuppressMessageId(path, messageId, theMessageArguments);
+    }
+  }
+
+  @Override
+  public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    for (CompliesWithReasonRule rule : compliesWithReasonRules) {
+      if (rule.matches(claimedProfileUrl, elementPath)) {
+        log.debug("Suppressed compliesWith reason for profile " + claimedProfileUrl + " at path " + elementPath);
+        return true;
+      }
+    }
+    if (base != null) {
+      return base.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
+    } else {
+      return false;
     }
   }
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisor.java
@@ -117,35 +117,10 @@ public class RulesDrivenPolicyAdvisor extends BasePolicyAdvisorForFullValidation
     } else if (actual == null) {
       return false;
     }
-    String[] expected = specifier.split("\\.");
-    String[] found = actual.split("\\.");
-    if (expected.length > found.length) {
-      return false;
-    }
-    for (int i = 0; i < expected.length; i++) {
-      if (!compliesWithPathSegmentMatches(expected[i], found[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean compliesWithPathSegmentMatches(String specifier, String actual) {
-    if ("*".equals(specifier)) {
-      return true;
-    }
-    return normalizeCompliesWithPathSegment(specifier).equals(normalizeCompliesWithPathSegment(actual));
-  }
-
-  private String normalizeCompliesWithPathSegment(String segment) {
-    String normalized = segment;
-    if (normalized.contains(":")) {
-      normalized = normalized.substring(0, normalized.indexOf(":"));
-    }
-    if (normalized.contains("[")) {
-      normalized = normalized.substring(0, normalized.indexOf("["));
-    }
-    return normalized;
+    // Reuse the same path matching as message suppression (messageId@path) so the two advisor
+    // formats behave identically: sub-paths require an explicit trailing ".*" and slices (":")
+    // are not normalized.
+    return pathMatches(specifier.split("\\."), actual.split("\\."));
   }
 
   boolean stringMatches(String specifier, String actual) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/TextDrivenPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/advisor/TextDrivenPolicyAdvisor.java
@@ -62,6 +62,15 @@ public class TextDrivenPolicyAdvisor extends RulesDrivenPolicyAdvisor {
       } else {
         addSuppressMessageRule(s);
       }
+    } else if (line.startsWith("=")) {
+      String s = line.substring(1).trim();
+      if (s.contains("@")) {
+        String profileUrl = s.substring(0, s.indexOf("@"));
+        String elementPath = s.substring(s.indexOf("@")+1);
+        addCompliesWithReasonRule(profileUrl, elementPath);
+      } else {
+        addCompliesWithReasonRule(s, null);
+      }
     } else {
       // ignore it for now
     }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
@@ -280,28 +280,7 @@ public class StructureDefinitionValidator extends BaseValidator {
               ok = rule(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, I18nConstants.SD_EXTENSION_COMPLIES_WITH_UNKNOWN, curl) && ok;
             } else {
               List<ValidationMessage> messages = new CompliesWithChecker(context).checkCompliesWith(sd, auth);
-              List<ValidationMessage> filteredMessages = messages.stream()
-                .filter(vm -> !isSuppressedCompliesWithReason(curl, vm.getLocation()))
-                .collect(Collectors.toList());
-              IssueSeverity level = IssueSeverity.INFORMATION;
-              for (ValidationMessage vm : filteredMessages) {
-                level = IssueSeverity.max(level, vm.getLevel());
-              }
-              if (level == IssueSeverity.ERROR) {
-                List<String> msgs = new ArrayList<>();
-                for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.ERROR).collect(Collectors.toList())) {
-                  msgs.add(vm.getMessage());
-                }
-                rule(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_ERROR, curl,
-                  CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
-              } else if (level == IssueSeverity.WARNING) {
-                List<String> msgs = new ArrayList<>();
-                for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.WARNING).collect(Collectors.toList())) {
-                  msgs.add(vm.getMessage());
-                }
-                warning(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, curl,
-                  CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
-              }            
+              reportCompliesWithMessages(errors, stack.getLiteralPath(), curl, messages);
             }
           }
         }
@@ -314,6 +293,40 @@ public class StructureDefinitionValidator extends BaseValidator {
       }
     }
     return ok;
+  }
+
+  void reportCompliesWithMessages(List<ValidationMessage> errors, String path, String claimedProfileUrl, List<ValidationMessage> messages) {
+    List<ValidationMessage> filteredMessages = messages.stream()
+      .filter(vm -> !isSuppressedCompliesWithReason(claimedProfileUrl, vm.getLocation()))
+      .collect(Collectors.toList());
+    IssueSeverity level = IssueSeverity.INFORMATION;
+    for (ValidationMessage vm : filteredMessages) {
+      level = IssueSeverity.max(level, vm.getLevel());
+    }
+    if (level == IssueSeverity.ERROR) {
+      List<String> msgs = new ArrayList<>();
+      for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.ERROR).collect(Collectors.toList())) {
+        msgs.add(messageWithLocation(vm));
+      }
+      rule(errors, "2025-03-30", IssueType.INVALID, path, false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_ERROR, claimedProfileUrl,
+        CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
+    } else if (level == IssueSeverity.WARNING) {
+      List<String> msgs = new ArrayList<>();
+      for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.WARNING).collect(Collectors.toList())) {
+        msgs.add(messageWithLocation(vm));
+      }
+      warning(errors, "2025-03-30", IssueType.INVALID, path, false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, claimedProfileUrl,
+        CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
+    }
+  }
+
+  private String messageWithLocation(ValidationMessage vm) {
+    String loc = vm.getLocation();
+    String msg = vm.getMessage();
+    if (loc != null && !msg.contains(loc)) {
+      return "at " + loc + ": " + msg;
+    }
+    return msg;
   }
 
   private boolean checkTypeParameters(List<ValidationMessage> errors, NodeStack stack, StructureDefinition base, StructureDefinition derived) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
@@ -280,23 +280,26 @@ public class StructureDefinitionValidator extends BaseValidator {
               ok = rule(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, I18nConstants.SD_EXTENSION_COMPLIES_WITH_UNKNOWN, curl) && ok;
             } else {
               List<ValidationMessage> messages = new CompliesWithChecker(context).checkCompliesWith(sd, auth);
+              List<ValidationMessage> filteredMessages = messages.stream()
+                .filter(vm -> !isSuppressedCompliesWithReason(curl, vm.getLocation()))
+                .collect(Collectors.toList());
               IssueSeverity level = IssueSeverity.INFORMATION;
-              for (ValidationMessage vm : messages) {
+              for (ValidationMessage vm : filteredMessages) {
                 level = IssueSeverity.max(level, vm.getLevel());
               }
               if (level == IssueSeverity.ERROR) {
                 List<String> msgs = new ArrayList<>();
-                for (ValidationMessage vm : messages.stream().filter(vm -> vm.getLevel() == IssueSeverity.ERROR).collect(Collectors.toList())) {
+                for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.ERROR).collect(Collectors.toList())) {
                   msgs.add(vm.getMessage());
                 }
-                rule(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, messages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_ERROR, curl,
+                rule(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_ERROR, curl,
                   CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
               } else if (level == IssueSeverity.WARNING) {
                 List<String> msgs = new ArrayList<>();
-                for (ValidationMessage vm : messages.stream().filter(vm -> vm.getLevel() == IssueSeverity.WARNING).collect(Collectors.toList())) {
+                for (ValidationMessage vm : filteredMessages.stream().filter(vm -> vm.getLevel() == IssueSeverity.WARNING).collect(Collectors.toList())) {
                   msgs.add(vm.getMessage());
                 }
-                warning(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, messages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, curl,
+                warning(errors, "2025-03-30", IssueType.INVALID, stack.getLiteralPath(), false, filteredMessages, I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, curl,
                   CommaSeparatedStringBuilder.join2(", ", " and ", msgs));
               }            
             }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidator.java
@@ -324,7 +324,7 @@ public class StructureDefinitionValidator extends BaseValidator {
     String loc = vm.getLocation();
     String msg = vm.getMessage();
     if (loc != null && !msg.contains(loc)) {
-      return "at " + loc + ": " + msg;
+      return loc + ": " + msg;
     }
     return msg;
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/DisabledValidationPolicyAdvisor.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/DisabledValidationPolicyAdvisor.java
@@ -38,6 +38,11 @@ public class DisabledValidationPolicyAdvisor implements IValidationPolicyAdvisor
   }
 
   @Override
+  public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    return policyAdvisor != null && policyAdvisor.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
+  }
+
+  @Override
   public ContainedReferenceValidationPolicy policyForContained(IResourceValidator validator, Object appContext,
       StructureDefinition structure, ElementDefinition element, String containerType, String containerId,
       SpecialElement containingResourceType, String path, String url) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/StandAloneValidatorFetcher.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/StandAloneValidatorFetcher.java
@@ -413,6 +413,11 @@ public class StandAloneValidatorFetcher implements IValidatorResourceFetcher, IV
   }
 
   @Override
+  public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+    return policyAdvisor != null && policyAdvisor.isSuppressCompliesWithReason(claimedProfileUrl, elementPath);
+  }
+
+  @Override
   public ContainedReferenceValidationPolicy policyForContained(IResourceValidator validator, Object appContext,
       StructureDefinition structure, ElementDefinition element, String containerType, String containerId,
       SpecialElement containingResourceType, String path, String url) {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
@@ -35,13 +35,20 @@ class RulesDrivenPolicyAdvisorTest {
   void textDrivenAdvisorSuppressesCompliesWithReasons() throws JsonException, IOException {
     String source = "- SOME_MESSAGE@Patient\n"
       + "= http://example.org/Profile@Patient.name\n"
+      + "= http://example.org/Sub@Patient.name.*\n"
       + "= *@Observation.code\n";
 
     TextDrivenPolicyAdvisor advisor = new TextDrivenPolicyAdvisor(baseAdvisor(), "advisor.txt", source);
 
     assertTrue(advisor.isSuppressMessageId("Patient", "SOME_MESSAGE"));
     assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name"));
-    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name:official.given"));
+    // consistent with messageId@path: a bare path matches only exactly, not sub-paths or slices
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name.given"));
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name:official.given"));
+    // an explicit trailing wildcard matches sub-paths
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Sub", "Patient.name.given"));
+    // but slices are not normalized, so the wildcard does not reach into a slice
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Sub", "Patient.name:official.given"));
     assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Other", "Observation.code"));
     assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.birthDate"));
   }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
@@ -54,6 +54,15 @@ class RulesDrivenPolicyAdvisorTest {
   }
 
   @Test
+  void degenerateDotOnlyPathDoesNotThrow() throws JsonException, IOException {
+    // a malformed rule whose path is just "." splits to an empty path; it must not crash the validator
+    TextDrivenPolicyAdvisor advisor = new TextDrivenPolicyAdvisor(baseAdvisor(), "advisor.txt",
+      "= http://example.org/Degenerate@.\n");
+
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Degenerate", "Patient.name"));
+  }
+
+  @Test
   void rulesDrivenAdvisorDelegatesToBaseAdvisor() {
     RulesDrivenPolicyAdvisor advisor = new RulesDrivenPolicyAdvisor(new DelegatingAdvisor());
 
@@ -71,6 +80,7 @@ class RulesDrivenPolicyAdvisorTest {
       super(ReferenceValidationPolicy.CHECK_VALID, null);
     }
 
+    @Override
     public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
       return "http://example.org/Base".equals(claimedProfileUrl) && "Patient.name".equals(elementPath);
     }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
@@ -1,0 +1,70 @@
+package org.hl7.fhir.validation.instance.advisor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.hl7.fhir.r5.utils.validation.constants.ReferenceValidationPolicy;
+import org.hl7.fhir.utilities.json.JsonException;
+import org.junit.jupiter.api.Test;
+
+class RulesDrivenPolicyAdvisorTest {
+
+  @Test
+  void jsonDrivenAdvisorSuppressesCompliesWithReasons() throws JsonException, IOException {
+    String source = "{\n"
+      + "  \"suppress-complies-with\": [\n"
+      + "    \"http://example.org/Profile@Patient.name\",\n"
+      + "    \"*@Observation.code\",\n"
+      + "    \"http://example.org/Any@*\",\n"
+      + "    \"http://example.org/ProfileOnly\"\n"
+      + "  ]\n"
+      + "}";
+
+    JsonDrivenPolicyAdvisor advisor = new JsonDrivenPolicyAdvisor(baseAdvisor(), "advisor.json", source);
+
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name"));
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.birthDate"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Other", "Observation.code"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Any", "Patient.birthDate"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/ProfileOnly", "Patient.birthDate"));
+  }
+
+  @Test
+  void textDrivenAdvisorSuppressesCompliesWithReasons() throws JsonException, IOException {
+    String source = "- SOME_MESSAGE@Patient\n"
+      + "= http://example.org/Profile@Patient.name\n"
+      + "= *@Observation.code\n";
+
+    TextDrivenPolicyAdvisor advisor = new TextDrivenPolicyAdvisor(baseAdvisor(), "advisor.txt", source);
+
+    assertTrue(advisor.isSuppressMessageId("Patient", "SOME_MESSAGE"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Other", "Observation.code"));
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.birthDate"));
+  }
+
+  @Test
+  void rulesDrivenAdvisorDelegatesToBaseAdvisor() {
+    RulesDrivenPolicyAdvisor advisor = new RulesDrivenPolicyAdvisor(new DelegatingAdvisor());
+
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Base", "Patient.name"));
+    assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Base", "Patient.birthDate"));
+  }
+
+  private static BasePolicyAdvisorForFullValidation baseAdvisor() {
+    return new BasePolicyAdvisorForFullValidation(ReferenceValidationPolicy.CHECK_VALID, null);
+  }
+
+  private static class DelegatingAdvisor extends BasePolicyAdvisorForFullValidation {
+
+    private DelegatingAdvisor() {
+      super(ReferenceValidationPolicy.CHECK_VALID, null);
+    }
+
+    public boolean isSuppressCompliesWithReason(String claimedProfileUrl, String elementPath) {
+      return "http://example.org/Base".equals(claimedProfileUrl) && "Patient.name".equals(elementPath);
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/advisor/RulesDrivenPolicyAdvisorTest.java
@@ -41,6 +41,7 @@ class RulesDrivenPolicyAdvisorTest {
 
     assertTrue(advisor.isSuppressMessageId("Patient", "SOME_MESSAGE"));
     assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name"));
+    assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.name:official.given"));
     assertTrue(advisor.isSuppressCompliesWithReason("http://example.org/Other", "Observation.code"));
     assertFalse(advisor.isSuppressCompliesWithReason("http://example.org/Profile", "Patient.birthDate"));
   }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
@@ -34,7 +34,7 @@ class StructureDefinitionValidatorTest {
     List<ValidationMessage> errors = new ArrayList<>();
 
     validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
-      reason("Patient.name", "suppressed reason", IssueSeverity.ERROR),
+      reason("Patient.name:official.given", "suppressed reason", IssueSeverity.ERROR),
       reason("Patient.birthDate", "reported reason", IssueSeverity.ERROR)));
 
     assertEquals(1, errors.size());
@@ -72,6 +72,19 @@ class StructureDefinitionValidatorTest {
     assertEquals(I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, errors.get(0).getMessageId());
     assertTrue(errors.get(0).getMessage().contains("remaining warning"), errors.get(0).getMessage());
     assertFalse(errors.get(0).getMessage().contains("suppressed error"), errors.get(0).getMessage());
+  }
+
+  @Test
+  void includesLocationWithoutHardcodedEnglishPrefix() throws Exception {
+    StructureDefinitionValidator validator = validatorWithAdvisor("");
+    List<ValidationMessage> errors = new ArrayList<>();
+
+    validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
+      reason("Patient.birthDate", "reported reason", IssueSeverity.ERROR)));
+
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).getMessage().contains("Patient.birthDate: reported reason"), errors.get(0).getMessage());
+    assertFalse(errors.get(0).getMessage().contains("at Patient.birthDate"), errors.get(0).getMessage());
   }
 
   private static TestStructureDefinitionValidator validatorWithAdvisor(String advisorSource) throws Exception {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
@@ -88,6 +88,19 @@ class StructureDefinitionValidatorTest {
     assertFalse(errors.get(0).getMessage().contains("at Patient.birthDate"), errors.get(0).getMessage());
   }
 
+  @Test
+  void doesNotPrefixLocationWhenReasonAlreadyContainsIt() throws Exception {
+    StructureDefinitionValidator validator = validatorWithAdvisor("");
+    List<ValidationMessage> errors = new ArrayList<>();
+
+    validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
+      reason("Patient.name", "Patient.name must comply", IssueSeverity.ERROR)));
+
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).getMessage().contains("Patient.name must comply"), errors.get(0).getMessage());
+    assertFalse(errors.get(0).getMessage().contains("Patient.name: Patient.name"), errors.get(0).getMessage());
+  }
+
   private static TestStructureDefinitionValidator validatorWithAdvisor(String advisorSource) throws Exception {
     IWorkerContext context = mock(IWorkerContext.class);
     when(context.getResourceNames()).thenReturn(List.of("Patient"));

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
@@ -30,7 +30,8 @@ class StructureDefinitionValidatorTest {
 
   @Test
   void suppressesOnlyMatchingCompliesWithReasons() throws Exception {
-    StructureDefinitionValidator validator = validatorWithAdvisor("= " + CLAIMED_PROFILE + "@Patient.name\n");
+    // slices are not normalized, so the slice has to be named explicitly (consistent with messageId@path)
+    StructureDefinitionValidator validator = validatorWithAdvisor("= " + CLAIMED_PROFILE + "@Patient.name:official.given\n");
     List<ValidationMessage> errors = new ArrayList<>();
 
     validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/StructureDefinitionValidatorTest.java
@@ -1,0 +1,140 @@
+package org.hl7.fhir.validation.instance.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.utils.xver.XVerExtensionManager;
+import org.hl7.fhir.r5.utils.validation.constants.ReferenceValidationPolicy;
+import org.hl7.fhir.utilities.i18n.I18nConstants;
+import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
+import org.hl7.fhir.utilities.validation.ValidationMessage.Source;
+import org.hl7.fhir.validation.BaseValidator;
+import org.hl7.fhir.validation.ValidatorSettings;
+import org.hl7.fhir.validation.instance.advisor.BasePolicyAdvisorForFullValidation;
+import org.hl7.fhir.validation.instance.advisor.TextDrivenPolicyAdvisor;
+import org.junit.jupiter.api.Test;
+
+class StructureDefinitionValidatorTest {
+
+  private static final String CLAIMED_PROFILE = "http://example.org/StructureDefinition/Claimed";
+
+  @Test
+  void suppressesOnlyMatchingCompliesWithReasons() throws Exception {
+    StructureDefinitionValidator validator = validatorWithAdvisor("= " + CLAIMED_PROFILE + "@Patient.name\n");
+    List<ValidationMessage> errors = new ArrayList<>();
+
+    validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
+      reason("Patient.name", "suppressed reason", IssueSeverity.ERROR),
+      reason("Patient.birthDate", "reported reason", IssueSeverity.ERROR)));
+
+    assertEquals(1, errors.size());
+    assertEquals(I18nConstants.SD_EXTENSION_COMPLIES_WITH_ERROR, errors.get(0).getMessageId());
+    assertTrue(errors.get(0).getMessage().contains("reported reason"), errors.get(0).getMessage());
+    assertFalse(errors.get(0).getMessage().contains("suppressed reason"), errors.get(0).getMessage());
+    assertNotNull(errors.get(0).getSliceInfo());
+    assertEquals(1, errors.get(0).getSliceInfo().size());
+    assertEquals("Patient.birthDate", errors.get(0).getSliceInfo().get(0).getLocation());
+  }
+
+  @Test
+  void suppressesAggregateCompliesWithErrorWhenAllReasonsAreSuppressed() throws Exception {
+    StructureDefinitionValidator validator = validatorWithAdvisor("= " + CLAIMED_PROFILE + "@*\n");
+    List<ValidationMessage> errors = new ArrayList<>();
+
+    validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
+      reason("Patient.name", "suppressed reason", IssueSeverity.ERROR),
+      reason("Patient.birthDate", "also suppressed", IssueSeverity.ERROR)));
+
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void recalculatesCompliesWithSeverityAfterSuppression() throws Exception {
+    StructureDefinitionValidator validator = validatorWithAdvisor("= " + CLAIMED_PROFILE + "@Patient.name\n");
+    List<ValidationMessage> errors = new ArrayList<>();
+
+    validator.reportCompliesWithMessages(errors, "StructureDefinition", CLAIMED_PROFILE, List.of(
+      reason("Patient.name", "suppressed error", IssueSeverity.ERROR),
+      reason("Patient.birthDate", "remaining warning", IssueSeverity.WARNING)));
+
+    assertEquals(1, errors.size());
+    assertEquals(IssueSeverity.WARNING, errors.get(0).getLevel());
+    assertEquals(I18nConstants.SD_EXTENSION_COMPLIES_WITH_WARNING, errors.get(0).getMessageId());
+    assertTrue(errors.get(0).getMessage().contains("remaining warning"), errors.get(0).getMessage());
+    assertFalse(errors.get(0).getMessage().contains("suppressed error"), errors.get(0).getMessage());
+  }
+
+  private static TestStructureDefinitionValidator validatorWithAdvisor(String advisorSource) throws Exception {
+    IWorkerContext context = mock(IWorkerContext.class);
+    when(context.getResourceNames()).thenReturn(List.of("Patient"));
+
+    BaseValidator parent = new BaseValidator(context, new ValidatorSettings(), mock(XVerExtensionManager.class), null);
+    parent.setPolicyAdvisor(new TextDrivenPolicyAdvisor(baseAdvisor(), "advisor.txt", advisorSource));
+    return new TestStructureDefinitionValidator(parent);
+  }
+
+  private static BasePolicyAdvisorForFullValidation baseAdvisor() {
+    return new BasePolicyAdvisorForFullValidation(ReferenceValidationPolicy.CHECK_VALID, null);
+  }
+
+  private static ValidationMessage reason(String location, String message, IssueSeverity severity) {
+    return new ValidationMessage(Source.InstanceValidator, IssueType.BUSINESSRULE, location, message, severity);
+  }
+
+  private static class TestStructureDefinitionValidator extends StructureDefinitionValidator {
+
+    private TestStructureDefinitionValidator(BaseValidator parent) {
+      super(parent, null, false);
+    }
+
+    @Override
+    protected boolean rule(List<ValidationMessage> errors, String ruleDate, IssueType type, String path, boolean thePass,
+        List<ValidationMessage> details, String theMessage, Object... theMessageArguments) {
+      addMessage(errors, type, path, IssueSeverity.ERROR, details, theMessage, theMessageArguments);
+      return thePass;
+    }
+
+    @Override
+    protected boolean warning(List<ValidationMessage> errors, String ruleDate, IssueType type, String path, boolean thePass,
+        List<ValidationMessage> details, String msg, Object... theMessageArguments) {
+      addMessage(errors, type, path, IssueSeverity.WARNING, details, msg, theMessageArguments);
+      return thePass;
+    }
+
+    private void addMessage(List<ValidationMessage> errors, IssueType type, String path, IssueSeverity severity,
+        List<ValidationMessage> details, String messageId, Object... arguments) {
+      ValidationMessage message = new ValidationMessage(Source.InstanceValidator, type, path,
+        messageId + ": " + formatArguments(arguments), severity).setMessageId(messageId);
+      message.setSliceInfo(details);
+      errors.add(message);
+    }
+
+    private String formatArguments(Object... arguments) {
+      List<String> values = new ArrayList<>();
+      for (Object argument : arguments) {
+        addArgument(values, argument);
+      }
+      return String.join("|", values);
+    }
+
+    private void addArgument(List<String> values, Object argument) {
+      if (argument instanceof Object[] arguments) {
+        for (Object value : arguments) {
+          addArgument(values, value);
+        }
+      } else {
+        values.add(String.valueOf(argument));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The `compliesWith` check on `StructureDefinition` (validating that a profile complies with a claimed authority profile) reports all of its findings as a single aggregate message:

> This profile does not comply with claimed profile 'X' because: reason1, reason2, …

Until now this could only be suppressed as a whole, which is too coarse-grained: an author with a single legitimate, reviewed deviation had to silence *every* reason for that profile. This PR lets a policy advisor suppress **individual** reasons by claimed-profile URL and element path, consistent with the existing `messageId@path` message-suppression mechanism.

When reasons are suppressed:
- the aggregate severity is recomputed from the remaining reasons (e.g. suppressing all `error` reasons while a `warning` remains downgrades the result to a warning), and
- if every reason is suppressed, the check passes and no message is emitted.

Behaviour is unchanged unless an advisor opts in.

## New advisor configuration

**JSON advisor** — a new `suppress-complies-with` array of `profileUrl@elementPath` entries:

```json
{
  "suppress-complies-with": [
    "http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips@Composition.type",
    "*@Composition.section:sectionPastProblems",
    "http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips@*"
  ]
}
```

**Text advisor** — new `=` lines:

```
= http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips@Composition.type
= *@Composition.section:sectionPastProblems
```

### Matching semantics (identical to the existing `messageId@path` format)

| Entry | Matches |
|---|---|
| `Profile@Composition.type` | exactly `Composition.type` |
| `Profile@Composition.section.*` | sub-paths under `Composition.section` (explicit trailing `.*`) |
| `Profile@Composition.section:slice` | the named slice (slices are matched explicitly; `:` is not normalized) |
| `Profile@*` or bare `Profile` | all paths of that profile |
| `*@Composition.type` | that path for any claimed profile |

Element-path matching deliberately reuses the same logic as the existing message suppression, so the two advisor formats behave the same way.

## Implementation

- `IValidationPolicyAdvisor.isSuppressCompliesWithReason(claimedProfileUrl, elementPath)` — new `default` method returning `false` (backwards compatible).
- `RulesDrivenPolicyAdvisor` parses the new entries (`suppress-complies-with` / `=`) and matches them, reusing the existing path-matching helper; `BaseValidator` adds an `isSuppressedCompliesWithReason` helper mirroring `isSuppressedValidationMessage`.
- `StructureDefinitionValidator` filters suppressed reasons before reporting and recomputes the severity.
- The new method is wired through `ValidationEngine`, `DisabledValidationPolicyAdvisor`, and `StandAloneValidatorFetcher`.

## Note on output

Each reason in the aggregate `compliesWith` message is now prefixed with its element path (`<path>: <reason>`) so authors can see exactly which path to reference in a suppression rule. This is an intentional, unconditional change to the `compliesWith` message text.

## Tests

New unit tests: `RulesDrivenPolicyAdvisorTest` (JSON/text parsing, exact/sub-path/slice/wildcard matching, advisor delegation, degenerate-path robustness) and `StructureDefinitionValidatorTest` (selective suppression, all-suppressed → passes, severity downgrade, message formatting).

Closes #2451