### PR TITLE
Add POST /fml, parsing FHIR Mapping Language into a StructureMap

### DIFF
--- a/documentation/validator-server.md
+++ b/documentation/validator-server.md
@@ -102,6 +102,7 @@ the HTTP status.
 | POST | `/snapshot` | Generate the snapshot for a StructureDefinition |
 | POST | `/narrative` | Generate the narrative for a resource |
 | POST | `/transform` | Run a StructureMap over a resource |
+| POST | `/fml` | Parse FHIR Mapping Language into a StructureMap |
 | GET | `/compile` | Fetch a StructureMap by canonical URL |
 | GET | `/txTest` | Run one terminology ecosystem test against a server |
 | POST | `/stop` | Shut the server down |
@@ -259,6 +260,19 @@ curl 'http://localhost:8080/compile?url=http://example.org/StructureMap/Example'
 ```
 
 `/compile` does not check the HTTP method, so POST and other methods behave the same as GET.
+
+### POST /fml
+
+Parses FHIR Mapping Language source into a StructureMap and returns it, serialised for the FHIR
+version the engine is running rather than for R5. Nothing is registered - the result is returned
+to the caller.
+
+```sh
+curl -X POST 'http://localhost:8080/fml?name=Example'   -H 'Content-Type: text/plain'   --data-binary @example.fml
+```
+
+`name` is used only in parse error messages; `format` (`json` or `xml`, default `json`) picks the
+output format, and `Accept` is not consulted.
 
 ### GET /txTest
 

--- a/documentation/validator-server.openapi.yaml
+++ b/documentation/validator-server.openapi.yaml
@@ -669,6 +669,47 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '500':
           $ref: '#/components/responses/ServerError'
+  /fml:
+    post:
+      tags: [StructureMap]
+      summary: Parse FHIR Mapping Language into a StructureMap
+      description: >-
+        Parses the posted FML source text into a StructureMap and returns it, serialised for the
+        FHIR version the engine is running rather than for R5. Nothing is registered: the result
+        is returned to the caller. This is the counterpart of `/transform`, which runs a map
+        instead of parsing one.
+      parameters:
+        - name: name
+          in: query
+          description: Name for the source, used in parse error messages.
+          schema: { type: string, default: map }
+        - name: format
+          in: query
+          description: Format of the returned StructureMap. `Accept` is not consulted.
+          schema: { type: string, enum: [json, xml], default: json }
+      requestBody:
+        required: true
+        description: The FML map source text.
+        content:
+          text/plain:
+            schema: { type: string }
+      responses:
+        '200':
+          description: The parsed StructureMap.
+          content:
+            application/fhir+json:
+              schema: { type: object }
+            application/fhir+xml:
+              schema: { type: string }
+        '400':
+          description: Missing request body.
+          content:
+            application/fhir+json:
+              schema: { $ref: '#/components/schemas/OperationOutcome' }
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /compile:
     get:
       tags: [StructureMap]

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -998,6 +998,58 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     return baos.toByteArray();
   }
 
+  /**
+   * Parse FHIR Mapping Language (FML) text into a {@link StructureMap} resource.
+   *
+   * @param fml          the FML map source text
+   * @param srcName      a name for the source (used in parse error messages); defaults to {@code "map"}
+   * @param outputFormat format of the returned bytes (JSON or XML)
+   */
+  public byte[] parseStructureMap(String fml, String srcName, FhirFormat outputFormat) throws FHIRException, IOException {
+    StructureMapUtilities scu = new StructureMapUtilities(context);
+    StructureMap map = scu.parse(fml, (srcName == null || srcName.trim().isEmpty()) ? "map" : srcName.trim());
+    // Emit the StructureMap in the format that matches the engine's runtime FHIR version.
+    // Otherwise an R4-mode validator round-tripping an R5-format SM through /loadResource
+    // silently drops R5-only fields (e.g., the typed `parameter` array on group-rule
+    // dependents, where R4 expects a `variable` string list). See ITB REST spec § version
+    // compatibility.
+    String effectiveVersion = version != null ? version : (context != null ? context.getVersion() : null);
+    return serialiseStructureMapForVersion(map, effectiveVersion, outputFormat);
+  }
+
+  /**
+   * Convert {@code map} (an R5 StructureMap) to the structure matching
+   * {@code targetVersion}, then serialise it in {@code outputFormat}.
+   * If {@code targetVersion} is null, R5, or R6 the map is emitted as R5
+   * (no conversion needed); for R3, R4, or R4B it is converted via the
+   * matching {@link org.hl7.fhir.convertors.factory.VersionConvertorFactory} first.
+   */
+  private static byte[] serialiseStructureMapForVersion(StructureMap map, String targetVersion, FhirFormat outputFormat) throws FHIRException, IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    if (targetVersion == null || targetVersion.startsWith("5.") || targetVersion.startsWith("6.")) {
+      // Native R5 — keep as-is.
+      if (outputFormat == FhirFormat.XML) new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, map);
+      else                                new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, map);
+    } else if (targetVersion.startsWith("4.0")) {
+      org.hl7.fhir.r4.model.Resource r4 = org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50.convertResource(map);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.r4.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY).compose(baos, r4);
+      else                                new org.hl7.fhir.r4.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4.formats.IParser.OutputStyle.PRETTY).compose(baos, r4);
+    } else if (targetVersion.startsWith("4.3")) {
+      org.hl7.fhir.r4b.model.Resource r4b = org.hl7.fhir.convertors.factory.VersionConvertorFactory_43_50.convertResource(map);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.r4b.formats.XmlParser().setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY).compose(baos, r4b);
+      else                                new org.hl7.fhir.r4b.formats.JsonParser().setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY).compose(baos, r4b);
+    } else if (targetVersion.startsWith("3.")) {
+      org.hl7.fhir.dstu3.model.Resource r3 = org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_50.convertResource(map);
+      if (outputFormat == FhirFormat.XML) new org.hl7.fhir.dstu3.formats.XmlParser().setOutputStyle(org.hl7.fhir.dstu3.formats.IParser.OutputStyle.PRETTY).compose(baos, r3);
+      else                                new org.hl7.fhir.dstu3.formats.JsonParser().setOutputStyle(org.hl7.fhir.dstu3.formats.IParser.OutputStyle.PRETTY).compose(baos, r3);
+    } else {
+      // Unknown / unsupported — fall back to native R5.
+      if (outputFormat == FhirFormat.XML) new XmlParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, map);
+      else                                new JsonParser().setOutputStyle(OutputStyle.PRETTY).compose(baos, map);
+    }
+    return baos.toByteArray();
+  }
+
   public byte[] generateSnapshot(byte[] resource, FhirFormat format) throws FHIRException, IOException {
     Element e = Manager.parseSingle(context, new ByteArrayInputStream(resource), format);
     Resource res = new ObjectConverter(context).convert(e);

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
@@ -53,6 +53,7 @@ public class FhirValidatorHttpService {
     server.createContext("/snapshot", new SnapshotHTTPHandler(this));
     server.createContext("/narrative", new NarrativeHTTPHandler(this));
     server.createContext("/transform", new TransformHTTPHandler(this));
+    server.createContext("/fml", new FmlHTTPHandler(this));
     server.createContext("/version", new VersionHTTPHandler(this));
     server.createContext("/compile", new CompileHTTPHandler(this));
     server.createContext("/openapi.json", new OpenApiHTTPHandler());

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FmlHTTPHandler.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FmlHTTPHandler.java
@@ -1,0 +1,64 @@
+package org.hl7.fhir.validation.http;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.hl7.fhir.r5.elementmodel.Manager.FhirFormat;
+import org.hl7.fhir.r5.utils.OperationOutcomeUtilities;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Handler for parsing FHIR Mapping Language (FML) text into a StructureMap resource.
+ * {@code POST /fml?name=<name>&format=json|xml} with the FML map source as the request body.
+ *
+ * <p>Companion to {@code /transform} (which <i>applies</i> a StructureMap); this one
+ * <i>parses</i> FML source into a StructureMap resource.
+ */
+class FmlHTTPHandler extends BaseHTTPHandler implements HttpHandler {
+  private final FhirValidatorHttpService fhirValidatorHttpService;
+
+  public FmlHTTPHandler(FhirValidatorHttpService fhirValidatorHttpService) {
+    this.fhirValidatorHttpService = fhirValidatorHttpService;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    if (!"POST".equals(exchange.getRequestMethod())) {
+      sendResponse(exchange, 405, "Method not allowed", "text/plain");
+      return;
+    }
+
+    try {
+      byte[] body = readRequestBody(exchange);
+      if (body == null || body.length == 0) {
+        sendOperationOutcome(exchange, 400,
+          OperationOutcomeUtilities.createError("Missing request body: the FML map source text"),
+          getAcceptHeader(exchange));
+        return;
+      }
+
+      Map<String, String> params = parseQueryParams(exchange.getRequestURI().getQuery());
+      String name = params.get("name");
+      String format = params.get("format");
+      FhirFormat outputFormat = "xml".equalsIgnoreCase(format) ? FhirFormat.XML : FhirFormat.JSON;
+
+      byte[] result = fhirValidatorHttpService.getValidationEngine()
+        .parseStructureMap(new String(body, StandardCharsets.UTF_8), name, outputFormat);
+
+      String outContentType = outputFormat == FhirFormat.XML ? "application/fhir+xml" : "application/fhir+json";
+      exchange.getResponseHeaders().set("Content-Type", outContentType);
+      exchange.sendResponseHeaders(200, result.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(result);
+      }
+
+    } catch (Throwable e) {
+      sendOperationOutcome(exchange, 500,
+        OperationOutcomeUtilities.createError("FML parse failed: " + e.getMessage()),
+        getAcceptHeader(exchange));
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
+++ b/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
@@ -1090,6 +1090,83 @@
         }
       }
     },
+    "/fml": {
+      "post": {
+        "tags": [
+          "StructureMap"
+        ],
+        "summary": "Parse FHIR Mapping Language into a StructureMap",
+        "description": "Parses the posted FML source text into a StructureMap and returns it, serialised for the FHIR version the engine is running rather than for R5. Nothing is registered: the result is returned to the caller. This is the counterpart of `/transform`, which runs a map instead of parsing one.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name for the source, used in parse error messages.",
+            "schema": {
+              "type": "string",
+              "default": "map"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Format of the returned StructureMap. `Accept` is not consulted.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "xml"
+              ],
+              "default": "json"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The FML map source text.",
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The parsed StructureMap.",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "type": "object"
+                }
+              },
+              "application/fhir+xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing request body.",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/compile": {
       "get": {
         "tags": [

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/FhirValidatorHttpServiceTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/FhirValidatorHttpServiceTests.java
@@ -1179,6 +1179,126 @@ class FhirValidatorHttpServiceTest {
         throw new RuntimeException(e);
       }
     }
+
+    private static final String SAMPLE_FML =
+        "map \"http://example.org/StructureMap/IdentityTest\" = \"IdentityTest\"\n" +
+        "\n" +
+        "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias PatientSrc as source\n" +
+        "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias PatientTgt as target\n" +
+        "\n" +
+        "group IdentityTest(source src : PatientSrc, target tgt : PatientTgt) {\n" +
+        "  src.id -> tgt.id;\n" +
+        "}\n";
+
+    @Test
+    @DisplayName("FML - parse FML text to a StructureMap (legacy POST /fml)")
+    void testFmlParseLegacy() throws Exception {
+      setUpService(getValidationEngine());
+
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/fml?name=IdentityTest"))
+        .POST(HttpRequest.BodyPublishers.ofString(SAMPLE_FML))
+        .header("Content-Type", "text/plain")
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(200, response.statusCode(), "expected 200; body: " + response.body());
+      org.hl7.fhir.utilities.json.model.JsonObject sm =
+        org.hl7.fhir.utilities.json.parser.JsonParser.parseObject(response.body());
+      assertEquals("StructureMap", sm.asString("resourceType"));
+      assertEquals("http://example.org/StructureMap/IdentityTest", sm.asString("url"));
+      assertTrue(sm.has("group"), "parsed StructureMap should have a group");
+    }
+
+    /**
+     * Two-group FML that exercises a dependent group invocation with named arguments.
+     * In R4 the parsed SM emits {@code dependent.variable: ["a","b"]};
+     * in R5 it emits {@code dependent.parameter: [{valueId:"a"},{valueId:"b"}]}.
+     * Used by the version-format round-trip tests.
+     */
+    private static final String FML_WITH_DEPENDENT =
+        "map \"http://example.org/StructureMap/PassThrough\" = \"PassThrough\"\n" +
+        "\n" +
+        "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias PatientSrc as source\n" +
+        "uses \"http://hl7.org/fhir/StructureDefinition/Patient\" alias PatientTgt as target\n" +
+        "\n" +
+        "group PassThrough(source s : PatientSrc, target t : PatientTgt) {\n" +
+        "  s as src then InnerCopy(src, t) \"outer\";\n" +
+        "}\n" +
+        "\n" +
+        "group InnerCopy(source src : PatientSrc, target tgt : PatientTgt) {\n" +
+        "  src.id as v -> tgt.id = v \"copyId\";\n" +
+        "}\n";
+
+    @Test
+    @DisplayName("FML - parse output uses the engine's runtime FHIR version (R4 emits 'variable' on dependent, not 'parameter')")
+    void testFmlParseEmitsRuntimeVersion() throws Exception {
+      // The test engine is R4 (hl7.fhir.r4.core#4.0.1). The parsed StructureMap
+      // must round-trip through an R4 JSON parser without losing dependent data —
+      // i.e. its dependent invocation must be encoded as `variable: [...]` (the R4 form),
+      // NOT as `parameter: [...]` (R5-only).
+      setUpService(getValidationEngine());
+
+      HttpResponse<String> resp = httpClient.send(
+        HttpRequest.newBuilder()
+          .uri(URI.create(BASE_URL + "/fml?name=PassThrough"))
+          .POST(HttpRequest.BodyPublishers.ofString(FML_WITH_DEPENDENT))
+          .header("Content-Type", "text/plain")
+          .build(),
+        HttpResponse.BodyHandlers.ofString());
+      assertEquals(200, resp.statusCode(), "parse: " + resp.body());
+
+      // The whole point: dependent encoded in R4 form, not R5.
+      // R4 uses dependent.variable (string list); R5 uses dependent.parameter (typed list).
+      // Walk into the JSON to inspect just the dependent (R4 SM target transforms also use
+      // 'parameter' so a body-wide substring check is too coarse).
+      org.hl7.fhir.utilities.json.model.JsonObject sm =
+        org.hl7.fhir.utilities.json.parser.JsonParser.parseObject(resp.body());
+      org.hl7.fhir.utilities.json.model.JsonObject outerGroup = sm.getJsonArray("group").get(0).asJsonObject();
+      org.hl7.fhir.utilities.json.model.JsonObject outerRule  = outerGroup.getJsonArray("rule").get(0).asJsonObject();
+      org.hl7.fhir.utilities.json.model.JsonObject dependent  = outerRule.getJsonArray("dependent").get(0).asJsonObject();
+      assertTrue(dependent.has("variable"),
+        "R4-mode parse must emit dependent.variable (R4 form): " + dependent.toString());
+      assertFalse(dependent.has("parameter"),
+        "R4-mode parse must NOT emit dependent.parameter (R5-only) — would silently lose data: " + dependent.toString());
+      assertEquals(2, dependent.getJsonArray("variable").size(),
+        "dependent.variable must carry both args (src, t): " + dependent.toString());
+    }
+
+    @Test
+    @DisplayName("FML - Missing body returns 400")
+    void testFmlParseMissingBody() throws Exception {
+      setUpService(getValidationEngine());
+
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/fml"))
+        .POST(HttpRequest.BodyPublishers.ofString(""))
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(400, response.statusCode());
+      assertTrue(response.body().contains("Missing request body"));
+    }
+
+    @Test
+    @DisplayName("FML - GET method not allowed")
+    void testFmlGetNotAllowed() throws Exception {
+      setUpService(getValidationEngine());
+
+      HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(BASE_URL + "/fml"))
+        .GET()
+        .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(405, response.statusCode());
+    }
+
+    // ─── CRMI $package tests ───
+
   }
 
 }


### PR DESCRIPTION
Parses posted FHIR Mapping Language source into a StructureMap and returns it — the counterpart of `/transform`, which runs a map rather than parsing one.

```
POST /fml?name=<name>&format=json|xml       body: the FML source text
```

Nothing is registered; the parsed map is returned to the caller. `name` is used only in parse error messages. `format` (`json` or `xml`, default `json`) picks the output format — `Accept` is not consulted, matching the other query-parameter endpoints rather than the body-posting ones.

**Purely additive** — a new handler, a new engine method, one route registration. No existing behaviour changes.

## The map is serialised for the engine's FHIR version, not R5

This is the part worth a look. A StructureMap is emitted in the version the engine is actually running, rather than always in R5.

It matters because of a specific shape difference: R5 carries a **typed `parameter` array** on `group.rule.dependent`, where R4 expects a **flat `variable` string list**. An R4-mode validator that emitted R5 JSON would silently drop the variable names — the resource parses without complaint, and the loss only surfaces later, at transform time, as the misleading

```
Rule 'X' has N but the invocation has 0 variables
```

from the R4 executor. Serialising for the runtime version avoids producing a map that is quietly wrong for the engine that will run it.

## What's in it

| File | |
| --- | --- |
| `ValidationEngine.java` | +52 — `parseStructureMap` and the version-aware serialisation behind it |
| `FmlHTTPHandler.java` | new |
| `FhirValidatorHttpService.java` | +1 — route registration |
| `validator-http-openapi.json` / `.openapi.yaml` / `validator-server.md` | the served spec, its YAML rendering and the prose docs, kept in step |
| `FhirValidatorHttpServiceTests.java` | +4 tests, run against a live server |

The JSON and YAML specs were checked to parse to identical documents.

## Tests

| Test | Covers |
| --- | --- |
| `testFmlParseLegacy` | FML source parses to a StructureMap |
| `testFmlParseEmitsRuntimeVersion` | the map comes back in the engine's version, not R5 |
| `testFmlParseMissingBody` | empty body → 400 with an OperationOutcome |
| `testFmlGetNotAllowed` | GET → 405 |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
