### PR TITLE
HTTP server: /loadIG accepts a server-local path only when bound to loopback

### DIFF
--- a/documentation/validator-server.md
+++ b/documentation/validator-server.md
@@ -212,8 +212,9 @@ used.
 
 ### POST /loadIG
 
-Loads an IG into the running engine. The value may be a package reference, a URL, or a path on
-the server's file system.
+Loads an IG into the running engine. The value may be a package reference or a URL. A path on
+the server's file system is accepted only while the server is bound to loopback (the default);
+with `-allowNetworkAccess` a path is refused with 400.
 
 ```sh
 curl -X POST http://localhost:8080/loadIG \

--- a/documentation/validator-server.openapi.yaml
+++ b/documentation/validator-server.openapi.yaml
@@ -480,9 +480,10 @@ paths:
       summary: Load an implementation guide into the running engine
       description: >-
         Loads an IG into the shared validation engine, making its profiles, value sets and maps
-        available to every subsequent request. The value may be a package reference
-        (`id#version`), a URL, or a path on the server's file system. The load is permanent for
-        the lifetime of the process - there is no unload.
+        available to every subsequent request. The value may be a package reference (`id#version`)
+        or a URL. A path on the server's file system is accepted only while the server is bound to
+        loopback (the default); with `-allowNetworkAccess` a path is refused with 400. The load is
+        permanent for the lifetime of the process - there is no unload.
       requestBody:
         required: true
         content:
@@ -493,7 +494,7 @@ paths:
               properties:
                 ig:
                   type: string
-                  description: Package reference, URL, or local path.
+                  description: Package reference or URL; a local path only while the server is bound to loopback.
             example: { ig: 'hl7.fhir.us.core#5.0.1' }
       responses:
         '200':
@@ -502,7 +503,7 @@ paths:
             application/fhir+json:
               schema: { $ref: '#/components/schemas/OperationOutcome' }
         '400':
-          description: Missing `ig` field.
+          description: Missing `ig` field, or a server-local path while the server is not bound to loopback.
           content:
             application/fhir+json:
               schema: { $ref: '#/components/schemas/OperationOutcome' }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/IgLoader.java
@@ -64,6 +64,30 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
 
   }
 
+  public static class SourceWithFHIRVersion {
+
+    @Getter private final String fhirVersion;
+    @Getter private final String source;
+
+    public SourceWithFHIRVersion(String src) throws FHIRException {
+      if (src.startsWith("[") && src.indexOf(']', 1) > 1) {
+        this.fhirVersion = src.substring(1, src.indexOf(']', 1));
+        this.source = src.substring(src.indexOf(']', 1) + 1);
+        if (!VersionUtilities.isSupportedVersion(this.fhirVersion)) {
+          throw new FHIRException("Unsupported FHIR Version: " + this.fhirVersion + " valid versions are " + VersionUtilities.listSupportedVersions());
+        }
+      } else {
+        this.fhirVersion = null;
+        this.source = src;
+      }
+    }
+
+    public SourceWithFHIRVersion(String fhirVersion, String source) {
+      this.fhirVersion = fhirVersion;
+      this.source = source;
+    }
+  }
+
   private static final String[] IGNORED_EXTENSIONS = {"md", "css", "js", "png", "gif", "jpg", "html", "tgz", "pack", "zip"};
   private static final String[] EXEMPT_FILES = {"spec.internals", "version.info", "schematron.zip", "package.json"};
   private static final int SCAN_HEADER_SIZE = 2048;
@@ -107,26 +131,15 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
                      String src,
                      boolean recursive) throws IOException, FHIRException {
 
-    final String explicitFhirVersion;
-    final String srcPackage;
-    if (src.startsWith("[") && src.indexOf(']', 1) > 1) {
-      explicitFhirVersion = src.substring(1,src.indexOf(']', 1));
-      srcPackage = src.substring(src.indexOf(']',1) + 1);
-      if (!VersionUtilities.isSupportedVersion(explicitFhirVersion)) {
-        throw new FHIRException("Unsupported FHIR Version: " + explicitFhirVersion + " valid versions are " + VersionUtilities.listSupportedVersions());
-      }
-    } else {
-      explicitFhirVersion = null;
-      srcPackage = src;
-    }
+    final SourceWithFHIRVersion sourceWithFHIRVersion = new SourceWithFHIRVersion(src);
 
     @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
     //anchored package name pattern, safe
-    NpmPackage npm = srcPackage.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT) && !ManagedFileAccess.file(srcPackage).exists() ? getPackageCacheManager().loadPackage(srcPackage, null) : null;
-    if (npm == null && ManagedFileAccess.file(srcPackage).exists()) {
+    NpmPackage npm = sourceWithFHIRVersion.getSource().matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT) && !ManagedFileAccess.file(sourceWithFHIRVersion.getSource()).exists() ? getPackageCacheManager().loadPackage(sourceWithFHIRVersion.getSource(), null) : null;
+    if (npm == null && ManagedFileAccess.file(sourceWithFHIRVersion.getSource()).exists()) {
       // try treating the file as an npm
       try {
-        npm = NpmPackage.fromPackage(ManagedFileAccess.inStream(srcPackage));
+        npm = NpmPackage.fromPackage(ManagedFileAccess.inStream(sourceWithFHIRVersion.getSource()));
       } catch (Exception e) {
         // nothing - any errors will be properly handled later in the process
       }
@@ -140,8 +153,8 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
         }
       }
       StringBuilder packageLoadLine = new StringBuilder();
-      packageLoadLine.append("  Load " + srcPackage);
-      if (!srcPackage.contains("#")) {
+      packageLoadLine.append("  Load " + sourceWithFHIRVersion.getSource());
+      if (!sourceWithFHIRVersion.getSource().contains("#")) {
         packageLoadLine.append("#" + npm.version());
       }
       IContextResourceLoader loader = ValidatorUtils.loaderForVersion(npm.fhirVersion());
@@ -150,10 +163,10 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
       log.info(packageLoadLine + " - " + count + " resources (" + getContext().clock().milestone() + ")");
     } else {
       StringBuilder packageLoadLine = new StringBuilder();
-      packageLoadLine.append("  Load " + srcPackage);
+      packageLoadLine.append("  Load " + sourceWithFHIRVersion.getSource());
       String canonical = null;
       int count = 0;
-      Map<String, ByteProvider> source = loadIgSource(srcPackage, recursive, true);
+      Map<String, ByteProvider> source = loadIgSource(sourceWithFHIRVersion.getSource(), recursive, true);
       String version = Constants.VERSION;
       if (getVersion() != null) {
         version = getVersion();
@@ -161,8 +174,8 @@ public class IgLoader implements IValidationEngineLoader, SimpleWorkerContext.IL
       if (source.containsKey("version.info")) {
         version = readInfoVersion(source.get("version.info"));
       }
-      if (explicitFhirVersion != null) {
-        version = explicitFhirVersion;
+      if (sourceWithFHIRVersion.getFhirVersion() != null) {
+        version = sourceWithFHIRVersion.getFhirVersion();
       }
 
       for (Map.Entry<String, ByteProvider> t : source.entrySet()) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
@@ -21,6 +21,14 @@ public class FhirValidatorHttpService {
   private final boolean loopbackOnly;
   private final int port;
 
+  /**
+   * Whether this server is bound to the loopback interface only, so that the only possible
+   * caller is a process on this machine. Handlers use this to decide what a caller may name.
+   */
+  public boolean isLoopbackOnly() {
+    return loopbackOnly;
+  }
+
   private Map<String, TxTestHTTPHandler.ServerTxTester> txTesters = new HashMap<>();
 
   public FhirValidatorHttpService(ValidationEngine validationEngine, boolean loopBackOnly, int port) {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/FhirValidatorHttpService.java
@@ -1,6 +1,7 @@
 package org.hl7.fhir.validation.http;
 
 import com.sun.net.httpserver.HttpServer;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.instance.ResourcePercentageLogger;
@@ -18,16 +19,14 @@ public class FhirValidatorHttpService {
 
   private final ValidationEngine validationEngine;
   private HttpServer server;
+  /**
+   * -- GETTER --
+   *  Whether this server is bound to the loopback interface only, so that the only possible
+   *  caller is a process on this machine. Handlers use this to decide what a caller may name.
+   */
+  @Getter
   private final boolean loopbackOnly;
   private final int port;
-
-  /**
-   * Whether this server is bound to the loopback interface only, so that the only possible
-   * caller is a process on this machine. Handlers use this to decide what a caller may name.
-   */
-  public boolean isLoopbackOnly() {
-    return loopbackOnly;
-  }
 
   private Map<String, TxTestHTTPHandler.ServerTxTester> txTesters = new HashMap<>();
 

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
@@ -1,13 +1,14 @@
 package org.hl7.fhir.validation.http;
 
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import lombok.extern.slf4j.Slf4j;
-import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.utils.OperationOutcomeUtilities;
 import org.hl7.fhir.utilities.json.model.JsonObject;
+import org.hl7.fhir.validation.IgLoader;
 
 import java.io.IOException;
 
@@ -58,6 +59,10 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
     }
   }
 
+  protected static String stripVersionFromSource(String src) throws FHIRException {
+    return new IgLoader.SourceWithFHIRVersion(src).getSource();
+  }
+
   /**
    * Whether {@code src} is something a caller on the network may legitimately name: a package
    * reference ({@code id} or {@code id#version}, optionally prefixed with a {@code [version]}
@@ -67,11 +72,14 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
    * a path on this host.
    */
   static boolean isRemoteLoadableSource(String src) {
-    String s = src;
-    if (s.startsWith("[") && s.indexOf(']', 1) > 1) {
-      s = s.substring(s.indexOf(']', 1) + 1);
+    String versionLessSrc;
+    try {
+      versionLessSrc = stripVersionFromSource(src);
+    } catch (FHIRException e) {
+      return false;
     }
-    String lower = s.toLowerCase(java.util.Locale.ROOT);
+
+    String lower = versionLessSrc.toLowerCase(java.util.Locale.ROOT);
     if (lower.startsWith("http://") || lower.startsWith("https://")) {
       return true;
     }
@@ -82,11 +90,11 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
     if (lower.endsWith(".tgz") || lower.endsWith(".zip") || lower.endsWith(".pack")) {
       return false;
     }
-    if (!s.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT)) {
+    if (!versionLessSrc.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT)) {
       return false;
     }
     try {
-      return !ManagedFileAccess.file(s).exists();
+      return !ManagedFileAccess.file(versionLessSrc).exists();
     } catch (IOException e) {
       return false;
     }

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
@@ -90,7 +90,10 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
     if (lower.endsWith(".tgz") || lower.endsWith(".zip") || lower.endsWith(".pack")) {
       return false;
     }
-    if (!versionLessSrc.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT)) {
+    @SuppressWarnings("checkstyle:stringImplicitPatternUsage")
+    //anchored package name pattern, safe
+    boolean matchesPackageVersionRegex = versionLessSrc.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT);
+    if (!matchesPackageVersionRegex) {
       return false;
     }
     try {

--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/http/LoadIGHTTPHandler.java
@@ -1,5 +1,7 @@
 package org.hl7.fhir.validation.http;
 
+import org.hl7.fhir.utilities.filesystem.ManagedFileAccess;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +39,12 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
         sendOperationOutcome(exchange, 400, OperationOutcomeUtilities.createError("Missing required field: ig"), getAcceptHeader(exchange));
         return;
       }
+      if (!fhirValidatorHttpService.isLoopbackOnly() && !isRemoteLoadableSource(ig.trim())) {
+        sendOperationOutcome(exchange, 400, OperationOutcomeUtilities.createError(
+          "Loading an IG from a server-local path is only permitted when the server is bound to loopback; "
+          + "supply a package reference (id#version) or an http(s) URL instead"), getAcceptHeader(exchange));
+        return;
+      }
 
       log.info("Loading IG: " + ig);
       org.hl7.fhir.validation.ValidationEngine engine = fhirValidatorHttpService.getValidationEngine();
@@ -47,6 +55,40 @@ class LoadIGHTTPHandler extends BaseHTTPHandler implements HttpHandler {
 
     } catch (Throwable e) {
       sendOperationOutcome(exchange, 500, OperationOutcomeUtilities.createError("Failed to load IG: " + e.getMessage()), getAcceptHeader(exchange));
+    }
+  }
+
+  /**
+   * Whether {@code src} is something a caller on the network may legitimately name: a package
+   * reference ({@code id} or {@code id#version}, optionally prefixed with a {@code [version]}
+   * hint as {@code IgLoader} accepts) or an http(s) URL. A filesystem path is neither - and
+   * neither is a package-shaped name that happens to exist as a file here, since
+   * {@code IgLoader} would read the file. The point is that a remote caller never gets to name
+   * a path on this host.
+   */
+  static boolean isRemoteLoadableSource(String src) {
+    String s = src;
+    if (s.startsWith("[") && s.indexOf(']', 1) > 1) {
+      s = s.substring(s.indexOf(']', 1) + 1);
+    }
+    String lower = s.toLowerCase(java.util.Locale.ROOT);
+    if (lower.startsWith("http://") || lower.startsWith("https://")) {
+      return true;
+    }
+    // A dotted file name matches the package pattern too (package.tgz, secrets.json), and
+    // IgLoader resolves that ambiguity in favour of a file that exists. Mirror both rules here:
+    // archive names are never package references (IgLoader makes the same exclusion), and a
+    // package-shaped name that exists on this host's file system is a file, not a package.
+    if (lower.endsWith(".tgz") || lower.endsWith(".zip") || lower.endsWith(".pack")) {
+      return false;
+    }
+    if (!s.matches(FilesystemPackageCacheManager.PACKAGE_VERSION_REGEX_OPT)) {
+      return false;
+    }
+    try {
+      return !ManagedFileAccess.file(s).exists();
+    } catch (IOException e) {
+      return false;
     }
   }
 }

--- a/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
+++ b/org.hl7.fhir.validation/src/main/resources/validator-http-openapi.json
@@ -750,7 +750,7 @@
           "Configuration"
         ],
         "summary": "Load an implementation guide into the running engine",
-        "description": "Loads an IG into the shared validation engine, making its profiles, value sets and maps available to every subsequent request. The value may be a package reference (`id#version`), a URL, or a path on the server's file system. The load is permanent for the lifetime of the process - there is no unload.",
+        "description": "Loads an IG into the shared validation engine, making its profiles, value sets and maps available to every subsequent request. The value may be a package reference (`id#version`) or a URL. A path on the server's file system is accepted only while the server is bound to loopback (the default); with `-allowNetworkAccess` a path is refused with 400. The load is permanent for the lifetime of the process - there is no unload.",
         "requestBody": {
           "required": true,
           "content": {
@@ -763,7 +763,7 @@
                 "properties": {
                   "ig": {
                     "type": "string",
-                    "description": "Package reference, URL, or local path."
+                    "description": "Package reference or URL; a local path only while the server is bound to loopback."
                   }
                 }
               },
@@ -785,7 +785,7 @@
             }
           },
           "400": {
-            "description": "Missing `ig` field.",
+            "description": "Missing `ig` field, or a server-local path while the server is not bound to loopback.",
             "content": {
               "application/fhir+json": {
                 "schema": {

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/standalone/terminology/tests/TerminologyServiceTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/standalone/terminology/tests/TerminologyServiceTests.java
@@ -100,7 +100,6 @@ private static TxTestData testData;
 
     ValidationEngine engine = new ValidationEngine(this.baseEngine);
     for (String s : setup.getSuite().forceArray("setup").asStrings()) {
-      // System.out.println(s);
       Resource res = loadResource(s);
       engine.seeResource(res);
     }

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/http/LoadIgSourcePolicyTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/http/LoadIgSourcePolicyTests.java
@@ -1,0 +1,115 @@
+package org.hl7.fhir.validation.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.hl7.fhir.validation.ValidationEngine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * {@code POST /loadIG} accepts a server-local path only when the server is bound to loopback,
+ * where the caller is by definition a process on the same machine. Once the server is reachable
+ * over the network, a caller may name a package reference or an http(s) URL, never a path on
+ * the host.
+ */
+class LoadIgSourcePolicyTests {
+
+  // -- the classifier ---------------------------------------------------------------------
+
+  @ParameterizedTest
+  @DisplayName("Package references and http(s) URLs may be named by a remote caller")
+  @ValueSource(strings = {
+    "hl7.fhir.us.core",
+    "hl7.fhir.us.core#5.0.1",
+    "hl7.fhir.be.core#2.1.2",
+    "[4.0]hl7.fhir.us.core#5.0.1",
+    "https://example.org/ig/package.tgz",
+    "http://example.org/ig/package.tgz",
+    "HTTPS://EXAMPLE.ORG/PACKAGE.TGZ",
+    "[5.0]https://example.org/ig/package.tgz"
+  })
+  void remoteLoadableSources(String src) {
+    assertTrue(LoadIGHTTPHandler.isRemoteLoadableSource(src), src);
+  }
+
+  @ParameterizedTest
+  @DisplayName("Anything that names a path on the host may not")
+  @ValueSource(strings = {
+    "/etc/passwd",
+    "/home/op/private-ig",
+    "C:\\Users\\op\\ig",
+    "..\\..\\secrets",
+    "../secrets",
+    "./output/package.tgz",
+    "output/package.tgz",
+    "package.tgz",
+    "igpack.zip",
+    "validator.pack",
+    "my.ig.tgz",
+    "file:///etc/passwd",
+    "\\\\server\\share\\ig",
+    "[4.0]/home/op/private-ig"
+  })
+  void localPathsAreNotRemoteLoadable(String src) {
+    assertFalse(LoadIGHTTPHandler.isRemoteLoadableSource(src), src);
+  }
+
+  // -- the handler, by bind mode ----------------------------------------------------------
+
+  private static final int NETWORK_PORT = 18091;
+  private static final int LOOPBACK_PORT = 18092;
+  private static final String LOCAL_PATH_BODY = "{\"ig\": \"/definitely/not/a/package\"}";
+
+  private static HttpResponse<String> postLoadIg(int port, String body) throws Exception {
+    HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    HttpRequest request = HttpRequest.newBuilder()
+      .uri(URI.create("http://127.0.0.1:" + port + "/loadIG"))
+      .header("Content-Type", "application/json")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build();
+    return client.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  @Test
+  @DisplayName("Network-accessible server refuses a local path with 400, before touching the engine")
+  void networkModeRefusesLocalPath() throws Exception {
+    // A mocked engine has no IgLoader: if the handler reached it, the result would be a 500,
+    // so a 400 here proves the refusal happens first.
+    FhirValidatorHttpService service = new FhirValidatorHttpService(mock(ValidationEngine.class), false, NETWORK_PORT);
+    service.startServer();
+    try {
+      HttpResponse<String> response = postLoadIg(NETWORK_PORT, LOCAL_PATH_BODY);
+      assertEquals(400, response.statusCode());
+      assertTrue(response.body().contains("loopback"), response.body());
+    } finally {
+      service.stop();
+    }
+  }
+
+  @Test
+  @DisplayName("Loopback-only server still hands a local path to the engine")
+  void loopbackModePassesLocalPathThrough() throws Exception {
+    // Same mocked engine: reaching it yields a 500 from the null loader, which is exactly what
+    // shows the path was NOT refused by the policy check.
+    FhirValidatorHttpService service = new FhirValidatorHttpService(mock(ValidationEngine.class), true, LOOPBACK_PORT);
+    service.startServer();
+    try {
+      HttpResponse<String> response = postLoadIg(LOOPBACK_PORT, LOCAL_PATH_BODY);
+      assertFalse(response.body().contains("loopback"), response.body());
+      assertFalse(response.statusCode() == 400, "the policy check must not apply on loopback");
+    } finally {
+      service.stop();
+    }
+  }
+}

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/http/LoadIgSourcePolicyTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/http/LoadIgSourcePolicyTests.java
@@ -33,11 +33,11 @@ class LoadIgSourcePolicyTests {
     "hl7.fhir.us.core",
     "hl7.fhir.us.core#5.0.1",
     "hl7.fhir.be.core#2.1.2",
-    "[4.0]hl7.fhir.us.core#5.0.1",
+    "[4.0.1]hl7.fhir.us.core#5.0.1",
     "https://example.org/ig/package.tgz",
     "http://example.org/ig/package.tgz",
     "HTTPS://EXAMPLE.ORG/PACKAGE.TGZ",
-    "[5.0]https://example.org/ig/package.tgz"
+    "[5.0.0]https://example.org/ig/package.tgz"
   })
   void remoteLoadableSources(String src) {
     assertTrue(LoadIGHTTPHandler.isRemoteLoadableSource(src), src);


### PR DESCRIPTION
## Problem

`POST /loadIG` hands the caller's `ig` string straight to `IgLoader.loadIg`, which reads a server-local file or directory when one exists at that path. That is the intended use when the server is bound to loopback - the caller is a process on the same machine, and loading a local IG is the point. But with `-allowNetworkAccess`, any network caller can name a path on the host: the server reads any FHIR-shaped file it can reach, and `/loadIG`'s distinct error messages tell the caller whether a path exists at all.

## Change

When the server is **not** bound to loopback, `ig` must be a package reference (`id` or `id#version`, optionally with a `[version]` prefix) or an http(s) URL; anything else is refused with 400 and an explanation. Loopback behaviour is unchanged.

The classifier mirrors `IgLoader`'s own precedence rather than inventing a new one: archive names (`.tgz`, `.zip`, `.pack`) are never package references, and a package-shaped name that exists as a local file is a file - because that is what `IgLoader` would read. `FhirValidatorHttpService` gains an `isLoopbackOnly()` getter for the handler to consult.

Residual, stated plainly: a package-shaped name that exists in the working directory is refused with a different status than a package that doesn't exist, so *existence* of bare dotted names in the working directory is still inferable. *Contents* are not readable any more.

## Tests

`LoadIgSourcePolicyTests`: the classifier over package references, URLs, and every path shape I could think of (absolute, relative, traversal, UNC, `file:`, archive names); and two servers with a mocked engine - network-bound refuses a path with 400 *before* touching the engine, loopback-bound passes it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
