### PR TITLE
Fix intermittent ScannerTest failure due to test order

### DIFF
--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/ScannerTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/ScannerTest.java
@@ -10,11 +10,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
+import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r5.model.OperationOutcome;
@@ -139,11 +138,8 @@ public class ScannerTest implements ResourceLoaderTests {
    * */
   private List<ScanOutputItem> getFakeResults(List<String> sources, SimpleWorkerContext context) {
     String ref = sources.get(0);
-
-    // The id of this IG itself is a 'malicious' script element.
-    ImplementationGuide ig = context.allImplementationGuides().stream()
-        .filter(i -> "<script>alert(\"package.json.name\")</script>".equals(i.getId()))
-        .findFirst().orElse(null);
+    // The URI of this IG itself is a 'malicious' script element.
+    ImplementationGuide ig = context.fetchResource(ImplementationGuide.class, "http://example.org/fhir/ImplementationGuide/<script>alert(\"package.json.name\")</script>", IWorkerContext.VersionResolutionRules.LATEST);
 
     // The profile
     StructureDefinition profile = context.fetchResource(StructureDefinition.class,


### PR DESCRIPTION
ScannerTest fails when other tests save hl7.fhir.uv.ips#1.1.0 in the cache in R5  format.

This change requests the required IG for the test with more specificity, bypassing the need to reload all other IGs from the cache and bypassing this issue.

