### PR TITLE
Copied ValidationEngine shares the original's IgLoader, so loads through the copy land in the original

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -215,7 +215,7 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
 
   }
 
-  @Getter @Setter private SimpleWorkerContext context;
+  @Getter private SimpleWorkerContext context;
   @Getter @Setter private Map<String, ByteProvider> binaries = new HashMap<>();
   @Getter @Setter private boolean doNative;
   @Getter @Setter private boolean displayWarnings;

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -281,9 +281,30 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     matchetypes.addAll(other.matchetypes);
     showTimes = other.showTimes;
     fhirPathEngine = other.fhirPathEngine;
-    igLoader = other.igLoader;
+    // The IgLoader captures the context it was built against, so sharing other's loader would
+    // make this copy's loadIg() write into other's context rather than its own. Build a loader
+    // bound to the freshly copied context instead - the same construction the builder uses.
+    if (other.igLoader != null) {
+      igLoader = new IgLoader(pcm, context, version, debug);
+      igLoader.setDirectProvider(other.igLoader.getDirectProvider());
+    }
     displayWarnings = other.displayWarnings;
     defaultInstanceValidatorParameters = new InstanceValidatorParameters(other.defaultInstanceValidatorParameters);
+  }
+
+  /**
+   * Replaces the worker context. The IgLoader is bound to the context it was constructed
+   * against, so an existing loader is rebuilt against the new context - otherwise loadIg()
+   * would keep writing into the context that has just been replaced. An engine that has no
+   * loader yet (the builder sets the context before the loader) is left as it is.
+   */
+  public void setContext(SimpleWorkerContext context) {
+    this.context = context;
+    if (igLoader != null && context != null) {
+      IgLoader rebound = new IgLoader(pcm, context, version, debug);
+      rebound.setDirectProvider(igLoader.getDirectProvider());
+      igLoader = rebound;
+    }
   }
 
   /**

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineCopyTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineCopyTests.java
@@ -68,4 +68,18 @@ class ValidationEngineCopyTests {
     assertNull(base.getContext().fetchResource(ValueSet.class, URL),
       "the resource must not leak into the original engine's context");
   }
+
+  @Test
+  @DisplayName("Replacing the context rebinds the IgLoader to the new context")
+  void setContextRebindsTheLoader() throws Exception {
+    ValidationEngine engine = new ValidationEngine(base);
+    org.hl7.fhir.r5.context.SimpleWorkerContext replacement =
+      new org.hl7.fhir.r5.context.SimpleWorkerContext(engine.getContext());
+
+    engine.setContext(replacement);
+
+    assertSame(replacement, engine.getContext());
+    assertSame(replacement, engine.getIgLoader().getContext(),
+      "after setContext the loader must be bound to the new context");
+  }
 }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineCopyTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ValidationEngineCopyTests.java
@@ -1,0 +1,71 @@
+package org.hl7.fhir.validation.tests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.utilities.FhirPublication;
+import org.hl7.fhir.utilities.settings.FhirSettings;
+import org.hl7.fhir.validation.ValidationEngine;
+import org.hl7.fhir.validation.tests.utilities.TestUtilities;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A ValidationEngine built by the copy constructor gets its own worker context, so that
+ * mutations to the copy leave the original alone. That only holds if the copy's IgLoader is
+ * bound to the copy's context - IgLoader captures the context it is constructed against, so a
+ * loader shared with the original would make the copy's loadIg() write into the original.
+ */
+class ValidationEngineCopyTests {
+
+  private static final String URL = "http://example.org/test/ValueSet/engine-copy-isolation";
+
+  private static ValidationEngine base;
+
+  @BeforeAll
+  static void setup() throws Exception {
+    base = TestUtilities.getValidationEngine(
+      "hl7.fhir.r4.core#4.0.1",
+      FhirSettings.getTxFhirDevelopment(),
+      FhirPublication.R4, "4.0.1");
+  }
+
+  @Test
+  @DisplayName("A copy's IgLoader is bound to the copy's context, not the original's")
+  void copyHasItsOwnLoaderBoundToItsOwnContext() throws Exception {
+    ValidationEngine copy = new ValidationEngine(base);
+
+    assertNotSame(base.getContext(), copy.getContext(), "copy must have its own context");
+    assertNotSame(base.getIgLoader(), copy.getIgLoader(), "copy must have its own IgLoader");
+    assertSame(copy.getContext(), copy.getIgLoader().getContext(),
+      "the copy's loader must be bound to the copy's context");
+    assertSame(base.getContext(), base.getIgLoader().getContext(),
+      "the original's loader must still be bound to the original's context");
+  }
+
+  @Test
+  @DisplayName("Loading a resource through a copy does not register it in the original")
+  void loadThroughCopyDoesNotReachOriginal() throws Exception {
+    ValidationEngine copy = new ValidationEngine(base);
+
+    File f = File.createTempFile("engine-copy-isolation", ".json");
+    f.deleteOnExit();
+    Files.write(f.toPath(), ("{\"resourceType\":\"ValueSet\",\"id\":\"engine-copy-isolation\","
+      + "\"url\":\"" + URL + "\",\"status\":\"active\"}").getBytes(StandardCharsets.UTF_8));
+
+    copy.getIgLoader().loadIg(copy.getIgs(), copy.getBinaries(), f.getAbsolutePath(), false);
+
+    assertNotNull(copy.getContext().fetchResource(ValueSet.class, URL),
+      "the resource should be registered in the copy that loaded it");
+    assertNull(base.getContext().fetchResource(ValueSet.class, URL),
+      "the resource must not leak into the original engine's context");
+  }
+}


### PR DESCRIPTION
## Problem

`ValidationEngine`'s copy constructor copies the worker context but shares the original's `IgLoader`. `IgLoader` captures the context it was constructed against, so `loadIg()` through a copy registers resources in the **original's** context, and the copy never sees them.

Anything that clones a base engine to isolate work is affected - `ValidationService.baseEngines` clones per request, and any server that wants a per-session context (the "clone the worker context first" model) gets no isolation for IG loads. The Lombok `setContext` had the same mismatch: it swapped the context and left the loader bound to the old one.

## Change

- Copy constructor: build the copy a loader bound to its own context (same construction the builder uses), keeping the direct provider.
- Explicit `setContext`: rebinds the loader to the new context.

No behaviour change for a single engine that is never copied.

## Tests

`ValidationEngineCopyTests` (3, all passing on R4 core):

- the copy's loader is bound to the copy's context, the original's to the original's;
- a ValueSet loaded through the copy is present in the copy and **absent** from the original - a shared loader cannot satisfy both assertions;
- after `setContext`, the loader is bound to the new context.

Two commits, one per change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
