### PR TITLE
Avoid mutating shared bases during snapshot generation

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/conformance/profile/ProfileUtilities.java
@@ -766,7 +766,7 @@ public class ProfileUtilities {
       checkNotGenerating(sdb, "an extension base");
       generateSnapshot(sdb, base, base.getUrl(), (sdb.hasWebPath()) ? Utilities.extractBaseUrl(sdb.getWebPath()) : webUrl, base.getName());
     }
-    fixTypeOfResourceId(base);
+    base = fixTypeOfResourceId(base);
     if (base.hasExtension(ExtensionDefinitions.EXT_TYPE_PARAMETER)) {
       checkTypeParameters(base, derived);
     }
@@ -1287,10 +1287,22 @@ public class ProfileUtilities {
     return (i < list.size() - 1) && list.get(i + 1).getPath().startsWith(ed.getPath()+".");
   }
 
-  private void fixTypeOfResourceId(StructureDefinition base) {
+  private StructureDefinition fixTypeOfResourceId(StructureDefinition base) {
     if (base.getKind() == StructureDefinitionKind.RESOURCE && (base.getFhirVersion() == null || VersionUtilities.isR4Plus(base.getFhirVersion().toCode()))) {
+      base = copyBaseWithUserData(base);
       fixTypeOfResourceId(base.getSnapshot().getElement());
       fixTypeOfResourceId(base.getDifferential().getElement());      
+    }
+    return base;
+  }
+
+  private StructureDefinition copyBaseWithUserData(StructureDefinition base) {
+    boolean oldCopyUserData = Base.isCopyUserData();
+    Base.setCopyUserData(true);
+    try {
+      return base.copy();
+    } finally {
+      Base.setCopyUserData(oldCopyUserData);
     }
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ProfileUtilitiesTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/ProfileUtilitiesTests.java
@@ -1,0 +1,85 @@
+package org.hl7.fhir.r5.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.extensions.ExtensionDefinitions;
+import org.hl7.fhir.r5.extensions.ExtensionUtilities;
+import org.hl7.fhir.r5.model.ElementDefinition;
+import org.hl7.fhir.r5.model.ElementDefinition.TypeRefComponent;
+import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionKind;
+import org.hl7.fhir.r5.model.StructureDefinition.TypeDerivationRule;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.junit.jupiter.api.Test;
+
+public class ProfileUtilitiesTests {
+
+  private static final String RESOURCE_ID_PATH = "Resource.id";
+  private static final String TEST_USER_DATA_KEY = "profile-utilities-test";
+
+  @Test
+  public void generateSnapshotDoesNotMutateBase() throws IOException {
+    IWorkerContext context = TestingUtilities.getSharedWorkerContext("5.0.0");
+    StructureDefinition base =
+        context
+            .fetchResource(
+                StructureDefinition.class,
+                "http://hl7.org/fhir/StructureDefinition/Patient")
+            .copy();
+    ElementDefinition baseResourceId = getResourceId(base);
+    TypeRefComponent baseResourceIdType = baseResourceId.getTypeFirstRep();
+    baseResourceIdType.setCode("id");
+    baseResourceIdType.removeExtension(ExtensionDefinitions.EXT_FHIR_TYPE);
+    ExtensionUtilities.addUrlExtension(
+        baseResourceIdType, ExtensionDefinitions.EXT_FHIR_TYPE, "original-id");
+    Object userData = new Object();
+    baseResourceId.setUserData(TEST_USER_DATA_KEY, userData);
+    StructureDefinition originalBase = base.copy();
+
+    StructureDefinition derived = patientProfile();
+    new ProfileUtilities(context, null, null)
+        .generateSnapshot(base, derived, derived.getUrl(), "http://example.org", derived.getName());
+
+    assertTrue(base.equalsDeep(originalBase), "Snapshot generation mutated the supplied base");
+    ElementDefinition derivedResourceId = getResourceId(derived);
+    TypeRefComponent derivedResourceIdType = derivedResourceId.getTypeFirstRep();
+    assertEquals("http://hl7.org/fhirpath/System.String", derivedResourceIdType.getCode());
+    assertEquals(
+        "id",
+        ExtensionUtilities.readStringExtension(
+            derivedResourceIdType, ExtensionDefinitions.EXT_FHIR_TYPE));
+    assertSame(userData, derivedResourceId.getUserData(TEST_USER_DATA_KEY));
+  }
+
+  private static ElementDefinition getResourceId(StructureDefinition structureDefinition) {
+    return structureDefinition.getSnapshot().getElement().stream()
+        .filter(
+            element ->
+                element.hasBase() && RESOURCE_ID_PATH.equals(element.getBase().getPath()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static StructureDefinition patientProfile() {
+    StructureDefinition profile = new StructureDefinition();
+    profile.setId("patient-profile");
+    profile.setUrl("http://example.org/StructureDefinition/patient-profile");
+    profile.setName("PatientProfile");
+    profile.setStatus(PublicationStatus.ACTIVE);
+    profile.setType("Patient");
+    profile.setKind(StructureDefinitionKind.RESOURCE);
+    profile.setAbstract(false);
+    profile.setDerivation(TypeDerivationRule.CONSTRAINT);
+    profile.setBaseDefinition("http://hl7.org/fhir/StructureDefinition/Patient");
+    ElementDefinition root = profile.getDifferential().addElement();
+    root.setId("Patient");
+    root.setPath("Patient");
+    return profile;
+  }
+}


### PR DESCRIPTION
## Summary

- generate snapshots from a private copy before normalizing `Resource.id`
- preserve nested model `userData` while creating that copy
- add a regression test that verifies the supplied base remains unchanged

## Root cause

`ProfileUtilities.generateSnapshot()` called `fixTypeOfResourceId(base)` directly on the caller-provided `StructureDefinition`. Cached base definitions can be shared by concurrent validation requests, so changing their type extensions introduced a shared-state race.

The normalization now returns a private working copy for R4+ resource definitions. This keeps the generated snapshot behavior unchanged without modifying the shared base.

Fixes #2470

## Testing

- `mvn -f org.hl7.fhir.r5/pom.xml -Dtest=ProfileUtilitiesTests test`
- `mvn -f org.hl7.fhir.r5/pom.xml -Dtest=SnapShotGenerationTests test` (164 cases)
- `mvn -f org.hl7.fhir.r5/pom.xml -PCHECKSTYLE -DskipTests process-sources`
- `git diff --check`
