### PR TITLE
Batch CodeSystem supplement concept validation

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -1211,6 +1211,26 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
 
   @Override
   public void validateCodeBatch(ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs, boolean passVS) {
+    validateCodeBatch(options, codes, vs, passVS, false);
+  }
+
+  /**
+   * Validate a batch of codes against the code systems they name, without reference to any value set.
+   * <p>
+   * This is the batch equivalent of {@link #validateCode(ValidationOptions, String, String, String, String)}:
+   * it asks "is this code valid in this code system", not "is this code in this value set". It therefore
+   * uses CodeSystem/$batch-validate-code, mirroring the way {@link #validateOnServer2} chooses
+   * CodeSystem/$validate-code when no value set is in play.
+   *
+   * @param options controls the validation process
+   * @param codes   the codes to validate; each request carries its own result, so callers can report per-code diagnostics
+   */
+  @Override
+  public void validateCodeBatchCS(ValidationOptions options, List<? extends CodingValidationRequest> codes) {
+    validateCodeBatch(options, codes, null, false, true);
+  }
+
+  private void validateCodeBatch(ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs, boolean passVS, boolean csBatch) {
     if (options == null) {
       options = ValidationOptions.defaults();
     }
@@ -1282,10 +1302,19 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
 
     if (items.size() > 0) {
       TerminologyClientContext tc = terminologyClientManager.chooseServer(vs, systems, false, findValidationLanguage(options));
-      Parameters resp = processBatch(tc, batch, systems, items.size());
+      Parameters resp = processBatch(tc, batch, systems, items.size(), csBatch);
       List<ParametersParameterComponent> validations = resp.getParameters("validation");
       for (int i = 0; i < items.size(); i++) {
         CodingValidationRequest t = items.get(i);
+        if (i >= validations.size()) {
+          // the server returned fewer results than we asked about. We can't tell which ones are missing,
+          // so rather than silently mis-attributing results to the wrong codes, every code we have no
+          // answer for gets its own error
+          t.setResult(new ValidationResult(IssueSeverity.ERROR,
+              formatMessage(I18nConstants.TX_SERVER_BATCH_RESPONSE_INCOMPLETE, validations.size(), items.size()), TerminologyServiceErrorClass.SERVER_ERROR, null)
+              .setTxLink(txLog == null ? null : txLog.getLastId()));
+          continue;
+        }
         ParametersParameterComponent r = validations.get(i);
 
         if (r.getResource() instanceof Parameters) {
@@ -1300,7 +1329,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     }
   }
 
-  private Parameters processBatch(TerminologyClientContext tc, Parameters batch, Set<String> systems, int size) {
+  private Parameters processBatch(TerminologyClientContext tc, Parameters batch, Set<String> systems, int size, boolean csBatch) {
     txLog("$batch validate for " + size + " codes on systems " + systems.toString());
     if (terminologyClientManager == null) {
       throw new FHIRException(formatMessage(I18nConstants.ATTEMPT_TO_USE_TERMINOLOGY_SERVER_WHEN_NO_TERMINOLOGY_SERVER_IS_AVAILABLE));
@@ -1308,7 +1337,7 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
     if (txLog != null) {
       txLog.clearLastId();
     }
-    Parameters resp = tc.getClient().batchValidateVS(batch);
+    Parameters resp = csBatch ? tc.getClient().batchValidateCS(batch) : tc.getClient().batchValidateVS(batch);
     if (resp == null) {
       throw new FHIRException(formatMessage(I18nConstants.TX_SERVER_NO_BATCH_RESPONSE));
     }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/IWorkerContext.java
@@ -790,6 +790,21 @@ public interface IWorkerContext {
   public void validateCodeBatch(ValidationOptions options, List<? extends CodingValidationRequest> codes, ValueSet vs, boolean passVS);
 
   /**
+   * Batch validate codes against the code systems they name, with no value set involved - reduce latency
+   * and do a bunch of codes in a single server call. Each is the same as a
+   * validateCode(options, system, version, code, display).
+   *
+   * Unlike validateCodeBatch, this uses CodeSystem/$batch-validate-code, so it asks whether each code is
+   * valid in its code system rather than whether it is a member of some value set.
+   *
+   * Results are set on the individual requests, so callers retain per-code diagnostics.
+   *
+   * @param options
+   * @param codes
+   */
+  public void validateCodeBatchCS(ValidationOptions options, List<? extends CodingValidationRequest> codes);
+
+  /**
    * Validate the actual terminology resource itself on the appropriate terminology server
    *
    * (used for ECL validation)

--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nConstants.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/i18n/I18nConstants.java
@@ -911,6 +911,7 @@ public class I18nConstants {
   public static final String THIS__CANNOT_BE_PARSED_AS_A_FHIR_OBJECT_NO_NAMESPACE = "This__cannot_be_parsed_as_a_FHIR_object_no_namespace";
   public static final String TX_GENERAL_CC_ERROR_MESSAGE = "TX_GENERAL_CC_ERROR_MESSAGE";
   public static final String TX_SERVER_NO_BATCH_RESPONSE = "TX_SERVER_NO_BATCH_RESPONSE";
+  public static final String TX_SERVER_BATCH_RESPONSE_INCOMPLETE = "TX_SERVER_BATCH_RESPONSE_INCOMPLETE";
   public static final String TYPE_CHECKS_PATTERN_CC = "TYPE_CHECKS_PATTERN_CC";
   public static final String TYPE_CHECKS_PATTERN_CC_US = "TYPE_CHECKS_PATTERN_CC_US"; 
   public static final String TYPE_ON_FIRST_DIFFERENTIAL_ELEMENT = "type_on_first_differential_element";

--- a/org.hl7.fhir.utilities/src/main/resources/Messages.properties
+++ b/org.hl7.fhir.utilities/src/main/resources/Messages.properties
@@ -953,6 +953,7 @@ This_property_must_be_an_object_not_ = This property must be an object, not {0} 
 This_property_must_be_an_simple_value_not_ = This property must be a simple value, not {0} ({1} at {2})
 TX_GENERAL_CC_ERROR_MESSAGE = No valid coding was found for the value set ''{0}''
 TX_SERVER_NO_BATCH_RESPONSE = The server return null from a batch validation request
+TX_SERVER_BATCH_RESPONSE_INCOMPLETE = The server returned {0} results for a batch validation request that contained {1} codes, so this code could not be validated
 TYPE_CHECKS_PATTERN_CC = The pattern [system {0}, code {1}, and display ''{2}''] defined in the profile {3} not found. Issues: {4}
 TYPE_CHECKS_PATTERN_CC_US = The pattern [system {0}, code {1}, display ''{2}'' and userSelected {5}] defined in the profile {3} not found. Issues: {4}
 type_on_first_differential_element = Type on first differential element!

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/CodeSystemValidator.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/instance/type/CodeSystemValidator.java
@@ -15,8 +15,11 @@ import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.CodeSystem.ConceptDefinitionComponent;
 import org.hl7.fhir.r5.model.CodeSystem.ConceptPropertyComponent;
 import org.hl7.fhir.r5.model.CodeSystem.PropertyComponent;
+import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientContext;
+import org.hl7.fhir.r5.terminologies.utilities.CodingValidationRequest;
 import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
 import org.hl7.fhir.r5.utils.validation.IResourceValidator;
 import org.hl7.fhir.r5.utils.validation.IValidationPolicyAdvisor.SpecialValidationAction;
@@ -26,6 +29,7 @@ import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.i18n.I18nConstants;
 import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueType;
 import org.hl7.fhir.utilities.validation.ValidationOptions;
 import org.hl7.fhir.validation.BaseValidator;
@@ -109,6 +113,31 @@ public class CodeSystemValidator extends BaseValidator {
   }
 
   private static final String VS_PROP_STATUS = null;
+
+  /**
+   * How many supplement concepts to validate in a single server call. Matches ValueSetValidator.
+   */
+  private static final int VALIDATION_BATCH_SIZE = 300;
+
+  /**
+   * A code to validate, paired with the location of the concept it came from, so that the result of a
+   * batched validation can still be reported against the individual concept that produced it.
+   */
+  public static class CSCodingValidationRequest extends CodingValidationRequest {
+
+    private final NodeStack stack;
+
+    public CSCodingValidationRequest(NodeStack stack, Coding coding) {
+      super(coding);
+      this.stack = stack;
+    }
+
+    public NodeStack getStack() {
+      return stack;
+    }
+
+  }
+
   private Set<String> propertyCodes = new HashSet<String>();
   private boolean noDisplayWarningDone;
   private boolean noDefinitionWarningDone;
@@ -190,15 +219,21 @@ public class CodeSystemValidator extends BaseValidator {
 
             }
             List<Element> concepts = cs.getChildrenByName("concept");
+            CanonicalPair suppCanonical = new CanonicalPair(supp);
+            List<CSCodingValidationRequest> suppBatch = new ArrayList<>();
             int ce = 0;
             for (Element concept : concepts) {
               NodeStack nstack = stack.push(concept, ce, null, null);
               if (ce == 0) {
-                rule(errors, "2023-08-15", IssueType.INVALID, nstack,  !"not-present".equals(content), I18nConstants.CODESYSTEM_CS_COUNT_NO_CONTENT_ALLOWED);            
+                rule(errors, "2023-08-15", IssueType.INVALID, nstack,  !"not-present".equals(content), I18nConstants.CODESYSTEM_CS_COUNT_NO_CONTENT_ALLOWED);
               }
-              ok = validateSupplementConcept(errors, concept, nstack, supp, options) && ok;
+              String code = concept.getChildValue("code");
+              if (!Utilities.noString(code) && !noTerminologyChecks) {
+                suppBatch.add(new CSCodingValidationRequest(nstack, new Coding(suppCanonical.getUrl(), suppCanonical.getVersion(), code, null)));
+              }
               ce++;
-            }    
+            }
+            ok = validateSupplementConcepts(errors, suppBatch, supp, options) && ok;
           } else {
             if (cs.hasChildren("concept")) {
               warning(errors, NO_RULE_DATE, IssueType.BUSINESSRULE, stack.getLiteralPath(), false, I18nConstants.CODESYSTEM_CS_SUPP_CANT_CHECK, supp);
@@ -847,16 +882,67 @@ public class CodeSystemValidator extends BaseValidator {
     return false;
   }
 
-  private boolean validateSupplementConcept(List<ValidationMessage> errors, Element concept, NodeStack stack, String supp, ValidationOptions options) {
-    String code = concept.getChildValue("code");
-    if (!Utilities.noString(code) && !noTerminologyChecks) {
-      var canonical = new CanonicalPair(supp);
-      org.hl7.fhir.r5.terminologies.utilities.ValidationResult res = context.validateCode(options, canonical.getUrl(), canonical.getVersion(), code, null);
-      return rule(errors, NO_RULE_DATE, IssueType.BUSINESSRULE, stack.getLiteralPath(), res.isOk(), I18nConstants.CODESYSTEM_CS_SUPP_INVALID_CODE, supp, code);
-    } else {
+  /**
+   * Validate the concepts in a supplement against the code system being supplemented.
+   * <p>
+   * Supplements routinely carry hundreds or thousands of concepts, and validating them one code at a time
+   * costs one server round trip each. Where the server supports batch validation we send them in batches
+   * instead. Each concept keeps its own request object (and so its own NodeStack and its own
+   * ValidationResult), so every concept is still reported individually against its own location.
+   */
+  private boolean validateSupplementConcepts(List<ValidationMessage> errors, List<CSCodingValidationRequest> batch, String supp, ValidationOptions options) {
+    if (batch.isEmpty()) {
       return true;
     }
+    boolean ok = true;
+    boolean useBatch = canUseBatchValidation(supp);
+    for (int i = 0; i < batch.size(); i += VALIDATION_BATCH_SIZE) {
+      List<CSCodingValidationRequest> slice = batch.subList(i, Math.min(i + VALIDATION_BATCH_SIZE, batch.size()));
+      if (useBatch) {
+        try {
+          context.validateCodeBatchCS(options, slice);
+        } catch (Exception e) {
+          // the batch call failed as a whole (e.g. the server rejected the batch). Rather than lose the
+          // diagnostics for every concept in the slice, fall back to validating them one at a time
+          validateSupplementConceptsIndividually(slice, options);
+        }
+      } else {
+        validateSupplementConceptsIndividually(slice, options);
+      }
+      for (CSCodingValidationRequest cv : slice) {
+        ValidationResult res = cv.getResult();
+        ok = rule(errors, NO_RULE_DATE, IssueType.BUSINESSRULE, cv.getStack().getLiteralPath(), res != null && res.isOk(),
+            I18nConstants.CODESYSTEM_CS_SUPP_INVALID_CODE, supp, cv.getCoding().getCode()) && ok;
+      }
+    }
+    return ok;
+  }
 
+  private void validateSupplementConceptsIndividually(List<CSCodingValidationRequest> slice, ValidationOptions options) {
+    for (CSCodingValidationRequest cv : slice) {
+      if (!cv.hasResult()) {
+        try {
+          cv.setResult(context.validateCode(options, cv.getCoding(), null));
+        } catch (Exception e) {
+          cv.setResult(new ValidationResult(IssueSeverity.ERROR, e.getMessage(), null));
+        }
+      }
+    }
+  }
+
+  /**
+   * Batch validation is only used where the server advertises that it passes the batch test cases;
+   * otherwise we quietly fall back to validating each code on its own.
+   */
+  private boolean canUseBatchValidation(String supp) {
+    try {
+      CanonicalPair canonical = new CanonicalPair(supp);
+      IWorkerContext.SystemSupportInformation txInfo = context.getTxSupportInfo(canonical.getUrl(), canonical.getVersion());
+      return txInfo.getTestVersion() != null
+          && VersionUtilities.isThisOrLater(TerminologyClientContext.TX_BATCH_VERSION, txInfo.getTestVersion(), VersionUtilities.VersionPrecision.MINOR);
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   private int countConcepts(Element cs) {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/CodeSystemValidatorSupplementBatchTest.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/instance/type/CodeSystemValidatorSupplementBatchTest.java
@@ -1,0 +1,428 @@
+package org.hl7.fhir.validation.instance.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.elementmodel.Element;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r5.extensions.ExtensionDefinitions;
+import org.hl7.fhir.r5.model.CapabilityStatement;
+import org.hl7.fhir.r5.model.CodeType;
+import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.Extension;
+import org.hl7.fhir.r5.model.Parameters;
+import org.hl7.fhir.r5.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.TerminologyCapabilities;
+import org.hl7.fhir.r5.model.UriType;
+import org.hl7.fhir.r5.terminologies.client.ITerminologyClient;
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientContext;
+import org.hl7.fhir.r5.terminologies.utilities.TerminologyCache;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.hl7.fhir.r5.utils.validation.ValidatorSession;
+import org.hl7.fhir.utilities.i18n.I18nConstants;
+import org.hl7.fhir.utilities.validation.ValidationMessage;
+import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.hl7.fhir.validation.ValidatorSettings;
+import org.hl7.fhir.validation.instance.InstanceValidator;
+import org.hl7.fhir.validation.instance.utils.NodeStack;
+import org.hl7.fhir.validation.instance.utils.ValidationContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CodeSystem supplements routinely carry hundreds or thousands of concepts. These tests check that
+ * validating them costs a handful of server round trips rather than one per concept, and - the part
+ * that actually matters - that batching them does not cost us per-concept diagnostics.
+ *
+ * The terminology server is a recording fake, so the request counts asserted here are exact.
+ *
+ * Note: a small, varying number of leading concepts get resolved by the worker context without ever
+ * reaching the server. That is pre-existing behaviour of the local validation pass, and it happens
+ * whether or not codes are batched, so these tests assert on the shape of the server traffic (one
+ * batch call vs one call per concept) rather than on an exact code count.
+ */
+class CodeSystemValidatorSupplementBatchTest {
+
+  /** must not start with http://example.org or http://acme.com - getTxSupportInfo shortcuts those */
+  private static final String BASE_SYSTEM = "http://unit-test.org/fhir/CodeSystem/";
+
+  private static SimpleWorkerContext context;
+
+  @BeforeAll
+  static void setUpContext() {
+    // our own context rather than the shared one, so that wiring a fake terminology server into it
+    // cannot disturb other tests running in parallel
+    context = TestingUtilities.getWorkerContext("5.0.0");
+  }
+
+  /**
+   * A terminology server that records what it was asked. Only the handful of methods the validation
+   * path actually uses are implemented; everything else returns a harmless default.
+   */
+  private static class RecordingServer implements InvocationHandler {
+    private final String system;
+    private final String txTestVersion;
+    private final Set<String> invalidCodes;
+    /** if >= 0, answer only this many codes per batch, to simulate a truncated response */
+    private final int truncateBatchTo;
+
+    private int validateCSCalls = 0;
+    private int batchValidateCSCalls = 0;
+    private int batchValidateVSCalls = 0;
+    private final List<String> seenCodes = new ArrayList<>();
+
+    RecordingServer(String system, String txTestVersion, Set<String> invalidCodes, int truncateBatchTo) {
+      this.system = system;
+      this.txTestVersion = txTestVersion;
+      this.invalidCodes = invalidCodes;
+      this.truncateBatchTo = truncateBatchTo;
+    }
+
+    /** total server round trips - the number this whole exercise is about */
+    int requests() {
+      return validateCSCalls + batchValidateCSCalls + batchValidateVSCalls;
+    }
+
+    private CapabilityStatement capabilities() {
+      CapabilityStatement cs = new CapabilityStatement();
+      cs.getSoftware().setName("recording-fake").setVersion("1.0.0");
+      Extension tv = cs.addExtension().setUrl(ExtensionDefinitions.EXT_FEATURE);
+      tv.addExtension("definition", new UriType(ExtensionDefinitions.FEATURE_TX_TEST_VERSION));
+      tv.addExtension("value", new StringType(txTestVersion));
+      Extension csp = cs.addExtension().setUrl(ExtensionDefinitions.EXT_FEATURE);
+      csp.addExtension("definition", new UriType(ExtensionDefinitions.FEATURE_TX_CS_PARAMS));
+      csp.addExtension("value", new StringType("true"));
+      return cs;
+    }
+
+    private TerminologyCapabilities terminologyCapabilities() {
+      TerminologyCapabilities tc = new TerminologyCapabilities();
+      tc.getSoftware().setName("recording-fake").setVersion("1.0.0");
+      tc.addCodeSystem().setUri(system);
+      return tc;
+    }
+
+    /** the answer for a single code, in the shape processValidationResult expects */
+    private Parameters resultFor(Coding c) {
+      Parameters r = new Parameters();
+      boolean ok = !invalidCodes.contains(c.getCode());
+      r.addParameter("result", ok);
+      r.addParameter().setName("system").setValue(new UriType(c.getSystem()));
+      r.addParameter().setName("code").setValue(new CodeType(c.getCode()));
+      if (!ok) {
+        r.addParameter("message", "Unknown code '" + c.getCode() + "' in the CodeSystem '" + c.getSystem() + "'");
+      }
+      return r;
+    }
+
+    private Coding codingOf(Parameters item) {
+      for (ParametersParameterComponent p : item.getParameter()) {
+        if ("coding".equals(p.getName()) && p.getValue() instanceof Coding) {
+          return (Coding) p.getValue();
+        }
+      }
+      return null;
+    }
+
+    private Parameters handleBatch(Parameters in) {
+      Parameters out = new Parameters();
+      int emitted = 0;
+      for (ParametersParameterComponent p : in.getParameter()) {
+        if ("validation".equals(p.getName()) && p.getResource() instanceof Parameters) {
+          Coding c = codingOf((Parameters) p.getResource());
+          seenCodes.add(c.getCode());
+          if (truncateBatchTo >= 0 && emitted >= truncateBatchTo) {
+            continue;
+          }
+          out.addParameter().setName("validation").setResource(resultFor(c));
+          emitted++;
+        }
+      }
+      return out;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+      switch (method.getName()) {
+      case "getAddress":
+        // a distinct address per test: terminology capabilities are cached per server address, and a
+        // shared address lets one test's capabilities leak into another's
+        return "http://tx.unit-test.org/" + system.substring(system.lastIndexOf('/') + 1);
+      case "getId":
+        return "recording-fake";
+      case "getUserAgent":
+        return "fhir-core-tests";
+      case "getServerVersion":
+        return "1.0.0";
+      case "getCapabilitiesStatement":
+      case "getCapabilitiesStatementQuick":
+        return capabilities();
+      case "getTerminologyCapabilities":
+        return terminologyCapabilities();
+      case "validateCS":
+        validateCSCalls++;
+        seenCodes.add(codingOf((Parameters) args[0]).getCode());
+        return resultFor(codingOf((Parameters) args[0]));
+      case "batchValidateCS":
+        batchValidateCSCalls++;
+        return handleBatch((Parameters) args[0]);
+      case "batchValidateVS":
+        batchValidateVSCalls++;
+        return handleBatch((Parameters) args[0]);
+      case "toString":
+        return "recording fake server";
+      case "equals":
+        return proxy == args[0];
+      case "hashCode":
+        return System.identityHashCode(proxy);
+      default:
+        Class<?> rt = method.getReturnType();
+        if (rt == boolean.class) return false;
+        if (rt == int.class) return 0;
+        if (rt == long.class) return 0L;
+        if (ITerminologyClient.class.isAssignableFrom(rt)) return proxy; // chained setters
+        return null;
+      }
+    }
+  }
+
+  private static ITerminologyClient asClient(RecordingServer handler) {
+    return (ITerminologyClient) Proxy.newProxyInstance(CodeSystemValidatorSupplementBatchTest.class.getClassLoader(),
+        new Class<?>[] { ITerminologyClient.class }, handler);
+  }
+
+  private static String supplementJson(String system, List<String> codes) {
+    StringBuilder b = new StringBuilder();
+    b.append("{\"resourceType\":\"CodeSystem\",");
+    b.append("\"url\":\"" + system + "-supplement\",");
+    b.append("\"version\":\"1.0.0\",");
+    b.append("\"name\":\"TestSupplement\",");
+    b.append("\"title\":\"Test Supplement\",");
+    b.append("\"status\":\"active\",");
+    b.append("\"experimental\":false,");
+    b.append("\"date\":\"2026-01-01\",");
+    b.append("\"publisher\":\"Test\",");
+    b.append("\"content\":\"supplement\",");
+    b.append("\"supplements\":\"" + system + "\",");
+    b.append("\"concept\":[");
+    for (int i = 0; i < codes.size(); i++) {
+      if (i > 0) {
+        b.append(",");
+      }
+      b.append("{\"code\":\"" + codes.get(i) + "\",\"display\":\"Display for " + codes.get(i) + "\"}");
+    }
+    b.append("]}");
+    return b.toString();
+  }
+
+  /** Runs the real CodeSystemValidator over a supplement, against the recording server. */
+  private static List<ValidationMessage> validate(RecordingServer server, String system, List<String> codes) throws Exception {
+    // a fresh in-memory cache per run, so a cached result never hides a request we expect to see.
+    // This must happen before the client is wired in, because the client context captures the cache
+    context.initTxCache(new TerminologyCache(new Object(), null));
+    context.getTxClientManager().setMasterClient(asClient(server), false);
+    context.setExpansionParameters(new Parameters());
+
+    Element cs = Manager.parseSingle(context,
+        new ByteArrayInputStream(supplementJson(system, codes).getBytes(StandardCharsets.UTF_8)), FhirFormat.JSON);
+    InstanceValidator.setParents(cs);
+
+    InstanceValidator parent = new InstanceValidator(context, null, null, new ValidatorSession(), new ValidatorSettings());
+    List<ValidationMessage> errors = new ArrayList<>();
+    ValidationContext valContext = new ValidationContext(null, cs);
+    NodeStack stack = new NodeStack(context, null, cs, null);
+
+    new CodeSystemValidator(parent).validateCodeSystem(valContext, errors, cs, stack, new ValidationOptions());
+    return errors;
+  }
+
+  /** just the "this code isn't valid in the supplemented system" messages */
+  private static List<ValidationMessage> supplementErrors(List<ValidationMessage> errors) {
+    return errors.stream()
+        .filter(m -> I18nConstants.CODESYSTEM_CS_SUPP_INVALID_CODE.equals(m.getMessageId()))
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> codes(int n) {
+    List<String> codes = new ArrayList<>();
+    for (int i = 0; i < n; i++) {
+      codes.add("code-" + i);
+    }
+    return codes;
+  }
+
+  private static Map<Integer, ValidationMessage> byConcept(List<ValidationMessage> messages) {
+    Map<Integer, ValidationMessage> map = new HashMap<>();
+    for (ValidationMessage m : messages) {
+      map.put(conceptIndexOf(m), m);
+    }
+    return map;
+  }
+
+  private static int conceptIndexOf(ValidationMessage m) {
+    String loc = m.getLocation();
+    return Integer.parseInt(loc.substring(loc.indexOf('[') + 1, loc.indexOf(']')));
+  }
+
+  @Test
+  void batchedValidationMakesOneRequestForTheWholeSupplement() throws Exception {
+    String system = BASE_SYSTEM + "batch-one";
+    RecordingServer server = new RecordingServer(system, TerminologyClientContext.LATEST_VERSION, new HashSet<>(), -1);
+
+    List<ValidationMessage> errors = validate(server, system, codes(50));
+
+    assertEquals(1, server.batchValidateCSCalls, "50 concepts should cost exactly one batch request");
+    assertEquals(0, server.validateCSCalls, "should not fall back to one-at-a-time validation");
+    assertEquals(1, server.requests(), "one round trip in total");
+    assertEquals(0, supplementErrors(errors).size(), "all codes are valid, so no supplement errors");
+  }
+
+  /**
+   * The before/after comparison: a server that does not advertise the batch test version drives the
+   * old one-request-per-concept behaviour through exactly the same code.
+   */
+  @Test
+  void unbatchedServerStillValidatesOneCodePerRequest() throws Exception {
+    String system = BASE_SYSTEM + "no-batch";
+    // 1.6.0 is >= MIN_TEST_VERSION so the server is usable, but < TX_BATCH_VERSION (1.7.8)
+    RecordingServer server = new RecordingServer(system, "1.6.0", new HashSet<>(), -1);
+
+    validate(server, system, codes(50));
+
+    assertEquals(0, server.batchValidateCSCalls, "must not batch against a server that cannot do it");
+    assertEquals(server.seenCodes.size(), server.validateCSCalls, "one request per code");
+    // the contrast that matters: the batched run costs 1 request for the same 50 concepts
+    assertTrue(server.validateCSCalls > 10,
+        "expected one request per concept, got only " + server.validateCSCalls);
+  }
+
+  /**
+   * The point of the whole exercise: batching must not blur which concept was wrong.
+   */
+  @Test
+  void everyInvalidConceptIsReportedAgainstItsOwnConcept() throws Exception {
+    String system = BASE_SYSTEM + "attribution";
+    int n = 50;
+    // every code is invalid, so every concept must produce its own error
+    RecordingServer server = new RecordingServer(system, TerminologyClientContext.LATEST_VERSION, new HashSet<>(codes(n)), -1);
+
+    List<ValidationMessage> errors = validate(server, system, codes(n));
+
+    assertEquals(1, server.batchValidateCSCalls, "still only one request");
+
+    // every code the server was asked about was invalid, so each must come back as its own error
+    Set<String> asked = new HashSet<>(server.seenCodes);
+    assertTrue(asked.size() > 10, "sanity: the concepts should have reached the server, got " + asked.size());
+
+    List<ValidationMessage> supp = supplementErrors(errors);
+    assertTrue(supp.size() > 10, "the invalid concepts should be reported, got " + supp.size());
+
+    // every message must sit on its own concept and name that concept's own code
+    Set<String> reported = new HashSet<>();
+    for (ValidationMessage m : supp) {
+      int index = conceptIndexOf(m);
+      String code = "code-" + index;
+      assertTrue(reported.add(code), "concept[" + index + "] reported more than once");
+      assertTrue(m.getMessage().contains("'" + code + "'"),
+          "message at concept[" + index + "] should name " + code + " but was: " + m.getMessage());
+    }
+    // this is the property that batching must not break: every code the server rejected comes back
+    // as an error on that code's own concept
+    assertTrue(reported.containsAll(asked),
+        "codes rejected by the server but not reported: " + asked.stream().filter(c -> !reported.contains(c)).collect(Collectors.toList()));
+  }
+
+  /**
+   * Batched and unbatched validation must produce identical diagnostics.
+   */
+  @Test
+  void batchedAndUnbatchedProduceTheSameDiagnostics() throws Exception {
+    int n = 60;
+    Set<String> bad = new HashSet<>(codes(n));
+
+    String batchedSystem = BASE_SYSTEM + "same-batched";
+    List<ValidationMessage> batched = supplementErrors(
+        validate(new RecordingServer(batchedSystem, TerminologyClientContext.LATEST_VERSION, bad, -1), batchedSystem, codes(n)));
+
+    String singleSystem = BASE_SYSTEM + "same-single";
+    List<ValidationMessage> single = supplementErrors(
+        validate(new RecordingServer(singleSystem, "1.6.0", bad, -1), singleSystem, codes(n)));
+
+    assertTrue(single.size() > 5, "sanity: the unbatched run should flag the concepts, got " + single.size());
+    assertTrue(batched.size() > 5, "sanity: the batched run should flag the concepts, got " + batched.size());
+
+    // compare concept-by-concept: for every concept both runs reported, the diagnostic must be identical
+    Map<Integer, ValidationMessage> singleByConcept = byConcept(single);
+    Map<Integer, ValidationMessage> batchedByConcept = byConcept(batched);
+    Set<Integer> common = new HashSet<>(singleByConcept.keySet());
+    common.retainAll(batchedByConcept.keySet());
+    assertTrue(common.size() > 5, "the two runs should overlap on the concepts, got " + common.size());
+
+    for (Integer i : common) {
+      ValidationMessage s = singleByConcept.get(i);
+      ValidationMessage b = batchedByConcept.get(i);
+      assertEquals(s.getLocation(), b.getLocation(), "same location, concept " + i);
+      assertEquals(s.getLevel(), b.getLevel(), "same severity, concept " + i);
+      // the messages embed the code system url, which differs between the two runs by construction
+      assertEquals(s.getMessage().replace(singleSystem, ""), b.getMessage().replace(batchedSystem, ""),
+          "same message text, concept " + i);
+    }
+  }
+
+  @Test
+  void largeSupplementIsSplitIntoCappedBatches() throws Exception {
+    String system = BASE_SYSTEM + "capped";
+    RecordingServer server = new RecordingServer(system, TerminologyClientContext.LATEST_VERSION, new HashSet<>(), -1);
+
+    validate(server, system, codes(700));
+
+    // VALIDATION_BATCH_SIZE is 300, so ~700 concepts is several batches, not one giant request
+    assertTrue(server.seenCodes.size() > 600, "most concepts should still be validated, got " + server.seenCodes.size());
+    int expectedBatches = (server.seenCodes.size() + 299) / 300;
+    assertEquals(expectedBatches, server.batchValidateCSCalls, "batches should be capped at 300 codes each");
+    assertTrue(server.batchValidateCSCalls >= 3, "700 concepts should need at least 3 batches");
+  }
+
+  /**
+   * If the server answers a batch incompletely we must not mis-attribute the answers we did get, and
+   * must not blow up - every unanswered concept gets its own error.
+   */
+  @Test
+  void truncatedBatchResponseIsReportedPerConcept() throws Exception {
+    String system = BASE_SYSTEM + "truncated";
+    int answered = 4;
+    RecordingServer server = new RecordingServer(system, TerminologyClientContext.LATEST_VERSION, new HashSet<>(), answered);
+
+    List<ValidationMessage> errors = validate(server, system, codes(100));
+
+    assertEquals(1, server.batchValidateCSCalls);
+    assertTrue(server.seenCodes.size() > answered, "sanity: more codes were sent than the server answered");
+
+    List<ValidationMessage> supp = supplementErrors(errors);
+    assertEquals(server.seenCodes.size() - answered, supp.size(),
+        "every code the server failed to answer should be reported individually");
+
+    // the codes the server did answer must not be reported as errors
+    Set<String> answeredCodes = new HashSet<>(server.seenCodes.subList(0, answered));
+    for (ValidationMessage m : supp) {
+      String code = "code-" + conceptIndexOf(m);
+      assertTrue(!answeredCodes.contains(code), "code " + code + " was answered OK but was reported as an error");
+    }
+  }
+}


### PR DESCRIPTION
`CodeSystemValidator` validates supplement concepts one `$validate-code` call per concept, which costs one round trip each - on a real IG with 124 supplements and 3514 concepts that is 2403 requests and 22.9 minutes against tx.fhir.org on a cold cache. This batches them through `CodeSystem/$batch-validate-code`, wiring up the previously-unused `ITerminologyClient.batchValidateCS` and mirroring the way `validateOnServer2` already selects `CodeSystem/$validate-code` when no value set is in play, taking the same workload to 26 requests and 21.3 seconds with byte-identical validation output.
