### PR TITLE
PropertyFilter: test every value of a repeating concept property, not just the first

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/expansion/PropertyFilter.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/expansion/PropertyFilter.java
@@ -1,5 +1,6 @@
 package org.hl7.fhir.r5.terminologies.expansion;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
@@ -30,94 +31,110 @@ public class PropertyFilter extends ConceptFilter {
 
   @Override
   public boolean includeConcept(CodeSystem cs, ConceptDefinitionComponent def) {
-    ConceptPropertyComponent propertyComponent = getPropertyForConcept(def);
-    if (propertyComponent != null) {
-      if (propertyComponent.hasValue() && propertyComponent.getValue().isPrimitive()) {
-        String value = propertyComponent.getValue().primitiveValue();
-        switch (filter.getOp()) {
-          case DESCENDENTOF:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case EQUAL:
-            return filter.getValue().equals(value);
-          case EXISTS:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case GENERALIZES:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case IN:
+    // CodeSystem.concept.property is 0..*, so a concept may carry several values for the filtered
+    // property. The filter is about whether the concept HAS a matching value, so every value is
+    // tested, not just the first one found.
+    List<ConceptPropertyComponent> propertyComponents = getPropertiesForConcept(def);
+    if (propertyComponents.isEmpty()) {
+      return filter.getOp() == FilterOperator.NOTIN;
+    }
+    // NOTIN is satisfied only when NO value matches, so it needs every value to pass; the other
+    // operators are satisfied by any one value.
+    boolean negated = filter.getOp() == FilterOperator.NOTIN;
+    for (ConceptPropertyComponent propertyComponent : propertyComponents) {
+      boolean matches = matchesValue(propertyComponent);
+      if (negated != matches) {
+        return matches;
+      }
+    }
+    return negated;
+  }
+
+  private boolean matchesValue(ConceptPropertyComponent propertyComponent) {
+    if (propertyComponent.hasValue() && propertyComponent.getValue().isPrimitive()) {
+      String value = propertyComponent.getValue().primitiveValue();
+      switch (filter.getOp()) {
+        case DESCENDENTOF:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case EQUAL:
+          return filter.getValue().equals(value);
+        case EXISTS:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case GENERALIZES:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case IN:
+          @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
+          //single literal character split
+          String[] primitiveInParts = filter.getValue().split("\\,");
+          return Utilities.existsInListTrimmed(value, primitiveInParts);
+        case ISA:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case ISNOTA:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case NOTIN:
+          @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
+          //single literal character split
+          String[] primitiveNotInParts = filter.getValue().split("\\,");
+          return !Utilities.existsInListTrimmed(value, primitiveNotInParts);
+        case NULL:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case REGEX:
+          try {
             @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
-            //single literal character split
-            String[] primitiveInParts = filter.getValue().split("\\,");
-            return Utilities.existsInListTrimmed(value, primitiveInParts);
-          case ISA:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case ISNOTA:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case NOTIN:
-            @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
-            //single literal character split
-            String[] primitiveNotInParts = filter.getValue().split("\\,");
-            return !Utilities.existsInListTrimmed(value, primitiveNotInParts);
-          case NULL:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case REGEX:
-            try {
-              @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
-              //False positive: RegexTimeout.matches is the approved timeout wrapper. The regex comes from the ValueSet filter value - user-supplied at runtime
-              boolean matches = RegexTimeout.matches(value, filter.getValue());
-              return value != null && matches;
-            } catch (TimeoutException e) {
-              throw fail("The regex filter '"+filter.getValue()+"' took too long to evaluate");
-            }
-          default:
-            throw fail("Shouldn't get here");
-        }
-      } else if (propertyComponent.getValue() instanceof Coding) {
-        Coding c = propertyComponent.getValueCoding();
-        switch (filter.getOp()) {
-          case DESCENDENTOF:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case EQUAL:
-            return CodingUtilities.filterEquals(c, filter.getValue());
-          case EXISTS:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case GENERALIZES:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case IN:
-            @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
-            //single literal character split
-            String[] codingInParts = filter.getValue().split("\\,");
-            return CodingUtilities.filterInList(c, codingInParts);
-          case ISA:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case ISNOTA:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case NOTIN:
-            @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
-            //single literal character split
-            String[] codingNotInParts = filter.getValue().split("\\,");
-            return !CodingUtilities.filterInList(c, codingNotInParts);
-          case NULL:
-            throw fail("not supported yet: " + filter.getOp().toCode());
-          case REGEX:
-            return CodingUtilities.filterMatches(c, filter.getValue());
-          default:
-            throw fail("Shouldn't get here");
-        }
-      } else {
-        throw fail("not supported yet: " + propertyComponent.getValue().fhirType());
+            //False positive: RegexTimeout.matches is the approved timeout wrapper. The regex comes from the ValueSet filter value - user-supplied at runtime
+            boolean matches = RegexTimeout.matches(value, filter.getValue());
+            return value != null && matches;
+          } catch (TimeoutException e) {
+            throw fail("The regex filter '"+filter.getValue()+"' took too long to evaluate");
+          }
+        default:
+          throw fail("Shouldn't get here");
+      }
+    } else if (propertyComponent.getValue() instanceof Coding) {
+      Coding c = propertyComponent.getValueCoding();
+      switch (filter.getOp()) {
+        case DESCENDENTOF:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case EQUAL:
+          return CodingUtilities.filterEquals(c, filter.getValue());
+        case EXISTS:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case GENERALIZES:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case IN:
+          @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
+          //single literal character split
+          String[] codingInParts = filter.getValue().split("\\,");
+          return CodingUtilities.filterInList(c, codingInParts);
+        case ISA:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case ISNOTA:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case NOTIN:
+          @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
+          //single literal character split
+          String[] codingNotInParts = filter.getValue().split("\\,");
+          return !CodingUtilities.filterInList(c, codingNotInParts);
+        case NULL:
+          throw fail("not supported yet: " + filter.getOp().toCode());
+        case REGEX:
+          return CodingUtilities.filterMatches(c, filter.getValue());
+        default:
+          throw fail("Shouldn't get here");
       }
     } else {
-      return filter.getOp() == FilterOperator.NOTIN;
+      throw fail("not supported yet: " + propertyComponent.getValue().fhirType());
     }
   }
 
-  private ConceptPropertyComponent getPropertyForConcept(ConceptDefinitionComponent def) {
+  private List<ConceptPropertyComponent> getPropertiesForConcept(ConceptDefinitionComponent def) {
+    List<ConceptPropertyComponent> res = new ArrayList<>();
     for (ConceptPropertyComponent pc : def.getProperty()) {
       if (pc.hasCode() && pc.getCode().equals(property.getCode())) {
-        return pc;
+        res.add(pc);
       }
     }
-    return null;
+    return res;
   }
 
 }


### PR DESCRIPTION
Fixes #2559.

`CodeSystem.concept.property` is `0..*`, and a compose filter on a property is satisfied when the concept **has** a matching value. `getPropertyForConcept` returned the *first* property carrying the filtered code and `includeConcept` tested only that one, so every later value was unreachable — making the outcome depend on the order the properties happen to be serialised in.

It fails in **both** directions, and the second is the one I'd flag:

- **`EQUAL` / `IN` / `REGEX` under-match** — a concept whose matching value isn't first is dropped. On LOINC 2.82 held locally, `CLASS = http://loinc.org/part#LP7787-7` returned **7,762 of the 28,614** concepts that carry that value, with no error and a self-consistent `total`.
- **`NOTIN` over-matches** — a concept that *does* carry an excluded value is **included**, because only its first value was examined. A value set can contain a code it explicitly excluded.

## The change

Every value with the filtered code is tested. The positive operators are satisfied by any one value; `NOTIN` requires every value to pass, preserving its meaning of "the concept has no value in this list". A concept carrying one value, or none, behaves exactly as before.

The diff is larger than the logic because removing the vestigial `else` block de-indents the existing `switch` body — the actual change is the loop in `includeConcept` plus `getPropertyForConcept` → `getPropertiesForConcept`. Reviewing with whitespace ignored shows it clearly.

## Verification

Compiled against 6.10.2 and run with only this class replaced, on a concept holding `kind=target` and `kind=other`:

| filter | before | after |
|---|---|---|
| `kind = target` | `first` | `first second` |
| `kind not-in target` | `second` | *(none)* |

## Regression test

Proposed separately as HL7/fhir-tx-ecosystem-ig#65 — it adds a repeating property to the `simple` code system and filters on the value that is not first. `TerminologyServiceTests` picks that up through `hl7.fhir.uv.tx-ecosystem`, so this fix gets covered there rather than by a new unit test here. That test fails on stock 6.9.12 (`total = 0`) and passes with this change (`total = 1`).

## One related thing, not fixed here

`expansion.contains.property` also collapses a repeating property to a single value, and keeps the **last** one — with `property=kind` requested, the concept above comes back as `first[kind=other]`. That's a different code path from the filter (which keeps the first), so I've left it alone rather than widen this PR. Happy to take it on separately if you'd like it fixed.
