### PR TITLE
feat: Add `-only-direct-ig-dependencies` flag to suppress transitive package loading

### DIFF
--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/ValidationEngineOptions.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/ValidationEngineOptions.java
@@ -47,6 +47,11 @@ public class ValidationEngineOptions {
   @With
   public boolean recursive = false;
 
+  @CommandLine.Option(names = {"-only-direct-ig-dependencies"},
+    description = "Skip transitive package dependencies when loading IGs, including hardcoded ones (e.g. hl7.terminology). Warning: may cause validation errors if resources depend on transitively loaded content.")
+  @With
+  public boolean onlyDirectIgDependencies = false;
+
   @CommandLine.Option(names = {"-clear-tx-cache"},
     description = "Clear the terminology cache before validation")
   @With

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/ValidationEngineOptionsConvertor.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/options/ValidationEngineOptionsConvertor.java
@@ -23,6 +23,7 @@ public class ValidationEngineOptionsConvertor {
     // Boolean flags
     validationEngineParameters.setDoNative(options.doNative);
     validationEngineParameters.setRecursive(options.recursive);
+    validationEngineParameters.setOnlyDirectIgDependencies(options.onlyDirectIgDependencies);
     validationEngineParameters.setClearTxCache(options.clearTxCache);
     validationEngineParameters.setCheckReferences(options.checkReferences);
     validationEngineParameters.setNoInternalCaching(options.noInternalCaching);

--- a/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/picocli/ValidationEngineOptionsConvertorTest.java
+++ b/org.hl7.fhir.validation.cli/src/test/java/org/hl7/fhir/validation/cli/picocli/ValidationEngineOptionsConvertorTest.java
@@ -50,6 +50,10 @@ public class ValidationEngineOptionsConvertorTest {
         new ValidationEngineOptions().withRecursive(true),
         new ValidationEngineParameters().setRecursive(true)
       ),
+      Arguments.of("onlyDirectIgDependencies flag",
+        new ValidationEngineOptions().withOnlyDirectIgDependencies(true),
+        new ValidationEngineParameters().setOnlyDirectIgDependencies(true)
+      ),
       Arguments.of("clearTxCache flag",
         new ValidationEngineOptions().withClearTxCache(true),
         new ValidationEngineParameters().setClearTxCache(true)

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
@@ -106,7 +106,27 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
                      Map<String, ByteProvider> binaries,
                      String src,
                      boolean recursive) throws IOException, FHIRException {
+    loadIg(igs, binaries, src, recursive, false);
+  }
 
+  /**
+   * @param igs
+   * @param binaries
+   * @param src Source of the IG
+   * @param recursive
+   * @param onlyDirectIgDependencies if true, load only direct dependencies of a package without recursing into
+   *                                 their transitive dependencies. Resources that rely on transitively loaded
+   *                                 content may fail validation.
+   * @throws IOException
+   * @throws FHIRException
+   *
+   * @see IgLoader#loadIgSource(String, boolean, boolean) loadIgSource for detailed description of the src parameter
+   */
+  public void loadIg(List<ImplementationGuide> igs,
+                     Map<String, ByteProvider> binaries,
+                     String src,
+                     boolean recursive,
+                     boolean onlyDirectIgDependencies) throws IOException, FHIRException {
     final String explicitFhirVersion;
     final String srcPackage;
     if (src.startsWith("[") && src.indexOf(']', 1) > 1) {
@@ -135,19 +155,18 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
       for (String s : npm.dependencies()) {
         if (!getContext().getLoadedPackages().contains(s)) {
           if (!VersionUtilities.isCorePackage(s)) {
-            loadIg(igs, binaries, s, false);
+            if (onlyDirectIgDependencies) {
+              NpmPackage dep = getPackageCacheManager().loadPackage(s, null);
+              if (dep != null) {
+                loadPackageIntoContext(dep, s);
+              }
+            } else {
+              loadIg(igs, binaries, s, false);
+            }
           }
         }
       }
-      StringBuilder packageLoadLine = new StringBuilder();
-      packageLoadLine.append("  Load " + srcPackage);
-      if (!srcPackage.contains("#")) {
-        packageLoadLine.append("#" + npm.version());
-      }
-      IContextResourceLoader loader = ValidatorUtils.loaderForVersion(npm.fhirVersion());
-      loader.setPatchUrls(VersionUtilities.isCorePackage(npm.id()));
-      int count = getContext().loadFromPackage(npm, loader, false);
-      log.info(packageLoadLine + " - " + count + " resources (" + getContext().clock().milestone() + ")");
+      loadPackageIntoContext(npm, srcPackage);
     } else {
       StringBuilder packageLoadLine = new StringBuilder();
       packageLoadLine.append("  Load " + srcPackage);
@@ -189,6 +208,18 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
       }
       log.info(packageLoadLine + " - " + count + " resources (" + getContext().clock().milestone() + ")");
     }
+  }
+
+  private void loadPackageIntoContext(NpmPackage npm, String srcPackage) throws IOException {
+    StringBuilder packageLoadLine = new StringBuilder();
+    packageLoadLine.append("  Load " + srcPackage);
+    if (!srcPackage.contains("#")) {
+      packageLoadLine.append("#" + npm.version());
+    }
+    IContextResourceLoader loader = ValidatorUtils.loaderForVersion(npm.fhirVersion());
+    loader.setPatchUrls(VersionUtilities.isCorePackage(npm.id()));
+    int count = getContext().loadFromPackage(npm, loader, false);
+    log.info(packageLoadLine + " - " + count + " resources (" + getContext().clock().milestone() + ")");
   }
 
   /**
@@ -556,8 +587,9 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
             found = true;
           }
         }
-        if (found)
+        if (found) {
           continue;
+        }
       }
       if (!getContext().getLoadedPackages().contains(s)) {
         if (!VersionUtilities.isCorePackage(s)) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/ValidationService.java
@@ -642,7 +642,7 @@ public class ValidationService {
     log.info(lineStart + " - Version " + txver + " (" + timeTracker.milestone() + ")");
     validationEngine.setDebug(validationEngineParameters.isDoDebug());
     validationEngine.getContext().setLogger(new Slf4JLoggingService(log));
-    loadIgsAndExtensions(validationEngine, validationEngineParameters.getIgs(), validationEngineParameters.isRecursive());
+    loadIgsAndExtensions(validationEngine, validationEngineParameters.getIgs(), validationEngineParameters.isRecursive(), validationEngineParameters.isOnlyDirectIgDependencies());
     if (validationEngineParameters.getTxCache() != null) {
       TerminologyCache cache = new TerminologyCache(new Object(), validationEngineParameters.getTxCache());
       validationEngine.getContext().initTxCache(cache);
@@ -705,15 +705,15 @@ public class ValidationService {
     return validationEngine;
   }
 
-  protected void loadIgsAndExtensions(ValidationEngine validationEngine, List<String> igs, boolean isRecursive) throws IOException, URISyntaxException {
+  protected void loadIgsAndExtensions(ValidationEngine validationEngine, List<String> igs, boolean isRecursive, boolean onlyDirectIgDependencies) throws IOException, URISyntaxException {
     IgLoader igLoader = new IgLoader(validationEngine.getPcm(), validationEngine.getContext(), validationEngine.getVersion(), validationEngine.isDebug());
-    igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), "hl7.terminology", false);
+    igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), "hl7.terminology", false, onlyDirectIgDependencies);
     if (!VersionUtilities.isR5Ver(validationEngine.getContext().getVersion())) {
-      igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), "hl7.fhir.uv.extensions", false);
+      igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), "hl7.fhir.uv.extensions", false, onlyDirectIgDependencies);
     }
 
     for (String src : igs) {
-      igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), src, isRecursive);
+      igLoader.loadIg(validationEngine.getIgs(), validationEngine.getBinaries(), src, isRecursive, onlyDirectIgDependencies);
     }
     log.info("  Package Summary: "+ validationEngine.getContext().loadedPackageSummary());
   }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContext.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContext.java
@@ -52,6 +52,10 @@ public class ValidationContext {
   @SerializedName("recursive")
   private
   boolean recursive = false;
+  @JsonProperty("onlyDirectIgDependencies")
+  @SerializedName("onlyDirectIgDependencies")
+  private
+  boolean onlyDirectIgDependencies = false;
   @JsonProperty("showMessagesFromReferences")
   @SerializedName("showMessagesFromReferences")
   private
@@ -399,6 +403,7 @@ public class ValidationContext {
     this.doNative = other.doNative;
     this.hintAboutNonMustSupport = other.hintAboutNonMustSupport;
     this.recursive = other.recursive;
+    this.onlyDirectIgDependencies = other.onlyDirectIgDependencies;
     this.showMessagesFromReferences = other.showMessagesFromReferences;
     this.doDebug = other.doDebug;
     this.assumeValidRestReferences = other.assumeValidRestReferences;
@@ -722,6 +727,19 @@ public class ValidationContext {
   @JsonProperty("recursive")
   public ValidationContext setRecursive(boolean recursive) {
     this.recursive = recursive;
+    return this;
+  }
+
+  @SerializedName("onlyDirectIgDependencies")
+  @JsonProperty("onlyDirectIgDependencies")
+  public boolean isOnlyDirectIgDependencies() {
+    return onlyDirectIgDependencies;
+  }
+
+  @SerializedName("onlyDirectIgDependencies")
+  @JsonProperty("onlyDirectIgDependencies")
+  public ValidationContext setOnlyDirectIgDependencies(boolean onlyDirectIgDependencies) {
+    this.onlyDirectIgDependencies = onlyDirectIgDependencies;
     return this;
   }
 
@@ -1379,6 +1397,7 @@ public class ValidationContext {
       doNative == that.doNative &&
       hintAboutNonMustSupport == that.hintAboutNonMustSupport &&
       recursive == that.recursive &&
+      onlyDirectIgDependencies == that.onlyDirectIgDependencies &&
       showMessagesFromReferences == that.showMessagesFromReferences &&
       doDebug == that.doDebug &&
       assumeValidRestReferences == that.assumeValidRestReferences &&
@@ -1458,7 +1477,7 @@ public class ValidationContext {
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseEngine, doNative, extensions, certSources, matchetypes, hintAboutNonMustSupport, recursive, doDebug, assumeValidRestReferences, checkReferences,canDoNative, noInternalCaching, resolutionContext, aiService,
+    return Objects.hash(baseEngine, doNative, extensions, certSources, matchetypes, hintAboutNonMustSupport, recursive, onlyDirectIgDependencies, doDebug, assumeValidRestReferences, checkReferences,canDoNative, noInternalCaching, resolutionContext, aiService,
       noExtensibleBindingMessages, noInvariants, displayWarnings, wantInvariantsInMessages, map, output, outputSuffix, htmlOutput, txServer, sv, txLog, txCache, mapLog, lang, srcLang, tgtLang, fhirpath, snomedCT,
       targetVer, packageName, igs, questionnaireMode, level, profiles, options, sources, inputs, mode, locale, locations, crumbTrails, showMessageIds, forPublication, showTimes, allowExampleUrls, outputStyle, jurisdiction, noUnicodeBiDiControlChars,
       watchMode, watchScanDelay, watchSettleTime, bestPracticeLevel, unknownCodeSystemsCauseErrors, noExperimentalContent, advisorFile, expansionParameters, format, htmlInMarkdownCheck, allowDoubleQuotesInFHIRPath, checkIPSCodes);
@@ -1474,6 +1493,7 @@ public class ValidationContext {
       ", matchetypes=" + matchetypes +
       ", hintAboutNonMustSupport=" + hintAboutNonMustSupport +
       ", recursive=" + recursive +
+      ", onlyDirectIgDependencies=" + onlyDirectIgDependencies +
       ", doDebug=" + doDebug +
       ", assumeValidRestReferences=" + assumeValidRestReferences +
       ", checkReferences=" + checkReferences +

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContextUtilities.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationContextUtilities.java
@@ -16,6 +16,7 @@ public class ValidationContextUtilities {
     validationContext.setInferFhirVersion(validationEngineParameters.isInferFhirVersion());
     validationContext.setDoNative(validationEngineParameters.isDoNative());
     validationContext.setRecursive(validationEngineParameters.isRecursive());
+    validationContext.setOnlyDirectIgDependencies(validationEngineParameters.isOnlyDirectIgDependencies());
     validationContext.setSnomedCT(validationEngineParameters.getSnomedCT());
     validationContext.setSv(validationEngineParameters.getSv());
     for (String ig : validationEngineParameters.getIgs()) {
@@ -153,6 +154,7 @@ public class ValidationContextUtilities {
     validationEngineParameters.setInferFhirVersion(validationContext.isInferFhirVersion());
     validationEngineParameters.setDoNative(validationContext.isDoNative());
     validationEngineParameters.setRecursive(validationContext.isRecursive());
+    validationEngineParameters.setOnlyDirectIgDependencies(validationContext.isOnlyDirectIgDependencies());
     validationEngineParameters.setSnomedCT(validationContext.getSnomedCT());
     validationEngineParameters.setSv(validationContext.getSv());
     for (String ig : validationContext.getIgs()) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationEngineParameters.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/service/model/ValidationEngineParameters.java
@@ -86,6 +86,24 @@ public class ValidationEngineParameters {
     return this;
   }
 
+  @JsonProperty("onlyDirectIgDependencies")
+  @SerializedName("onlyDirectIgDependencies")
+  private
+  boolean onlyDirectIgDependencies = false;
+
+  @SerializedName("onlyDirectIgDependencies")
+  @JsonProperty("onlyDirectIgDependencies")
+  public boolean isOnlyDirectIgDependencies() {
+    return onlyDirectIgDependencies;
+  }
+
+  @SerializedName("onlyDirectIgDependencies")
+  @JsonProperty("onlyDirectIgDependencies")
+  public ValidationEngineParameters setOnlyDirectIgDependencies(boolean onlyDirectIgDependencies) {
+    this.onlyDirectIgDependencies = onlyDirectIgDependencies;
+    return this;
+  }
+
   @JsonProperty("snomedCT")
   @SerializedName("snomedCT")
   private String snomedCT = "900000000000207008";
@@ -561,6 +579,7 @@ public class ValidationEngineParameters {
     return Objects.equals(baseEngine, that.baseEngine)
       && doNative == that.doNative
       && recursive == that.recursive
+      && onlyDirectIgDependencies == that.onlyDirectIgDependencies
       && snomedCT.equals(that.snomedCT)
       && Objects.equals(sv, that.sv)
       && isInferFhirVersion() == that.isInferFhirVersion()
@@ -593,6 +612,7 @@ public class ValidationEngineParameters {
       baseEngine,
       doNative,
       recursive,
+      onlyDirectIgDependencies,
       snomedCT,
       sv,
       inferFhirVersion,
@@ -625,6 +645,7 @@ public class ValidationEngineParameters {
       "baseEngine=" + baseEngine +
       ", doNative=" + doNative +
       ", recursive=" + recursive +
+      ", onlyDirectIgDependencies=" + onlyDirectIgDependencies +
       ", snomedCT=" + snomedCT +
       ", sv=" + sv +
       ", inferFhirVersion=" + inferFhirVersion +

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/IgLoaderTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/IgLoaderTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
+import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.hl7.fhir.utilities.ByteProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -170,5 +172,58 @@ public class IgLoaderTests {
     assertNotNull(es4);
     assertNotNull(es5);
 
+  }
+
+  @Test
+  public void testPackageIgLoadIncludesTransitiveDependenciesByDefault() throws IOException {
+    IgLoader igLoader = new IgLoader(filesystemPackageCacheManager, simpleWorkerContext, "4.0.1");
+
+    NpmPackage root = mockPackage("test.root", "1.0.0", "4.0.1", List.of("test.dep#1.0.0"));
+    NpmPackage dependency = mockPackage("test.dep", "1.0.0", "4.0.1", List.of("test.trans#1.0.0"));
+    NpmPackage transitiveDependency = mockPackage("test.trans", "1.0.0", "4.0.1", List.of());
+
+    doReturn(root).when(filesystemPackageCacheManager).loadPackage("test.root#1.0.0", null);
+    doReturn(dependency).when(filesystemPackageCacheManager).loadPackage("test.dep#1.0.0", null);
+    doReturn(transitiveDependency).when(filesystemPackageCacheManager).loadPackage("test.trans#1.0.0", null);
+    doReturn(new ArrayList<String>()).when(simpleWorkerContext).getLoadedPackages();
+    doReturn(timeTracker).when(simpleWorkerContext).clock();
+    doReturn("0").when(timeTracker).milestone();
+    doReturn(1).when(simpleWorkerContext).loadFromPackage(Mockito.any(), Mockito.any(), Mockito.eq(false));
+
+    igLoader.loadIg(Collections.emptyList(), Collections.emptyMap(), "test.root#1.0.0", false);
+
+    Mockito.verify(filesystemPackageCacheManager).loadPackage("test.root#1.0.0", null);
+    Mockito.verify(filesystemPackageCacheManager).loadPackage("test.dep#1.0.0", null);
+    Mockito.verify(filesystemPackageCacheManager).loadPackage("test.trans#1.0.0", null);
+  }
+
+  @Test
+  public void testPackageIgLoadCanLoadOnlyDirectDependencies() throws IOException {
+    IgLoader igLoader = new IgLoader(filesystemPackageCacheManager, simpleWorkerContext, "4.0.1");
+
+    NpmPackage root = mockPackage("test.root", "1.0.0", "4.0.1", List.of("test.dep#1.0.0"));
+    NpmPackage dependency = mockPackage("test.dep", "1.0.0", "4.0.1", List.of("test.trans#1.0.0"));
+
+    doReturn(root).when(filesystemPackageCacheManager).loadPackage("test.root#1.0.0", null);
+    doReturn(dependency).when(filesystemPackageCacheManager).loadPackage("test.dep#1.0.0", null);
+    doReturn(new ArrayList<String>()).when(simpleWorkerContext).getLoadedPackages();
+    doReturn(timeTracker).when(simpleWorkerContext).clock();
+    doReturn("0").when(timeTracker).milestone();
+    doReturn(1).when(simpleWorkerContext).loadFromPackage(Mockito.any(), Mockito.any(), Mockito.eq(false));
+
+    igLoader.loadIg(Collections.emptyList(), Collections.emptyMap(), "test.root#1.0.0", false, true);
+
+    Mockito.verify(filesystemPackageCacheManager).loadPackage("test.root#1.0.0", null);
+    Mockito.verify(filesystemPackageCacheManager).loadPackage("test.dep#1.0.0", null);
+    Mockito.verify(filesystemPackageCacheManager, Mockito.never()).loadPackage("test.trans#1.0.0", null);
+  }
+
+  private NpmPackage mockPackage(String id, String version, String fhirVersion, List<String> dependencies) {
+    NpmPackage npmPackage = Mockito.mock(NpmPackage.class);
+    Mockito.lenient().doReturn(id).when(npmPackage).id();
+    Mockito.lenient().doReturn(version).when(npmPackage).version();
+    Mockito.lenient().doReturn(fhirVersion).when(npmPackage).fhirVersion();
+    Mockito.lenient().doReturn(dependencies).when(npmPackage).dependencies();
+    return npmPackage;
   }
 }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/ValidationServiceTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/ValidationServiceTests.java
@@ -310,7 +310,7 @@ class ValidationServiceTests {
       }
 
       @Override
-      protected void loadIgsAndExtensions(ValidationEngine validationEngine, List<String> igs, boolean isRecursive) {
+      protected void loadIgsAndExtensions(ValidationEngine validationEngine, List<String> igs, boolean isRecursive, boolean onlyDirectIgDependencies) {
         //Don't care. Do nothing.
       }
     };

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/model/ValidationContextUtilitiesTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/model/ValidationContextUtilitiesTests.java
@@ -1,0 +1,22 @@
+package org.hl7.fhir.validation.service.model;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ValidationContextUtilitiesTests {
+
+  @Test
+  void testOnlyDirectIgDependenciesRoundTrip() {
+    ValidationEngineParameters validationEngineParameters = new ValidationEngineParameters()
+      .setRecursive(true)
+      .setOnlyDirectIgDependencies(true)
+      .addIg("hl7.fhir.us.core");
+
+    ValidationContext validationContext = new ValidationContext();
+    ValidationContextUtilities.addValidationEngineParameters(validationContext, validationEngineParameters);
+
+    assertTrue(validationContext.isOnlyDirectIgDependencies());
+    assertTrue(ValidationContextUtilities.getValidationEngineParameters(validationContext).isOnlyDirectIgDependencies());
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new CLI flag `-only-direct-ig-dependencies` to the Java validator that prevents transitive
package dependencies from being loaded when resolving `-ig` package references.

By default the validator walks the full dependency tree of every loaded package. This flag limits
loading to direct dependencies only — for every package loaded (including the hardcoded ones such
as `hl7.terminology` and `hl7.fhir.uv.extensions`).

**Warning:** Enabling this flag may cause validation errors if resources rely on content from
transitively loaded packages.

## Changes

- `ValidationEngineOptions` — new `@CommandLine.Option` field `-only-direct-ig-dependencies`
- `ValidationEngineOptionsConvertor` — maps the CLI flag to `ValidationEngineParameters`
- `ValidationEngineParameters` — new `onlyDirectIgDependencies` field (with `equals`/`hashCode`/`toString`)
- `ValidationContext` — same field added, including copy constructor, `equals`/`hashCode`/`toString`
- `ValidationContextUtilities` — bi-directional mapping between `ValidationContext` and `ValidationEngineParameters`
- `ValidationService#loadIgsAndExtensions` — passes the flag through to `IgLoader` for all packages,
  including `hl7.terminology` and `hl7.fhir.uv.extensions`
- `IgLoader` — new 5-arg `loadIg` overload; when flag is set, direct dependencies are loaded via
  `loadPackageIntoContext` without recursing; extracted `loadPackageIntoContext` helper to remove
  code duplication

## Tests

- `IgLoaderTests` — two new unit tests: verifies default transitive loading behaviour is unchanged,
  and verifies that transitive deps are skipped when the flag is set
- `ValidationEngineOptionsConvertorTest` — new parameterized case for the flag mapping
- `ValidationContextUtilitiesTests` — new round-trip test (`ValidationEngineParameters` →
  `ValidationContext` → `ValidationEngineParameters`)
