### PR TITLE
Resolve extension(url) discriminators against inline sub-extensions

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngine.java
@@ -7116,6 +7116,20 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
   }
 
 
+  private String fixedExtensionUrl(StructureDefinition sd, ElementDefinition ed) throws DefinitionException {
+    for (ElementDefinition child : profileUtilities.getChildMap(sd, ed, false).getList()) {
+      if (child.getPath().endsWith(".url")) {
+        if (child.hasFixed() && child.getFixed().isPrimitive()) {
+          return child.getFixed().primitiveValue();
+        }
+        if (child.hasPattern() && child.getPattern().isPrimitive()) {
+          return child.getPattern().primitiveValue();
+        }
+      }
+    }
+    return null;
+  }
+
   /** given an element definition in a profile, what element contains the differentiating fixed 
    * for the element, given the differentiating expression. The expression is only allowed to 
    * use a subset of FHIRPath
@@ -7197,10 +7211,15 @@ private TimeType timeAdd(TimeType d, Quantity q, boolean negate, ExpressionNode 
               focus = new TypedElementDefinition(t);
               break;
             }
+            if (exsd == null && targetUrl.equals(fixedExtensionUrl(sd, t))) { // sub-extension defined inline, identified by its fixed url
+              focus = new TypedElementDefinition(t);
+              break;
+            }
           }
         }
         if (focus == null) { 
-          throw makeException(expr, I18nConstants.FHIRPATH_DISCRIMINATOR_CANT_FIND_EXTENSION, expr.toString(), targetUrl, element.getElement().getId(), sd.getUrl());
+          // the extension is absent on this slice, so the discriminator contributes an empty value (R5 5.1.0.13)
+          okToNotResolve = true;
         }
       } else if ("ofType".equals(expr.getName())) {
         if (!element.getElement().hasType()) {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngineDiscriminatorTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/fhirpath/FHIRPathEngineDiscriminatorTests.java
@@ -1,0 +1,142 @@
+package org.hl7.fhir.r5.fhirpath;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hl7.fhir.exceptions.PathEngineException;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.fhirpath.FHIRPathUtilityClasses.TypedElementDefinition;
+import org.hl7.fhir.r5.model.ElementDefinition;
+import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionKind;
+import org.hl7.fhir.r5.model.UriType;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behaviour of the extension(url) function when used in a slicing discriminator, exercised through
+ * FHIRPathEngine.evaluateDefinition.
+ *
+ * Each fixture uses a distinct canonical url: the shared worker context caches StructureDefinitions
+ * by url, so reusing one would let an earlier fixture satisfy a later assertion.
+ */
+public class FHIRPathEngineDiscriminatorTests {
+
+  private static final String SUB_EXTENSION_URL = "http://example.org/StructureDefinition/test-sub-function";
+
+  private static IWorkerContext context;
+  private static FHIRPathEngine fp;
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    context = TestingUtilities.getSharedWorkerContext();
+    fp = new FHIRPathEngine(context);
+    context.getManager().cacheResource(subExtensionDefinition());
+  }
+
+  /** A standalone extension definition, referenced by profile url from a parent extension. */
+  private static StructureDefinition subExtensionDefinition() {
+    StructureDefinition sd = newExtension(SUB_EXTENSION_URL);
+    addElement(sd, "Extension", "Extension");
+    addElement(sd, "Extension.url", "Extension.url").setFixed(new UriType(SUB_EXTENSION_URL));
+    addElement(sd, "Extension.value[x]", "Extension.value[x]");
+    return sd;
+  }
+
+  private static StructureDefinition newExtension(String url) {
+    StructureDefinition sd = new StructureDefinition();
+    sd.setUrl(url);
+    sd.setName(url.substring(url.lastIndexOf('/') + 1).replace("-", ""));
+    sd.setStatus(PublicationStatus.DRAFT);
+    sd.setKind(StructureDefinitionKind.COMPLEXTYPE);
+    sd.setType("Extension");
+    sd.setBaseDefinition("http://hl7.org/fhir/StructureDefinition/Extension");
+    return sd;
+  }
+
+  private static ElementDefinition addElement(StructureDefinition sd, String id, String path) {
+    ElementDefinition ed = sd.getSnapshot().addElement();
+    ed.setId(id);
+    ed.setPath(path);
+    return ed;
+  }
+
+  /**
+   * A complex extension with one sub-extension slice named 'function'.
+   *
+   * @param fixedUrl the fixed url on the sub-extension, or null for none
+   * @param typeProfile a profile url on the sub-extension's type, or null for none
+   */
+  private StructureDefinition complexExtension(String canonical, String fixedUrl, String typeProfile) {
+    StructureDefinition sd = newExtension(canonical);
+    addElement(sd, "Extension", "Extension");
+    addElement(sd, "Extension.extension", "Extension.extension");
+    ElementDefinition slice = addElement(sd, "Extension.extension:function", "Extension.extension");
+    slice.setSliceName("function");
+    if (typeProfile != null) {
+      slice.addType().setCode("Extension").addProfile(typeProfile);
+    }
+    ElementDefinition url = addElement(sd, "Extension.extension:function.url", "Extension.extension.url");
+    if (fixedUrl != null) {
+      url.setFixed(new UriType(fixedUrl));
+    }
+    addElement(sd, "Extension.extension:function.value[x]", "Extension.extension.value[x]");
+    return sd;
+  }
+
+  private TypedElementDefinition evaluate(StructureDefinition sd, String expression) throws Exception {
+    ExpressionNode expr = fp.parse(expression);
+    TypedElementDefinition root = new TypedElementDefinition(sd.getSnapshot().getElementFirstRep());
+    return fp.evaluateDefinition(expr, sd, root, sd, false);
+  }
+
+  @Test
+  public void subExtensionDeclaredByProfileIsResolved() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-by-profile", null, SUB_EXTENSION_URL);
+    TypedElementDefinition ted = evaluate(sd, "extension('" + SUB_EXTENSION_URL + "')");
+    assertNotNull(ted);
+    assertEquals("Extension.extension:function", ted.getElement().getId());
+  }
+
+  @Test
+  public void subExtensionDefinedInlineIsResolvedByItsFixedUrl() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-inline", "function", null);
+    TypedElementDefinition ted = evaluate(sd, "extension('function')");
+    assertNotNull(ted);
+    assertEquals("Extension.extension:function", ted.getElement().getId());
+  }
+
+  @Test
+  public void valueOfAnInlineSubExtensionIsReachable() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-inline-value", "function", null);
+    TypedElementDefinition ted = evaluate(sd, "extension('function').value");
+    assertNotNull(ted);
+    assertEquals("Extension.extension:function.value[x]", ted.getElement().getId());
+  }
+
+  @Test
+  public void subExtensionWithNeitherFixedUrlNorProfileIsNotResolved() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-unidentified", null, null);
+    assertNull(evaluate(sd, "extension('function')"));
+  }
+
+  /**
+   * R5 5.1.0.13: a composite discriminator may designate elements that only some slices carry, so an
+   * unresolved component contributes an empty value rather than failing.
+   */
+  @Test
+  public void unknownExtensionUrlYieldsEmptyRatherThanThrowing() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-absent", "function", null);
+    assertNull(evaluate(sd, "extension('absent').value"));
+  }
+
+  @Test
+  public void unsupportedFunctionInADiscriminatorIsRejected() throws Exception {
+    StructureDefinition sd = complexExtension("http://example.org/StructureDefinition/test-bad-fn", "function", null);
+    assertThrows(PathEngineException.class, () -> evaluate(sd, "extension.where(url = 'function')"));
+  }
+}


### PR DESCRIPTION
A profile cannot re-slice a complex extension when that extension's sub-extensions are defined inline. `FHIRPathEngine.evaluateDefinition()` throws `FHIRPATH_DISCRIMINATOR_CANT_FIND_EXTENSION` while resolving the discriminator, and snapshot generation and validation both fail.

This is the symptom reported in #2138 and #2511, and the fix #2279 attempted.

## Two distinct defects

**1. An absent extension is treated as fatal.** When the named extension is not present on a slice, the `extension(url)` branch throws. But a composite discriminator may legitimately designate an element that only some slices carry — R5 §5.1.0.13 says it then contributes an empty value for the others. The sibling `ofType()` branch a few lines up already models exactly this with `okToNotResolve`; this change makes the `extension()` branch consistent with it.

**2. Inline sub-extensions are unaddressable.** The branch matched sub-extensions only through `type.profile`. A complex extension that declares its children inline has no profile to match on, so `extension('function')` could never resolve. Inline children are now matched on the fixed (or pattern) value of their `url` element, which is the thing that identifies them.

Defect 2 is the more consequential one in practice: **every** extension generated into `hl7.fhir.uv.xver-r5.r4` declares its sub-extensions inline, so no R5-to-R4 backported complex extension could be re-sliced at all. That is how we hit this — re-slicing the backported `ImagingSelection.performer` in the HL7 Europe Imaging IG.

## Scope

20 lines of production change in one file, plus one new sub-extension-url helper. No behaviour changes for discriminators that already resolved.

## Test case

The validator test case asked for in #2279 now exists: **FHIR/fhir-test-cases#280**. It exercises both defects — a sibling slice with no `function` child (defect 1) and inline sub-extensions with no `type.profile` (defect 2). It fails on current `master` and passes with this change.

This PR also adds 6 unit tests driving `evaluateDefinition()` through its public API over purpose-built StructureDefinitions. Four fail without the fix; two cover behaviour that already worked, to guard it.

## Verification

- `org.hl7.fhir.r5`: 5203 tests, 0 failures (includes SnapShotGenerationTests, SqlOnFhirRunnerTests)
- `org.hl7.fhir.validation` `ValidationTests`: 988 tests, 0 failures
- End to end on the IG that surfaced this: 171 `Unable to resolve discriminator` errors before, 0 after

## Two things worth your steer

**r4/r4b parity.** The identical throw exists at `org.hl7.fhir.r4/.../FHIRPathEngine.java:6820` and `org.hl7.fhir.r4b/.../FHIRPathEngine.java:6507`. I've deliberately left them alone rather than guess at your policy for porting fixes across the versioned modules. Happy to mirror it if you'd like.

**Relationship to #2279.** That PR fixed a neighbouring problem — an xver fallback in `ProfileUtilities.findProfile`. The two are complementary rather than overlapping; this one does not subsume it.

Refs #2138, #2511. Also reported downstream as ahdis/matchbox#424.