### PR TITLE
R6 RDF concept IRI fix for examples - FHIR-57496

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleConceptIri.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleConceptIri.java
@@ -1,0 +1,110 @@
+package org.hl7.fhir.r5.elementmodel;
+
+import java.util.List;
+
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.model.NamingSystem;
+import org.hl7.fhir.r5.model.NamingSystem.NamingSystemIdentifierType;
+import org.hl7.fhir.r5.model.NamingSystem.NamingSystemType;
+import org.hl7.fhir.r5.terminologies.NamingSystemUtilities;
+import org.hl7.fhir.utilities.Utilities;
+
+/**
+ * An RDF (Turtle) Concept IRI is the RDF-equivalent of a FHIR Coding 
+ * as specified by the IRI stem registered in the NamingSystem that corresponds to the Coding.system.
+ * <p>
+ * This class also serves as a registry of well-known concept IRIs (SNOMED CT, LOINC, MeSH)
+ * via {@link #forSystem(String)} and {@link #forIriStem(String)}.
+ */
+class TurtleConceptIri {
+
+  private static final String SNOMED_SYSTEM = "http://snomed.info/sct";
+
+  /** Known code systems and how to render their codes as RDF concept IRIs in Turtle. */
+  private static final List<TurtleConceptIri> KNOWN_CONCEPT_IRIS = List.of(
+      new TurtleConceptIri(SNOMED_SYSTEM, "http://snomed.info/id/", "sct", false),
+      new TurtleConceptIri("http://loinc.org", "https://loinc.org/rdf/", "loinc", true),
+      new TurtleConceptIri("https://www.nlm.nih.gov/mesh", "http://id.nlm.nih.gov/mesh/", "mesh", false));
+
+  final String system;
+  final String iriStem;
+  final String prefix;
+  final boolean upperCaseCode;
+
+  TurtleConceptIri(String system, String iriStem, String prefix, boolean upperCaseCode) {
+    this.system = system;
+    this.iriStem = iriStem;
+    this.prefix = prefix;
+    this.upperCaseCode = upperCaseCode;
+  }
+
+  /** Concept IRI with only a stem — used when a NamingSystem declares a stem we don't recognize. */
+  static TurtleConceptIri stemOnly(String iriStem) {
+    return new TurtleConceptIri(null, iriStem, null, false);
+  }
+
+  /** Returns the known concept IRI for the given code system URL, or {@code null} if unknown. */
+  static TurtleConceptIri forSystem(String system) {
+    for (TurtleConceptIri iri : KNOWN_CONCEPT_IRIS) {
+      if (iri.system.equals(system)) {
+        return iri;
+      }
+    }
+    return null;
+  }
+
+  /** Returns the known concept IRI whose stem matches, or {@code null} if none does. */
+  static TurtleConceptIri forIriStem(String iriStem) {
+    for (TurtleConceptIri iri : KNOWN_CONCEPT_IRIS) {
+      if (iri.iriStem.equals(iriStem)) {
+        return iri;
+      }
+    }
+    return null;
+  }
+
+  /** Resolves the built-in concept IRI to use for {@code system}, or {@code null} if none applies. */
+  static TurtleConceptIri resolve(IWorkerContext context, String system) {
+    return resolve(context, system, false);
+  }
+
+  /** Resolves the concept IRI to use for {@code system}, or {@code null} if none applies. */
+  static TurtleConceptIri resolve(IWorkerContext context, String system, boolean lookupNamingSystem) {
+    TurtleConceptIri known = forSystem(system);
+    if (known != null || !lookupNamingSystem) {
+      return known;
+    }
+    String iriStem = iriStemFrom(NamingSystemUtilities.getNamingSystem(context, system));
+    if (Utilities.noString(iriStem)) {
+      return null;
+    }
+    TurtleConceptIri byStem = forIriStem(iriStem);
+    return byStem != null ? byStem : stemOnly(iriStem);
+  }
+
+  /** Returns the IRI stem declared on a code-system {@link NamingSystem}, or {@code null} if none. */
+  static String iriStemFrom(NamingSystem namingSystem) {
+    if (namingSystem == null || namingSystem.getKind() != NamingSystemType.CODESYSTEM) {
+      return null;
+    }
+    for (NamingSystem.NamingSystemUniqueIdComponent uniqueId : namingSystem.getUniqueId()) {
+      if (uniqueId.getType() == NamingSystemIdentifierType.IRISTEM && uniqueId.hasValue()) {
+        return uniqueId.getValue();
+      }
+    }
+    return null;
+  }
+
+  /** Renders {@code code} as a concept IRI, or {@code null} if this IRI cannot render it. */
+  String render(String code) {
+    // Post-coordinated codes not supported, but could be translate to OWL in some cases
+    if (SNOMED_SYSTEM.equals(system) && (code.contains(":") || code.contains("="))) {
+      return null;
+    }
+    String renderedCode = upperCaseCode ? TurtleParserBase.urlescape(code).toUpperCase() : TurtleParserBase.urlescape(code);
+    if (prefix != null) {
+      return prefix + ":" + renderedCode;
+    }
+    return "<" + iriStem + renderedCode + ">";
+  }
+}

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -49,6 +49,8 @@ import org.hl7.fhir.utilities.turtle.Turtle.Section;
 @MarkedToMoveToAdjunctPackage
 public class TurtleParser extends TurtleParserBase {
 
+  private boolean deriveConceptIriFromNamingSystem;
+
   // `volatile` so the one-shot lazy publish of the cross-version delegates is visible across threads.
   // Per-call setting sync below is intentionally NOT synchronized: the inherited ParserBase
   // setters/fields aren't thread-safe to begin with, and parse()/compose() mutate other
@@ -108,6 +110,18 @@ public class TurtleParser extends TurtleParserBase {
     delegate.canonicalFilter = canonicalFilter;
     delegate.setStyle(getStyle());
     delegate.base = base;
+    if (delegate instanceof TurtleParserR6) {
+      ((TurtleParserR6) delegate).setDeriveConceptIriFromNamingSystem(deriveConceptIriFromNamingSystem);
+    }
+  }
+
+  public boolean isDeriveConceptIriFromNamingSystem() {
+    return deriveConceptIriFromNamingSystem;
+  }
+
+  public TurtleParser setDeriveConceptIriFromNamingSystem(boolean deriveConceptIriFromNamingSystem) {
+    this.deriveConceptIriFromNamingSystem = deriveConceptIriFromNamingSystem;
+    return this;
   }
 
   @Override

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParser.java
@@ -42,6 +42,8 @@ import org.hl7.fhir.r5.formats.IParser.OutputStyle;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.turtle.Turtle;
+import org.hl7.fhir.utilities.turtle.Turtle.Complex;
+import org.hl7.fhir.utilities.turtle.Turtle.Section;
 
 
 @MarkedToMoveToAdjunctPackage
@@ -167,5 +169,33 @@ public class TurtleParser extends TurtleParserBase {
 
   public static String getClassName(String name) {
     return name; // R5 ShEx type names are not transformed
+  }
+
+  @Override
+  protected void decorateCoding(Complex t, Element coding, Section section) throws FHIRException {
+    String system = coding.getChildValue("system");
+    String code = coding.getChildValue("code");
+
+    if (system == null || code == null)
+      return;
+    if ("http://snomed.info/sct".equals(system)) {
+      t.prefix("sct", "http://snomed.info/id/");
+      if (code.contains(":") || code.contains("=")) {
+        // Post-coordinated expressions aren't supported
+      } else {
+        t.linkedPredicate("a", "sct:" + urlescape(code), null, null);
+      }
+    } else if ("http://loinc.org".equals(system)) {
+      t.prefix("loinc", "https://loinc.org/rdf/");
+      t.linkedPredicate("a", "loinc:"+urlescape(code).toUpperCase(), null, null);
+    } else if ("https://www.nlm.nih.gov/mesh".equals(system)) {
+      t.prefix("mesh", "http://id.nlm.nih.gov/mesh/");
+      t.linkedPredicate("a", "mesh:"+urlescape(code), null, null);
+    }
+  }
+
+  @Override
+  protected void decorateCodeableConcept(Complex t, Element codeableConcept, Section section) throws FHIRException {
+    // Do nothing in R5
   }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserBase.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserBase.java
@@ -76,6 +76,8 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 public abstract class TurtleParserBase extends ParserBase {
 
   protected String base;
+  /** Type of the resource currently being composed; set in {@link #compose(Element, Turtle, String)}. */
+  protected String resourceType;
   private OutputStyle style;
 
   public static String FHIR_URI_BASE = "http://hl7.org/fhir/";
@@ -330,6 +332,7 @@ public abstract class TurtleParserBase extends ParserBase {
     if (e.getPath() == null) {
       e.populatePaths(null);
     }
+    resourceType = e.getType();
 
     ttl.prefix("fhir", FHIR_URI_BASE);
     ttl.prefix("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserBase.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserBase.java
@@ -411,7 +411,7 @@ public abstract class TurtleParserBase extends ParserBase {
       return "<" + Utilities.pathURL(base, e.getType(), id) + ">";
   }
 
-  protected String urlescape(String s) {
+  protected static String urlescape(String s) {
     StringBuilder b = new StringBuilder();
     for (char ch : s.toCharArray()) {
       if (Utilities.charInSet(ch,  ':', ';', '=', ','))
@@ -462,6 +462,11 @@ public abstract class TurtleParserBase extends ParserBase {
 
     if ("Coding".equals(element.getType()))
       decorateCoding(t, element, section);
+
+    if ("CodeableConcept".equals(element.getType())) {
+      decorateCodeableConcept(t, element, section);
+    }
+
     if (Utilities.existsInList(element.getType(), "Reference"))
       decorateReference(t, element);
 
@@ -572,30 +577,13 @@ public abstract class TurtleParserBase extends ParserBase {
   }
 
   protected void decorateCoding(Complex t, Element coding, Section section) throws FHIRException {
-    String system = coding.getChildValue("system");
-    String code = coding.getChildValue("code");
-
-    if (system == null || code == null)
-      return;
-    if ("http://snomed.info/sct".equals(system)) {
-      t.prefix("sct", "http://snomed.info/id/");
-      if (code.contains(":") || code.contains("="))
-        generateLinkedPredicate(t, code);
-      else
-        t.linkedPredicate("a", "sct:" + urlescape(code), null, null);
-    } else if ("http://loinc.org".equals(system)) {
-      t.prefix("loinc", "https://loinc.org/rdf/");
-      t.linkedPredicate("a", "loinc:"+urlescape(code).toUpperCase(), null, null);
-    } else if ("https://www.nlm.nih.gov/mesh".equals(system)) {
-      t.prefix("mesh", "http://id.nlm.nih.gov/mesh/");
-      t.linkedPredicate("a", "mesh:"+urlescape(code), null, null);
-    }  
+    // Do nothing by default
   }
 
-  private void generateLinkedPredicate(Complex t, String code) throws FHIRException {
-    Expression expression = SnomedExpressions.parse(code);
-
+  protected void decorateCodeableConcept(Complex t, Element codeableConcept, Section section) throws FHIRException {
+    // Do nothing by default
   }
+
   public OutputStyle getStyle() {
     return style;
   }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserR6.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserR6.java
@@ -39,6 +39,7 @@ import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.turtle.Turtle;
 import org.hl7.fhir.utilities.turtle.Turtle.Complex;
+import org.hl7.fhir.utilities.turtle.Turtle.Section;
 import org.hl7.fhir.utilities.turtle.Turtle.Subject;
 
 
@@ -76,6 +77,16 @@ public class TurtleParserR6 extends TurtleParserBase {
     if (Utilities.existsInList(element.getType(), "canonical", "oid", "uri", "url", "uuid")) {
       linkURI(t, element.primitiveValue(), element.getType());
     }
+  }
+
+  @Override
+  protected void decorateCoding(Complex t, Element coding, Section section) throws FHIRException {
+    // Do nothing in R6
+  }
+
+  @Override
+  protected void decorateCodeableConcept(Complex t, Element codeableConcept, Section section) throws FHIRException {
+    // Do nothing in R6
   }
 
   @Override

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserR6.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/TurtleParserR6.java
@@ -31,13 +31,15 @@ package org.hl7.fhir.r5.elementmodel;
 
 
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r5.extensions.ExtensionDefinitions;
 import org.hl7.fhir.r5.extensions.ExtensionUtilities;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
 import org.hl7.fhir.utilities.Utilities;
-import org.hl7.fhir.utilities.turtle.Turtle;
 import org.hl7.fhir.utilities.turtle.Turtle.Complex;
 import org.hl7.fhir.utilities.turtle.Turtle.Section;
 import org.hl7.fhir.utilities.turtle.Turtle.Subject;
@@ -46,8 +48,23 @@ import org.hl7.fhir.utilities.turtle.Turtle.Subject;
 @MarkedToMoveToAdjunctPackage
 public class TurtleParserR6 extends TurtleParserBase {
 
+  private final Map<String, TurtleConceptIri> conceptIriCache = new HashMap<>();
+  private boolean deriveConceptIriFromNamingSystem;
+
   public TurtleParserR6(IWorkerContext context) {
     super(context);
+  }
+
+  public boolean isDeriveConceptIriFromNamingSystem() {
+    return deriveConceptIriFromNamingSystem;
+  }
+
+  public TurtleParserR6 setDeriveConceptIriFromNamingSystem(boolean deriveConceptIriFromNamingSystem) {
+    if (this.deriveConceptIriFromNamingSystem != deriveConceptIriFromNamingSystem) {
+      conceptIriCache.clear();
+    }
+    this.deriveConceptIriFromNamingSystem = deriveConceptIriFromNamingSystem;
+    return this;
   }
 
   protected String getReferenceURI(String ref) {
@@ -84,9 +101,20 @@ public class TurtleParserR6 extends TurtleParserBase {
     // Do nothing in R6
   }
 
+  private boolean isDefinitionalResource(String resourceType) {
+    return resourceType.endsWith("Definition");
+  }
+
   @Override
   protected void decorateCodeableConcept(Complex t, Element codeableConcept, Section section) throws FHIRException {
-    // Do nothing in R6
+    if (isDefinitionalResource(resourceType)) {
+      // Don't assert `rdf:type` for CodeableConcepts that used in definitional ways (describing a class of codes) instead of as instance data
+      // Example: ElementDefinition.pattern (CodeableConcept) defines a class of values that all target Elements must have
+      return;
+    }
+    for (Element coding : codeableConcept.getChildrenByName("coding")) {
+      decorateCodeableConceptFromNamingSystem(t, coding);
+    }
   }
 
   @Override
@@ -120,5 +148,35 @@ public class TurtleParserR6 extends TurtleParserBase {
     if (refURI != null) {
       t.linkedPredicate(getReferencePredicate(), refURI, linkResolver == null ? null : linkResolver.resolveType(type), null);
     }
+  }
+
+  private void decorateCodeableConceptFromNamingSystem(Complex codeableConcept, Element coding) {
+    String system = coding.getChildValue("system");
+    String code = coding.getChildValue("code");
+    if (system == null || code == null) {
+      return;
+    }
+
+    TurtleConceptIri conceptIri = getConceptIri(system);
+    if (conceptIri == null) {
+      return;
+    }
+    String iri = conceptIri.render(code);
+    if (iri == null) {
+      return;
+    }
+    if (conceptIri.prefix != null) {
+      codeableConcept.prefix(conceptIri.prefix, conceptIri.iriStem);
+    }
+    codeableConcept.linkedPredicate("a", iri, null, null);
+  }
+
+  private TurtleConceptIri getConceptIri(String system) {
+    if (conceptIriCache.containsKey(system)) {
+      return conceptIriCache.get(system);
+    }
+    TurtleConceptIri resolved = TurtleConceptIri.resolve(context, system, deriveConceptIriFromNamingSystem);
+    conceptIriCache.put(system, resolved);
+    return resolved;
   }
 }

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/TurtleGeneratorTestUtils.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/TurtleGeneratorTestUtils.java
@@ -62,6 +62,14 @@ public final class TurtleGeneratorTestUtils {
       return workerContext;
     }
 
+    public void setDeriveConceptIriFromNamingSystem(boolean deriveConceptIriFromNamingSystem) {
+      turtleParser.setDeriveConceptIriFromNamingSystem(deriveConceptIriFromNamingSystem);
+    }
+    
+    public String getFhirVersion() {
+      return workerContext.getVersion();
+    }
+
     
     // ---------------------------------------------------------------------------
     // TTL parsers
@@ -89,14 +97,19 @@ public final class TurtleGeneratorTestUtils {
         InputStream inputXmlStream = ManagedFileAccess.inStream(xmlResourcePath.toString());
         OutputStream outputTurtleStream = ManagedFileAccess.outStream(turtleFilePath)
       ) {
-        System.out.println("Generating " + turtleFilePath);
         generateTurtleFromXmlStream(inputXmlStream, outputTurtleStream);
         return turtleFilePath;
       }
     }
 
     public void generateTurtleFromXmlStream(InputStream xmlStream, OutputStream turtleStream) throws IOException, UcumException {
-      Element resourceElement = parseXmlResource(xmlStream);
+      Element resourceElement;
+      try {
+        resourceElement = parseXmlResource(xmlStream);
+      } catch (Exception ex) {
+        System.out.println("Unable to parse XML -- not relevant for Turtle generation");
+        return;
+      }
       turtleParser.compose(resourceElement, turtleStream, OutputStyle.PRETTY, null);
     }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/TurtleGeneratorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/TurtleGeneratorTests.java
@@ -2,16 +2,20 @@ package org.hl7.fhir.r5.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,11 +23,18 @@ import java.util.stream.Collectors;
 
 import org.fhir.ucum.UcumException;
 import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
 import org.hl7.fhir.r5.elementmodel.ParserBase;
 import org.hl7.fhir.r5.elementmodel.ParserBase.IdRenderingPolicy;
 import org.hl7.fhir.r5.elementmodel.ParserBase.ValidationPolicy;
 import org.hl7.fhir.r5.elementmodel.TurtleParser;
 import org.hl7.fhir.r5.elementmodel.TurtleParserR6;
+import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r5.model.NamingSystem;
+import org.hl7.fhir.r5.model.NamingSystem.NamingSystemIdentifierType;
+import org.hl7.fhir.r5.model.NamingSystem.NamingSystemType;
+import org.hl7.fhir.r5.terminologies.NamingSystemUtilities;
+import org.hl7.fhir.r5.test.TurtleGeneratorTestUtils.ParserContext;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.hl7.fhir.utilities.turtle.Turtle;
 import org.hl7.fhir.utilities.FileUtilities;
@@ -51,6 +62,10 @@ public class TurtleGeneratorTests {
   private static TurtleGeneratorTestUtils.ParserContext r6Parsers;
   private static final String R4_VERSION = "4.0.1";
   private static final String R6_VERSION = "6.0.0";
+  private static final String TEST_CODE_SYSTEM = "http://example.org/fhir/CodeSystem/test";
+  private static final String TEST_IRI_STEM = "http://example.org/rdf/";
+  private static final String TEST_CODE = "test-code";
+  private static final String TEST_CONCEPT_IRI = "a <http://example.org/rdf/test-code>";
 
   private static final Path ROOT_TEST_PATH = Paths.get("testUtilities");
   private static final Path DEFAULT_EXPECTED_XML_DIR = ROOT_TEST_PATH.resolve("xml/examples/expected");
@@ -212,6 +227,7 @@ public class TurtleGeneratorTests {
     parser.setupValidation(ValidationPolicy.EVERYTHING);
     parser.setIdPolicy(IdRenderingPolicy.None);
     parser.setShowDecorations(true);
+    parser.setDeriveConceptIriFromNamingSystem(true);
 
     Method r6ParserMethod = TurtleParser.class.getDeclaredMethod("r6Parser");
     r6ParserMethod.setAccessible(true);
@@ -220,6 +236,7 @@ public class TurtleGeneratorTests {
     assertThat(delegate.getPolicy()).isEqualTo(ValidationPolicy.EVERYTHING);
     assertThat(delegate.getIdPolicy()).isEqualTo(IdRenderingPolicy.None);
     assertThat(delegate.isShowDecorations()).isTrue();
+    assertThat(delegate.isDeriveConceptIriFromNamingSystem()).isTrue();
   }
 
   /**
@@ -250,6 +267,103 @@ public class TurtleGeneratorTests {
         .isEmpty();
   }
 
+  @Test
+  void testR6CodeableConceptUsesBuiltInConceptIriByDefault() throws Exception {
+    ParserContext builtInParserContext = ParserContext.fromWorkerContext(TurtleGeneratorTestUtils.getVersionOverrideWorkerContext(R6_VERSION));
+    String builtInTurtle = generateObservationCodeableConcept(builtInParserContext, "http://loinc.org", "8867-4");
+    assertThat(builtInTurtle).contains("@prefix loinc: <https://loinc.org/rdf/> .");
+    assertThat(builtInTurtle).contains("a loinc:8867-4");
+  }
+
+  @Test
+  void testR6StructureDefinitionPatternCodeableConceptIsNotDecorated() throws IOException, UcumException {
+    IWorkerContext r6context = TurtleGeneratorTestUtils.getVersionOverrideWorkerContext("6.0.0");
+    TurtleGeneratorTestUtils.ParserContext parserContext = TurtleGeneratorTestUtils.ParserContext.fromWorkerContext(r6context);
+    String xml = """
+        <StructureDefinition xmlns="http://hl7.org/fhir">
+          <url value="http://example.org/StructureDefinition/body-weight"/>
+          <name value="BodyWeight"/>
+          <status value="active"/>
+          <kind value="resource"/>
+          <abstract value="false"/>
+          <type value="Observation"/>
+          <derivation value="constraint"/>
+          <differential>
+            <element>
+              <id value="Observation.code"/>
+              <path value="Observation.code"/>
+              <patternCodeableConcept>
+                <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="29463-7"/>
+                </coding>
+              </patternCodeableConcept>
+            </element>
+          </differential>
+        </StructureDefinition>
+        """;
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    parserContext.generateTurtleFromXmlStream(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), output);
+    String turtle = output.toString(StandardCharsets.UTF_8);
+
+    assertThat(turtle).doesNotContain("a loinc:");
+    assertThat(turtle).doesNotContain("@prefix loinc:");
+    // Coding itself must still be emitted
+    assertThat(turtle).contains("29463-7");
+  }
+
+  @Disabled("Not critical")
+  @Test
+  void testSharedWorkerContextProvidesLoincNamingSystem() {
+    NamingSystem namingSystem = NamingSystemUtilities.getNamingSystem(TestingUtilities.getSharedWorkerContext(), "http://loinc.org");
+
+    assertThat(namingSystem).isNotNull();
+    assertThat(namingSystem.getUniqueId()).anySatisfy(uniqueId -> {
+      assertThat(uniqueId.getType()).isEqualTo(NamingSystemIdentifierType.IRISTEM);
+      assertThat(uniqueId.getValue()).endsWith("loinc.org/rdf/");
+    });
+  }
+
+  @Disabled("NamingSystem-derived concept IRIs are opt-in and not enabled by default")
+  @Test
+  void testR6CodeableConceptCanDeriveConceptIriFromNamingSystemWhenEnabled() throws Exception {
+    ParserContext parserContext = ParserContext.fromWorkerContext(r6ContextWithTestNamingSystem());
+    String defaultTurtle = generateObservationCodeableConcept(parserContext, TEST_CODE_SYSTEM, TEST_CODE);
+    assertThat(defaultTurtle).doesNotContain(TEST_CONCEPT_IRI);
+
+    parserContext.setDeriveConceptIriFromNamingSystem(true);
+    String optInTurtle = generateObservationCodeableConcept(parserContext, TEST_CODE_SYSTEM, TEST_CODE);
+    assertThat(optInTurtle).contains(TEST_CONCEPT_IRI);
+  }
+
+  private IWorkerContext r6ContextWithTestNamingSystem() throws Exception {
+    IWorkerContext context = TurtleGeneratorTestUtils.getVersionOverrideWorkerContext(R6_VERSION);
+    NamingSystem namingSystem = new NamingSystem("TestCodeSystem", PublicationStatus.ACTIVE, NamingSystemType.CODESYSTEM, new Date(),
+        new NamingSystem.NamingSystemUniqueIdComponent(NamingSystemIdentifierType.URI, TEST_CODE_SYSTEM));
+    namingSystem.setUrl("http://example.org/fhir/NamingSystem/test-code-system");
+    namingSystem.addUniqueId(new NamingSystem.NamingSystemUniqueIdComponent(NamingSystemIdentifierType.IRISTEM, TEST_IRI_STEM));
+    ((SimpleWorkerContext) context).cacheResource(namingSystem);
+    return context;
+  }
+
+  private String generateObservationCodeableConcept(ParserContext parserContext, String system, String code) throws IOException, UcumException {
+    String xml = """
+        <Observation xmlns="http://hl7.org/fhir">
+          <status value="final"/>
+          <code>
+            <coding>
+              <system value="%s"/>
+              <code value="%s"/>
+            </coding>
+          </code>
+        </Observation>
+        """.formatted(system, code);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    parserContext.generateTurtleFromXmlStream(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), output);
+    return output.toString(StandardCharsets.UTF_8);
+  }
 
   @Disabled("TODO this doesn't pass due to some FHIR URLs containing vertical bars |, which are allowed in XSD 1.1 but not XSD 1.0")
   @Test
@@ -257,19 +371,36 @@ public class TurtleGeneratorTests {
     testStructureDefinitionGeneration("Encounter");
   }
 
+  @Disabled("Run manually for testing with XML resources generated from FHIR specification publishing library")
+  @Test
+  public void testPublishedXmlExamplesR5() throws IOException, UcumException {
+    testPublishedXmlExamples(r5Parsers);
+  }
 
   @Disabled("Run manually for testing with XML resources generated from FHIR specification publishing library")
   @Test
-  public void testPublishedXmlExamples() throws IOException, UcumException {
+  public void testPublishedXmlExamplesR4() throws IOException, UcumException {
+    testPublishedXmlExamples(getVersionOverrideParsers(R4_VERSION));
+  }
+
+  @Disabled("Run manually for testing with XML resources generated from FHIR specification publishing library")
+  @Test
+  public void testPublishedXmlExamplesR6() throws IOException, UcumException {
+    testPublishedXmlExamples(getVersionOverrideParsers(R6_VERSION));
+  }
+
+  private void testPublishedXmlExamples(TurtleGeneratorTestUtils.ParserContext parserContext) throws IOException, UcumException {
     System.out.println("Using input XML directory: " + inputXmlDirectory);
-    System.out.println("Using output Turtle directory: " + outputTurtleDirectory);
+    var examplesOutputDirectory = outputTurtleDirectory.resolve("all-examples-" + parserContext.getFhirVersion());
+    Files.createDirectories(examplesOutputDirectory);
+    System.out.println("Using output Turtle directory: " + examplesOutputDirectory);
     int success = 0;
     var failures = new ArrayList<String>();
     try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(inputXmlDirectory, "*.xml")) {
       for (Path xml : dirStream) {
-        if (xml == null || Files.isDirectory(xml)) continue;
+        if (xml == null || xml.toString().endsWith("diff.xml") || Files.isDirectory(xml)) continue;
         try {
-          testInstanceGeneration(xml);
+          testInstanceGeneration(parserContext, xml, examplesOutputDirectory);
           success++;
         } catch (Exception e) {
           System.out.println("Failed to generate Turtle for " + xml.getFileName() + ": " + e.getMessage());
@@ -346,9 +477,9 @@ public class TurtleGeneratorTests {
     }
   }
 
-  private String testInstanceGeneration(Path resourcePath) throws IOException, UcumException {
-    var generatedTurtlePath = parsers.generateTurtleFromXmlResourcePath(resourcePath, outputTurtleDirectory);
-    parsers.parseGeneratedTurtle(generatedTurtlePath);
+  private String testInstanceGeneration(ParserContext parserContext, Path resourcePath, Path outputDirectory) throws IOException, UcumException {
+    var generatedTurtlePath = parserContext.generateTurtleFromXmlResourcePath(resourcePath, outputDirectory);
+    parserContext.parseGeneratedTurtle(generatedTurtlePath);
     return generatedTurtlePath;
   }
 

--- a/org.hl7.fhir.r5/src/test/resources/testUtilities/ttl/examples/expected/R6/patient-example-f201-roel.ttl
+++ b/org.hl7.fhir.r5/src/test/resources/testUtilities/ttl/examples/expected/R6/patient-example-f201-roel.ttl
@@ -2,7 +2,6 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sct: <http://snomed.info/id/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 # - resource -------------------------------------------------------------------
@@ -64,7 +63,6 @@
   ] ) ; # Indicates that the individual is not deceased, ISO 3166 3 letter code
   fhir:maritalStatus [
      fhir:coding ( [
-       a sct:36629006 ;
        fhir:system [
          fhir:v "http://snomed.info/sct"^^xsd:anyURI ;
          fhir:l <http://snomed.info/sct>
@@ -93,7 +91,6 @@
   fhir:contact ( [
      fhir:relationship ( [
        fhir:coding ( [
-         a sct:127850001 ;
          fhir:system [
            fhir:v "http://snomed.info/sct"^^xsd:anyURI ;
            fhir:l <http://snomed.info/sct>

--- a/org.hl7.fhir.r5/src/test/resources/testUtilities/ttl/examples/expected/R6/patient-example-f201-roel.ttl
+++ b/org.hl7.fhir.r5/src/test/resources/testUtilities/ttl/examples/expected/R6/patient-example-f201-roel.ttl
@@ -2,6 +2,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sct: <http://snomed.info/id/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 # - resource -------------------------------------------------------------------
@@ -62,6 +63,7 @@
      fhir:country [ fhir:v "NLD" ]
   ] ) ; # Indicates that the individual is not deceased, ISO 3166 3 letter code
   fhir:maritalStatus [
+     a sct:36629006 ;
      fhir:coding ( [
        fhir:system [
          fhir:v "http://snomed.info/sct"^^xsd:anyURI ;
@@ -90,6 +92,7 @@
   ] ) ; # 
   fhir:contact ( [
      fhir:relationship ( [
+       a sct:127850001 ;
        fhir:coding ( [
          fhir:system [
            fhir:v "http://snomed.info/sct"^^xsd:anyURI ;


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-57496 - task 4:
> Change the examples generator (in the FHIR build process) to add Concept IRIs to CodeableConcepts using rdf:type (in examples where the appropriate Concept IRI is known to the generator), and no longer add them to Codings.

This PR affects R6 only.

This PR removes `rdf:type` from Codings which wasn't the right interpretation for most codes. It also moves `rdf:type` to example CodeableConcepts in cases where it's more plausible (skipping cases like `ElementDefinition.pattern[CodeableConcept]`) -- like in [DSTU2](https://hl7.org/fhir/DSTU2/rdf.html#1.18.3.4.5). The new guidance stipulates that this should *only* be done when it makes sense for the FHIR element and concept in question. 

This is separate from the Concept IRI Extension https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-rdf-concept-iri.html which is also optional on *Coding*, is more round-trippable in JSON/XML, still RDF-linkable, and helps preserve backwards compatibility. That extension is NOT added to any examples but documented on the RDF page.

