### PR TITLE
txTests: evaluate test-level version gates against the server's FHIR version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## Validator Changes
 
-* no changes
+* txTests: evaluate test-level `version` gates against the server's reported FHIR version (previously the tests-package version was compared, so gated tests ran against every server), and support the `!` negation prefix
 
 ## Other code changes
 

--- a/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/TxTestsCommand.java
+++ b/org.hl7.fhir.validation.cli/src/main/java/org/hl7/fhir/validation/cli/picocli/commands/TxTestsCommand.java
@@ -100,13 +100,15 @@ public class TxTestsCommand extends ValidationServiceCommand implements Callable
       // Load externals if provided
       JsonObject externalsJson = loadExternals(externals);
 
-      // Create TxTester instance
+      // Create TxTester instance. The last argument is the FHIR version used to
+      // evaluate test-level "version" gates - not the tests-package version, so
+      // pass null and let TxTester use the version the server reports.
       TxTester txTester = new TxTester(
         new TxTester.InternalTxLoader(version),
         tx,
         false,
         externalsJson,
-        testVersion
+        null
       );
 
       // Add input loaders

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/special/TxTester.java
@@ -144,6 +144,10 @@ public class TxTester implements ITerminologyRequestIdProvider {
   private final List<String> warnings = new CopyOnWriteArrayList<>();
   private CapabilityStatement capabilityStatement;
   private TerminologyCapabilities terminologyCapabilities;
+  // FHIR version the server reported during connect ($versions, falling back to
+  // /metadata); used to evaluate test-level "version" gates when no explicit
+  // version was passed to the constructor.
+  private volatile String serverVersion;
   // Server-side caching state, per thread (clients are per-thread). Maps a suite
   // name to the server-issued cache-id this thread holds for it. The first test a
   // thread runs from a suite starts a cache and front-loads that suite's setup
@@ -464,6 +468,8 @@ public class TxTester implements ITerminologyRequestIdProvider {
       }
     }
 
+    serverVersion = fhirVersion;
+
     ITerminologyClient client = null;
 
     if (VersionUtilities.isR5Plus(fhirVersion)) {
@@ -585,11 +591,26 @@ public class TxTester implements ITerminologyRequestIdProvider {
   }
 
   private boolean passesVersion(JsonObject item) {
-    if (item.has("version") && version != null) {
-      return VersionUtilities.versionMatches(version, item.asString("version"));
-    } else {
+    if (!item.has("version")) {
       return true;
     }
+    // the gate names the FHIR version(s) the item applies to ("4.0", or "!4.0" for
+    // everything else); evaluate it against the version passed to the constructor,
+    // falling back to what the server reported when connecting
+    String v = version != null ? version : serverVersion;
+    if (v == null) {
+      return true;
+    }
+    String criteria = item.asString("version");
+    boolean negated = criteria.startsWith("!");
+    if (negated) {
+      criteria = criteria.substring(1);
+    }
+    if (!criteria.endsWith("?")) {
+      criteria = criteria + "?";
+    }
+    boolean matches = VersionUtilities.versionMatches(criteria, v);
+    return negated ? !matches : matches;
   }
 
   private ResultInformation runTest(ITxTesterLoader loader, JsonObject suite, JsonObject test, List<Resource> setup, Set<String> modes, String filter,


### PR DESCRIPTION
## Problem

Fixes #2567.

test-cases.json now version-gates whole test entries (`"version": "4.0"` / `"!4.0"` on the split `translate-reverse-r4` / `-r5+` pair; `4.0`/`5.0` gates already existed in the UCUM and bugs suites). The gate never engages:

1. `passesVersion` compares against the `version` constructor argument, which the CLI wires from `-test-version` — the version of the *tests package* to load (null by default) — so with defaults every gated variant runs against every server: `translate-reverse-r4` executes against a server whose /metadata reports 5.0.0, and necessarily fails.
2. Even with a FHIR-shaped version supplied (as `ExternalTerminologyServiceTests` does), the arguments are inverted — the gate is parsed as the semver *candidate*, so `"!4.0"` throws and `"4.0"` can never partial-match a concrete `4.0.1`.
3. Nothing implements the `!` negation.

## Change

* `TxTester` records the FHIR version the server reports during connect (`$versions`, falling back to /metadata) and `passesVersion` evaluates the entry's gate as the criteria against it (explicit constructor version still wins, preserving the `ExternalTerminologyServiceTests` usage), honouring the `!` prefix and partial criteria (`4.0` matches `4.0.x`).
* `TxTestsCommand` stops passing the tests-package version into the gate.

## Evidence

Against an independent server reporting 5.0.0 (tests: tx-ecosystem current master content): before, `translate-reverse-r4` runs and fails (its R4-form request means nothing to an R5 server); after, it is skipped and the run's test count drops accordingly, while `translate-reverse-r5+` still runs.
