### PR TITLE
CompareUtilities: implement the $only$ version-gate marker

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Validator Changes
 
-* no changes
+* txTests: support the `$only$` version-gate marker in expected responses (used by the tx-ecosystem test cases)
 
 ## Other code changes
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/CompareUtilities.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/test/utils/CompareUtilities.java
@@ -378,7 +378,7 @@ public class CompareUtilities extends BaseTestingUtilities {
   }
 
   private boolean isOptional(String n, List<String> optionals) {
-    return n.equals("$optional$") || optionals.contains("*")  || optionals.contains(n);
+    return n.equals("$optional$") || n.equals("$only$") || optionals.contains("*")  || optionals.contains(n);
   }
 
   private boolean allOptional(JsonElement value) {
@@ -387,7 +387,8 @@ public class CompareUtilities extends BaseTestingUtilities {
       for (JsonElement e : a) {
         if (e.isJsonObject()) {
           JsonObject o = e.asJsonObject();
-          if (!o.has("$optional$")) {
+          boolean filteredOnly = o.isJsonString("$only$") && !passesOptionalFilter(o.asString("$only$"));
+          if (!o.has("$optional$") && !filteredOnly) {
             return false;
           }
         } else {
@@ -455,7 +456,7 @@ public class CompareUtilities extends BaseTestingUtilities {
         return s;
     } else if (actualJsonElement instanceof JsonArray) {
       JsonArray actualArray = (JsonArray) actualJsonElement;
-      JsonArray expectedArray = (JsonArray) expectedJsonElement;
+      JsonArray expectedArray = filterOnlys((JsonArray) expectedJsonElement);
 
       int as = actualArray.size();
       int es = expectedArray.size();
@@ -518,6 +519,32 @@ public class CompareUtilities extends BaseTestingUtilities {
     } else
       return "unhandled property " + actualJsonElement.getClass().getName();
     return null;
+  }
+
+  /**
+   * Remove expected array items whose $only$ gate does not pass in the current comparison
+   * context - e.g. an item marked "$only$" : "version:4" is dropped when comparing the
+   * response of a version 5 server. Items whose gate passes remain in place as required
+   * items (unlike $optional$, which merely tolerates absence in either context).
+   */
+  private JsonArray filterOnlys(JsonArray arr) {
+    boolean found = false;
+    for (JsonElement e : arr) {
+      if (e.isJsonObject() && e.asJsonObject().isJsonString("$only$")) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return arr;
+    }
+    JsonArray res = new JsonArray();
+    for (JsonElement e : arr) {
+      if (!(e.isJsonObject() && e.asJsonObject().isJsonString("$only$")) || passesOptionalFilter(e.asJsonObject().asString("$only$"))) {
+        res.add(e);
+      }
+    }
+    return res;
   }
 
   private int optionalCount(JsonArray arr, String name, JsonObject parent) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/utils/CompareUtilitiesTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/utils/CompareUtilitiesTests.java
@@ -3,6 +3,7 @@ package org.hl7.fhir.r5.test.utils;
 import org.apache.commons.io.IOUtils;
 
 import org.hl7.fhir.utilities.tests.ResourceLoaderTests;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -14,6 +15,7 @@ import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CompareUtilitiesTests implements ResourceLoaderTests {
@@ -99,5 +101,43 @@ public class CompareUtilitiesTests implements ResourceLoaderTests {
      String expectedOutput = normalizeNewlines(getResourceAsString(expectedOutputPath));
      assertEquals(expectedOutput, normalizeNewlines(actualOutput));
    }
+ }
+
+ // $only$ gates an expected array item to a comparison context (tx-ecosystem uses it to
+ // version-gate response parts): the item is required when the gate matches the "version"
+ // variable and ignored entirely when it doesn't.
+ private static final String ONLY_EXPECTED_JSON = "{\"item\" : [" +
+     "{\"name\" : \"concept\"}," +
+     "{\"$only$\" : \"version:4\", \"name\" : \"equivalence\"}," +
+     "{\"name\" : \"originMap\"}," +
+     "{\"$only$\" : \"version:5\", \"name\" : \"relationship\"}]}";
+
+ private String compareWithVersion(String version, String expected, String actual) throws IOException {
+   return new CompareUtilities(null, null, java.util.Map.of("version", version)).checkJsonSrcIsSame("$only$", expected, actual, false);
+ }
+
+ @Test
+ public void testCompareJSONOnlyMatchingGateIsRequired() throws IOException {
+   final String r5Actual = "{\"item\" : [{\"name\" : \"concept\"}, {\"name\" : \"originMap\"}, {\"name\" : \"relationship\"}]}";
+   final String r4Actual = "{\"item\" : [{\"name\" : \"concept\"}, {\"name\" : \"equivalence\"}, {\"name\" : \"originMap\"}]}";
+   assertNull(compareWithVersion("5.0.0", ONLY_EXPECTED_JSON, r5Actual));
+   assertNull(compareWithVersion("4.0.1", ONLY_EXPECTED_JSON, r4Actual));
+   // an item gated to the matching version stays required
+   final String r5MissingRelationship = "{\"item\" : [{\"name\" : \"concept\"}, {\"name\" : \"originMap\"}]}";
+   assertNotNull(compareWithVersion("5.0.0", ONLY_EXPECTED_JSON, r5MissingRelationship));
+   // an item gated to the other version may not appear
+   final String r5WithEquivalence = "{\"item\" : [{\"name\" : \"concept\"}, {\"name\" : \"equivalence\"}, {\"name\" : \"originMap\"}, {\"name\" : \"relationship\"}]}";
+   assertNotNull(compareWithVersion("5.0.0", ONLY_EXPECTED_JSON, r5WithEquivalence));
+ }
+
+ @Test
+ public void testCompareJSONOnlyFilteredPropertyMayBeAbsent() throws IOException {
+   // a property whose expected array is entirely gated away may be missing from the actual
+   final String expected = "{\"item\" : [{\"name\" : \"concept\"}], \"gated\" : [{\"$only$\" : \"version:4\", \"name\" : \"equivalence\"}]}";
+   final String actualWithout = "{\"item\" : [{\"name\" : \"concept\"}]}";
+   assertNull(compareWithVersion("5.0.0", expected, actualWithout));
+   assertNotNull(compareWithVersion("4.0.1", expected, actualWithout));
+   final String actualWith = "{\"item\" : [{\"name\" : \"concept\"}], \"gated\" : [{\"name\" : \"equivalence\"}]}";
+   assertNull(compareWithVersion("4.0.1", expected, actualWith));
  }
 }


### PR DESCRIPTION
## Problem

Fixes #2566.

`tests/translate/translate-1-response-parameters.json` in the tx-ecosystem suite (current master) version-gates individual match parts with an `$only$` marker (`"version:4"` / `"version:5"`), but `CompareUtilities` only implements `$optional$`/`$optional-properties$`/`$count-arrays$`. The `$only$` items are treated as required for every server, so the comparison fails on the raw array count (`Expected:"6" Actual:"4"`) regardless of server version — the expected file mixes both versions' parts, so no server of either version can satisfy it.

## Change

Before comparing an expected array, filter out items whose `$only$` gate does not match the current context — the same token grammar `$optional$` already uses (`version:N` against the `version` variable the tx tester supplies from the server's reported FHIR version, mode names, `!` negation). Unlike `$optional$`, an item whose gate *does* match stays **required**. A property whose expected array is gated away entirely may be absent from the actual response, and the marker property itself is ignored during object comparison.

Unit tests added in `CompareUtilitiesTests` covering: gate matching per version, a matching-gate item being required, an other-version item being rejected as unexpected, and a fully-gated-away property.

## Evidence

Against an independent R5 terminology server (tests: tx-ecosystem current master content):

* before: `translate-1` fails `array item count differs at .parameter[0].part — Expected:"6" Actual:"4"` no matter what the server returns;
* after: the comparison correctly reduces the expectation to the four R5 parts (`concept`, `originMap`, `relationship`, `sourceConcept`), and with the server producing them, `translate-1` **passes**; a server missing one now gets a genuine diff instead of an unsatisfiable count mismatch.
