### PR TITLE
FHIRPath: no NullPointerException on primitives that have extensions but no value

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Validator Changes
 
-* no changes
+* FHIRPath: don't throw a NullPointerException when a FHIR primitive has extensions but no value (e.g. data-absent-reason)
 
 ## Other code changes
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -1680,6 +1680,18 @@ public class FHIRPathEngine {
     return res;
   }
 
+  /**
+   * A FHIR primitive can have extensions but no value (e.g. when the data-absent-reason extension is used).
+   * Such an element is present in the tree - so exists() is true - but it has no value in the FHIRPath type
+   * system, so anything that needs the value gets nothing (see hasValue() and getValue() in the FHIR spec)
+   *
+   * @param list the focus or an operand
+   * @return true if the list is a single primitive that has no value
+   */
+  private boolean hasNoPrimitiveValue(List<Base> list) {
+    return list.size() == 1 && list.get(0).isPrimitive() && list.get(0).primitiveValue() == null;
+  }
+
   private TypeDetails executeTypeName(ExecutionTypeContext context, TypeDetails focus, ExpressionNode exp, boolean atEntry) throws PathEngineException, DefinitionException {
     return new TypeDetails(CollectionStatus.SINGLETON, exp.getName());
   }
@@ -2542,6 +2554,9 @@ public class FHIRPathEngine {
   private List<Base> opLessThan(List<Base> left, List<Base> right, ExpressionNode expr) throws FHIRException {
     if (left.size() == 0 || right.size() == 0) 
       return new ArrayList<Base>();
+    if (hasNoPrimitiveValue(left) || hasNoPrimitiveValue(right)) {
+      return makeNull();
+    }
 
     if (left.size() == 1 && right.size() == 1 && left.get(0).isPrimitive() && right.get(0).isPrimitive()) {
       Base l = left.get(0);
@@ -2592,6 +2607,9 @@ public class FHIRPathEngine {
   private List<Base> opGreater(List<Base> left, List<Base> right, ExpressionNode expr) throws FHIRException {
     if (left.size() == 0 || right.size() == 0) 
       return new ArrayList<Base>();
+    if (hasNoPrimitiveValue(left) || hasNoPrimitiveValue(right)) {
+      return makeNull();
+    }
     if (left.size() == 1 && right.size() == 1 && left.get(0).isPrimitive() && right.get(0).isPrimitive()) {
       Base l = left.get(0);
       Base r = right.get(0);
@@ -2641,6 +2659,9 @@ public class FHIRPathEngine {
   private List<Base> opLessOrEqual(List<Base> left, List<Base> right, ExpressionNode expr) throws FHIRException {
     if (left.size() == 0 || right.size() == 0) { 
       return new ArrayList<Base>();
+    }
+    if (hasNoPrimitiveValue(left) || hasNoPrimitiveValue(right)) {
+      return makeNull();
     }
     if (left.size() == 1 && right.size() == 1 && left.get(0).isPrimitive() && right.get(0).isPrimitive()) {
       Base l = left.get(0);
@@ -2693,6 +2714,9 @@ public class FHIRPathEngine {
   private List<Base> opGreaterOrEqual(List<Base> left, List<Base> right, ExpressionNode expr) throws FHIRException {
     if (left.size() == 0 || right.size() == 0) { 
       return new ArrayList<Base>();
+    }
+    if (hasNoPrimitiveValue(left) || hasNoPrimitiveValue(right)) {
+      return makeNull();
     }
     if (left.size() == 1 && right.size() == 1 && left.get(0).isPrimitive() && right.get(0).isPrimitive()) {
       Base l = left.get(0);
@@ -4753,7 +4777,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
     List<Base> result = new ArrayList<Base>();
 
-    if (focus.size() == 1) {
+    if (focus.size() == 1 && focus.get(0).primitiveValue() != null) {
       String cnt = focus.get(0).primitiveValue();
       if ("hex".equals(param)) {
         result.add(new StringType(bytesToHex(cnt.getBytes())));        
@@ -4773,7 +4797,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     String param = nl.get(0).primitiveValue();
 
     List<Base> result = new ArrayList<Base>();
-    if (focus.size() == 1) {
+    if (focus.size() == 1 && focus.get(0).primitiveValue() != null) {
       String cnt = focus.get(0).primitiveValue();
       if ("hex".equals(param)) {
         result.add(new StringType(new String(hexStringToByteArray(cnt))));        
@@ -4793,7 +4817,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     String param = nl.get(0).primitiveValue();
 
     List<Base> result = new ArrayList<Base>();
-    if (focus.size() == 1) {
+    if (focus.size() == 1 && focus.get(0).primitiveValue() != null) {
       String cnt = focus.get(0).primitiveValue();
       if ("html".equals(param)) {
         result.add(new StringType(Utilities.escapeXml(cnt)));        
@@ -4814,7 +4838,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     String param = nl.get(0).primitiveValue();
 
     List<Base> result = new ArrayList<Base>();
-    if (focus.size() == 1) {
+    if (focus.size() == 1 && focus.get(0).primitiveValue() != null) {
       String cnt = focus.get(0).primitiveValue();
       if ("html".equals(param)) {
         result.add(new StringType(Utilities.unescapeXml(cnt)));        
@@ -4832,7 +4856,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
   private List<Base> funcTrim(ExecutionContext context, List<Base> focus, ExpressionNode exp) {
     List<Base> result = new ArrayList<Base>();
-    if (focus.size() == 1) {
+    if (focus.size() == 1 && focus.get(0).primitiveValue() != null) {
       String cnt = focus.get(0).primitiveValue();
       result.add(new StringType(cnt.trim()));
     }
@@ -5196,11 +5220,12 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     if (focus.size() == 0 || regexB.size() == 0 || replB.size() == 0) {
       // no-op
     } else if (focus.size() == 1 && !Utilities.noString(regex)) {
-      if (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion) {
+      String f = convertToString(focus.get(0));
+      if ((focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion) && f != null) {
         try {
           @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
           //False positive: RegexTimeout.matches is safe for user-supplied regular expressions
-          String replaced = RegexTimeout.replaceAll(convertToString(focus.get(0)), regex, repl);
+          String replaced = RegexTimeout.replaceAll(f, regex, repl);
           result.add(new StringType(replaced).noExtensions());
         } catch (TimeoutException te) {
           throw new FHIRException("Timeout evaluating regex: " + regex, te);
@@ -5225,8 +5250,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     } else if (Utilities.noString(sw)) {
       result.add(new BooleanType(true).noExtensions());
     } else if (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion) {
-      if (focus.size() == 1 && !Utilities.noString(sw)) {
-        result.add(new BooleanType(convertToString(focus.get(0)).endsWith(sw)).noExtensions());
+      String s = convertToString(focus.get(0));
+      if (focus.size() == 1 && !Utilities.noString(sw) && s != null) {
+        result.add(new BooleanType(s.endsWith(sw)).noExtensions());
       } else {
         result.add(new BooleanType(false).noExtensions());
       }
@@ -5331,8 +5357,8 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
 
       @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
       //non-overlapping alternation with bounded optional groups, safe
-      boolean isMatch = s.matches(RegexConstants.DATE_TIME_REGEX);
-      if (s != null && isMatch) {
+      boolean isMatch = s != null && s.matches(RegexConstants.DATE_TIME_REGEX);
+      if (isMatch) {
         try {
           result.add(new DateTimeType(s).noExtensions());
         } catch (Exception e) {
@@ -6126,7 +6152,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     List<Base> result = new ArrayList<Base>();
     if (focus.size() == 1 && (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion)) {
       String s = convertToString(focus.get(0));
-      result.add(new IntegerType(s.length()).noExtensions());
+      if (s != null) {
+        result.add(new IntegerType(s.length()).noExtensions());
+      }
     }
     return result;
   }
@@ -6190,8 +6218,10 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     List<Base> result = new ArrayList<Base>();
     if (focus.size() == 1 && (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion)) {
       String s = convertToString(focus.get(0));
-      for (char c : s.toCharArray()) {  
-        result.add(new StringType(String.valueOf(c)).noExtensions());
+      if (s != null) {
+        for (char c : s.toCharArray()) {  
+          result.add(new StringType(String.valueOf(c)).noExtensions());
+        }
       }
     }
     return result;
@@ -6246,7 +6276,7 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     if (focus.size() == 1 && (focus.get(0).hasType(FHIR_TYPES_STRING) || doImplicitStringConversion)) {
       String sw = convertToString(focus.get(0));
       String s;
-      if (i1 < 0 || i1 >= sw.length()) {
+      if (sw == null || i1 < 0 || i1 >= sw.length()) {
         return new ArrayList<Base>();
       }
       if (exp.parameterCount() == 2) {
@@ -6301,7 +6331,8 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     } else if (focus.get(0) instanceof BooleanType) {
       result.add(new BooleanType(true).noExtensions());
     } else if (focus.get(0) instanceof StringType) {
-      result.add(new BooleanType(Utilities.existsInList(convertToString(focus.get(0)).toLowerCase(), "true", "false")).noExtensions());
+      String s = convertToString(focus.get(0));
+      result.add(new BooleanType(s != null && Utilities.existsInList(s.toLowerCase(), "true", "false")).noExtensions());
     } else { 
       result.add(new BooleanType(false).noExtensions());
     }
@@ -6315,8 +6346,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     } else if (focus.get(0) instanceof DateTimeType || focus.get(0) instanceof DateType) {
       result.add(new BooleanType(true).noExtensions());
     } else if (focus.get(0) instanceof StringType) {
-      result.add(new BooleanType((convertToString(focus.get(0)).matches
-          (RegexConstants.DATE_TIME_REGEX))).noExtensions());
+      String s = convertToString(focus.get(0));
+      result.add(new BooleanType(s != null && s.matches
+          (RegexConstants.DATE_TIME_REGEX)).noExtensions());
     } else {
       result.add(new BooleanType(false).noExtensions());
     }
@@ -6330,8 +6362,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     } else if (focus.get(0) instanceof DateTimeType || focus.get(0) instanceof DateType) {
       result.add(new BooleanType(true).noExtensions());
     } else if (focus.get(0) instanceof StringType) {
-      result.add(new BooleanType((convertToString(focus.get(0)).matches
-          (RegexConstants.DATE_TIME_REGEX))).noExtensions()); // FIXME Why is this regex not DATE_REGEX? Tests fail if the 'correct' regex is used.
+      String s = convertToString(focus.get(0));
+      result.add(new BooleanType(s != null && s.matches
+          (RegexConstants.DATE_TIME_REGEX)).noExtensions()); // FIXME Why is this regex not DATE_REGEX? Tests fail if the 'correct' regex is used.
     } else {
       result.add(new BooleanType(false).noExtensions());
     }
@@ -6359,8 +6392,9 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
     } else if (focus.get(0) instanceof TimeType) {
       result.add(new BooleanType(true).noExtensions());
     } else if (focus.get(0) instanceof StringType) {
-      result.add(new BooleanType((convertToString(focus.get(0)).matches
-          ("(T)?([01][0-9]|2[0-3])(:[0-5][0-9](:([0-5][0-9]|60))?)?(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"))).noExtensions());
+      String s = convertToString(focus.get(0));
+      result.add(new BooleanType(s != null && s.matches
+          ("(T)?([01][0-9]|2[0-3])(:[0-5][0-9](:([0-5][0-9]|60))?)?(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?")).noExtensions());
     } else {
       result.add(new BooleanType(false).noExtensions());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <guava_version>32.0.1-jre</guava_version>
         <gson_version>2.13.1</gson_version>
         <hapi_fhir_version>8.10.0</hapi_fhir_version>
-        <validator_test_case_version>1.7.67</validator_test_case_version>
+        <validator_test_case_version>1.7.68-SNAPSHOT</validator_test_case_version>
         <jackson_version>2.22.1</jackson_version>
         <jackson_annotations_version>2.22</jackson_annotations_version>
         <junit_jupiter_version>5.14.0</junit_jupiter_version>


### PR DESCRIPTION
### Problem

A FHIR primitive can carry extensions but no value, typically through the data-absent-reason extension:

```json
"name": [{ "_family": { "extension": [{
  "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
  "valueCode": "masked" }]}}]
```

An invariant such as `name.first().family.exists() and name.first().family.length() = 1` then aborts validation with

```
java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
	at org.hl7.fhir.r5.fhirpath.FHIRPathEngine.funcLength(FHIRPathEngine.java:5754)
	at org.hl7.fhir.r5.fhirpath.FHIRPathEngine.evaluateFunction(FHIRPathEngine.java:3975)
	...
```

The element exists, so the expression gets past `exists()`, but `primitiveValue()` is null and `convertToString()` hands that null to `String.length()`.

Per the FHIR spec such an element has no value at all: `hasValue()` is "true if the input collection contains a single value which is a FHIR primitive, and it has a primitive value (e.g. as opposed to not having a value and just having extensions)" and `getValue()` "otherwise the return value is empty" (https://hl7.org/fhir/R5/fhirpath.html). With no system value there is no string to measure, and FHIRPath says `length()` on an empty input is empty. The invariant then evaluates to empty and is reported as a constraint failure - which is the intended outcome - instead of killing the validation run.

### What changed

`FHIRPathEngine` (R5) no longer dereferences the value of a primitive that doesn't have one. The behaviour per function follows what its already-guarded siblings do:

* empty result: `length()`, `toChars()`, `substring()`, `trim()`, `replaceMatches()`, `encode()`, `decode()`, `escape()`, `unescape()`, `toDateTime()` - same as `upper()`/`lower()`, which already checked
* false: `endsWith()`, `convertsToBoolean()`, `convertsToDate()`, `convertsToDateTime()`, `convertsToTime()` - same as `startsWith()`, `contains()`, `matches()` and `convertsToInteger()`, which already checked
* empty result for `<`, `<=`, `>`, `>=` - FHIRPath says comparing with empty gives empty

`escape()`/`unescape()` previously returned the literal string `"null"` or `""` rather than throwing; they now return empty as well.

`toDateTime()` had its `s != null` check after the regex was applied; it now happens before.

Every other expression that was tried against a valueless primitive is unchanged.

The R4 and R4B copies of `FHIRPathEngine` carry the same code. The validator uses the R5 engine, so this PR only touches that one - say the word and I'll port it.

### Tests

FHIR/fhir-test-cases: https://github.com/FHIR/fhir-test-cases/pull/276 - new `primitivesWithoutValue` group in `r5/fhirpath/tests-fhir-r5.xml`, using the existing `patient-name-extensions.json`, in both the POJO and element model. Six of those tests fail on master with the NPE and pass with this change; `FHIRPathTests` is green (1067 tests).

That's why `validator_test_case_version` moves to `1.7.68-SNAPSHOT` here - happy to change that to whatever you prefer once the test cases are released.

Reported at ahdis/matchbox#240.


Fixes #2558
