### PR TITLE
Fix SpotBugs annotations transitive dependencies

### DIFF
--- a/org.hl7.fhir.r4/pom.xml
+++ b/org.hl7.fhir.r4/pom.xml
@@ -156,8 +156,6 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
-			<scope>provided</scope>
-            <optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/org.hl7.fhir.r4/pom.xml
+++ b/org.hl7.fhir.r4/pom.xml
@@ -157,6 +157,7 @@
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
 			<scope>provided</scope>
+            <optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/elementmodel/TurtleParser.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.r4.context.IWorkerContext;
@@ -60,6 +61,7 @@ import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
 
 @Deprecated
+@SuppressFBWarnings("MS_SHOULD_BE_FINAL")
 public class TurtleParser extends ParserBase {
 
   private String base;

--- a/org.hl7.fhir.r4b/pom.xml
+++ b/org.hl7.fhir.r4b/pom.xml
@@ -22,8 +22,6 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
 		</dependency>
 
 		<!-- HAPI Dependencies -->

--- a/org.hl7.fhir.r4b/pom.xml
+++ b/org.hl7.fhir.r4b/pom.xml
@@ -23,6 +23,7 @@
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
 		</dependency>
 
 		<!-- HAPI Dependencies -->

--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -22,8 +22,6 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
 		</dependency>
 
 		<!-- HAPI Dependencies -->

--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -23,6 +23,7 @@
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
 		</dependency>
 
 		<!-- HAPI Dependencies -->

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -270,7 +270,8 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope>
+            <scope>provided</scope> <!--  available at compile time and test time, but not bundled into the jar. Maven assumes the runtime environment will provide it -->
+            <optional>true</optional> <!-- prevents the dependency from being transitively inherited by downstream consumers -->
         </dependency>
     </dependencies>
 

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -270,8 +270,6 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <scope>provided</scope> <!--  available at compile time and test time, but not bundled into the jar. Maven assumes the runtime environment will provide it -->
-            <optional>true</optional> <!-- prevents the dependency from being transitively inherited by downstream consumers -->
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -404,8 +404,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>4.9.8</version>
-                <scope>provided</scope>
-                <optional>true</optional>
+                <!-- spotbugs-annotations is LGPL licensed. To keep licensing simple, it is not included in the distributed software, using the settings below -->
+                <scope>provided</scope> <!--  available at compile time and test time, but not bundled into the jar. Maven assumes the runtime environment will provide it -->
+                <optional>true</optional> <!-- prevents the dependency from being transitively inherited by downstream consumers -->
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.javaagent</groupId>
@@ -438,11 +439,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.4</version>
-                </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,7 @@
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>4.9.8</version>
                 <scope>provided</scope>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.javaagent</groupId>


### PR DESCRIPTION
SpotBugs annotations were not included in distributions, but not correctly marked as optional, requiring downstream projects to include them in order to build. 

This fixes the issue and maintains the exclusion of those dependencies.