### PR TITLE
Exact-match the package id in getPackageUrl so dependsOn validation stops reporting spurious canonical clashes

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/BasePackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/BasePackageCacheManager.java
@@ -135,11 +135,16 @@ public abstract class BasePackageCacheManager implements IPackageCacheManager {
   private String getPackageUrl(String packageId, PackageServer server) throws IOException {
     PackageClient pc = myClientFactory.apply(server);
     List<PackageInfo> res = pc.search(packageId, null, null, false, null);
-    if (res.size() == 0) {
-      return null;
-    } else {
-      return res.get(0).getUrl();
+    // Exact-match the package id and return its canonical. The prior code took res.get(0).getUrl(),
+    // which (a) fuzzy-matched siblings (e.g. "hl7.terminology.r4" hitting "hl7.terminology.r4b") and
+    // (b) returned the package download url rather than the canonical, producing spurious
+    // IG_DEPENDENCY_CLASH_CANONICAL errors on a cache miss.
+    for (PackageInfo pi : res) {
+      if (packageId.equals(pi.getId())) {
+        return pi.getCanonical();
+      }
     }
+    return null;
   }
 
 


### PR DESCRIPTION
## Problem

Validating an IG's `ImplementationGuide.dependsOn` can report a dependency as clashing with its own canonical when nothing is actually wrong:

> The packageId hl7.terminology.r4 points to the canonical https://packages2.fhir.org/web/hl7.terminology.r4b-6.0.2.tgz which is inconsistent with the stated canonical of http://terminology.hl7.org/

The stated canonical (`http://terminology.hl7.org/`) is correct. The "points to" value is wrong twice over: it is the **`r4b`** sibling package rather than `r4`, and it is a **`.tgz` download URL**, not a canonical.

Real-world case: AU Base 6.1.x on GitHub-hosted runners. We keep the package cache in a custom folder (`-package-cache-folder`), so the *default* `~/.fhir/packages` is cold. Every `dependsOn` on `hl7.terminology.r4` (plus `hl7.fhir.uv.extensions.r4` and `hl7.fhir.uv.xver-r5.r4`) tripped this, producing 3 spurious QA errors. build.fhir.org never sees them because its default cache is warm, so the lookup stays on the cache-hit path.

## Root cause

`ImplementationGuideValidator.checkDependency` resolves the canonical with `pcm.getPackageUrl(packageId)` and compares it to the stated `uri`. (It builds `new FilesystemPackageCacheManager.Builder().build()`, i.e. the **default** cache location; a configured `-package-cache-folder` is not consulted here.)

In `BasePackageCacheManager.getPackageUrl`, the cache-hit branch returns `npm.canonical()`, which is correct. On a **cache miss** it falls through to a package-server search:

```java
private String getPackageUrl(String packageId, PackageServer server) throws IOException {
    PackageClient pc = myClientFactory.apply(server);
    List<PackageInfo> res = pc.search(packageId, null, null, false, null);
    if (res.size() == 0) {
      return null;
    } else {
      return res.get(0).getUrl();
    }
}
```

Two problems:
- `pc.search()` matches by substring, so `hl7.terminology.r4` also returns `hl7.terminology.r4b`, and `res.get(0)` takes whichever comes back first.
- it returns `.getUrl()` (the package download URL), not `.getCanonical()`.

So on a cold cache the "canonical" comes back as `.../hl7.terminology.r4b-6.0.2.tgz`, which can never equal the stated canonical, and the clash rule fires. `getPackageId`, the inverse lookup directly below it, already iterates the results and matches on `getCanonical()`; this brings `getPackageUrl` into line.

## Fix

Iterate the results, match the package id exactly, and return that package's canonical, consistent with the cache-hit branch:

```java
for (PackageInfo pi : res) {
  if (packageId.equals(pi.getId())) {
    return pi.getCanonical();
  }
}
return null;
```

No signature change, and a genuine miss still returns `null` (the caller already treats `null` as "no clash"). The only behavioural change is that a partial/sibling name no longer resolves to an unrelated package's download URL.

## Testing

Built the jar and rebuilt AU Base 6.1.1-draft with it: the three canonical clashes (`hl7.terminology.r4`, `hl7.fhir.uv.extensions.r4`, `hl7.fhir.uv.xver-r5.r4`) no longer appear in QA, and no other messages changed.

## Additional related bug found

The dependsOn check building its own cache manager at the default location (rather than the one the run was configured with) is a related latent issue: it is why a cold default cache is reachable at all in a build that otherwise uses `-package-cache-folder`. Honouring the configured cache folder there is broader and out of scope here; this change makes the resolution itself correct regardless of which cache the check reads.
