### PR TITLE
Update fetchTheOldWay urls to https

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java
@@ -837,7 +837,7 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
   }
 
   // ----- the old way, from before package server, while everything gets onto the package server
-  private InputStreamWithSrc fetchTheOldWay(String id, String v) {
+  private InputStreamWithSrc fetchTheOldWay(String id, String version) {
     String url = getUrlForPackage(id);
     if (url == null) {
       try {
@@ -846,31 +846,31 @@ public class FilesystemPackageCacheManager extends BasePackageCacheManager imple
       }
     }
     if (url == null) {
-      throw new FHIRException("Unable to resolve package id " + id + "#" + v);
+      throw new FHIRException("Unable to resolve package id " + id + "#" + version);
     }
     if (url.contains("/ImplementationGuide/")) {
       url = url.substring(0, url.indexOf("/ImplementationGuide/"));
     }
-    String pu = Utilities.pathURL(url, "package-list.json");
+    String packageListUrl = ManagedWebAccess.makeSecureRef(Utilities.pathURL(url, "package-list.json"));
 
-    PackageList pl;
+    PackageList packageList;
     try {
-      pl = PackageList.fromUrl(pu);
+      packageList = PackageList.fromUrl(packageListUrl);
     } catch (Exception e) {
-      String pv = Utilities.pathURL(url, v, "package.tgz");
+      String packageTgzUrl = ManagedWebAccess.makeSecureRef(Utilities.pathURL(url, version, "package.tgz"));
+
       try {
-        return new InputStreamWithSrc(fetchFromUrlSpecific(pv, false), pv, v);
+        return new InputStreamWithSrc(fetchFromUrlSpecific(packageTgzUrl, false), packageTgzUrl, version);
       } catch (Exception e1) {
-        throw new FHIRException("Error fetching package directly (" + pv + "), or fetching package list for " + id + " from " + pu + ": " + e1.getMessage(), e1);
+        throw new FHIRException("Error fetching package directly (" + packageTgzUrl + "), or fetching package list for " + id + " from " + packageListUrl + ": " + e1.getMessage(), e1);
       }
     }
-    if (!id.equals(pl.pid()))
-      throw new FHIRException("Package ids do not match in " + pu + ": " + id + " vs " + pl.pid());
-    for (PackageListEntry vo : pl.versions()) {
-      if (v.equals(vo.version())) {
-
-        String u = Utilities.pathURL(vo.path(), "package.tgz");
-        return new InputStreamWithSrc(fetchFromUrlSpecific(u, true), u, v);
+    if (!id.equals(packageList.pid()))
+      throw new FHIRException("Package ids do not match in " + packageListUrl + ": " + id + " vs " + packageList.pid());
+    for (PackageListEntry packageEntry : packageList.versions()) {
+      if (version.equals(packageEntry.version())) {
+        String packageTgzUrl = ManagedWebAccess.makeSecureRef(Utilities.pathURL(packageEntry.path(), "package.tgz"));
+        return new InputStreamWithSrc(fetchFromUrlSpecific(packageTgzUrl, true), packageTgzUrl, version);
       }
     }
 


### PR DESCRIPTION
fetchTheOldWay fetched older IGs via direct URLs, including now blocked http protocol URLs. 

This makes these URLs secure (https) before fetching.