### PR TITLE
Share the HTTP connection pool across ManagedHTTPClient instances

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedHTTPClient.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/http/ManagedHTTPClient.java
@@ -88,6 +88,41 @@ public class ManagedHTTPClient {
   private final OkHttpClient baseClient;
   private final OkHttpClient nonPublicAddressRejectingClient;
 
+  /**
+   * The single {@link OkHttpClient} every client built by this class is derived from, via
+   * {@link OkHttpClient#newBuilder()}.
+   * <p>
+   * This exists so that connections are pooled and reused. A {@link ManagedHTTPClient} is
+   * constructed per request by both {@link ManagedFhirWebAccessor#httpCall(HTTPRequest)} and
+   * {@link ManagedWebAccessor}, so building each one's {@link OkHttpClient} with
+   * {@code new OkHttpClient.Builder()} gave every request its own {@link okhttp3.ConnectionPool}.
+   * A pool that is never consulted again cannot hand its connection to the next request, so each
+   * request paid a fresh TCP and TLS handshake, and each just-used socket sat idle in an
+   * unreachable pool until its 5 minute keep-alive expired - accumulating as CLOSE-WAIT once the
+   * server timed it out first. Deriving from a shared client means the pool, dispatcher and
+   * SSL socket factory are shared, which is what OkHttp requires for connection reuse: those are
+   * part of the {@code Address} that pooled connections are keyed by.
+   * <p>
+   * Only connection infrastructure is shared. Timeouts and interceptors are still applied
+   * per instance in {@link #buildBaseClient()} - neither participates in {@code Address}
+   * equality, so they do not prevent reuse. Interceptors in particular must NOT be hoisted
+   * here: {@link RetryInterceptor} holds a per-request retry counter that it never resets.
+   */
+  private static final OkHttpClient SHARED_CLIENT = new OkHttpClient.Builder()
+    .proxyAuthenticator(new ProxyAuthenticator())
+    .dns(Dns.SYSTEM)
+    .followRedirects(false)
+    .followSslRedirects(false)
+    .build();
+
+  /**
+   * Shared because {@code Address} equality - and therefore connection reuse - compares the
+   * {@link Dns} by identity for implementations that do not override {@code equals}. A new
+   * instance per client would put every request on its own pool key even with a shared pool.
+   * {@link NonPublicAddressRejectingDns} is stateless, so sharing one is safe.
+   */
+  private static final Dns SHARED_NON_PUBLIC_ADDRESS_REJECTING_DNS = new NonPublicAddressRejectingDns();
+
   @Builder
   private ManagedHTTPClient(Long timeout,
                             TimeUnit timeoutUnit,
@@ -112,15 +147,11 @@ public class ManagedHTTPClient {
    * @return An OkHTTPClient configured from our settings, but with no additional protocol or network blocking.
    */
   private OkHttpClient buildBaseClient() {
-    OkHttpClient.Builder builder = new OkHttpClient.Builder()
-      .proxyAuthenticator(new ProxyAuthenticator())
-      .dns(Dns.SYSTEM)
+    OkHttpClient.Builder builder = SHARED_CLIENT.newBuilder()
       .addInterceptor(new RetryInterceptor(retries))
       .connectTimeout(timeout, timeoutUnit)
       .writeTimeout(timeout, timeoutUnit)
-      .readTimeout(timeout, timeoutUnit)
-      .followRedirects(false)
-      .followSslRedirects(false);
+      .readTimeout(timeout, timeoutUnit);
     if (logger != null) {
       builder.addInterceptor(new LoggingInterceptor(logger));
     }
@@ -135,7 +166,7 @@ public class ManagedHTTPClient {
    */
   private OkHttpClient buildNonPublicAddressRejectingClient(OkHttpClient baseClient) {
     OkHttpClient.Builder builder = baseClient.newBuilder()
-      .dns(new NonPublicAddressRejectingDns());
+      .dns(SHARED_NON_PUBLIC_ADDRESS_REJECTING_DNS);
     return builder.build();
   }
 

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedHTTPClientTest.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/http/ManagedHTTPClientTest.java
@@ -507,4 +507,45 @@ public class ManagedHTTPClientTest {
     }
   }
 
+  @Nested
+  class ConnectionReuse {
+
+    /**
+     * Callers construct a {@link ManagedHTTPClient} per request (see
+     * {@link ManagedFhirWebAccessor#httpCall(HTTPRequest)} and {@link ManagedWebAccessor}), so
+     * separately-built clients must still share a connection pool. When they did not, every
+     * request paid a fresh TCP + TLS handshake and left its socket to rot in an unreachable pool
+     * until the keep-alive expired, which showed up as an ever-growing pile of CLOSE-WAIT sockets
+     * against a terminology server.
+     * <p>
+     * MockWebServer numbers requests within a connection: a sequence number of 0 means the request
+     * opened a new connection. If the pool is shared, only the very first request should be 0.
+     */
+    @Test
+    void separatelyBuiltClientsReuseTheSameConnection() throws IOException, InterruptedException {
+      int requestCount = 5;
+      for (int i = 0; i < requestCount; i++) {
+        server.enqueue(new MockResponse().setBody("Monkeys").setResponseCode(200));
+      }
+      String url = server.url("some/path").url().toString();
+
+      for (int i = 0; i < requestCount; i++) {
+        // A new client each time, exactly as the per-request callers do.
+        ManagedHTTPClient client = ManagedHTTPClient.builder().ssrfProtectionEnabled(false).build();
+        assertThat(client.get(url, "application/json").getCode()).isEqualTo(200);
+      }
+
+      assertThat(server.getRequestCount()).isEqualTo(requestCount);
+      int newConnections = 0;
+      for (int i = 0; i < requestCount; i++) {
+        if (server.takeRequest().getSequenceNumber() == 0) {
+          newConnections++;
+        }
+      }
+      assertThat(newConnections)
+        .as("every request opened its own connection - the connection pool is not being shared")
+        .isEqualTo(1);
+    }
+  }
+
 }


### PR DESCRIPTION
`ManagedHTTPClient` builds each `OkHttpClient` with `new OkHttpClient.Builder()`, and instances are constructed per request by both `ManagedFhirWebAccessor` and `ManagedWebAccessor`, so every request gets its own `ConnectionPool`, pays a fresh TCP and TLS handshake, and leaves the just-used socket in an unreachable pool until it shows up as `CLOSE-WAIT` - a regression from #2526, which dropped the `static` from `ManagedFhirWebAccessor`'s client and left the *"singleton instance of the HttpClient, used for all requests"* comment stranded on the now non-static field.

Deriving every client from one shared instance via `newBuilder()` restores pooling while keeping timeouts and interceptors per-instance (`RetryInterceptor` holds a counter it never resets, so it must not be hoisted) and preserving the SSRF boundary, since `Address` compares `dns` and the checked and unchecked clients still use different `Dns` instances.

On a real IG Publisher 2.3.0 build with a cold terminology cache, this takes 1196 TCP connections and 412 peak `CLOSE-WAIT` down to 4 and 1, completing 2.9x more terminology work in the same window; the added test fails without the fix (expected 1 connection, got 5).
