### PR TITLE
Enhance CDA Narrative export

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -355,65 +355,41 @@ public class CDANarrativeFormat {
   
   private void processChildNode(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
     switch (n.getNodeType()) {
-    case DocType: 
-    case Document: 
-    case Instruction: 
+      case DocType, Document, Instruction, CData:
       return;
-    case Comment: 
+    case Comment:
       xml.comment(n.getContent(), true);
       return;
     case Text: 
       xml.text(n.getContent());
       return;
     case Element:
-      if (n.getName().equals("br"))
-        processBreak(xml, n);
-      else if (n.getName().equals("h1") || n.getName().equals("h2") || n.getName().equals("h3") || n.getName().equals("h4") || n.getName().equals("h5") || n.getName().equals("h6") || n.getName().equals("caption"))
-        processCaption(xml, n);
-      else if (n.getName().equals("col"))
-        processCol(xml, n);
-      else if (n.getName().equals("colgroup"))
-        processColGroup(xml, n);
-      else if (n.getName().equals("span") || n.getName().equals("div"))
-        processContent(xml, n);
-      else if (n.getName().equals("footnote"))
-        processFootNote(xml, n);
-      else if (n.getName().equals("footnoteRef"))
-        processFootNodeRef(xml, n);
-      else if (n.getName().equals("li"))
-        processItem(xml, n);
-      else if (n.getName().equals("linkHtml"))
-        processlinkHtml(xml, n);
-      else if (n.getName().equals("ul") || n.getName().equals("ol"))
-        processList(xml, n);
-      else if (n.getName().equals("p"))
-        processParagraph(xml, n);
-      else if (n.getName().equals("img"))
-        processRenderMultiMedia(xml, n);
-      else if (n.getName().equals("sub"))
-        processSub(xml, n);
-      else if (n.getName().equals("sup"))
-        processSup(xml, n);
-      else if (n.getName().equals("table"))
-        processTable(xml, n);
-      else if (n.getName().equals("tbody"))
-        processTBody(xml, n);
-      else if (n.getName().equals("td"))
-        processTd(xml, n);
-      else if (n.getName().equals("tfoot"))
-        processTFoot(xml, n);
-      else if (n.getName().equals("th"))
-        processTh(xml, n);
-      else if (n.getName().equals("thead"))
-        processTHead(xml, n);
-      else if (n.getName().equals("a"))
-        processA(xml, n);
-      else if (n.getName().equals("tr"))
-        processTr(xml, n);
-      else if (n.getName().equals("list") || n.getName().equals("item") || n.getName().equals("paragraph") || n.getName().equals("renderMultiMedia") || n.getName().equals("content"))
-        processPassThrough(xml, n);
-      else
-        stripTag(xml, n);
+      String elementName = n.getName().toLowerCase();
+      switch (elementName) {
+        case "br" -> processBreak(xml, n);
+        case "h1", "h2", "h3", "h4", "h5", "h6", "caption" -> processCaption(xml, n);
+        case "col" -> processCol(xml, n);
+        case "colgroup" -> processColGroup(xml, n);
+        case "span", "div" -> processContent(xml, n);
+        case "li" -> processItem(xml, n);
+        case "linkhtml" -> processlinkHtml(xml, n);
+        case "ul", "ol" -> processList(xml, n);
+        case "p" -> processParagraph(xml, n);
+        case "img" -> processRenderMultiMedia(xml, n);
+        case "sub" -> processSub(xml, n);
+        case "sup" -> processSup(xml, n);
+        case "table" -> processTable(xml, n);
+        case "tbody" -> processTBody(xml, n);
+        case "td" -> processTd(xml, n);
+        case "tfoot" -> processTFoot(xml, n);
+        case "th" -> processTh(xml, n);
+        case "thead" -> processTHead(xml, n);
+        case "a" -> processA(xml, n);
+        case "tr" -> processTr(xml, n);
+        case "list", "item", "paragraph", "rendermultimedia", "content", "footnote", "footnoteref" ->
+          processPassThrough(xml, n);
+        default -> stripTag(xml, n);
+      }
     }
   }
 
@@ -448,14 +424,6 @@ public class CDANarrativeFormat {
     // todo: do something with revised..., "revised"
     processChildren(xml, n);
     xml.exit("content");
-  }
-
-  private void processFootNote(IXMLWriter xml, XhtmlNode n) {
-    throw new Error("element "+n.getName()+" not handled yet");
-  }
-
-  private void processFootNodeRef(IXMLWriter xml, XhtmlNode n) {
-    throw new Error("element "+n.getName()+" not handled yet");
   }
 
   private void processItem(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -30,15 +30,15 @@ package org.hl7.fhir.utilities.xhtml;
  */
 
 
-
-import java.io.IOException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.utilities.xml.IXMLWriter;
 import org.hl7.fhir.utilities.xml.XMLUtil;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+
+import java.io.IOException;
+import java.util.Set;
 
 public class CDANarrativeFormat {
 
@@ -368,13 +368,13 @@ public class CDANarrativeFormat {
     case Element:
       if (n.getName().equals("br"))
         processBreak(xml, n);
-      else if (n.getName().equals("h2") || n.getName().equals("caption"))
+      else if (n.getName().equals("h1") || n.getName().equals("h2") || n.getName().equals("h3") || n.getName().equals("h4") || n.getName().equals("h5") || n.getName().equals("h6") || n.getName().equals("caption"))
         processCaption(xml, n);
       else if (n.getName().equals("col"))
         processCol(xml, n);
       else if (n.getName().equals("colgroup"))
         processColGroup(xml, n);
-      else if (n.getName().equals("span"))
+      else if (n.getName().equals("span") || n.getName().equals("div"))
         processContent(xml, n);
       else if (n.getName().equals("footnote"))
         processFootNote(xml, n);
@@ -410,8 +410,10 @@ public class CDANarrativeFormat {
         processA(xml, n);
       else if (n.getName().equals("tr"))
         processTr(xml, n);
+      else if (n.getName().equals("list") || n.getName().equals("item") || n.getName().equals("paragraph") || n.getName().equals("renderMultiMedia") || n.getName().equals("content"))
+        processPassThrough(xml, n);
       else
-        throw new FHIRException("Unknown element "+n.getName());
+        stripTag(xml, n);
     }
   }
 
@@ -492,7 +494,8 @@ public class CDANarrativeFormat {
 
   private void processRenderMultiMedia(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
     String v = n.getAttribute("src");
-    xml.attribute("referencedObject", v);
+    if (StringUtils.isNotBlank(v))
+      xml.attribute("referencedObject", v);
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("renderMultiMedia");
     processChildren(xml, n);
@@ -561,10 +564,29 @@ public class CDANarrativeFormat {
   }
 
   private void processA(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+    String v = n.getAttribute("href");
+    if (StringUtils.isNotBlank(v))
+      xml.attribute("referencedObject", v);
+
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("linkHtml");
     processChildren(xml, n);
     xml.exit("linkHtml");
+  }
+
+  /**
+   * Pass an element and all its children through from the source XHTML to the CDA Narrative unchanged.
+   */
+  private void processPassThrough(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+    processAllAttributes(n, xml);
+    xml.enter(n.getName());
+    processChildren(xml, n);
+    xml.exit(n.getName());
+  }
+
+  private void processAllAttributes(XhtmlNode xn, IXMLWriter xml) throws IOException, FHIRException {
+    Set<String> attributeNames = xn.getAttributes().keySet();
+    processAttributes(xn, xml, attributeNames.toArray(new String[0]));
   }
 
   private void processAttributes(XhtmlNode xn, IXMLWriter xml, String... names) throws IOException {
@@ -637,5 +659,10 @@ public class CDANarrativeFormat {
     }
   }
 
-
+  /**
+   * drop an element from the document while preserving its children (if possible).
+   */
+  private void stripTag(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+    processChildren(xml, n);
+  }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -335,25 +335,38 @@ public class CDANarrativeFormat {
   }
 
   /**
-   * For XHTML return the matching CDA narrative. This is only guaranteed to work for XML produced from CDA, but will try whatever
-   * @param node
-   * @return
-   * @throws IOException 
-   * @throws FHIRException 
+   * For XHTML return the matching CDA narrative. This is a strict conversion that will fail if invalid XHTML is encountered.
+   * @param xml      the writer to which the CDA narrative will be written
+   * @param div      the root node of the FHIR narrative
+   * @throws IOException   if a write operation on the XML writer fails
+   * @throws FHIRException if invalid XHTML is encountered in strict mode
    */
   public void convert(IXMLWriter xml, XhtmlNode div) throws IOException, FHIRException {
+    convert(xml, div, true);
+  }
+
+  /**
+   * For XHTML return the matching CDA narrative. In strict mode, conversion will fail if invalid XHTML is encountered. In lenient mode, a best-effort conversion will skip unrecognized elements.
+   *
+   * @param xml      the writer to which the CDA narrative will be written
+   * @param div      the root node of the FHIR narrative
+   * @param isStrict if true (default), the method will throw an exception if it encounters any elements within the FHIR narrative that are not valid XHTML. If false, the method will ignore invalid XHTML tags and continue on a best-effort basis.
+   * @throws IOException   if a write operation on the XML writer fails
+   * @throws FHIRException if invalid XHTML is encountered in strict mode
+   */
+  public void convert(IXMLWriter xml, XhtmlNode div, boolean isStrict) throws IOException, FHIRException {
     processAttributes(div, xml, "ID", "language", "styleCode");
     xml.enter("text");
-    processChildren(xml, div);
+    processChildren(xml, div, isStrict);
     xml.exit("text");
   }
 
-  private void processChildren(IXMLWriter xml, XhtmlNode x) throws IOException, FHIRException {
+  private void processChildren(IXMLWriter xml, XhtmlNode x, boolean isStrict) throws IOException, FHIRException {
     for (XhtmlNode n : x.getChildNodes()) 
-      processChildNode(xml, n);
+      processChildNode(xml, n, isStrict);
   }
   
-  private void processChildNode(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processChildNode(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     switch (n.getNodeType()) {
       case DocType, Document, Instruction, CData:
       return;
@@ -367,28 +380,28 @@ public class CDANarrativeFormat {
       String elementName = n.getName().toLowerCase();
       switch (elementName) {
         case "br" -> processBreak(xml, n);
-        case "h1", "h2", "h3", "h4", "h5", "h6", "caption" -> processCaption(xml, n);
-        case "col" -> processCol(xml, n);
-        case "colgroup" -> processColGroup(xml, n);
-        case "span", "div" -> processContent(xml, n);
-        case "li" -> processItem(xml, n);
-        case "linkhtml" -> processlinkHtml(xml, n);
-        case "ul", "ol" -> processList(xml, n);
-        case "p" -> processParagraph(xml, n);
-        case "img" -> processRenderMultiMedia(xml, n);
-        case "sub" -> processSub(xml, n);
-        case "sup" -> processSup(xml, n);
-        case "table" -> processTable(xml, n);
-        case "tbody" -> processTBody(xml, n);
-        case "td" -> processTd(xml, n);
-        case "tfoot" -> processTFoot(xml, n);
-        case "th" -> processTh(xml, n);
-        case "thead" -> processTHead(xml, n);
-        case "a" -> processA(xml, n);
-        case "tr" -> processTr(xml, n);
+        case "h1", "h2", "h3", "h4", "h5", "h6", "caption" -> processCaption(xml, n, isStrict);
+        case "col" -> processCol(xml, n, isStrict);
+        case "colgroup" -> processColGroup(xml, n, isStrict);
+        case "span", "div" -> processContent(xml, n, isStrict);
+        case "li" -> processItem(xml, n, isStrict);
+        case "linkhtml" -> processlinkHtml(xml, n, isStrict);
+        case "ul", "ol" -> processList(xml, n, isStrict);
+        case "p" -> processParagraph(xml, n, isStrict);
+        case "img" -> processRenderMultiMedia(xml, n, isStrict);
+        case "sub" -> processSub(xml, n, isStrict);
+        case "sup" -> processSup(xml, n, isStrict);
+        case "table" -> processTable(xml, n, isStrict);
+        case "tbody" -> processTBody(xml, n, isStrict);
+        case "td" -> processTd(xml, n, isStrict);
+        case "tfoot" -> processTFoot(xml, n, isStrict);
+        case "th" -> processTh(xml, n, isStrict);
+        case "thead" -> processTHead(xml, n, isStrict);
+        case "a" -> processA(xml, n, isStrict);
+        case "tr" -> processTr(xml, n, isStrict);
         case "list", "item", "paragraph", "rendermultimedia", "content", "footnote", "footnoteref" ->
-          processPassThrough(xml, n);
-        default -> stripTag(xml, n);
+          processPassThrough(xml, n, isStrict);
+        default -> stripTag(xml, n, isStrict);
       }
     }
   }
@@ -397,158 +410,158 @@ public class CDANarrativeFormat {
     xml.element("br");
   }
 
-  private void processCaption(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processCaption(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("caption");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("caption");
   }
 
-  private void processCol(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processCol(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "span", "width", "align", "char", "charoff", "valign");
     xml.enter("col");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("col");
   }
 
-  private void processColGroup(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processColGroup(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "span", "width", "align", "char", "charoff", "valign");
     xml.enter("colgroup");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("colgroup");
   }
 
-  private void processContent(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processContent(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("content");
     // todo: do something with revised..., "revised"
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("content");
   }
 
-  private void processItem(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processItem(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("item");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("item");
   }
 
-  private void processlinkHtml(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processlinkHtml(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     String v = n.getAttribute("src");
     xml.attribute("referencedObject", v);
     processAttributes(n, xml, "name", "href", "rel", "rev", "title", "id", "language", "styleCode");
     xml.enter("linkHtml");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("linkHtml");
   }
 
-  private void processList(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processList(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     if (n.getName().equals("ol"))
       xml.attribute("listType", "ordered");
     else
       xml.attribute("listType", "unordered");
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("list");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("list");
   }
 
-  private void processParagraph(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processParagraph(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("paragraph");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("paragraph");
   }
 
-  private void processRenderMultiMedia(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processRenderMultiMedia(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     String v = n.getAttribute("src");
     if (StringUtils.isNotBlank(v))
       xml.attribute("referencedObject", v);
     processAttributes(n, xml, "id", "language", "styleCode");
     xml.enter("renderMultiMedia");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("renderMultiMedia");
   }
 
-  private void processSub(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processSub(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     xml.enter("sub");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("sub");
   }
 
-  private void processSup(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processSup(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     xml.enter("sup");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("sup");
   }
 
-  private void processTable(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTable(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "summary", "width", "border", "frame", "rules", "cellspacing", "cellpadding");
     xml.enter("table");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("table");
   }
 
-  private void processTBody(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTBody(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("tbody");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("tbody");
   }
 
-  private void processTd(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTd(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "abbr", "axis", "headers", "scope", "rowspan", "colspan", "align", "char", "charoff", "valign");
     xml.enter("td");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("td");
   }
 
-  private void processTFoot(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTFoot(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("tfoot");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("tfoot");
   }
 
-  private void processTh(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTh(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "abbr", "axis", "headers", "scope", "rowspan", "colspan", "align", "char", "charoff", "valign");
     xml.enter("th");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("th");
   }
 
-  private void processTHead(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTHead(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("thead");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("thead");
   }
 
-  private void processTr(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processTr(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("tr");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("tr");
   }
 
-  private void processA(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processA(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     String v = n.getAttribute("href");
     if (StringUtils.isNotBlank(v))
       xml.attribute("referencedObject", v);
 
     processAttributes(n, xml, "id", "language", "styleCode", "align", "char", "charoff", "valign");
     xml.enter("linkHtml");
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit("linkHtml");
   }
 
   /**
    * Pass an element and all its children through from the source XHTML to the CDA Narrative unchanged.
    */
-  private void processPassThrough(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
+  private void processPassThrough(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
     processAllAttributes(n, xml);
     xml.enter(n.getName());
-    processChildren(xml, n);
+    processChildren(xml, n, isStrict);
     xml.exit(n.getName());
   }
 
@@ -630,7 +643,7 @@ public class CDANarrativeFormat {
   /**
    * drop an element from the document while preserving its children (if possible).
    */
-  private void stripTag(IXMLWriter xml, XhtmlNode n) throws IOException, FHIRException {
-    processChildren(xml, n);
+  private void stripTag(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
+    processChildren(xml, n, isStrict);
   }
 }

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormat.java
@@ -335,11 +335,11 @@ public class CDANarrativeFormat {
   }
 
   /**
-   * For XHTML return the matching CDA narrative. This is a strict conversion that will fail if invalid XHTML is encountered.
+   * For XHTML return the matching CDA narrative. This is only guaranteed to work for XML produced from CDA, but will try whatever
    * @param xml      the writer to which the CDA narrative will be written
    * @param div      the root node of the FHIR narrative
    * @throws IOException   if a write operation on the XML writer fails
-   * @throws FHIRException if invalid XHTML is encountered in strict mode
+   * @throws FHIRException if unexpected elements are encountered in strict mode
    */
   public void convert(IXMLWriter xml, XhtmlNode div) throws IOException, FHIRException {
     convert(xml, div, true);
@@ -377,31 +377,48 @@ public class CDANarrativeFormat {
       xml.text(n.getContent());
       return;
     case Element:
-      String elementName = n.getName().toLowerCase();
-      switch (elementName) {
-        case "br" -> processBreak(xml, n);
-        case "h1", "h2", "h3", "h4", "h5", "h6", "caption" -> processCaption(xml, n, isStrict);
-        case "col" -> processCol(xml, n, isStrict);
-        case "colgroup" -> processColGroup(xml, n, isStrict);
-        case "span", "div" -> processContent(xml, n, isStrict);
-        case "li" -> processItem(xml, n, isStrict);
-        case "linkhtml" -> processlinkHtml(xml, n, isStrict);
-        case "ul", "ol" -> processList(xml, n, isStrict);
-        case "p" -> processParagraph(xml, n, isStrict);
-        case "img" -> processRenderMultiMedia(xml, n, isStrict);
-        case "sub" -> processSub(xml, n, isStrict);
-        case "sup" -> processSup(xml, n, isStrict);
-        case "table" -> processTable(xml, n, isStrict);
-        case "tbody" -> processTBody(xml, n, isStrict);
-        case "td" -> processTd(xml, n, isStrict);
-        case "tfoot" -> processTFoot(xml, n, isStrict);
-        case "th" -> processTh(xml, n, isStrict);
-        case "thead" -> processTHead(xml, n, isStrict);
-        case "a" -> processA(xml, n, isStrict);
-        case "tr" -> processTr(xml, n, isStrict);
-        case "list", "item", "paragraph", "rendermultimedia", "content", "footnote", "footnoteref" ->
-          processPassThrough(xml, n, isStrict);
-        default -> stripTag(xml, n, isStrict);
+      processElement(xml, n, isStrict);
+    }
+  }
+
+  private void processElement(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException {
+    String elementName = n.getName().toLowerCase();
+    switch (elementName) {
+      case "br" -> processBreak(xml, n);
+      case "h1", "h2", "h3", "h4", "h5", "h6", "caption" -> processCaption(xml, n, isStrict);
+      case "col" -> processCol(xml, n, isStrict);
+      case "colgroup" -> processColGroup(xml, n, isStrict);
+      case "span", "div" -> processContent(xml, n, isStrict);
+      case "footnote" -> processFootNote(xml, n, isStrict);
+      case "footnoteref" -> processFootNodeRef(xml, n, isStrict);
+      case "li" -> processItem(xml, n, isStrict);
+      case "linkhtml" -> processlinkHtml(xml, n, isStrict);
+      case "ul", "ol" -> processList(xml, n, isStrict);
+      case "p" -> processParagraph(xml, n, isStrict);
+      case "img" -> processRenderMultiMedia(xml, n, isStrict);
+      case "sub" -> processSub(xml, n, isStrict);
+      case "sup" -> processSup(xml, n, isStrict);
+      case "table" -> processTable(xml, n, isStrict);
+      case "tbody" -> processTBody(xml, n, isStrict);
+      case "td" -> processTd(xml, n, isStrict);
+      case "tfoot" -> processTFoot(xml, n, isStrict);
+      case "th" -> processTh(xml, n, isStrict);
+      case "thead" -> processTHead(xml, n, isStrict);
+      case "a" -> processA(xml, n, isStrict);
+      case "tr" -> processTr(xml, n, isStrict);
+      case "list", "item", "paragraph", "rendermultimedia", "content" -> {
+        if (isStrict) {
+          throw new FHIRException("Unknown element " + elementName);
+        } else {
+          processPassThrough(xml, n, false);
+        }
+      }
+      default -> {
+        if (isStrict) {
+          throw new FHIRException("Unknown element " + elementName);
+        } else {
+          stripTag(xml, n, false);
+        }
       }
     }
   }
@@ -437,6 +454,22 @@ public class CDANarrativeFormat {
     // todo: do something with revised..., "revised"
     processChildren(xml, n, isStrict);
     xml.exit("content");
+  }
+
+  private void processFootNote(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
+    if (isStrict) {
+      throw new Error("element " + n.getName() + " not handled yet");
+    } else {
+      processPassThrough(xml, n, isStrict);
+    }
+  }
+
+  private void processFootNodeRef(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {
+    if (isStrict) {
+      throw new Error("element " + n.getName() + " not handled yet");
+    } else {
+      processPassThrough(xml, n, isStrict);
+    }
   }
 
   private void processItem(IXMLWriter xml, XhtmlNode n, boolean isStrict) throws IOException, FHIRException {

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
@@ -1,0 +1,69 @@
+package org.hl7.fhir.utilities.xhtml;
+
+import org.hl7.fhir.utilities.xml.XMLWriter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CDANarrativeFormatTest {
+
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+		# Blank input
+		<div></div>,<?xml version="1.0" encoding="UTF-8"?><text/>
+		# Ensure we don't introduce any regressions to the parent class's behaviour
+		<div>Plain text</div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
+		<div><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody><tfoot><tr><td>Footer</td></tr></tfoot></table></div>,<?xml version="1.0" encoding="UTF-8"?><text><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody><tfoot><tr><td>Footer</td></tr></tfoot></table></text>
+		<div><h2>Plain text</h2></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h2>Plain text</h2><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody></table></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody></table></text>
+		<div>One line<br/>Another line</div>,<?xml version="1.0" encoding="UTF-8"?><text>One line<br/>Another line</text>
+		<div><colgroup><col>Plain text</col></colgroup></div>,<?xml version="1.0" encoding="UTF-8"?><text><colgroup><col>Plain text</col></colgroup></text>
+		<div><span>Plain text</span></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		<div><ul><li>Plain text</li></ul></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
+		<div><ol><li>Plain text</li></ol></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="ordered"><item>Plain text</item></list></text>
+		<div><p>Plain text</p></div>,<?xml version="1.0" encoding="UTF-8"?><text><paragraph>Plain text</paragraph></text>
+		<div><img src="image.png"/></div>,<?xml version="1.0" encoding="UTF-8"?><text><renderMultiMedia referencedObject="image.png"/></text>
+		<div><sub>Plain text</sub></div>,<?xml version="1.0" encoding="UTF-8"?><text><sub>Plain text</sub></text>
+		<div><sup>Plain text</sup></div>,<?xml version="1.0" encoding="UTF-8"?><text><sup>Plain text</sup></text>
+		<div><a id="id" href="link.html"/></div>,<?xml version="1.0" encoding="UTF-8"?><text><linkHtml ID="id" referencedObject="link.html"/></text>
+		# Add support for <div> elements
+		<div><div>Plain text</div></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		# Add support for other header levels
+		<div><h1>Plain text</h1></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h3>Plain text</h3></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h4>Plain text</h4></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h5>Plain text</h5></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h6>Plain text</h6></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		# pass through CDA Narrative elements unchanged
+		<div><renderMultiMedia referencedObject="image.png"/></div>,<?xml version="1.0" encoding="UTF-8"?><text><renderMultiMedia referencedObject="image.png"/></text>
+		<div><paragraph>Plain text</paragraph></div>,<?xml version="1.0" encoding="UTF-8"?><text><paragraph>Plain text</paragraph></text>
+		<div><list listType="unordered"><item>Plain text</item></list></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
+		<div><list listType="ordered"><item>Plain text</item></list></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="ordered"><item>Plain text</item></list></text>
+		<div><content>Plain text</content></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		# strip unsupported tags but retain the contents
+		<div><b>Plain text</b></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
+		<div><i>Plain text</i></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
+		<div><notxhtml>Plain text</notxhtml></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
+		<div><empty/></div>,<?xml version="1.0" encoding="UTF-8"?><text/>
+		""")
+	void testConvert(String theInputXhtml, String theExpectedNarrative) throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		XMLWriter xmlWriter = new XMLWriter(out, "UTF-8");
+		xmlWriter.start();
+
+		XhtmlNode node = new XhtmlNode();
+		node.setValueAsString(theInputXhtml);
+
+		CDANarrativeFormat converter = new CDANarrativeFormat();
+		converter.convert(xmlWriter, node);
+
+		xmlWriter.close();
+		String actualNarrative = out.toString(StandardCharsets.UTF_8);
+		assertThat(actualNarrative).isEqualTo(theExpectedNarrative);
+
+	}
+}

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
@@ -44,11 +44,14 @@ class CDANarrativeFormatTest {
 		<div><list listType="unordered"><item>Plain text</item></list></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
 		<div><list listType="ordered"><item>Plain text</item></list></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="ordered"><item>Plain text</item></list></text>
 		<div><content>Plain text</content></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		<div>Text with a footnote.<footnoteRef IDREF="fn1"/><footnote ID="fn1">This is the footnote</footnote></div>,<?xml version="1.0" encoding="UTF-8"?><text>Text with a footnote.<footnoteRef IDREF="fn1"/><footnote ID="fn1">This is the footnote</footnote></text>
 		# strip unsupported tags but retain the contents
 		<div><b>Plain text</b></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
 		<div><i>Plain text</i></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
 		<div><notxhtml>Plain text</notxhtml></div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
 		<div><empty/></div>,<?xml version="1.0" encoding="UTF-8"?><text/>
+		# case insensitivity
+		<div><UL><LI>Plain text</LI></UL></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
 		""")
 	void testConvert(String theInputXhtml, String theExpectedNarrative) throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
@@ -8,10 +8,86 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CDANarrativeFormatTest {
 
-	@ParameterizedTest
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+		# Blank input
+		<div></div>,<?xml version="1.0" encoding="UTF-8"?><text/>
+		# Ensure we don't introduce any regressions to the parent class's behaviour
+		<div>Plain text</div>,<?xml version="1.0" encoding="UTF-8"?><text>Plain text</text>
+		<div><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody><tfoot><tr><td>Footer</td></tr></tfoot></table></div>,<?xml version="1.0" encoding="UTF-8"?><text><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody><tfoot><tr><td>Footer</td></tr></tfoot></table></text>
+		<div><h2>Plain text</h2></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h2>Plain text</h2><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody></table></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td>Body row</td></tr></tbody></table></text>
+		<div>One line<br/>Another line</div>,<?xml version="1.0" encoding="UTF-8"?><text>One line<br/>Another line</text>
+		<div><colgroup><col>Plain text</col></colgroup></div>,<?xml version="1.0" encoding="UTF-8"?><text><colgroup><col>Plain text</col></colgroup></text>
+		<div><span>Plain text</span></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		<div><ul><li>Plain text</li></ul></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
+		<div><ol><li>Plain text</li></ol></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="ordered"><item>Plain text</item></list></text>
+		<div><p>Plain text</p></div>,<?xml version="1.0" encoding="UTF-8"?><text><paragraph>Plain text</paragraph></text>
+		<div><img src="image.png"/></div>,<?xml version="1.0" encoding="UTF-8"?><text><renderMultiMedia referencedObject="image.png"/></text>
+		<div><sub>Plain text</sub></div>,<?xml version="1.0" encoding="UTF-8"?><text><sub>Plain text</sub></text>
+		<div><sup>Plain text</sup></div>,<?xml version="1.0" encoding="UTF-8"?><text><sup>Plain text</sup></text>
+		<div><a id="id" href="link.html"/></div>,<?xml version="1.0" encoding="UTF-8"?><text><linkHtml ID="id" referencedObject="link.html"/></text>
+		# Add support for <div> elements
+		<div><div>Plain text</div></div>,<?xml version="1.0" encoding="UTF-8"?><text><content>Plain text</content></text>
+		# Add support for other header levels
+		<div><h1>Plain text</h1></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h3>Plain text</h3></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h4>Plain text</h4></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h5>Plain text</h5></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		<div><h6>Plain text</h6></div>,<?xml version="1.0" encoding="UTF-8"?><text><caption>Plain text</caption></text>
+		# case insensitivity
+		<div><UL><LI>Plain text</LI></UL></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
+		""")
+  void testConvert_strictWithValidInput(String theInputXhtml, String theExpectedNarrative) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    XMLWriter xmlWriter = new XMLWriter(out, "UTF-8");
+    xmlWriter.start();
+
+    XhtmlNode node = new XhtmlNode();
+    node.setValueAsString(theInputXhtml);
+
+    CDANarrativeFormat converter = new CDANarrativeFormat();
+    converter.convert(xmlWriter, node);
+
+    xmlWriter.close();
+    String actualNarrative = out.toString(StandardCharsets.UTF_8);
+    assertThat(actualNarrative).isEqualTo(theExpectedNarrative);
+
+  }
+
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+		# some cases that would convert successfully in lenient mode should be rejected in strict mode
+		<div><renderMultiMedia referencedObject="image.png"/></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><paragraph>Plain text</paragraph></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><list listType="unordered"><item>Plain text</item></list></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><list listType="ordered"><item>Plain text</item></list></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><content>Plain text</content></div>,org.hl7.fhir.exceptions.FHIRException
+		<div>Text with a footnote.<footnoteRef IDREF="fn1"/><footnote ID="fn1">This is the footnote</footnote></div>,java.lang.Error
+		<div><b>Plain text</b></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><i>Plain text</i></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><notxhtml>Plain text</notxhtml></div>,org.hl7.fhir.exceptions.FHIRException
+		<div><empty/></div>,org.hl7.fhir.exceptions.FHIRException
+		""")
+  void testConvert_strictWithInvalidInput_throwsException(String theInputXhtml, String expectedThrowableType) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    XMLWriter xmlWriter = new XMLWriter(out, "UTF-8");
+    xmlWriter.start();
+
+    XhtmlNode node = new XhtmlNode();
+    node.setValueAsString(theInputXhtml);
+
+    Class<?> expectedClass = Class.forName(expectedThrowableType);
+
+    CDANarrativeFormat converter = new CDANarrativeFormat();
+    assertThatThrownBy(() -> converter.convert(xmlWriter, node)).isInstanceOf(expectedClass);
+  }
+
+  @ParameterizedTest
 	@CsvSource(textBlock = """
 		# Blank input
 		<div></div>,<?xml version="1.0" encoding="UTF-8"?><text/>
@@ -67,6 +143,5 @@ class CDANarrativeFormatTest {
 		xmlWriter.close();
 		String actualNarrative = out.toString(StandardCharsets.UTF_8);
 		assertThat(actualNarrative).isEqualTo(theExpectedNarrative);
-
-	}
+  }
 }

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/CDANarrativeFormatTest.java
@@ -53,7 +53,7 @@ class CDANarrativeFormatTest {
 		# case insensitivity
 		<div><UL><LI>Plain text</LI></UL></div>,<?xml version="1.0" encoding="UTF-8"?><text><list listType="unordered"><item>Plain text</item></list></text>
 		""")
-	void testConvert(String theInputXhtml, String theExpectedNarrative) throws Exception {
+	void testConvert_lenient(String theInputXhtml, String theExpectedNarrative) throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		XMLWriter xmlWriter = new XMLWriter(out, "UTF-8");
 		xmlWriter.start();
@@ -62,7 +62,7 @@ class CDANarrativeFormatTest {
 		node.setValueAsString(theInputXhtml);
 
 		CDANarrativeFormat converter = new CDANarrativeFormat();
-		converter.convert(xmlWriter, node);
+		converter.convert(xmlWriter, node, false);
 
 		xmlWriter.close();
 		String actualNarrative = out.toString(StandardCharsets.UTF_8);


### PR DESCRIPTION
The current `CDANarrativeFormat` has a key limitation in the XHTML -> CDA Narrative direction: it only consumes those XHTML elements that the class produces in the CDA Narrative -> XHTML direction. For our project, we require a best-effort transformation of a broader set of inputs. We have enhanced the transformation as follows:

- add support for `h1`, `h3`, `h4`, `h5`, and `h6` elements, equivalent to the existing support for `h2` elements
- add support for `div` elements, equivalent to the existing support for `span` elements
- if the input happens to contain CDA Narrative elements (e.g., `content`, `footnote`), these elements will pass through to the output unchanged
- any unsupported elements will be silently dropped, instead of failing the entire transformation with an error
- make the whole thing case insensitive

We also fixed a bug where the `href` attribute of an `a` element was not getting converted.