### PR TITLE
Proposal for replacing xpp3

### DIFF
--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -2,9 +2,8 @@
 (Unknown license) javaparser (com.google.code.javaparser:javaparser:1.0.11 - http://code.google.com/p/javaparser/)
 # Because of parsing issues, FHIR R4 shows up as a license. I really need to redo this script in Python for cleaner parsing. -dotasek
 (Apache Software License 2.0) HAPI FHIR - Validation Resources (FHIR R4) (ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:8.4.0 - https://hapifhir.io/hapi-deployable-pom/hapi-fhir-validation-resources-r4)
-# The following can be licensed with either license, of which the Apache is compatible
-(Apache Software License, version 1.1) (Indiana University Extreme! Lab Software License, vesion 1.1.1) (Public Domain) MXP1: Xml Pull Parser 3rd Edition (XPP3) (xpp3:xpp3:1.1.4c - http://www.extreme.indiana.edu/xgws/xsoap/xpp/mxp1/)
-(Indiana University Extreme! Lab Software License, vesion 1.1.1) MXP1: Xml Pull Parser 3rd Edition (XPP3) (xpp3:xpp3_xpath:1.1.4c - http://www.extreme.indiana.edu/xgws/xsoap/xpp/mxp1/)
+# XPP3 is incorrectly parsed as a license
+(The Apache Software License, Version 1.1) MXP1: Xml Pull Parser 3rd Edition (XPP3)
 # Aggregator is incorrectly parsed as a license.
 (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.10.1 - https://junit.org/junit5/)
 # https://www.jcp.org/en/jsr/detail?id=374 specifies this as an OR relationship between possible licenses, of which CDDL is compatible

--- a/.github/workflows/license-check/license-special-cases.txt
+++ b/.github/workflows/license-check/license-special-cases.txt
@@ -3,6 +3,7 @@
 # Because of parsing issues, FHIR R4 shows up as a license. I really need to redo this script in Python for cleaner parsing. -dotasek
 (Apache Software License 2.0) HAPI FHIR - Validation Resources (FHIR R4) (ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:8.4.0 - https://hapifhir.io/hapi-deployable-pom/hapi-fhir-validation-resources-r4)
 # XPP3 is incorrectly parsed as a license
+(The Apache Software License, Version 1.1) XPP3: Xml Pull Parser 3rd Edition (XPP3)
 (The Apache Software License, Version 1.1) MXP1: Xml Pull Parser 3rd Edition (XPP3)
 # Aggregator is incorrectly parsed as a license.
 (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.10.1 - https://junit.org/junit5/)

--- a/org.hl7.fhir.convertors/pom.xml
+++ b/org.hl7.fhir.convertors/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>

--- a/org.hl7.fhir.dstu2/pom.xml
+++ b/org.hl7.fhir.dstu2/pom.xml
@@ -45,7 +45,7 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>

--- a/org.hl7.fhir.dstu2016may/pom.xml
+++ b/org.hl7.fhir.dstu2016may/pom.xml
@@ -45,7 +45,7 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
         </dependency>
 

--- a/org.hl7.fhir.dstu3.support/pom.xml
+++ b/org.hl7.fhir.dstu3.support/pom.xml
@@ -52,7 +52,7 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>

--- a/org.hl7.fhir.dstu3/pom.xml
+++ b/org.hl7.fhir.dstu3/pom.xml
@@ -45,7 +45,7 @@
 
         <!-- XML Parsers -->
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>

--- a/org.hl7.fhir.r4/pom.xml
+++ b/org.hl7.fhir.r4/pom.xml
@@ -52,7 +52,7 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>org.ogce</groupId>
+			<groupId>org.codelibs</groupId>
 			<artifactId>xpp3</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/org.hl7.fhir.r4b/pom.xml
+++ b/org.hl7.fhir.r4b/pom.xml
@@ -63,7 +63,7 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>org.ogce</groupId>
+			<groupId>org.codelibs</groupId>
 			<artifactId>xpp3</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/org.hl7.fhir.r5/pom.xml
+++ b/org.hl7.fhir.r5/pom.xml
@@ -50,7 +50,7 @@
 
 		<!-- XML Parsers -->
 		<dependency>
-			<groupId>org.ogce</groupId>
+			<groupId>org.codelibs</groupId>
 			<artifactId>xpp3</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/org.hl7.fhir.utilities/pom.xml
+++ b/org.hl7.fhir.utilities/pom.xml
@@ -79,7 +79,7 @@
 
         <!-- XML Utilities -->
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
             <optional>true</optional>
         </dependency>

--- a/org.hl7.fhir.validation.cli/pom.xml
+++ b/org.hl7.fhir.validation.cli/pom.xml
@@ -298,7 +298,7 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
         </dependency>
 

--- a/org.hl7.fhir.validation/pom.xml
+++ b/org.hl7.fhir.validation/pom.xml
@@ -100,7 +100,7 @@
             <artifactId>Saxon-HE</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ogce</groupId>
+            <groupId>org.codelibs</groupId>
             <artifactId>xpp3</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -364,12 +364,12 @@
                 <artifactId>thymeleaf</artifactId>
                 <version>3.1.5.RELEASE</version>
             </dependency>
+			
             <dependency>
-                <groupId>org.ogce</groupId>
+                <groupId>org.codelibs</groupId>
                 <artifactId>xpp3</artifactId>
-                <version>1.1.6</version>
+                <version>1.1.4c.0</version>
             </dependency>
-
 
             <dependency>
               <groupId>com.nimbusds</groupId>


### PR DESCRIPTION
Swapping dependency to increase compatibility with JPMS for projects using module-info.Java and avoids collisions with java.xml exports.

## Justification for the change

When hl7 core is used in a project with JPMS enabled, a compiler error arises, citing the conflict between xpp3 and java.xml modules.

This in-place change removes the issue, since the fork has removed java.xml classes.