### PR TITLE
Fix inverted binding strength in QuestionnaireBuilder answer constraints

### DIFF
--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/QuestionnaireBuilder.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/QuestionnaireBuilder.java
@@ -879,10 +879,13 @@ public class QuestionnaireBuilder {
   private QuestionnaireAnswerConstraint constraintTypeForBinding(ElementDefinitionBindingComponent binding) {
     if (binding == null) 
       return null;
-    else if (binding.getStrength() != BindingStrength.REQUIRED) 
+    // A required binding means the answer must come from the value set, so only the
+    // listed options are allowed. Any weaker strength (extensible, preferred, example)
+    // also permits a value of the element's own type.
+    else if (binding.getStrength() == BindingStrength.REQUIRED)
       return QuestionnaireAnswerConstraint.OPTIONSONLY;
     else
-      return QuestionnaireAnswerConstraint.OPTIONSORTYPE; 
+      return QuestionnaireAnswerConstraint.OPTIONSORTYPE;
   }
 
   private void addCodingQuestions(QuestionnaireItemComponent group, ElementDefinition element, String path, List<QuestionnaireResponse.QuestionnaireResponseItemComponent> answerGroups) throws FHIRException {

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/QuestionnaireBuilderTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/utils/QuestionnaireBuilderTests.java
@@ -1,0 +1,86 @@
+package org.hl7.fhir.r5.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.model.Questionnaire;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireAnswerConstraint;
+import org.hl7.fhir.r5.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.test.utils.TestingUtilities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The answer constraint QuestionnaireBuilder derives from a binding follows the binding's
+ * strength: a required binding means the answer must come from the value set
+ * ({@code optionsOnly}); any weaker strength - extensible, preferred, example - also permits
+ * a value of the element's own type ({@code optionsOrType}).
+ */
+class QuestionnaireBuilderTests {
+
+  private static Questionnaire buildFor(String resourceType) throws Exception {
+    IWorkerContext context = TestingUtilities.getSharedWorkerContext();
+    StructureDefinition sd = context.fetchTypeDefinition(resourceType);
+    assertNotNull(sd, resourceType + " profile should be resolvable");
+    QuestionnaireBuilder builder = new QuestionnaireBuilder(context, null);
+    builder.setProfile(sd);
+    builder.build();
+    return builder.getQuestionnaire();
+  }
+
+  /** Depth-first search for the item with the given linkId. */
+  private static QuestionnaireItemComponent find(List<QuestionnaireItemComponent> items, String linkId) {
+    for (QuestionnaireItemComponent item : items) {
+      if (linkId.equals(item.getLinkId())) {
+        return item;
+      }
+      if (item.hasItem()) {
+        QuestionnaireItemComponent hit = find(item.getItem(), linkId);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static QuestionnaireAnswerConstraint constraintOf(Questionnaire q, String linkId) {
+    QuestionnaireItemComponent item = find(q.getItem(), linkId);
+    assertNotNull(item, "no questionnaire item for " + linkId);
+    return item.getAnswerConstraint();
+  }
+
+  @Test
+  @DisplayName("A required binding yields optionsOnly")
+  void requiredBinding_optionsOnly() throws Exception {
+    // Observation.status is bound to observation-status with strength=required
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSONLY,
+      constraintOf(buildFor("Observation"), "Observation.status.value"));
+  }
+
+  @Test
+  @DisplayName("A non-required binding yields optionsOrType")
+  void nonRequiredBinding_optionsOrType() throws Exception {
+    // Observation.code is bound to observation-codes with strength=example
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(buildFor("Observation"), "Observation.code.coding"));
+  }
+
+  @Test
+  @DisplayName("Required, preferred and example strengths, on CodeableConcept elements of one resource")
+  void threeStrengths_oneResource() throws Exception {
+    Questionnaire q = buildFor("AllergyIntolerance");
+    // clinicalStatus: required; type: preferred; code: example. For a CodeableConcept the
+    // constraint sits on the generated "coding" item.
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSONLY,
+      constraintOf(q, "AllergyIntolerance.clinicalStatus.coding"));
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(q, "AllergyIntolerance.type.coding"));
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(q, "AllergyIntolerance.code.coding"));
+  }
+}

--- a/org.hl7.fhir.services/src/main/java/org/hl7/fhir/services/utilities/QuestionnaireBuilder.java
+++ b/org.hl7.fhir.services/src/main/java/org/hl7/fhir/services/utilities/QuestionnaireBuilder.java
@@ -842,7 +842,10 @@ public class QuestionnaireBuilder {
   private QuestionnaireAnswerConstraint constraintTypeForBinding(ElementDefinitionBindingComponent binding) {
     if (binding == null) 
       return null;
-    else if (binding.getStrength() != BindingStrength.REQUIRED) 
+    // A required binding means the answer must come from the value set, so only the
+    // listed options are allowed. Any weaker strength (extensible, preferred, example)
+    // also permits a value of the element's own type.
+    else if (binding.getStrength() == BindingStrength.REQUIRED)
       return QuestionnaireAnswerConstraint.OPTIONSONLY;
     else
       return QuestionnaireAnswerConstraint.OPTIONSORTYPE; 

--- a/org.hl7.fhir.standalone/src/test/java/org/hl7/fhir/utilities/QuestionnaireBuilderTests.java
+++ b/org.hl7.fhir.standalone/src/test/java/org/hl7/fhir/utilities/QuestionnaireBuilderTests.java
@@ -1,0 +1,84 @@
+package org.hl7.fhir.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.hl7.fhir.model.core.Questionnaire;
+import org.hl7.fhir.model.core.Questionnaire.QuestionnaireAnswerConstraint;
+import org.hl7.fhir.model.core.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.model.core.StructureDefinition;
+import org.hl7.fhir.services.context.IWorkerContext;
+import org.hl7.fhir.services.utilities.QuestionnaireBuilder;
+import org.hl7.fhir.standalone.testing.TestingUtilities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * R6 copy of the r5 test of the same name: the answer constraint QuestionnaireBuilder derives
+ * from a binding follows the binding's strength - required gives {@code optionsOnly}, anything
+ * weaker gives {@code optionsOrType}.
+ */
+class QuestionnaireBuilderTests {
+
+  private static Questionnaire buildFor(String resourceType) throws Exception {
+    IWorkerContext context = TestingUtilities.getSharedWorkerContext();
+    StructureDefinition sd = context.fetchTypeDefinition(resourceType);
+    assertNotNull(sd, resourceType + " profile should be resolvable");
+    QuestionnaireBuilder builder = new QuestionnaireBuilder(context, null);
+    builder.setProfile(sd);
+    builder.build();
+    return builder.getQuestionnaire();
+  }
+
+  /** Depth-first search for the item with the given linkId. */
+  private static QuestionnaireItemComponent find(List<QuestionnaireItemComponent> items, String linkId) {
+    for (QuestionnaireItemComponent item : items) {
+      if (linkId.equals(item.getLinkId())) {
+        return item;
+      }
+      if (item.hasItem()) {
+        QuestionnaireItemComponent hit = find(item.getItemList(), linkId);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static QuestionnaireAnswerConstraint constraintOf(Questionnaire q, String linkId) {
+    QuestionnaireItemComponent item = find(q.getItemList(), linkId);
+    assertNotNull(item, "no questionnaire item for " + linkId);
+    return item.getAnswerConstraint();
+  }
+
+  @Test
+  @DisplayName("A required binding yields optionsOnly")
+  void requiredBinding_optionsOnly() throws Exception {
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSONLY,
+      constraintOf(buildFor("Observation"), "Observation.status.value"));
+  }
+
+  @Test
+  @DisplayName("A non-required binding yields optionsOrType")
+  void nonRequiredBinding_optionsOrType() throws Exception {
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(buildFor("Observation"), "Observation.code.coding"));
+  }
+
+  @Test
+  @DisplayName("Required, preferred and example strengths, on CodeableConcept elements of one resource")
+  void threeStrengths_oneResource() throws Exception {
+    Questionnaire q = buildFor("AllergyIntolerance");
+    // clinicalStatus: required; type: preferred; code: example. For a CodeableConcept the
+    // constraint sits on the generated "coding" item.
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSONLY,
+      constraintOf(q, "AllergyIntolerance.clinicalStatus.coding"));
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(q, "AllergyIntolerance.type.coding"));
+    assertEquals(QuestionnaireAnswerConstraint.OPTIONSORTYPE,
+      constraintOf(q, "AllergyIntolerance.code.coding"));
+  }
+}


### PR DESCRIPTION
`constraintTypeForBinding` has its condition the wrong way round, so the answer constraint `QuestionnaireBuilder` derives from a binding is inverted for every bound element.

```java
- else if (binding.getStrength() != BindingStrength.REQUIRED)
+ else if (binding.getStrength() == BindingStrength.REQUIRED)
      return QuestionnaireAnswerConstraint.OPTIONSONLY;
  else
      return QuestionnaireAnswerConstraint.OPTIONSORTYPE;
```

`OPTIONSONLY` means answers must come from the listed options; `OPTIONSORTYPE` allows the options *or* any value of the element's type. So today:

- a **required** binding gets `optionsOrType` — permitting any value of the type, even though a required binding says the answer has to come from the value set
- an **extensible / preferred / example** binding gets `optionsOnly` — restricting answers to the listed options, which those strengths do not call for

Building a Questionnaire from `Observation` on current master shows it directly:

| Element | Binding strength | Before | After |
| --- | --- | --- | --- |
| `Observation.status` | required | `optionsOrType` | `optionsOnly` |
| `Observation.code` | example | `optionsOnly` | `optionsOrType` |
| `AllergyIntolerance.clinicalStatus` | required | `optionsOrType` | `optionsOnly` |
| `AllergyIntolerance.type` | preferred | `optionsOnly` | `optionsOrType` |
| `AllergyIntolerance.code` | example | `optionsOnly` | `optionsOrType` |

The R4 and R4B builders have this the right way round; the inversion came in with the R5 move to `answerConstraint`. The R6 copy in `org.hl7.fhir.services` has the same condition and gets the same fix.

## Tests

`QuestionnaireBuilder` never expands a value set, so the tests need only the shared worker context: no validation engine, no terminology server.

- `org.hl7.fhir.r5` — `QuestionnaireBuilderTests` on `TestingUtilities.getSharedWorkerContext()`: required (`Observation.status`, `AllergyIntolerance.clinicalStatus`), preferred (`AllergyIntolerance.type`) and example (`Observation.code`, `AllergyIntolerance.code`). For a CodeableConcept the constraint sits on the generated `coding` item, which is what the test reads.
- `org.hl7.fhir.standalone` — the same three cases against the R6 copy. Standalone skips its tests by default; run with `-DskipTests=false`.

All three fail against the previous condition, with the constraints swapped. The earlier test in the validation module, which started a full engine on R4 core against tx-dev, is removed.

## Note on impact

This changes the output of every Questionnaire generated from a profile with bindings, so it is a behaviour change rather than a pure defect fix — worth a look from anyone relying on the current constraints.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

