### PR TITLE
Remove name from Swedish editor entry

### DIFF
--- a/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
+++ b/org.hl7.fhir.utilities/src/main/resources/source/editors.txt
@@ -9,4 +9,4 @@ Editors for the various languages (git tags):
 * PT:  Jose Costa Teixeira (costateixeira)
 * PT_BR: Italo ()
 * RU: Vadim Peretokin (vadi2)
-* SV: Joakim Berg ()
+* SV: 


### PR DESCRIPTION
Removed the name associated with the Swedish (SV) editor entry. Joakim Berg no longer works with FHIR.