### PR TITLE
policyForReference trusts any URL that merely contains "hl7.org" or "fhir.org"

### DIFF
--- a/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
+++ b/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/ValidationEngine.java
@@ -1369,13 +1369,41 @@ public class ValidationEngine implements IValidatorResourceFetcher, IValidationP
     return null;
   }
 
+  /**
+   * Whether a reference URL points at an HL7 or FHIR Foundation host - {@code hl7.org},
+   * {@code fhir.org}, or any subdomain of either. Decided on the parsed host, so a URL that
+   * merely mentions one of those names in its path or query does not qualify. Relative
+   * references, and anything that fails to parse, are not treated as HL7 hosts.
+   */
+  public static boolean isHl7OrFhirHost(String url) {
+    if (url == null) {
+      return false;
+    }
+    String host;
+    try {
+      host = new java.net.URI(url).getHost();
+    } catch (java.net.URISyntaxException e) {
+      return false;
+    }
+    if (host == null) {
+      return false;
+    }
+    host = host.toLowerCase(java.util.Locale.ROOT);
+    for (String domain : new String[] { "hl7.org", "fhir.org" }) {
+      if (host.equals(domain) || host.endsWith("." + domain)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override
   public ReferenceValidationPolicy policyForReference(IResourceValidator validator, Object appContext, String path, String url, ReferenceDestinationType destinationType) {
     Resource resource = context.fetchResource(StructureDefinition.class, url);
     if (resource != null) {
       return ReferenceValidationPolicy.CHECK_VALID;
     }
-    if (!(url.contains("hl7.org") || url.contains("fhir.org"))) {
+    if (!isHl7OrFhirHost(url)) {
       return ReferenceValidationPolicy.IGNORE;
     } else if (policyAdvisor != null) {
       return policyAdvisor.policyForReference(validator, appContext, path, url, destinationType);

--- a/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ReferenceHostAllowlistTests.java
+++ b/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/validation/tests/ReferenceHostAllowlistTests.java
@@ -1,0 +1,70 @@
+package org.hl7.fhir.validation.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hl7.fhir.validation.ValidationEngine;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * {@link ValidationEngine#policyForReference} ignores references that are not on an HL7 or
+ * FHIR Foundation host. That decision is made on the parsed host, not by substring - a URL
+ * that merely mentions {@code hl7.org} in its path or query is not an HL7 host.
+ */
+class ReferenceHostAllowlistTests {
+
+  @ParameterizedTest
+  @DisplayName("HL7 and FHIR Foundation hosts, and their subdomains, qualify")
+  @ValueSource(strings = {
+    "http://hl7.org/fhir/StructureDefinition/Patient",
+    "https://hl7.org/fhir/R4/patient.html",
+    "https://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "http://www.hl7.org/fhir",
+    "https://fhir.org/guides/example",
+    "https://build.fhir.org/ig/HL7/fhir-ig/",
+    "https://packages.fhir.org/hl7.fhir.r4.core/4.0.1",
+    "HTTPS://HL7.ORG/FHIR"
+  })
+  void hl7AndFhirHostsQualify(String url) {
+    assertTrue(ValidationEngine.isHl7OrFhirHost(url), url);
+  }
+
+  @ParameterizedTest
+  @DisplayName("A URL that only mentions the name in its path or query does not qualify")
+  @ValueSource(strings = {
+    "https://attacker.example/?hl7.org",
+    "https://attacker.example/hl7.org/fhir/StructureDefinition/Patient",
+    "https://attacker.example/fhir.org",
+    "https://simplifier.net/packages/hl7.org.something",
+    "https://evilhl7.org/fhir",
+    "https://fhir.org.attacker.example/",
+    "https://hl7.org.attacker.example/"
+  })
+  void lookalikesDoNotQualify(String url) {
+    assertFalse(ValidationEngine.isHl7OrFhirHost(url), url);
+  }
+
+  @ParameterizedTest
+  @DisplayName("Relative references, non-URL schemes and garbage are not HL7 hosts")
+  @ValueSource(strings = {
+    "Patient/123",
+    "#contained",
+    "urn:uuid:5c8b5b77-9c5e-4a18-a0d6-4d4d4c2f0f2c",
+    "urn:oid:2.16.840.1.113883",
+    "hl7.org",
+    "not a url at all",
+    ""
+  })
+  void nonHostReferencesDoNotQualify(String url) {
+    assertFalse(ValidationEngine.isHl7OrFhirHost(url), url);
+  }
+
+  @Test
+  @DisplayName("null is not an HL7 host")
+  void nullDoesNotQualify() {
+    assertFalse(ValidationEngine.isHl7OrFhirHost(null));
+  }
+}


### PR DESCRIPTION
## Problem

`ValidationEngine.policyForReference` decides whether a reference may be resolved over the network with a substring test:

```java
if (!(url.contains("hl7.org") || url.contains("fhir.org")))
```

So `https://attacker.example/?hl7.org`, `https://evilhl7.org/`, and `https://hl7.org.attacker.example/` are all treated as HL7 hosts, and a reference to them is resolved as if it were trusted. `ManagedWebAccess` still applies its own limits (https, no metadata hosts), so this is not open SSRF - but it fetches attacker-chosen content as a "trusted" reference target, which is exactly what the check exists to prevent.

## Change

Parse the host and match it exactly or as a subdomain of `hl7.org` / `fhir.org`. Extracted as `isHl7OrFhirHost(String)` so the rule is testable on its own. Relative references and anything that fails to parse are not HL7 hosts. Real `hl7.org` / `fhir.org` references behave exactly as before.

## One behaviour change to weigh: affiliate domains

The substring test also matched HL7 affiliate hosts by accident - `hl7.org.au`, `fhir.hl7.org.uk`, `hl7.org.nz` contain `hl7.org` without being it or a subdomain of it. With this change a `Reference` to an *instance* on those hosts is ignored like any other non-HL7 host, instead of being fetched and checked for existence and type. Canonical resolution (profiles, extensions, value sets) is unaffected either way, so nothing that validated before now fails - there are fewer checks, not more errors.

I left the rule strict rather than adding a `hl7.org.<cc>` pattern, because that would trust whoever controls `org.<cc>`, which is a public registry for `.au` but not for every two-letter TLD. If affiliates should be trusted, an explicit list is the safe way to do it - happy to add one here if you want.

## Tests

`ReferenceHostAllowlistTests` (parameterised): the real hosts and their subdomains are accepted; each lookalike above is refused; null, relative, and unparseable inputs are refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
