### PR TITLE
Expansion: carry every value of a repeating concept property into contains.property

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/ValueSetUtilities.java
@@ -354,6 +354,28 @@ public class ValueSetUtilities extends TerminologyUtilities {
     return p;
   }
 
+  /**
+   * Add another value for a property that may legitimately repeat, instead of replacing the value
+   * already carried.
+   *
+   * <p>{@link #addProperty} is a set: callers such as the label / order / weight handling
+   * deliberately write the code system's value and then let the value set's value replace it. That
+   * is the wrong behaviour when the values are siblings rather than overrides —
+   * {@code CodeSystem.concept.property} is 0..*, and every value belongs in the expansion.
+   *
+   * <p>An identical value already present is not added twice; a repeated identical value in the
+   * source says nothing the expansion does not already carry.
+   */
+  public static org.hl7.fhir.r5.model.ValueSet.ConceptPropertyComponent addPropertyValue(ValueSet vs, ValueSetExpansionContainsComponent ctxt, String url, String code, DataType value) {
+    code = defineProperty(vs, url, code);
+    for (org.hl7.fhir.r5.model.ValueSet.ConceptPropertyComponent t : ctxt.getProperty()) {
+      if (code.equals(t.getCode()) && t.hasValue() && value != null && t.getValue().equalsDeep(value)) {
+        return t;
+      }
+    }
+    return ctxt.addProperty().setCode(code).setValue(value);
+  }
+
   private static org.hl7.fhir.r5.model.ValueSet.ConceptPropertyComponent getProperty(List<org.hl7.fhir.r5.model.ValueSet.ConceptPropertyComponent> list, String code) {
     for (org.hl7.fhir.r5.model.ValueSet.ConceptPropertyComponent t : list) {
       if (code.equals(t.getCode())) {

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/expansion/ValueSetExpander.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/terminologies/expansion/ValueSetExpander.java
@@ -300,7 +300,7 @@ public class ValueSetExpander extends ValueSetProcessBase {
                   // ??
                 }
               }
-              ValueSetUtilities.addProperty(focus, n, url, cp.getCode(), cp.getValue()).copyExtensions(cp, "http://hl7.org/fhir/StructureDefinition/alternate-code-use", "http://hl7.org/fhir/StructureDefinition/alternate-code-status");
+              ValueSetUtilities.addPropertyValue(focus, n, url, cp.getCode(), cp.getValue()).copyExtensions(cp, "http://hl7.org/fhir/StructureDefinition/alternate-code-use", "http://hl7.org/fhir/StructureDefinition/alternate-code-status");
             }
           }
         }
@@ -320,7 +320,7 @@ public class ValueSetExpander extends ValueSetProcessBase {
                   // TODO: try looking it up from the code system
                 }
               }
-              ValueSetUtilities.addProperty(focus, n, url, cp.getCode(), cp.getValue()).copyExtensions(cp, "http://hl7.org/fhir/StructureDefinition/alternate-code-use", "http://hl7.org/fhir/StructureDefinition/alternate-code-status");
+              ValueSetUtilities.addPropertyValue(focus, n, url, cp.getCode(), cp.getValue()).copyExtensions(cp, "http://hl7.org/fhir/StructureDefinition/alternate-code-use", "http://hl7.org/fhir/StructureDefinition/alternate-code-status");
             }
           }
         }        


### PR DESCRIPTION
The second half of #2559, and independent of #2560.

`CodeSystem.concept.property` is `0..*` and `expansion.contains.property` is too, but a concept carrying several values for one property comes back with only **one** of them — the **last**.

## Cause

The two loops in `ValueSetExpander` that copy a concept's properties across already iterate every value. The loss happens beneath them, in `ValueSetUtilities.addProperty`:

```java
ConceptPropertyComponent p = getProperty(ctxt.getProperty(), code);
if (p != null) {
  p.setValue(value);          // <-- replaces the value already carried
} else {
  p = ctxt.addProperty().setCode(code).setValue(value);
}
```

That set behaviour is **wanted** by the other callers: `label`, `order` and `weight` are each written from the code system extension and then from the value set extension, precisely so the second replaces the first. So `addProperty` can't simply start appending — six of its eight call sites depend on it not doing that.

## The change

Adds `addPropertyValue` for the case where values are siblings rather than overrides, and uses it in the two loops that copy concept and expansion property values. An identical value already present is not added twice. A concept with one value for a property, or none, is unaffected, as are the label / order / weight paths.

## Verification

Against 6.10.2 with only these classes replaced, on a concept holding `kind=target` and `kind=other`, with `property=kind` requested:

| | result |
|---|---|
| before | `first[kind=other]` |
| after | `first[kind=target kind=other]` |

And the two fixes are visibly independent — this one alone does not change *which* concepts are returned, and #2560 alone does not change how many values each carries:

| | |
|---|---|
| stock | `first[kind=other]` |
| #2560 only | `first[kind=other] second[kind=target]` |
| both | `first[kind=target kind=other] second[kind=other kind=target]` |

## Note

I haven't added a test-cases entry for this one. HL7/fhir-tx-ecosystem-ig#65 adds a concept with a repeating property but deliberately filters on it rather than reporting it, because at the time it wasn't clear what the expected `contains.property` output should be. If you'd like this pinned in the suite too, I'm happy to extend that PR — the natural place is the existing `parameters-expand-all-property` / `parameters-expand-enum-property` tests, whose expectations would then show both values.
