### PR TITLE
fix(r5): handle inherited slices and contentReference traversal

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/DefinitionNavigator.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/DefinitionNavigator.java
@@ -205,6 +205,13 @@ public class DefinitionNavigator {
     DefinitionNavigator polymorphicDN = null;
     for (int i = indexMatches ? workingIndex + 1 : workingIndex; i < list().size(); i++) {
       String path = list().get(i).getPath();
+      // When following a contentReference, slices of the referenced element itself
+      // are siblings of that element, not children of the referencing element.
+      // The referenced master is intentionally skipped by workingIndex + 1, so skip
+      // its same-path named slices as well before walking the referenced children.
+      if (childrenFromReference && path.equals(prefix) && list().get(i).hasSliceName()) {
+        continue;
+      }
       if (path.startsWith(prefix)) {
         if (!path.substring(prefix.length()).contains(".")) {
           // immediate child
@@ -249,8 +256,22 @@ public class DefinitionNavigator {
               }
             }
           } else if (dn.current().hasSliceName()) {
-            // this is an error unless we're dealing with extensions, which are auto-sliced (for legacy reasons)
-            if (diff && "extension".equals(dn.current().getName())) {
+            // A differential may constrain a slice whose slicing declaration is inherited.
+            // In that case the local differential has no master element, but the generated
+            // snapshot does. Use a transient placeholder so the named slice can still be
+            // grouped without treating inherited snapshot constraints as local differential
+            // content.
+            ElementDefinition inheritedSlicing = diff ? makeInheritedSlicingDefinitionElement(path) : null;
+            if (inheritedSlicing != null) {
+              StructureDefinition vsd = new StructureDefinition(); // fake wrapper for placeholder element
+              vsd.getDifferential().getElement().add(inheritedSlicing);
+              DefinitionNavigator master = new DefinitionNavigator(context, vsd, diff, followTypes, 0, this.globalPath+"."+tail(path), path, names, null);
+              nameMap.put(path, master);
+              children.add(master);
+              master.slices = new ArrayList<DefinitionNavigator>();
+              master.slices.add(dn);
+            // extensions remain implicitly sliced by url for legacy reasons
+            } else if (diff && "extension".equals(dn.current().getName())) {
               StructureDefinition vsd = new StructureDefinition(); // fake wrapper for placeholder element
               vsd.getDifferential().getElement().add(makeExtensionDefinitionElement(path));
               DefinitionNavigator master = new DefinitionNavigator(context, vsd, diff, followTypes, 0, this.globalPath+"."+tail(path), path, names, null);
@@ -327,6 +348,21 @@ public class DefinitionNavigator {
       }
     }
     return -1;
+  }
+
+  private ElementDefinition makeInheritedSlicingDefinitionElement(String path) {
+    if (!structure.hasSnapshot()) {
+      return null;
+    }
+    for (ElementDefinition candidate : structure.getSnapshot().getElement()) {
+      if (path.equals(candidate.getPath()) && !candidate.hasSliceName() && candidate.hasSlicing()) {
+        ElementDefinition ed = new ElementDefinition(path);
+        ed.setUserData(UserDataNames.DN_TRANSIENT, "true");
+        ed.setSlicing(candidate.getSlicing().copy());
+        return ed;
+      }
+    }
+    return null;
   }
 
   private ElementDefinition makeExtensionDefinitionElement(String path) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/DefinitionNavigatorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/DefinitionNavigatorTests.java
@@ -1,6 +1,9 @@
 package org.hl7.fhir.r5.utils;
 
 import org.hl7.fhir.r5.context.SimpleWorkerContext;
+import org.hl7.fhir.r5.model.ElementDefinition;
+import org.hl7.fhir.r5.model.ElementDefinition.DiscriminatorType;
+import org.hl7.fhir.r5.model.ElementDefinition.SlicingRules;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.test.utils.TestingUtilities;
 import org.junit.jupiter.api.Assertions;
@@ -29,4 +32,68 @@ public class DefinitionNavigatorTests {
     dn1 = dn1.childByName("input");
     Assertions.assertNotNull(dn1);
   }
+  @Test
+  @DisplayName("Inherited differential slice uses snapshot slicing master")
+  void inheritedDifferentialSliceUsesSnapshotSlicingMaster() {
+    SimpleWorkerContext ctxt = TestingUtilities.getWorkerContext("4.0");
+    StructureDefinition sd = new StructureDefinition();
+    sd.setType("Observation");
+
+    sd.getDifferential().getElement().add(new ElementDefinition("Observation"));
+    sd.getDifferential().getElement().add(
+        new ElementDefinition("Observation.category").setSliceName("us-core"));
+
+    sd.getSnapshot().getElement().add(new ElementDefinition("Observation"));
+    ElementDefinition master = new ElementDefinition("Observation.category");
+    master.getSlicing()
+        .setRules(SlicingRules.OPEN)
+        .setOrdered(false)
+        .addDiscriminator()
+        .setType(DiscriminatorType.VALUE)
+        .setPath("coding.system");
+    sd.getSnapshot().getElement().add(master);
+    sd.getSnapshot().getElement().add(
+        new ElementDefinition("Observation.category").setSliceName("us-core"));
+
+    DefinitionNavigator dn = new DefinitionNavigator(ctxt, sd, true, false);
+    DefinitionNavigator category = dn.childByName("category");
+    Assertions.assertNotNull(category);
+    Assertions.assertEquals(1, category.slices().size());
+    Assertions.assertEquals("us-core", category.slices().get(0).current().getSliceName());
+  }
+
+  @Test
+  @DisplayName("ContentReference ignores slices of referenced element")
+  void contentReferenceIgnoresSlicesOfReferencedElement() {
+    SimpleWorkerContext ctxt = TestingUtilities.getWorkerContext("4.0");
+    StructureDefinition sd = new StructureDefinition();
+    sd.setType("Composition");
+
+    sd.getSnapshot().getElement().add(new ElementDefinition("Composition"));
+    ElementDefinition section = new ElementDefinition("Composition.section");
+    section.getSlicing()
+        .setRules(SlicingRules.OPEN)
+        .setOrdered(false)
+        .addDiscriminator()
+        .setType(DiscriminatorType.VALUE)
+        .setPath("code");
+    sd.getSnapshot().getElement().add(section);
+    sd.getSnapshot().getElement().add(new ElementDefinition("Composition.section.title"));
+    sd.getSnapshot().getElement().add(
+        new ElementDefinition("Composition.section.section")
+            .setContentReference("#Composition.section"));
+    sd.getSnapshot().getElement().add(
+        new ElementDefinition("Composition.section").setSliceName("sectionProblems"));
+
+    DefinitionNavigator dn = new DefinitionNavigator(ctxt, sd, false, true);
+    DefinitionNavigator firstSection = dn.childByName("section");
+    Assertions.assertNotNull(firstSection);
+    DefinitionNavigator recursiveSection = firstSection.childByName("section");
+    Assertions.assertNotNull(recursiveSection);
+
+    Assertions.assertDoesNotThrow(recursiveSection::children);
+    Assertions.assertNotNull(recursiveSection.childByName("title"));
+    Assertions.assertNotNull(recursiveSection.childByName("section"));
+  }
+
 }


### PR DESCRIPTION
## Summary

Fix two independent `DefinitionNavigator` traversal failures that can make `StructureDefinitionComparer` fail even when comparing valid published profiles with themselves.

## Fixes

1. In differential mode, allow named slices to use slicing metadata inherited into the StructureDefinition snapshot when the differential does not repeat a local slicing master. The existing extension auto-slicing branch is preserved unchanged, and only the slicing declaration is copied — no other inherited snapshot constraint enters the differential view.
2. When following a `contentReference`, ignore same-path named slices of the referenced element because they are siblings of the referenced master, not children of the referencing element.

## Real-world reproductions

- US Core `us-core-observation-lab`:
  `Observation.category`
- IPS `Composition-uv-ips`:
  `Composition.section`

Both failures reproduced during self-comparison before the fix.

## Validation

On this branch (`master` @ `b06c7ee` + this commit):

- upstream `DefinitionNavigatorTests`: **PASS** — `Tests run: 3, Failures: 0, Errors: 0`
  (`mvn -B -ntp -pl org.hl7.fhir.r5 -am -Dtest=DefinitionNavigatorTests test`)
- With the two test additions but **without** the `DefinitionNavigator` change, both new tests fail on `master` with exactly the production exceptions, confirming they are genuine regression tests:
  - `Found a slice at 'Observation.category' but there was no definition for the slicing`
  - `Found a slice at 'Composition.section' but there was no definition for the slicing`

Against the `6.10.2` baseline, using the real published packages:

- inherited-slicing real probes: 6/6 PASS
- contentReference real probes: 6/6 PASS
- combined real probes: 12/12 PASS

The real probes were run under both direct dependency context and full deterministic transitive package closure.

Two regression tests are added to `DefinitionNavigatorTests`, one per defect.

Closes #2553
