### PR TITLE
[codex] Bound FHIR web calls across retries

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedFhirWebAccessor.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedFhirWebAccessor.java
@@ -5,7 +5,6 @@ import org.hl7.fhir.utilities.ToolingClientLogger;
 import org.hl7.fhir.utilities.http.okhttpimpl.LoggingInterceptor;
 import org.hl7.fhir.utilities.http.okhttpimpl.ProxyAuthenticator;
 import org.hl7.fhir.utilities.http.okhttpimpl.RetryInterceptor;
-import org.hl7.fhir.utilities.settings.ServerDetailsPOJO;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -133,7 +132,15 @@ public class ManagedFhirWebAccessor extends ManagedWebAccessorBase<ManagedFhirWe
     builder.proxyAuthenticator(new ProxyAuthenticator());
     return builder.connectTimeout(timeout, timeoutUnit)
       .writeTimeout(timeout, timeoutUnit)
-      .readTimeout(timeout, timeoutUnit).build();
+      .readTimeout(timeout, timeoutUnit)
+      .callTimeout(calculateCallTimeout(timeout, timeoutUnit, retries), TimeUnit.MILLISECONDS).build();
+  }
+
+  static long calculateCallTimeout(long perAttemptTimeout, TimeUnit perAttemptTimeoutUnit, int retries) {
+    long attemptTimeoutMillis = perAttemptTimeoutUnit.toMillis(perAttemptTimeout);
+    int attempts = Math.max(0, retries) + 1;
+    return Math.addExact(Math.multiplyExact(attemptTimeoutMillis, attempts),
+      Math.multiplyExact(RetryInterceptor.RETRY_DELAY_MILLIS, Math.max(0, retries)));
   }
 
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/okhttpimpl/RetryInterceptor.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/okhttpimpl/RetryInterceptor.java
@@ -8,23 +8,19 @@ import okhttp3.Response;
 import java.io.IOException;
 
 /**
- * An {@link Interceptor} for {@link okhttp3.OkHttpClient} that controls the number of times we retry a to execute a
- * given request, before reporting a failure. This includes unsuccessful return codes and timeouts.
+ * An {@link Interceptor} for {@link okhttp3.OkHttpClient} that controls the number of times we retry a request
+ * before reporting a failure. This includes unsuccessful return codes and timeouts.
  */
 @Slf4j
 public class RetryInterceptor implements Interceptor {
 
-  // Delay between retying failed requests, in millis
-  private final long RETRY_TIME = 2000;
+  public static final long RETRY_DELAY_MILLIS = 2000;
 
   // Maximum number of times to retry the request before failing
   private final int maxRetry;
 
-  // Internal counter for tracking the number of times we've tried this request
-  private int retryCounter = 0;
-
   public RetryInterceptor(int maxRetry) {
-    this.maxRetry = maxRetry;
+    this.maxRetry = Math.max(0, maxRetry);
   }
 
   @Override
@@ -32,30 +28,39 @@ public class RetryInterceptor implements Interceptor {
     Request request = chain.request();
     Response response = null;
 
-    do {
+    for (int attempt = 0; attempt <= maxRetry; attempt++) {
       try {
-        // If we are retrying a failed request that failed due to a bad response from the server, we must close it first
         if (response != null) {
           response.close();
+          response = null;
         }
         response = chain.proceed(request);
-      } catch (IOException e) {
-        try {
-          // Include a small break in between requests.
-          Thread.sleep(RETRY_TIME);
-        } catch (InterruptedException e1) {
-          log.info(chain.request().method() + " to url -> " + chain.request().url() + " interrupted on try <" + retryCounter + ">");
-        }
-      } finally {
-        retryCounter++;
-      }
-    } while ((response == null || !response.isSuccessful()) && (retryCounter <= maxRetry + 1));
 
-    /*
-     * if something has gone wrong, and we are unable to complete the request, we still need to initialize the return
-     * response so we don't get a null pointer exception.
-     */
-    return response != null ? response : chain.proceed(request);
+        if (response.isSuccessful() || attempt == maxRetry) {
+          return response;
+        }
+      } catch (IOException e) {
+        if (attempt == maxRetry) {
+          throw e;
+        }
+      }
+
+      try {
+        Thread.sleep(RETRY_DELAY_MILLIS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        log.info(chain.request().method() + " to url -> " + chain.request().url()
+          + " interrupted on try <" + attempt + ">");
+        if (response != null) {
+          return response;
+        }
+        throw new IOException("Interrupted while waiting to retry " + request.method()
+          + " to " + request.url(), e);
+      }
+    }
+
+    throw new IOException("Request retry loop exited without a response for " + request.method()
+      + " to " + request.url());
   }
 
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedFhirWebAccessorTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedFhirWebAccessorTests.java
@@ -1,14 +1,21 @@
 package org.hl7.fhir.utilities.http;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.doReturn;
 
 public class ManagedFhirWebAccessorTests {
@@ -48,5 +55,37 @@ public class ManagedFhirWebAccessorTests {
     Assertions.assertNotNull(HTTPHeaderUtil.getSingleHeader(requestWithDefaultHeaders.getHeaders(),"User-Agent"), "User-Agent header null.");
     Assertions.assertEquals(expectedUserAgent, HTTPHeaderUtil.getSingleHeader(requestWithDefaultHeaders.getHeaders(),"User-Agent"),
       "User-Agent header not populated with expected value \""+expectedUserAgent+"\".");
+  }
+
+  @Test
+  @DisplayName("Test the call timeout includes the configured retry budget.")
+  void callTimeoutIncludesRetries() {
+    Assertions.assertEquals(5000, ManagedFhirWebAccessor.calculateCallTimeout(5000, TimeUnit.MILLISECONDS, 0));
+    Assertions.assertEquals(19000, ManagedFhirWebAccessor.calculateCallTimeout(5000, TimeUnit.MILLISECONDS, 2));
+  }
+
+  @Test
+  @DisplayName("Test timed out calls do not retry when retries are disabled.")
+  void timeoutWithNoRetriesMakesOneAttempt() throws IOException {
+    MockWebServer server = new MockWebServer();
+    try {
+      server.enqueue(new MockResponse()
+        .setHeadersDelay(5, TimeUnit.SECONDS)
+        .setBody("{}"));
+
+      ManagedFhirWebAccessor accessor = new ManagedFhirWebAccessor(expectedUserAgent, null)
+        .withTimeout(250, TimeUnit.MILLISECONDS)
+        .withRetries(0);
+      HTTPRequest request = new HTTPRequest()
+        .withUrl(server.url("/metadata").toString())
+        .withMethod(HTTPRequest.HttpMethod.GET);
+
+      assertTimeoutPreemptively(Duration.ofMillis(1500),
+        () -> assertThrows(IOException.class, () -> accessor.httpCall(request)));
+
+      Assertions.assertEquals(1, server.getRequestCount());
+    } finally {
+      server.shutdown();
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds a whole-call timeout to `ManagedFhirWebAccessor` and tightens retry accounting in `RetryInterceptor` so stalled FHIR web calls are bounded across retries.

## Original bug

An IG Publisher run could hang for hours during terminology validation. The observed thread dump showed the publisher blocked in OkHttp while waiting for response headers from a terminology call:

- `okhttp3.internal.http2.Http2Stream.waitForIo`
- `okhttp3.internal.http2.Http2Stream.takeHeaders`
- `RetryInterceptor.intercept`
- `ManagedFhirWebAccessor.httpCall`
- R4 terminology client validation code

In that state, the existing retry interceptor could not help because the call never returned to the interceptor as either a response or an exception.

## Trigger

The failure mode is triggered when a terminology server connection accepts a request but then stalls before returning response headers. In the reported case this happened while IG Publisher was validating terminology through `tx.fhir.org`; locally, the same shape can be reproduced by pointing publisher `-tx` at a proxy that passes through metadata requests but intentionally holds a `$validate-code` response open.

## Fix

The change configures OkHttp `callTimeout` in addition to the existing connect/write/read timeouts. The call timeout is computed from:

- the per-attempt timeout already configured on the accessor
- the configured retry count
- the retry delay between attempts

That gives each attempt the existing timeout budget while still bounding the entire call, including retries and retry sleeps.

The retry interceptor was also updated to:

- treat `maxRetry` as the number of retries after the initial attempt
- avoid mutable interceptor-level retry state
- close unsuccessful responses before retrying
- return the final unsuccessful response or rethrow the final `IOException`
- preserve interrupt status if retry sleep is interrupted

## Testing

Local validation performed:

- `git diff --check`
- `../../bin/gym mvn -pl org.hl7.fhir.utilities -Dtest=ManagedFhirWebAccessorTests -Danimal.sniffer.skip=true test`
  - `ManagedFhirWebAccessorTests`: 4 tests, 0 failures, 0 errors
- `../../bin/gym build-core`
  - passed
- `../../bin/gym build-publisher --local-core`
  - passed; publisher jar was rebuilt with the patched local core
- Publisher-level smoke test:
  - ran the rebuilt IG Publisher jar against a temporary SMART Web Messaging IG with an added LOINC/UCUM Observation
  - used `-tx http://127.0.0.1:8765/r4`
  - local proxy passed through `GET /r4/metadata` and related lookup GETs to `https://tx.fhir.org`
  - local proxy intentionally stalled the first `POST /r4/CodeSystem/$validate-code` before response headers
  - publisher completed in about 85 seconds under a 300-second hard guard

The publisher smoke test was HTTP/1.1 rather than the exact HTTP/2 production path, but it exercises the same response-header stall class that left the original run blocked inside OkHttp.
