### PR TITLE
txTests: honour the tx-ecosystem lenient-display test attribute

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Validator Changes
 
-* no changes
+* txTests: honour the tx-ecosystem `lenient-display` test attribute by sending the `lenient-display-validation` parameter with the request
 
 ## Other code changes
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
@@ -635,6 +635,11 @@ public class TxTester implements ITerminologyRequestIdProvider {
         conversionLogger.testName.set(testName);
         String reqFile = chooseParam(test, "request", modes);
         Resource req = reqFile == null ? null : loader.loadResource(reqFile);
+        if (test.has("lenient-display") && req instanceof Parameters) {
+          // the lenient/strict display validation pairs share one request file; the
+          // test attribute determines the lenient-display-validation parameter sent
+          ((Parameters) req).addParameter("lenient-display-validation", test.asBoolean("lenient-display"));
+        }
 
         String fn = chooseParam(test, "response", modes);
         String resp = FileUtilities.bytesToString(loader.loadContent(fn));


### PR DESCRIPTION
## Problem

Fixes #2565.

The tx-ecosystem test suite splits its display-validation tests into lenient/strict pairs that share a single request file, distinguished by a `lenient-display` attribute on the test entry (6 entries in current test-cases.json). `TxTester` never reads the attribute, so both members of a pair send byte-identical requests while expecting contradictory responses — one `severity: warning` + `result: true`, the other `severity: error` + `result: false`. Whatever a server's default display-validation behaviour is, it fails exactly one member of each pair.

## Change

In `runTest`, when the test entry carries `lenient-display`, add the corresponding `lenient-display-validation` parameter to the request before dispatch — the same parameter the rest of the codebase uses for this option (`BaseWorkerContext.setTerminologyOptions`, `TxServiceTestHelper`). The attribute is sent explicitly for both values, so the strict member states its intent rather than relying on the server's default.

## Evidence

Running txTests (mode `general`, tests `hl7.fhir.uv.tx-ecosystem` current master content) against an independent R5 terminology server that implements `lenient-display-validation`:

* before: `validation/validation-simple-code-bad-display-lenient` **fails** (the server's default is strict, and the runner gives it no way to know the test wants lenient) while `-notlenient` passes;
* after: **both** members of the `validation/simple-code-bad-display` pair pass, and the requests of a pair now actually differ. (The `extensions/validate-code-inactive-display-notlenient` member still fails against our server — but on the server's own merits now, with a response that genuinely reflects strict mode being requested.)
