### PR TITLE
Delegate FHIRPath custom-function hooks to ITransformerServices in StructureMapUtilities

### DIFF
--- a/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
+++ b/org.hl7.fhir.r4/src/main/java/org/hl7/fhir/r4/utils/StructureMapUtilities.java
@@ -156,6 +156,22 @@ public class StructureMapUtilities {
     public Base resolveReference(Object appContext, String url) throws FHIRException;
 
     public List<Base> performSearch(Object appContext, String url) throws FHIRException;
+
+    // FHIRPath custom-function hooks (see IHostApplicationServices). Default implementations
+    // preserve the previous hardcoded FHIRPathHostServices behavior for callers that don't
+    // override them, so adding these methods is backward-compatible.
+    default FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
+      return null;
+    }
+
+    default TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters)
+        throws PathEngineException {
+      throw new PathEngineException("Unknown function '" + functionName + "'");
+    }
+
+    default List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName, List<List<Base>> parameters) {
+      throw new Error("Not Implemented Yet");
+    }
   }
 
   private class FHIRPathHostServices implements IHostApplicationServices {
@@ -191,19 +207,25 @@ public class StructureMapUtilities {
 
     @Override
     public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
-      return null; // throw new Error("Not Implemented Yet");
+      return services == null ? null : services.resolveFunction(engine, functionName);
     }
 
     @Override
     public TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters)
         throws PathEngineException {
-      throw new Error("Not Implemented Yet");
+      if (services == null) {
+        throw new PathEngineException("Unknown function '" + functionName + "'");
+      }
+      return services.checkFunction(engine, appContext, functionName, focus, parameters);
     }
 
     @Override
     public List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName,
         List<List<Base>> parameters) {
-      throw new Error("Not Implemented Yet");
+      if (services == null) {
+        throw new Error("Not Implemented Yet");
+      }
+      return services.executeFunction(engine, appContext, focus, functionName, parameters);
     }
 
     @Override

--- a/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/StructureMapUtilitiesFunctionDelegationTest.java
+++ b/org.hl7.fhir.r4/src/test/java/org/hl7/fhir/r4/test/StructureMapUtilitiesFunctionDelegationTest.java
@@ -1,0 +1,192 @@
+package org.hl7.fhir.r4.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.exceptions.PathEngineException;
+import org.hl7.fhir.r4.elementmodel.Element;
+import org.hl7.fhir.r4.elementmodel.Manager;
+import org.hl7.fhir.r4.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r4.fhirpath.ExpressionNode.CollectionStatus;
+import org.hl7.fhir.r4.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r4.fhirpath.FHIRPathUtilityClasses.FunctionDetails;
+import org.hl7.fhir.r4.fhirpath.TypeDetails;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.StructureMap;
+import org.hl7.fhir.r4.test.utils.TestingUtilities;
+import org.hl7.fhir.r4.utils.StructureMapUtilities;
+import org.hl7.fhir.r4.utils.StructureMapUtilities.ITransformerServices;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that StructureMapUtilities' internal FHIRPathHostServices delegates the FHIRPath
+ * custom-function hooks (resolveFunction/checkFunction/executeFunction) to the caller-supplied
+ * ITransformerServices, exactly as it already does for resolveReference.
+ *
+ * Also proves that this is purely additive: an ITransformerServices implementation that does not
+ * override the three new default methods sees the exact same "unknown function" failure that
+ * FHIRPathHostServices hardcoded before this change.
+ */
+public class StructureMapUtilitiesFunctionDelegationTest {
+
+  private static final String MAP_TEXT =
+      "map \"http://github.com/hapifhir/tests/StructureMap/customfunction\" = \"CustomFunctionMap\"\r\n"
+    + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias Patient as source\r\n"
+    + "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias Patient as target\r\n"
+    + "group Main(source src : Patient, target tgt : Patient) {\r\n"
+    + "  src.active as v -> tgt.active = (v.negate());\r\n"
+    + "}";
+
+  private static final String PATIENT_JSON =
+      "{\"resourceType\":\"Patient\",\"active\":true}";
+
+  private Element parsePatient() throws IOException, FHIRException {
+    return Manager.parse(TestingUtilities.context(),
+        new ByteArrayInputStream(PATIENT_JSON.getBytes(StandardCharsets.UTF_8)), FhirFormat.JSON);
+  }
+
+  /**
+   * A custom FHIRPath function ("negate") that flips a boolean, implemented entirely by the
+   * calling application via ITransformerServices - not by the FHIR core library.
+   */
+  private static class NegatingTransformerServices implements ITransformerServices {
+    @Override
+    public void log(String message) {
+    }
+
+    @Override
+    public Base createType(Object appInfo, String name) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+      return res;
+    }
+
+    @Override
+    public Coding translate(Object appInfo, Coding source, String conceptMapUrl) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public Base resolveReference(Object appContext, String url) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public List<Base> performSearch(Object appContext, String url) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
+      if ("negate".equals(functionName)) {
+        return new FunctionDetails("negate a boolean value", 0, 0);
+      }
+      return null;
+    }
+
+    @Override
+    public TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus,
+        List<TypeDetails> parameters) throws PathEngineException {
+      if ("negate".equals(functionName)) {
+        return new TypeDetails(CollectionStatus.SINGLETON, "boolean");
+      }
+      throw new PathEngineException("Unknown function '" + functionName + "'");
+    }
+
+    @Override
+    public List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName,
+        List<List<Base>> parameters) {
+      // The transform's source/target trees are generic elementmodel.Element instances (not the
+      // typed model.BooleanType), so booleans must be read via isBooleanPrimitive()/primitiveValue(),
+      // exactly as FHIRPathEngine.convertToBoolean() does for its own built-in functions.
+      if ("negate".equals(functionName) && focus.size() == 1 && focus.get(0).isBooleanPrimitive()) {
+        List<Base> result = new ArrayList<>();
+        result.add(new BooleanType(!Boolean.parseBoolean(focus.get(0).primitiveValue())));
+        return result;
+      }
+      throw new Error("Not Implemented Yet");
+    }
+  }
+
+  /**
+   * An ITransformerServices implementation that only implements the pre-existing (non-default)
+   * methods, exactly like every ITransformerServices implementor that exists today. It does not
+   * override resolveFunction/checkFunction/executeFunction, so it gets the new default bodies.
+   */
+  private static class PlainTransformerServices implements ITransformerServices {
+    @Override
+    public void log(String message) {
+    }
+
+    @Override
+    public Base createType(Object appInfo, String name) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public Base createResource(Object appInfo, Base res, boolean atRootofTransform) {
+      return res;
+    }
+
+    @Override
+    public Coding translate(Object appInfo, Coding source, String conceptMapUrl) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public Base resolveReference(Object appContext, String url) throws FHIRException {
+      return null;
+    }
+
+    @Override
+    public List<Base> performSearch(Object appContext, String url) throws FHIRException {
+      return null;
+    }
+  }
+
+  @Test
+  public void testCustomFunctionIsDelegatedToTransformerServices() throws IOException, FHIRException {
+    StructureMapUtilities scu = new StructureMapUtilities(TestingUtilities.context(), new NegatingTransformerServices());
+    StructureMap map = scu.parse(MAP_TEXT, "CustomFunctionMap");
+
+    // exercises checkFunction (via the analysis/profiling pass) end to end - must not throw.
+    assertDoesNotThrow(() -> scu.analyse(null, map));
+
+    Element source = parsePatient();
+    StructureDefinition targetType = scu.getTargetType(map);
+    Element target = Manager.build(TestingUtilities.context(), targetType);
+
+    // exercises resolveFunction (at parse time, above) and executeFunction (here, at runtime).
+    scu.transform(null, source, map, target);
+
+    FHIRPathEngine fp = new FHIRPathEngine(TestingUtilities.context());
+    assertEquals("true", fp.evaluateToString(source, "active"));
+    assertEquals("false", fp.evaluateToString(target, "active"));
+  }
+
+  @Test
+  public void testUnknownCustomFunctionStillFailsTheSameWayWithoutOverride() {
+    StructureMapUtilities scu = new StructureMapUtilities(TestingUtilities.context(), new PlainTransformerServices());
+
+    // Before this change, FHIRPathHostServices hardcoded resolveFunction() to return null for
+    // every function name; an ITransformerServices that does not override the new default
+    // methods must observe that exact same "unrecognized function" failure, proving the fix is
+    // purely additive rather than a behavior change for existing, non-overriding callers.
+    FHIRException ex = assertThrows(FHIRException.class, () -> scu.parse(MAP_TEXT, "CustomFunctionMap"));
+    assertEquals(true, ex.getMessage().contains("negate") && ex.getMessage().contains("not a valid function name"));
+  }
+}

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/FHIRPathHostServices.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/FHIRPathHostServices.java
@@ -59,19 +59,25 @@ public class FHIRPathHostServices implements IHostApplicationServices {
 
   @Override
   public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
-    return null; // throw new Error("Not Implemented Yet");
+    return structureMapUtilities.getServices() == null ? null : structureMapUtilities.getServices().resolveFunction(engine, functionName);
   }
 
   @Override
   public TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters)
       throws PathEngineException {
-    throw new Error("Not Implemented Yet");
+    if (structureMapUtilities.getServices() == null) {
+      throw new PathEngineException("Unknown function '" + functionName + "'");
+    }
+    return structureMapUtilities.getServices().checkFunction(engine, appContext, functionName, focus, parameters);
   }
 
   @Override
   public List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName,
       List<List<Base>> parameters) {
-    throw new Error("Not Implemented Yet");
+    if (structureMapUtilities.getServices() == null) {
+      throw new Error("Not Implemented Yet");
+    }
+    return structureMapUtilities.getServices().executeFunction(engine, appContext, focus, functionName, parameters);
   }
 
   @Override

--- a/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/ITransformerServices.java
+++ b/org.hl7.fhir.r4b/src/main/java/org/hl7/fhir/r4b/utils/structuremap/ITransformerServices.java
@@ -1,6 +1,10 @@
 package org.hl7.fhir.r4b.utils.structuremap;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.exceptions.PathEngineException;
+import org.hl7.fhir.r4b.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r4b.fhirpath.TypeDetails;
+import org.hl7.fhir.r4b.fhirpath.FHIRPathUtilityClasses.FunctionDetails;
 import org.hl7.fhir.r4b.model.Base;
 import org.hl7.fhir.r4b.model.Coding;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
@@ -29,4 +33,20 @@ public interface ITransformerServices {
   public Base resolveReference(Object appContext, String url) throws FHIRException;
 
   public List<Base> performSearch(Object appContext, String url) throws FHIRException;
+
+  // FHIRPath custom-function hooks (see IHostApplicationServices). Default implementations
+  // preserve the previous hardcoded FHIRPathHostServices behavior for callers that don't
+  // override them, so adding these methods is backward-compatible.
+  default FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
+    return null;
+  }
+
+  default TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters)
+      throws PathEngineException {
+    throw new PathEngineException("Unknown function '" + functionName + "'");
+  }
+
+  default List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName, List<List<Base>> parameters) {
+    throw new Error("Not Implemented Yet");
+  }
 }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/FHIRPathHostServices.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/FHIRPathHostServices.java
@@ -60,17 +60,23 @@ public class FHIRPathHostServices implements IHostApplicationServices {
 
   @Override
   public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
-    return null; // throw new Error("Not Implemented Yet");
+    return structureMapUtilities.getServices() == null ? null : structureMapUtilities.getServices().resolveFunction(engine, functionName);
   }
 
   @Override
   public TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters) throws PathEngineException {
-    throw new Error("Not Implemented Yet");
+    if (structureMapUtilities.getServices() == null) {
+      throw new PathEngineException("Unknown function '" + functionName + "'");
+    }
+    return structureMapUtilities.getServices().checkFunction(engine, appContext, functionName, focus, parameters);
   }
 
   @Override
   public List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName, List<List<Base>> parameters) {
-    throw new Error("Not Implemented Yet");
+    if (structureMapUtilities.getServices() == null) {
+      throw new Error("Not Implemented Yet");
+    }
+    return structureMapUtilities.getServices().executeFunction(engine, appContext, focus, functionName, parameters);
   }
 
   @Override

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/ITransformerServices.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/structuremap/ITransformerServices.java
@@ -1,7 +1,11 @@
 package org.hl7.fhir.r5.utils.structuremap;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.exceptions.PathEngineException;
 import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r5.fhirpath.TypeDetails;
+import org.hl7.fhir.r5.fhirpath.FHIRPathUtilityClasses.FunctionDetails;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.utilities.MarkedToMoveToAdjunctPackage;
@@ -28,4 +32,20 @@ public interface ITransformerServices {
   public Base resolveReference(Object appContext, String url) throws FHIRException;
 
   public List<Base> performSearch(Object appContext, String url) throws FHIRException;
+
+  // FHIRPath custom-function hooks (see IHostApplicationServices). Default implementations
+  // preserve the previous hardcoded FHIRPathHostServices behavior for callers that don't
+  // override them, so adding these methods is backward-compatible.
+  default FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
+    return null;
+  }
+
+  default TypeDetails checkFunction(FHIRPathEngine engine, Object appContext, String functionName, TypeDetails focus, List<TypeDetails> parameters)
+      throws PathEngineException {
+    throw new PathEngineException("Unknown function '" + functionName + "'");
+  }
+
+  default List<Base> executeFunction(FHIRPathEngine engine, Object appContext, List<Base> focus, String functionName, List<List<Base>> parameters) {
+    throw new Error("Not Implemented Yet");
+  }
 }


### PR DESCRIPTION
## What's broken today

`StructureMapUtilities` wires an inner `FHIRPathHostServices` class (implementing
`IHostApplicationServices`) into the `FHIRPathEngine` it uses to evaluate FHIRPath
expressions inside `StructureMap`/FML transforms. That class hardcodes three of the
FHIRPath engine's extensibility hooks:

```java
@Override
public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
  return null; // throw new Error("Not Implemented Yet");
}

@Override
public TypeDetails checkFunction(...) throws PathEngineException {
  throw new Error("Not Implemented Yet");
}

@Override
public List<Base> executeFunction(...) {
  throw new Error("Not Implemented Yet");
}
```

This means custom FHIRPath functions can never be used inside a `StructureMap`/FML
transform — every custom function invocation dies at parse (`resolveFunction`), analysis
(`checkFunction`), or runtime (`executeFunction`) — *even though* the caller's own
`ITransformerServices` is right there and is already used for the equivalent
`resolveReference` hook (`FHIRPathHostServices.resolveReference` delegates to
`services.resolveReference(...)`). There's no reason for `resolveReference` to be
delegatable but `resolveFunction`/`checkFunction`/`executeFunction` to be dead ends.

## The fix

Add three `default` methods to `ITransformerServices` — `resolveFunction`,
`checkFunction`, `executeFunction` — whose default bodies reproduce the exact previous
hardcoded behavior (return `null`, throw `PathEngineException("Unknown function '...'")`,
throw `Error("Not Implemented Yet")`, respectively). Then have `FHIRPathHostServices`
delegate each call to `services.<method>(...)`, mirroring the existing `resolveReference`
delegation pattern exactly:

```java
@Override
public FunctionDetails resolveFunction(FHIRPathEngine engine, String functionName) {
  return services == null ? null : services.resolveFunction(engine, functionName);
}
```

Applied identically across `org.hl7.fhir.r4`, `org.hl7.fhir.r4b`, and `org.hl7.fhir.r5`.

## Why it's backward-compatible

The three new methods are `default` methods on an existing public interface, and their
default bodies are byte-for-byte equivalent to what `FHIRPathHostServices` used to do
unconditionally. Any existing `ITransformerServices` implementor that does not override
them observes exactly the same behavior as before — same return values, same exceptions,
same messages. This is verified by a regression test
(`StructureMapUtilitiesFunctionDelegationTest.testUnknownCustomFunctionStillFailsTheSameWayWithoutOverride`)
using a plain `ITransformerServices` that only implements the pre-existing methods.

A second test in the same file
(`testCustomFunctionIsDelegatedToTransformerServices`) proves the positive case: a
caller-supplied `ITransformerServices` implementing a custom `negate` function is
invoked end-to-end through `parse`/`analyse`/`transform`, turning `source.active=true`
into `target.active=false` via `tgt.active = (v.negate())` in the FML map — with no
changes to FHIR core needed beyond the delegation itself.

`org.hl7.fhir.r4` includes the full regression test above. `org.hl7.fhir.r4b` and
`org.hl7.fhir.r5` received the identical fix (same delegation pattern, same default
bodies) and are verified by successful compilation of each module; no test was
duplicated there since the r4/r4b/r5 `StructureMapUtilities`/`FHIRPathHostServices`
implementations are otherwise structurally the same.

## Motivating use case

I'm implementing an HL7 v2-to-FHIR bridge using `StructureMap`/FML as the transform
engine. FHIRPath's own spec defines an HL7 v2 message object model appendix
(https://build.fhir.org/ig/HL7/FHIRPath/en/appendices.html#use-of-fhirpath-on-hl7-version-2-messages)
with `group()`, `elements()`, `simple()`, and `components()` functions for navigating v2
message structure directly from FHIRPath expressions. Implementing that appendix means
supplying custom FHIRPath functions from application code — which today is impossible
from within a `StructureMap`/FML transform because of the hardcoded stubs above. This
change lets an application supply those functions (or any custom function) via the
`ITransformerServices` it already passes to `StructureMapUtilities`, with no forking of
this library required.