### PR TITLE
Code Cleanup - Extract URLUtil, remove dead code, and tighten test visibility

### DIFF
--- a/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
+++ b/org.hl7.fhir.convertors/src/test/java/org/hl7/fhir/convertors/txClient/TerminologyClientFactoryTest.java
@@ -51,15 +51,15 @@ public class TerminologyClientFactoryTest {
 
   @ParameterizedTest
   @MethodSource("data")
-  public void testMakeClient(String url, FhirPublication fhirPublication, String expectedAddress) throws URISyntaxException {
+  void testMakeClient(String url, FhirPublication fhirPublication, String expectedAddress) throws URISyntaxException {
     ITerminologyClient terminologyClient = new TerminologyClientFactory(fhirPublication).makeClient("id", url, "dummyUserAgent", null);
     assertEquals(expectedAddress, terminologyClient.getAddress());
   }
 
   @Test
-  public void testMakeClientDstu1Fails() throws URISyntaxException {
+  void testMakeClientDstu1Fails() {
     assertThrows(Error.class, () -> {
-        ITerminologyClient terminologyClient = new TerminologyClientFactory(FhirPublication.DSTU1).makeClient("id", "urldoesnotmatter", "dummyUserAgent", null);
+         new TerminologyClientFactory(FhirPublication.DSTU1).makeClient("id", "urldoesnotmatter", "dummyUserAgent", null);
       }
     );
   }

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/utils/sql/SqlOnFhirRunnerTests.java
@@ -1,6 +1,5 @@
 package org.hl7.fhir.r4.utils.sql;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
@@ -16,12 +15,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.IWorkerContext;
-import org.hl7.fhir.r4.model.Base;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.test.utils.TestingUtilities;
-import org.hl7.fhir.r4.utils.sql.Runner;
 import org.hl7.fhir.utilities.json.model.JsonArray;
 import org.hl7.fhir.utilities.json.model.JsonElement;
 import org.hl7.fhir.utilities.json.model.JsonNull;
@@ -47,14 +43,14 @@ public class SqlOnFhirRunnerTests {
   private static Map<String, JsonObject> testFiles = new HashMap<>();
 
   @BeforeAll
-  public static void setUp() throws Exception {
+  static void setUp() throws Exception {
     context = TestingUtilities.context();
     reportGenerator = new TestReportGenerator();
     loadTestFiles();
   }
 
   @AfterAll
-  public static void tearDown() {
+  static void tearDown() {
     reportGenerator.writeReport("target/sof-test-report.json");
   }
 
@@ -97,7 +93,7 @@ public class SqlOnFhirRunnerTests {
   @ParameterizedTest(name = "{0}: {1}")
   @MethodSource("testCases")
   @DisplayName("SQL on FHIR Runner Test")
-  public void testRunner(String fileName, String testName, JsonObject testFile, JsonObject test) throws Exception {
+  void testRunner(String fileName, String testName, JsonObject testFile, JsonObject test) throws Exception {
     log.info("Running test: {} - {}", fileName, testName);
 
     TestResult result = new TestResult();

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/SHLParser.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/elementmodel/SHLParser.java
@@ -1,26 +1,17 @@
 package org.hl7.fhir.r5.elementmodel;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.UnknownHostException;
-import java.text.ParseException;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.zip.DataFormatException;
-import java.util.Date;
-import java.util.zip.Inflater;
 
 import org.hl7.fhir.exceptions.DefinitionException;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -28,25 +19,19 @@ import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.formats.IParser.OutputStyle;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
-import org.hl7.fhir.utilities.CommaSeparatedStringBuilder;
 import org.hl7.fhir.utilities.FileUtilities;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
 import org.hl7.fhir.utilities.Utilities;
-import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.http.HTTPResult;
 import org.hl7.fhir.utilities.http.ManagedWebAccess;
-import org.hl7.fhir.utilities.json.model.JsonArray;
 import org.hl7.fhir.utilities.json.model.JsonElement;
-import org.hl7.fhir.utilities.json.model.JsonElementType;
 import org.hl7.fhir.utilities.json.model.JsonObject;
-import org.hl7.fhir.utilities.json.model.JsonPrimitive;
 import org.hl7.fhir.utilities.json.model.JsonProperty;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
 
 import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.DirectDecrypter;
 
 /**
@@ -298,7 +283,6 @@ public class SHLParser extends ParserBase {
     if (testMode) {
       return new HTTPResult(url, 200, "OK", "application/json", FileUtilities.streamToBytes(TestingUtilities.loadTestResourceStream("validator", "shlink.manifest.json")));
     }
-
     JsonObject j = new JsonObject();
     j.add("recipient", "FHIR Validator");
     HTTPResult res = ManagedWebAccess.post(Arrays.asList("web"), url, org.hl7.fhir.utilities.json.parser.JsonParser.composeBytes(j), "application/json", "application/json");

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/elementmodel/SHCParserTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/elementmodel/SHCParserTests.java
@@ -1,17 +1,14 @@
 package org.hl7.fhir.r5.elementmodel;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SHCParserTests {
 

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedWebAccess.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedWebAccess.java
@@ -38,9 +38,10 @@ import java.util.*;
 
 import lombok.Getter;
 
-import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.settings.FhirSettings;
 import org.hl7.fhir.utilities.settings.ServerDetailsPOJO;
+
+import static org.hl7.fhir.utilities.Utilities.existsInList;
 
 /**
  * see security.md - manages web access by the FHIR HAPI Core library
@@ -78,6 +79,7 @@ public class ManagedWebAccess {
     PROHIBITED, // no access at all to the web
   }
 
+  @Getter
   private static WebAccessPolicy accessPolicy = WebAccessPolicy.DIRECT; // for legacy reasons
   //TODO get this from fhir settings
   private static List<String> allowedDomains = new ArrayList<>();
@@ -92,10 +94,6 @@ public class ManagedWebAccess {
 
   private static List<ServerDetailsPOJO> serverDetailsList;
   private static IHTTPAuthenticationProvider defaultAuthenticationProvider;
-
-  public static WebAccessPolicy getAccessPolicy() {
-    return accessPolicy;
-  }
 
   public static void setAccessPolicy(WebAccessPolicy accessPolicy) {
     ManagedWebAccess.accessPolicy = accessPolicy;
@@ -220,7 +218,7 @@ public class ManagedWebAccess {
       }
       
       // Fall back to hardcoded local addresses
-      return Utilities.existsInList(uri.getHost(), "localhost", "local.fhir.org", "127.0.0.1", "[::1]") || (uri.getHost() != null && uri.getHost().endsWith(".localhost"));
+      return existsInList(uri.getHost(), "localhost", "local.fhir.org", "127.0.0.1", "[::1]") || (uri.getHost() != null && uri.getHost().endsWith(".localhost"));
     } catch (URISyntaxException e) {
       return false;
     }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/URLUtil.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/URLUtil.java
@@ -1,0 +1,9 @@
+package org.hl7.fhir.utilities.http;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class URLUtil {
+  public static @NonNull String getUrlWithNoCacheParam(String url) {
+    return url.contains("?") ? url + "&nocache=" + System.currentTimeMillis() : url + "?nocache=" + System.currentTimeMillis();
+  }
+}

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/json/parser/JsonParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/json/parser/JsonParser.java
@@ -9,11 +9,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hl7.fhir.utilities.FileUtilities;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.utilities.http.HTTPResult;
 import org.hl7.fhir.utilities.http.ManagedWebAccess;
+import org.hl7.fhir.utilities.http.URLUtil;
 import org.hl7.fhir.utilities.json.JsonException;
 import org.hl7.fhir.utilities.json.model.JsonArray;
 import org.hl7.fhir.utilities.json.model.JsonBoolean;
@@ -732,11 +734,13 @@ public class JsonParser {
   }
 
   private static byte[] fetch(String source) throws IOException {
-    String murl = source.contains("?") ? source+"&nocache=" + System.currentTimeMillis() : source+"?nocache=" + System.currentTimeMillis();
-    HTTPResult res = ManagedWebAccess.get(Arrays.asList("web"), murl, "application/json, application/fhir+json");
+    String urlWithNoCacheParam = URLUtil.getUrlWithNoCacheParam(source);
+    HTTPResult res = ManagedWebAccess.get(Arrays.asList("web"), urlWithNoCacheParam, "application/json, application/fhir+json");
     res.checkThrowException();
     return res.getContent();
   }
+
+
 
   public String getSourceName() {
     return sourceName;

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageServer.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/PackageServer.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 
 public class PackageServer {
 
-
   public enum PackageServerType {
     FHIR,
     NPM
@@ -27,7 +26,7 @@ public class PackageServer {
   }
 
   @Getter
-  final private String url;
+  private final String url;
 
   @Getter
   private HTTPAuthenticationMode authenticationMode;

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/BasePackageCacheManagerTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/BasePackageCacheManagerTests.java
@@ -13,10 +13,10 @@ import org.hl7.fhir.utilities.http.HTTPAuthenticationMode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class BasePackageCacheManagerTests {
+class BasePackageCacheManagerTests {
 
   @Test
-  public void testPackageBasicAuth() throws IOException {
+  void testPackageBasicAuth() throws IOException {
     BasePackageCacheManager basePackageCacheManager = getFakeBasePackageCacheManager();
 
     MockPackageServer server = new MockPackageServer();
@@ -42,7 +42,7 @@ public class BasePackageCacheManagerTests {
 
   @Test
   @DisplayName("Test that package management moves to next server after 404")
-  public void testPackageWithConfiguredServer404() throws IOException {
+  void testPackageWithConfiguredServer404() throws IOException {
     BasePackageCacheManager basePackageCacheManager = getFakeBasePackageCacheManager();
 
     MockPackageServer serverA = new MockPackageServer();

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/CIBuildClientTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/CIBuildClientTests.java
@@ -64,7 +64,7 @@ public class CIBuildClientTests {
   }
 
   @Test
-  public void testNewQasQueryOverRefreshThreshold() throws IOException, InterruptedException {
+  void testNewQasQueryOverRefreshThreshold() throws IOException, InterruptedException {
     MockWebServer server = new MockWebServer();
     CIBuildClient ciBuildClient = getCiBuildClient(server);
 
@@ -84,7 +84,7 @@ public class CIBuildClientTests {
   }
 
   @Test
-  public void testGetPackageId() {
+  void testGetPackageId() {
     MockWebServer server = new MockWebServer();
     CIBuildClient ciBuildClient = getCiBuildClient(server);
 
@@ -95,7 +95,7 @@ public class CIBuildClientTests {
   }
 
   @Test
-  public void testGetPackageUrl() {
+  void testGetPackageUrl() {
     MockWebServer server = new MockWebServer();
     CIBuildClient ciBuildClient = getCiBuildClient(server);
 
@@ -106,7 +106,7 @@ public class CIBuildClientTests {
   }
 
   @Test
-  public void testIsCurrentPackage() throws IOException {
+  void testIsCurrentPackage() throws IOException {
     MockWebServer server = new MockWebServer();
     CIBuildClient ciBuildClient = getCiBuildClient(server);
 

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/PackageServerTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/npm/PackageServerTest.java
@@ -17,22 +17,22 @@ import org.junit.jupiter.api.Test;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 
-public class PackageServerTest {
+class PackageServerTest {
 
   MockPackageServer server;
 
   @BeforeEach
-  public void beforeEach() throws IOException {
+  void beforeEach() throws IOException {
     server = new MockPackageServer();
   }
 
   @AfterEach
-  public void afterEach() throws IOException {
+  void afterEach() throws IOException {
     server.shutdown();
   }
 
   @Test
-  public void testPackageServerBasicAuth() throws IOException, InterruptedException {
+  void testPackageServerBasicAuth() throws IOException, InterruptedException {
 
     String packageServerUrl = server.getPackageServerUrl();
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
@@ -43,6 +43,7 @@ import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.utilities.http.HTTPHeader;
 import org.hl7.fhir.utilities.http.HTTPResult;
 import org.hl7.fhir.utilities.http.ManagedWebAccess;
+import org.hl7.fhir.utilities.http.URLUtil;
 import org.hl7.fhir.utilities.json.JsonException;
 import org.hl7.fhir.utilities.json.model.JsonArray;
 import org.hl7.fhir.utilities.json.model.JsonObject;
@@ -411,9 +412,9 @@ public class TxTester implements ITerminologyRequestIdProvider {
     return JsonParser.parseObject(loader.loadContent(loader.testFileName()));
   }
 
-  private byte[] fetch(String source) throws IOException {
-    String murl = source.contains("?") ? source+"&nocache=" + System.currentTimeMillis() : source+"?nocache=" + System.currentTimeMillis();
-    HTTPResult res = ManagedWebAccess.get(Arrays.asList("web"), murl, "application/json, application/fhir+json");
+  private byte[] fetch(String url) throws IOException {
+    String urlWithNoCacheParam = URLUtil.getUrlWithNoCacheParam(url);
+    HTTPResult res = ManagedWebAccess.get(Arrays.asList("web"), urlWithNoCacheParam, "application/json, application/fhir+json");
     return res.getContent();
   }
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/ValidationServiceTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/service/ValidationServiceTests.java
@@ -132,7 +132,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that conversion works when a single source is set and the -output param is set")
-  public void convertSingleSource() throws Exception {
+  void convertSingleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -144,7 +144,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that conversion throws an Exception when no -output or -outputSuffix params are set")
-  public void convertSingleSourceNoOutput() {
+  void convertSingleSourceNoOutput() {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -156,7 +156,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that conversion throws an Exception when multiple sources are set and an -output param is set")
-  public void convertMultipleSourceOnlyOutput() {
+  void convertMultipleSourceOnlyOutput() {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -167,7 +167,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that conversion works when multiple sources are set and an output suffix parameter is set")
-  public void convertMultipleSource() throws Exception {
+  void convertMultipleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -180,7 +180,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that snapshot generation works when a single source is set and the -output param is set")
-  public void generateSnapshotSingleSource() throws Exception {
+  void generateSnapshotSingleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -195,7 +195,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that snapshot generation throws an Exception when no -output or -outputSuffix params are set")
-  public void generateSnapshotSingleSourceNoOutput() {
+  void generateSnapshotSingleSourceNoOutput() {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -205,7 +205,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that snapshot generation throws an Exception when multiple sources are set and an -output param is set")
-  public void generateSnapshotMultipleSourceOnlyOutput() {
+  void generateSnapshotMultipleSourceOnlyOutput() {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -216,7 +216,7 @@ class ValidationServiceTests {
 
   @Test
   @DisplayName("Test that snapshot generation works when multiple sources are set and an output suffix parameter is set")
-  public void generateSnapshotMultipleSource() throws Exception {
+  void generateSnapshotMultipleSource() throws Exception {
     SessionCache sessionCache = mock(SessionCache.class);
     ValidationService validationService = new ValidationService(sessionCache);
     ValidationEngine validationEngine = mock(ValidationEngine.class);
@@ -271,7 +271,7 @@ class ValidationServiceTests {
   }
 
   @Test
-  public void buildValidationEngineDisableDefaultResourceFetcherTest() throws IOException, URISyntaxException {
+  void buildValidationEngineDisableDefaultResourceFetcherTest() throws IOException, URISyntaxException {
     final TimeTracker timeTracker = mock(TimeTracker.class);
     final SimpleWorkerContext workerContext = mock(SimpleWorkerContext.class);
 

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineTests.java
@@ -349,7 +349,7 @@ public class ValidationEngineTests {
   }
 
   @Test
-  public void testResolveRelativeFileError() throws Exception {
+  void testResolveRelativeFileError() throws Exception {
     String folder = setupFolder();
     try {
       ValidationEngine ve = TestUtilities.getValidationEngine("hl7.fhir.r4.core#4.0.1", DEF_TX, FhirPublication.R4, "4.0.1");
@@ -414,7 +414,7 @@ public class ValidationEngineTests {
   }
 
   @Test
-  public void testResolveAbsoluteError() throws Exception {
+  void testResolveAbsoluteError() throws Exception {
       ValidationEngine ve = TestUtilities.getValidationEngine("hl7.fhir.r4.core#4.0.1", DEF_TX, FhirPublication.R4, "4.0.1");
       StandAloneValidatorFetcher fetcher = new StandAloneValidatorFetcher(ve.getPcm(), ve.getContext(), ve);
       ve.setFetcher(fetcher);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationTests.java
@@ -141,9 +141,9 @@ public class ValidationTests implements IHostApplicationServices, IValidatorReso
       JsonArray jsonTags = example.getAsJsonArray("tags");
       List<String> tags = jsonTags == null ? List.of() : jsonTags.asList().stream().map(JsonElement::getAsString).toList();
       if (testFilter.shouldRunBasedOnTags(tags)) {
-        objects.add(new Object[]{id, examples.get(id)});
+          objects.add(new Object[]{id, examples.get(id)});
+        }
       }
-    }
     return objects;
   }
 
@@ -179,10 +179,12 @@ public class ValidationTests implements IHostApplicationServices, IValidatorReso
     TerminologyClientContext.setCanUseCacheId(true);
   }
 
-  @AfterAll
-  public void cleanup() {
+  @AfterClass
+  public static void cleanup() throws IOException {
+    String content = new GsonBuilder().setPrettyPrinting().create().toJson(manifest);
+    FileUtilities.stringToFile(content, Utilities.path("[tmp]", "validator-produced-manifest.json"));
+
     currentEngine = null;
-    vCurr = null;
     igLoader = null;
     manifest = null;
     TerminologyClientContext.setCanUseCacheId(false); // don't leak the static into other suites
@@ -996,13 +998,6 @@ public class ValidationTests implements IHostApplicationServices, IValidatorReso
   @Override
   public ValueSet resolveValueSet(FHIRPathEngine engine, Object appContext, String url) {
     return vCurr.getContext().fetchResource(ValueSet.class, url);
-  }
-
-  @AfterClass
-  public static void saveWhenDone() throws IOException {
-    String content = new GsonBuilder().setPrettyPrinting().create().toJson(manifest);
-    FileUtilities.stringToFile(content, Utilities.path("[tmp]", "validator-produced-manifest.json"));
-
   }
 
   @Override


### PR DESCRIPTION
Extracts the duplicated nocache-URL logic into URLUtil, drops unused imports/dead code in SHLParser and SHCParserTests, removes redundant modifiers, and tightens test method/class visibility to package-private per project convention. 

No behavior changes.