### PR TITLE
Add GET /package, the CRMI $package operation

### DIFF
--- a/documentation/validator-server.md
+++ b/documentation/validator-server.md
@@ -102,6 +102,7 @@ the HTTP status.
 | POST | `/snapshot` | Generate the snapshot for a StructureDefinition |
 | POST | `/narrative` | Generate the narrative for a resource |
 | POST | `/transform` | Run a StructureMap over a resource |
+| GET | `/package` | Package an artifact with its dependencies |
 | GET | `/compile` | Fetch a StructureMap by canonical URL |
 | GET | `/txTest` | Run one terminology ecosystem test against a server |
 | POST | `/stop` | Shut the server down |
@@ -259,6 +260,32 @@ curl 'http://localhost:8080/compile?url=http://example.org/StructureMap/Example'
 ```
 
 `/compile` does not check the HTTP method, so POST and other methods behave the same as GET.
+
+### GET /package
+
+The CRMI `$package` operation: returns a `collection` Bundle holding the artifact at `url` and
+everything it transitively depends on. Core FHIR resources are not included, and the root artifact
+must already be loaded.
+
+```sh
+curl 'http://localhost:8080/package?url=http://example.org/StructureDefinition/MyProfile&expand=true'
+```
+
+| Parameter | Required | Default |
+| --- | --- | --- |
+| `url` | yes | - |
+| `expand` | no | `false` |
+| `includeRules` | no | `false` |
+| `format` | no | `json` |
+
+`expand=true` replaces each ValueSet entry by its expansion, best effort - a ValueSet that cannot
+be expanded is included unexpanded. `includeRules=true` also follows canonical references inside
+StructureMap rules, notably the ConceptMaps used by `translate(...)`; it is off by default because
+rule-walking can pull in a long tail of extra artifacts.
+
+Only part of the CRMI parameter surface is implemented: paging (`count`/`offset`),
+`contentEndpoint`/`terminologyEndpoint`, `packageOnly`, `manifest` and capability-based filtering
+are not.
 
 ### GET /txTest
 

--- a/documentation/validator-server.openapi.yaml
+++ b/documentation/validator-server.openapi.yaml
@@ -55,7 +55,7 @@ tags:
   - name: Conversion
     description: Format and FHIR version conversion
   - name: Profile Operations
-    description: StructureDefinition operations
+    description: StructureDefinition and canonical artifact operations
   - name: Resource Operations
     description: Operations that rewrite a resource
   - name: StructureMap
@@ -662,6 +662,58 @@ paths:
               schema: { type: string }
         '400':
           description: Missing `map` parameter.
+          content:
+            application/fhir+json:
+              schema: { $ref: '#/components/schemas/OperationOutcome' }
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /package:
+    get:
+      tags: [Profile Operations]
+      summary: Package an artifact with its dependencies
+      description: >-
+        The CRMI `$package` operation: returns a `collection` Bundle holding the artifact at
+        `url` and everything it transitively depends on - profiles, value sets, code systems,
+        libraries, concept maps and so on. Core FHIR resources are not included, and the root
+        artifact must already be loaded (server start up `-ig`, or `/loadIG`). Only part of the
+        CRMI parameter surface is implemented: paging (`count`/`offset`),
+        `contentEndpoint`/`terminologyEndpoint`, `packageOnly`, `manifest` and capability-based
+        filtering are not.
+      parameters:
+        - name: url
+          in: query
+          required: true
+          description: Canonical URL of the root artifact to package.
+          schema: { type: string, format: uri }
+        - name: expand
+          in: query
+          description: >-
+            When `true`, each ValueSet entry is replaced by its expansion. Best effort - a
+            ValueSet that cannot be expanded is included unexpanded.
+          schema: { type: boolean, default: false }
+        - name: includeRules
+          in: query
+          description: >-
+            When `true`, canonical references inside StructureMap rules are followed as well -
+            notably the ConceptMaps used by `translate(...)`. Off by default because rule-walking
+            can pull in a long tail of extra artifacts.
+          schema: { type: boolean, default: false }
+        - name: format
+          in: query
+          description: Format of the returned Bundle. `Accept` is not consulted.
+          schema: { type: string, enum: [json, xml], default: json }
+      responses:
+        '200':
+          description: A `collection` Bundle of the artifact and its dependencies.
+          content:
+            application/fhir+json:
+              schema: { type: object }
+            application/fhir+xml:
+              schema: { type: string }
+        '400':
+          description: Missing `url` parameter.
           content:
             application/fhir+json:
               schema: { $ref: '#/components/schemas/OperationOutcome' }

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/ResourceDependencyWalker.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/utils/ResourceDependencyWalker.java
@@ -39,6 +39,7 @@ import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.SearchParameter.SearchParameterComponentComponent;
 import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.model.StructureMap;
 import org.hl7.fhir.r5.model.UsageContext;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.hl7.fhir.r5.model.ValueSet.ConceptSetComponent;
@@ -75,6 +76,10 @@ public class ResourceDependencyWalker {
   private IWorkerContext context;
   private Set<String> processedLinks = new HashSet<>();
   private Set<Resource> processedResources = new HashSet<>();
+  // Off by default: walking into StructureMap rule expressions catches ConceptMaps
+  // referenced via `translate(<canonical>, ...)` and similar in-rule URLs, but
+  // surfaces a lot of churn that callers don't always want.
+  private boolean includeRuleReferences = false;
   
   public ResourceDependencyWalker(IWorkerContext context, IResourceDependencyNotifier notifier) {
     super();
@@ -85,6 +90,16 @@ public class ResourceDependencyWalker {
   public ResourceDependencyWalker(IWorkerContext context) {
     super();
     this.context = context;
+  }
+
+  /**
+   * When true, the walker also follows ConceptMap and similar canonical URLs
+   * that appear as parameters of rule-level transforms inside a {@link StructureMap}
+   * (notably {@code translate(<concept-map>, code, ...)}). Default: false.
+   */
+  public ResourceDependencyWalker setIncludeRuleReferences(boolean includeRuleReferences) {
+    this.includeRuleReferences = includeRuleReferences;
+    return this;
   }
   
   private void notify(Resource resource, String prefix) {
@@ -151,8 +166,44 @@ public class ResourceDependencyWalker {
       walkSP((SearchParameter) res);
     } else if (res instanceof Questionnaire) {
       walkQ((Questionnaire) res);
+    } else if (res instanceof StructureMap) {
+      walkSM((StructureMap) res);
     } else {
       throw new Error("Resource "+res.fhirType()+" not Processed yet");
+    }
+  }
+
+  private void walkSM(StructureMap sm) {
+    walkCR(sm);
+    // The source/target StructureDefinitions referenced by `structure[].url`.
+    for (StructureMap.StructureMapStructureComponent s : sm.getStructure()) {
+      walkIntoLink(s.getUrl(), sm);
+    }
+    // Other StructureMaps pulled in via `import`.
+    walkCT(sm.getImport(), sm);
+    // Rule-level references — only when opted in (see setIncludeRuleReferences).
+    if (includeRuleReferences) {
+      for (StructureMap.StructureMapGroupComponent g : sm.getGroup()) {
+        for (StructureMap.StructureMapGroupRuleComponent r : g.getRule()) {
+          walkSMRule(r, sm);
+        }
+      }
+    }
+  }
+
+  private void walkSMRule(StructureMap.StructureMapGroupRuleComponent rule, StructureMap sm) {
+    for (StructureMap.StructureMapGroupRuleTargetComponent target : rule.getTarget()) {
+      // `translate(<concept-map>, code, "code")` — the first parameter is a ConceptMap canonical.
+      if (target.getTransform() == StructureMap.StructureMapTransform.TRANSLATE
+          && !target.getParameter().isEmpty()) {
+        org.hl7.fhir.r5.model.DataType v = target.getParameter().get(0).getValue();
+        if (v != null && v.hasPrimitiveValue()) {
+          walkIntoLink(v.primitiveValue(), sm);
+        }
+      }
+    }
+    for (StructureMap.StructureMapGroupRuleComponent nested : rule.getRule()) {
+      walkSMRule(nested, sm);
     }
   }
   

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -74,6 +74,7 @@ import org.hl7.fhir.r5.renderers.utils.ResourceWrapper;
 import org.hl7.fhir.r5.terminologies.CodeSystemUtilities;
 import org.hl7.fhir.r5.terminologies.NamingSystemUtilities;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
+import org.hl7.fhir.r5.utils.ResourceDependencyWalker;
 import org.hl7.fhir.r5.utils.structuremap.StructureMapUtilities;
 import org.hl7.fhir.r5.utils.validation.BundleValidationRule;
 import org.hl7.fhir.r5.utils.validation.IMessagingServices;
@@ -996,6 +997,154 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     Manager.compose(context, e, baos, outputFormat, OutputStyle.PRETTY, null);
     return baos.toByteArray();
+  }
+
+  /**
+   * CRMI {@code $package}-style operation: given a root canonical artifact, build a
+   * {@code collection} Bundle containing that artifact plus every artifact it transitively
+   * references — profiles, extensions, ValueSets, CodeSystems, Library, ActivityDefinition,
+   * PlanDefinition, ConceptMap, NamingSystem, etc. Core FHIR resources
+   * ({@code hl7.fhir.r5.core}) are not included.
+   *
+   * <p>Dependency discovery uses {@link ResourceDependencyWalker}. When
+   * {@code expandValueSets} is true, each ValueSet entry is replaced by its expansion
+   * (best effort — an unexpandable ValueSet is included unexpanded).</p>
+   *
+   * <p>Not implemented (a subset of the full CRMI {@code $package} parameter surface):
+   * paging ({@code count}/{@code offset}), {@code contentEndpoint}/{@code terminologyEndpoint},
+   * {@code packageOnly}, {@code manifest}, and capability-based filtering.</p>
+   *
+   * @param rootUrl         canonical URL of the root artifact to package
+   * @param expandValueSets when true, ValueSet entries are expanded
+   * @param outputFormat    format of the returned bytes (JSON or XML)
+   */
+  public byte[] packageResource(String rootUrl, boolean expandValueSets, FhirFormat outputFormat)
+      throws FHIRException, IOException {
+    return packageResource(rootUrl, expandValueSets, false, outputFormat);
+  }
+
+  /**
+   * Same as {@link #packageResource(String, boolean, FhirFormat)} but with the option to
+   * also follow rule-level canonical references inside {@link org.hl7.fhir.r5.model.StructureMap}
+   * resources — notably ConceptMap URLs used by {@code translate(...)} transforms. Defaults
+   * to {@code false} on the 3-arg overload because rule-walking can pull in a long tail of
+   * additional artifacts that some callers don't want.
+   */
+  public byte[] packageResource(String rootUrl, boolean expandValueSets, boolean includeRuleReferences, FhirFormat outputFormat)
+      throws FHIRException, IOException {
+    Resource root = context.fetchResource(Resource.class, rootUrl);
+    if (root == null) {
+      throw new FHIRException("Resource not found: " + rootUrl);
+    }
+
+    final java.util.LinkedHashSet<Resource> collected = new java.util.LinkedHashSet<>();
+    final List<String> brokenLinks = new ArrayList<>();
+    ResourceDependencyWalker walker = new ResourceDependencyWalker(context,
+        new ResourceDependencyWalker.IResourceDependencyNotifier() {
+          @Override
+          public void seeResource(Resource resource, String summaryId) {
+            collected.add(resource);
+          }
+          @Override
+          public void brokenLink(String link) {
+            brokenLinks.add(link);
+          }
+        });
+    walker.setIncludeRuleReferences(includeRuleReferences);
+    walker.walk(root);
+
+    Bundle bundle = new Bundle();
+    bundle.setType(Bundle.BundleType.COLLECTION);
+    bundle.getMeta().setLastUpdated(new Date());
+    for (Resource r : collected) {
+      Resource toAdd = r;
+      if (expandValueSets && r instanceof ValueSet) {
+        try {
+          org.hl7.fhir.r5.terminologies.expansion.ValueSetExpansionOutcome outcome =
+              context.expandVS((ValueSet) r, true, false);
+          if (outcome.isOk() && outcome.getValueset() != null) {
+            toAdd = outcome.getValueset();
+          }
+        } catch (Exception e) {
+          // best effort: keep the unexpanded ValueSet if expansion fails
+        }
+      }
+      BundleEntryComponent entry = bundle.addEntry();
+      entry.setResource(toAdd);
+      if (toAdd instanceof CanonicalResource && ((CanonicalResource) toAdd).hasUrl()) {
+        entry.setFullUrl(((CanonicalResource) toAdd).getUrl());
+      } else if (toAdd.hasId()) {
+        entry.setFullUrl(toAdd.fhirType() + "/" + toAdd.getIdPart());
+      }
+    }
+    for (String broken : brokenLinks) {
+      if (isLikelyNonCanonical(broken)) {
+        log.debug("$package: ignoring non-canonical reference " + broken);
+        continue;
+      }
+      log.warn("$package: could not resolve dependency " + broken);
+    }
+
+    // Same version-matching as parseStructureMap: a Bundle returned to an R4-mode caller
+    // must be serialised as R4 so its StructureMaps round-trip cleanly through
+    // /loadResource. Without this, every StructureMap in the Bundle would emit
+    // dependent.parameter (R5-only) and silently lose variables on re-read.
+    String effectiveVersion = version != null ? version : (context != null ? context.getVersion() : null);
+    return serialiseBundleForVersion(bundle, effectiveVersion, outputFormat);
+  }
+
+  /**
+   * Convert {@code bundle} (an R5 Bundle) to the version matching {@code targetVersion}
+   * and serialise it. Mirrors {@link #serialiseStructureMapForVersion} but for the whole
+   * Bundle so every entry — including nested StructureMaps reached via $package's
+   * dependency walker — gets the same version conversion treatment.
+   */
+  private static byte[] serialiseBundleForVersion(Bundle bundle, String targetVersion, FhirFormat outputFormat) throws FHIRException, IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    if (targetVersion == null || targetVersion.startsWith("5.") || targetVersion.startsWith("6.")) {
+      if (outputFormat == FhirFormat.XML) new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, bundle);
+      else                                new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, bundle);
+    } else if (targetVersion.startsWith("4.0")) {
+      org.hl7.fhir.r4.model.Resource r4 = org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50.convertResource(bundle);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY).compose(baos, r4);
+      else                                new org.hl7.fhir.r4.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY).compose(baos, r4);
+    } else if (targetVersion.startsWith("4.3")) {
+      org.hl7.fhir.r4b.model.Resource r4b = org.hl7.fhir.convertors.factory.VersionConvertorFactory_43_50.convertResource(bundle);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.r4b.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY).compose(baos, r4b);
+      else                                new org.hl7.fhir.r4b.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY).compose(baos, r4b);
+    } else if (targetVersion.startsWith("3.")) {
+      org.hl7.fhir.dstu3.model.Resource r3 = org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_50.convertResource(bundle);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.dstu3.formats.XmlParser().setOutputStyle(org.hl7.fhir.dstu3.formats.IParser.OutputStyle.PRETTY).compose(baos, r3);
+      else                                new org.hl7.fhir.dstu3.formats.JsonParser().setOutputStyle(org.hl7.fhir.dstu3.formats.IParser.OutputStyle.PRETTY).compose(baos, r3);
+    } else {
+      if (outputFormat == FhirFormat.XML) new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, bundle);
+      else                                new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, bundle);
+    }
+    return baos.toByteArray();
+  }
+
+  /**
+   * URLs the dependency walker sometimes hands us that aren't FHIR canonicals — terminology
+   * concept identifiers, OIDs, UUIDs, etc. These can show up inside e.g. {@code useContext.valueReference}
+   * and trigger spurious "broken link" warnings. Drop them quietly.
+   *
+   * <p>Walker reports the URL as {@code "<url> from <pkg.id>#<version>"}; we strip the suffix
+   * before testing.</p>
+   */
+  private static boolean isLikelyNonCanonical(String brokenLinkKey) {
+    if (brokenLinkKey == null) return true;
+    String url = brokenLinkKey;
+    int idx = url.indexOf(" from ");
+    if (idx > 0) url = url.substring(0, idx);
+    if (url.startsWith("urn:oid:")) return true;
+    if (url.startsWith("urn:uuid:")) return true;
+    if (url.startsWith("urn:ietf:")) return true;
+    if (url.startsWith("mailto:")) return true;
+    if (url.startsWith("tel:")) return true;
+    if (url.startsWith("http://snomed.info/id/")) return true;          // SNOMED concept IRI
+    if (url.startsWith("http://snomed.info/sct/") && url.length() > 22  // SNOMED edition / module URI (numeric)
+        && Character.isDigit(url.charAt(22))) return true;
+    return false;
   }
 
   public byte[] generateSnapshot(byte[] resource, FhirFormat format) throws FHIRException, IOException {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
@@ -53,6 +53,7 @@ public class FhirValidatorHttpService {
     server.createContext("/snapshot", new SnapshotHTTPHandler(this));
     server.createContext("/narrative", new NarrativeHTTPHandler(this));
     server.createContext("/transform", new TransformHTTPHandler(this));
+    server.createContext("/package", new PackageHTTPHandler(this));
     server.createContext("/version", new VersionHTTPHandler(this));
     server.createContext("/compile", new CompileHTTPHandler(this));
     server.createContext("/openapi.json", new OpenApiHTTPHandler());

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/PackageHTTPHandler.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/PackageHTTPHandler.java
@@ -1,0 +1,65 @@
+package org.hl7.fhir.validation.http;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r5.utils.OperationOutcomeUtilities;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/**
+ * Handler for the CRMI {@code $package} operation: given a root canonical artifact,
+ * return a collection Bundle of that artifact plus its transitive dependencies.
+ * {@code GET /package?url=<canonical-url>&expand=true|false&format=json|xml}
+ *
+ * <p>Core FHIR resources are not included. The root artifact and its dependencies
+ * must already be loaded into the validator's context (e.g. via {@code /loadIG}).
+ */
+class PackageHTTPHandler extends BaseHTTPHandler implements HttpHandler {
+  private final FhirValidatorHttpService fhirValidatorHttpService;
+
+  public PackageHTTPHandler(FhirValidatorHttpService fhirValidatorHttpService) {
+    this.fhirValidatorHttpService = fhirValidatorHttpService;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    if (!"GET".equals(exchange.getRequestMethod())) {
+      sendResponse(exchange, 405, "Method not allowed", "text/plain");
+      return;
+    }
+
+    try {
+      Map<String, String> params = parseQueryParams(exchange.getRequestURI().getQuery());
+      String url = params.get("url");
+      if (url == null || url.trim().isEmpty()) {
+        sendOperationOutcome(exchange, 400,
+          OperationOutcomeUtilities.createError("Missing required query parameter: url"),
+          getAcceptHeader(exchange));
+        return;
+      }
+
+      boolean expandValueSets = "true".equalsIgnoreCase(params.get("expand"));
+      boolean includeRuleReferences = "true".equalsIgnoreCase(params.get("includeRules"));
+      String format = params.get("format");
+      FhirFormat outputFormat = "xml".equalsIgnoreCase(format) ? FhirFormat.XML : FhirFormat.JSON;
+
+      byte[] result = fhirValidatorHttpService.getValidationEngine()
+        .packageResource(url.trim(), expandValueSets, includeRuleReferences, outputFormat);
+
+      String outContentType = outputFormat == FhirFormat.XML ? "application/fhir+xml" : "application/fhir+json";
+      exchange.getResponseHeaders().set("Content-Type", outContentType);
+      exchange.sendResponseHeaders(200, result.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(result);
+      }
+
+    } catch (Throwable e) {
+      sendOperationOutcome(exchange, 500,
+        OperationOutcomeUtilities.createError("Package failed: " + e.getMessage()),
+        getAcceptHeader(exchange));
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
+++ b/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "Profile Operations",
-      "description": "StructureDefinition operations"
+      "description": "StructureDefinition and canonical artifact operations"
     },
     {
       "name": "Resource Operations",
@@ -1073,6 +1073,91 @@
           },
           "400": {
             "description": "Missing `map` parameter.",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/package": {
+      "get": {
+        "tags": [
+          "Profile Operations"
+        ],
+        "summary": "Package an artifact with its dependencies",
+        "description": "The CRMI `$package` operation: returns a `collection` Bundle holding the artifact at `url` and everything it transitively depends on - profiles, value sets, code systems, libraries, concept maps and so on. Core FHIR resources are not included, and the root artifact must already be loaded (server start up `-ig`, or `/loadIG`). Only part of the CRMI parameter surface is implemented: paging (`count`/`offset`), `contentEndpoint`/`terminologyEndpoint`, `packageOnly`, `manifest` and capability-based filtering are not.",
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "Canonical URL of the root artifact to package.",
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "description": "When `true`, each ValueSet entry is replaced by its expansion. Best effort - a ValueSet that cannot be expanded is included unexpanded.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeRules",
+            "in": "query",
+            "description": "When `true`, canonical references inside StructureMap rules are followed as well - notably the ConceptMaps used by `translate(...)`. Off by default because rule-walking can pull in a long tail of extra artifacts.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Format of the returned Bundle. `Accept` is not consulted.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "xml"
+              ],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A `collection` Bundle of the artifact and its dependencies.",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "type": "object"
+                }
+              },
+              "application/fhir+xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing `url` parameter.",
             "content": {
               "application/fhir+json": {
                 "schema": {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/FhirValidatorHttpServiceTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/FhirValidatorHttpServiceTests.java
@@ -1179,6 +1179,62 @@ class FhirValidatorHttpServiceTest {
         throw new RuntimeException(e);
       }
     }
+
+    @Test
+    @DisplayName("Package - bundle a canonical artifact and its dependencies (legacy GET /package)")
+    void testPackageLegacy() throws Exception {
+      setUpService(getValidationEngine());
+
+      // A base CodeSystem — minimal canonical dependencies, fast + predictable.
+      String url = java.net.URLEncoder.encode("http://hl7.org/fhir/administrative-gender", "UTF-8");
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/package?url=" + url))
+        .GET()
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(200, response.statusCode(), "expected 200; body: " + response.body());
+      org.hl7.fhir.utilities.json.model.JsonObject bundle =
+        org.hl7.fhir.utilities.json.parser.JsonParser.parseObject(response.body());
+      assertEquals("Bundle", bundle.asString("resourceType"));
+      assertEquals("collection", bundle.asString("type"));
+      org.hl7.fhir.utilities.json.model.JsonArray entries = bundle.getJsonArray("entry");
+      assertTrue(entries != null && entries.size() >= 1,
+        "package Bundle should contain at least the root artifact");
+    }
+
+    @Test
+    @DisplayName("Package - Missing url parameter returns 400")
+    void testPackageMissingUrl() throws Exception {
+      setUpService(getValidationEngine());
+
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/package"))
+        .GET()
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(400, response.statusCode());
+      assertTrue(response.body().contains("Missing required query parameter: url"));
+    }
+
+    @Test
+    @DisplayName("Package - POST method not allowed")
+    void testPackagePostNotAllowed() throws Exception {
+      setUpService(getValidationEngine());
+
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/package?url=x"))
+        .POST(HttpRequest.BodyPublishers.ofString(""))
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(405, response.statusCode());
+    }
+
   }
 
 }


### PR DESCRIPTION
Adds the CRMI `$package` operation to the validator's HTTP API: given a root canonical artifact, return a `collection` Bundle holding that artifact plus everything it transitively references.

```
GET /package?url=<canonical-url>[&expand=true][&includeRules=true][&format=json|xml]
```

Profiles, extensions, value sets, code systems, `Library`, `ActivityDefinition`, `PlanDefinition`, `ConceptMap`, `NamingSystem` and so on are pulled in. Core FHIR resources are not included, and the root artifact must already be loaded — via `-ig` at start up, or `/loadIG`.

| Parameter | Required | Default | |
| --- | --- | --- | --- |
| `url` | yes | — | canonical URL of the root artifact |
| `expand` | no | `false` | replace each ValueSet entry by its expansion (best effort — one that cannot be expanded is included unexpanded) |
| `includeRules` | no | `false` | also follow canonical URLs inside StructureMap rules |
| `format` | no | `json` | output format; `Accept` is not consulted |

**Not implemented**, from the full CRMI parameter surface: paging (`count`/`offset`), `contentEndpoint`/`terminologyEndpoint`, `packageOnly`, `manifest`, and capability-based filtering.

## The one change outside this feature — please look here

`ResourceDependencyWalker` learns to walk a `StructureMap`:

- the `StructureDefinition`s named by `structure[].url`
- other maps pulled in by `import`
- and, **only when opted in** via `setIncludeRuleReferences(true)`, canonical URLs appearing as parameters of rule-level transforms — notably the ConceptMap in `translate(<concept-map>, code, ...)`

Worth being explicit about the risk here, since the walker has an existing caller in `ResourceDependencyPackageBuilder`: **this cannot regress anything that currently works.** Before this change a `StructureMap` fell through the walker's final `else` and threw `Error("Resource StructureMap not Processed yet")`. Any dependency graph containing one was fatal. So the change converts a failure into working behaviour rather than altering a working path.

Rule-walking is off by default because it pulls in a long tail of extra artifacts that not every caller wants — `/package` exposes it as `includeRules`.

## Cost of a large graph

Worth flagging for anyone deploying this: a `/package` call walks the whole transitive dependency graph, and with `expand=true` each ValueSet entry also costs a terminology server round trip. `includeRules=true` compounds it, since rule-walking reaches ConceptMaps that the plain walk does not. A request against a large root artifact is therefore expensive in both time and outbound calls, and there is no paging (`count`/`offset` are among the unimplemented CRMI parameters).

This matches the server's existing posture rather than changing it — it binds to loopback unless `-allowNetworkAccess` is given, has no authentication, and already exposes `/loadIG` and `/txTest`, both of which make outbound calls on request. But it is the kind of endpoint worth keeping behind that default.

## Broken-link filtering

Not every unresolvable reference is a missing dependency. `urn:oid:`, `urn:uuid:`, `urn:ietf:`, `mailto:`, `tel:`, and SNOMED concept/edition IRIs are filtered out of the reported broken links rather than being surfaced as absent artifacts.

## What's in it

| File | |
| --- | --- |
| `ResourceDependencyWalker.java` | +51 — StructureMap support, opt-in rule references |
| `ValidationEngine.java` | +149 — `packageResource` in two forms, bundle serialisation for the engine's FHIR version, broken-link filtering |
| `PackageHTTPHandler.java` | new |
| `FhirValidatorHttpService.java` | +1 — route registration |
| `validator-http-openapi.json` / `.openapi.yaml` / `validator-server.md` | the served spec, its YAML rendering and the prose docs, kept in step |
| `FhirValidatorHttpServiceTests.java` | +3 tests, run against a live server |

The JSON and YAML specs were checked to parse to identical documents.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

