### PR TITLE
fix: terminate XhtmlParser.readUntil at end-of-input

### DIFF
--- a/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
+++ b/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
@@ -1004,7 +1004,7 @@ public class XhtmlParser {
   private String readUntil(char ch) throws IOException
   {
     StringBuilder s = new StringBuilder();
-    while (peekChar() != 0 && peekChar() != ch)
+    while (peekChar() != END_OF_CHARS && peekChar() != ch)
       s.append(readChar());
     readChar();
     return s.toString();
@@ -1014,7 +1014,7 @@ public class XhtmlParser {
   private String readUntil(String sc) throws IOException
   {
     StringBuilder s = new StringBuilder();
-    while (peekChar() != 0 && sc.indexOf(peekChar()) == -1)
+    while (peekChar() != END_OF_CHARS && sc.indexOf(peekChar()) == -1)
       s.append(readChar());
     readChar();
     return s.toString();

--- a/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/XhtmlParserTests.java
+++ b/org.hl7.fhir.utilities/src/test/java/org/hl7/fhir/utilities/xhtml/XhtmlParserTests.java
@@ -32,4 +32,36 @@ class XhtmlParserTests {
   void testModeratelyNestedDivStillParses() throws FHIRFormatError, IOException {
     Assertions.assertNotNull(new XhtmlParser().parse(nestedDiv(100), "div"));
   }
+
+  private static final String DIV = "<div xmlns=\"http://www.w3.org/1999/xhtml\">";
+
+  // An entity reference that runs into end-of-input must fail with a FHIRFormatError. Both
+  // readUntil overloads used to test peekChar() != 0, but peekChar() returns END_OF_CHARS
+  // ((char) -1) at EOF and does not consume, so the loop never terminated and appended
+  // (char) -1 to the StringBuilder until the heap was exhausted. A few bytes were enough.
+  @ParameterizedTest
+  @ValueSource(strings = {
+      DIV + "&",
+      "<div xmlns=\"http://www.w3.org/1999/xhtml\" title=\"&",
+  })
+  void testTruncatedEntityFailsCleanly(String src) {
+    Assertions.assertThrows(FHIRFormatError.class, () -> new XhtmlParser().parse(src, "div"));
+  }
+
+  // The same EOF path, reached where the partial entity is still resolvable, must simply
+  // terminate. These parse leniently rather than throwing; the point is that they return.
+  @ParameterizedTest
+  @ValueSource(strings = {
+      DIV + "text &amp",
+      DIV + "<p>&#3",
+  })
+  void testTruncatedEntityTerminates(String src) throws FHIRFormatError, IOException {
+    Assertions.assertNotNull(new XhtmlParser().parse(src, "div"));
+  }
+
+  // Guard the ordinary paths against an over-tight EOF check.
+  @Test
+  void testWellFormedEntitiesStillParse() throws FHIRFormatError, IOException {
+    Assertions.assertNotNull(new XhtmlParser().parse(DIV + "a &amp; b</div>", "div"));
+  }
 }


### PR DESCRIPTION
Fixes #2576.

### The defect

Both `readUntil` overloads guarded on `peekChar() != 0`, while every other loop in `XhtmlParser` guards on `peekChar() != END_OF_CHARS`. `END_OF_CHARS` is `(char) -1` and never `0`, so at end-of-input the condition stayed true — and since `peekChar()`/`readChar()` return `END_OF_CHARS` *without consuming*, each iteration appended another `(char) -1` and made no progress. The `StringBuilder` grew until the heap was exhausted.

It is reached from `parseLiteral`, which handles entity references in both element text and attribute values, so an XHTML narrative whose entity reference runs into end-of-input triggers it. A handful of bytes is enough. The failure arrives as `OutOfMemoryError` — an `Error`, not an `Exception` — so it escapes the `catch (Exception e)` guards callers typically wrap parsing in.

### The fix

Guard both overloads on `END_OF_CHARS`, matching the rest of the class. `readUntil(char)` has no callers today but carries the identical defect, so both are changed.

### Tests

Added to `XhtmlParserTests`, covering both post-fix outcomes rather than assuming one:

| input | behaviour after the fix |
|---|---|
| `<div…>&` | `FHIRFormatError` |
| `<div… title="&` | `FHIRFormatError` |
| `<div…>text &amp` | parses leniently, terminates |
| `<div…><p>&#3` | parses leniently, terminates |
| `<div…>a &amp; b</div>` | unchanged |

The last case guards against an over-tight EOF check breaking ordinary entities.

Verified these are genuine regression tests by reverting the fix and re-running: the suite then **kills the forked JVM** (`Tests run: 0`, `MojoExecutionException`) rather than reporting failures, which is the OOM taking the VM down.

`mvn -pl org.hl7.fhir.utilities test -Dtest='Xhtml*'` → 48 tests, 0 failures.
