### PR TITLE
Keep package information and master definitions when copying a worker context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,4 +4,4 @@
 
 ## Other code changes
 
-* no changes
+* Fix the copy of a worker context: keep the package information and the master definitions, so that unversioned canonicals resolve to the same version as in the original context (e.g. R4 core CodeSystem instead of the R5 one from hl7.fhir.uv.xver-r5.r4)

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/BaseWorkerContext.java
@@ -405,6 +405,9 @@ public abstract class BaseWorkerContext extends I18nBase implements IWorkerConte
       cachingAllowed = other.cachingAllowed;
       suppressedMappings = other.suppressedMappings;
       cutils.setSuppressedMappings(other.suppressedMappings);
+      // the package information is needed to resolve canonicals with the dependencies of the package of the 
+      // referencing resource (see populatePVList), without it the copy falls back to the latest version
+      packages.putAll(other.packages);
     }
   }
 

--- a/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/CanonicalResourceManager.java
+++ b/org.hl7.fhir.r5/src/main/java/org/hl7/fhir/r5/context/CanonicalResourceManager.java
@@ -301,10 +301,23 @@ public class CanonicalResourceManager<T extends CanonicalResource> {
   public void copy(CanonicalResourceManager<T> source) {
     allResources.clear();
     indexedResources.clear();
+    listForUrl.clear();
+    listForId.clear();
+    masterDefinitions.clear();
+    supplements.clear();
     allResources.addAll(source.allResources);
     indexedResources.putAll(source.indexedResources);
     for (Map.Entry<String, List<CachedCanonicalResource<T>>> entry : source.listForUrl.entrySet()) {
       listForUrl.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+    }
+    for (Map.Entry<String, List<CachedCanonicalResource<T>>> entry : source.listForId.entrySet()) {
+      listForId.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+    }
+    // the master definitions decide which version of an unversioned canonical is used when the referencing 
+    // resource has no package (see getByPackage), without them the copy falls back to the latest version
+    masterDefinitions.putAll(source.masterDefinitions);
+    for (Map.Entry<String, List<CachedCanonicalResource<T>>> entry : source.supplements.entrySet()) {
+      supplements.put(entry.getKey(), new ArrayList<>(entry.getValue()));
     }
   }
 

--- a/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
+++ b/org.hl7.fhir.r5/src/test/java/org/hl7/fhir/r5/test/CanonicalResourceManagerTests.java
@@ -16,6 +16,8 @@ import org.hl7.fhir.r5.model.PackageInformation;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.hl7.fhir.utilities.npm.NpmPackage;
+import org.hl7.fhir.utilities.npm.PackageGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Spy;
@@ -1474,6 +1476,55 @@ public class CanonicalResourceManagerTests {
     cs.setUrl("https://test");
     cs.setVersion(ver);
     return cs;
+  }
+
+  private PackageInformation packageInfo(String id, String version, String fhirVersion, boolean master, String... dependencies) {
+    PackageGenerator gen = new PackageGenerator().name(id).version(version).fhirVersions(List.of(fhirVersion));
+    for (int i = 0; i < dependencies.length; i += 2) {
+      gen.dependency(dependencies[i], dependencies[i + 1]);
+    }
+    return new PackageInformation(NpmPackage.empty(gen), master);
+  }
+
+  /**
+   * A copy of a manager must resolve unversioned canonicals like the original: the definition of the master package
+   * is preferred over the latest version, and the resources of a package are found by package
+   */
+  @Test
+  public void testCopyKeepsMasterDefinitions() {
+    PackageInformation core = packageInfo("hl7.fhir.r4.core", "4.0.1", "4.0.1", true);
+    PackageInformation xver = packageInfo("hl7.fhir.uv.xver-r5.r4", "0.1.0", "4.0.1", false);
+
+    CodeSystem cs4 = new CodeSystem();
+    cs4.setId("encounter-status-r4");
+    cs4.setUrl("http://hl7.org/fhir/encounter-status");
+    cs4.setVersion("4.0.1");
+    CodeSystem cs5 = new CodeSystem();
+    cs5.setId("encounter-status-r5");
+    cs5.setUrl("http://hl7.org/fhir/encounter-status");
+    cs5.setVersion("5.0.0");
+
+    CanonicalResourceManager<CodeSystem> mrm = new CanonicalResourceManager<>(false, false);
+    mrm.see(cs4, core);
+    mrm.see(cs5, xver);
+
+    // the master definition is preferred over the latest version, unless the referencing package says otherwise
+    Assertions.assertEquals("4.0.1", mrm.get("http://hl7.org/fhir/encounter-status").getVersion());
+    Assertions.assertEquals("4.0.1", mrm.getByPackage("http://hl7.org/fhir/encounter-status", null, List.of()).getVersion());
+    Assertions.assertEquals("5.0.0", mrm.getByPackage("http://hl7.org/fhir/encounter-status", null, List.of(xver.getVID())).getVersion());
+
+    CanonicalResourceManager<CodeSystem> copy = new CanonicalResourceManager<>(false, false);
+    copy.copy(mrm);
+
+    Assertions.assertEquals(2, copy.size());
+    Assertions.assertEquals("4.0.1", copy.get("http://hl7.org/fhir/encounter-status").getVersion());
+    Assertions.assertEquals("4.0.1", copy.getByPackage("http://hl7.org/fhir/encounter-status", null, List.of()).getVersion());
+    Assertions.assertEquals("5.0.0", copy.getByPackage("http://hl7.org/fhir/encounter-status", null, List.of(xver.getVID())).getVersion());
+
+    // dropping by id must still work in the copy
+    copy.drop("encounter-status-r5");
+    Assertions.assertEquals(1, copy.size());
+    Assertions.assertEquals("4.0.1", copy.get("http://hl7.org/fhir/encounter-status").getVersion());
   }
 
 }


### PR DESCRIPTION
## Problem
`BaseWorkerContext.copy()` does not copy the `packages` map, and `CanonicalResourceManager.copy()` does not copy `masterDefinitions` (nor `listForId` and `supplements`).

A copied context (via the `ValidationEngine` copy constructor, as used by `ValidationService` for sessions with a base engine, by `ValidationTests` with `CLONE = true`, and by downstream tools such as matchbox) therefore resolves an unversioned canonical differently from the original:
- `populatePVList` finds no dependencies for the package of the referencing resource
- `getByPackage` has no master definition to prefer

and falls back to the latest version. With `hl7.fhir.uv.xver-r5.r4` loaded in an R4 context, `http://hl7.org/fhir/encounter-status` resolves to 5.0.0 instead of 4.0.1 and the R4 code `finished` is rejected:

```
Unknown code 'finished' in the CodeSystem 'http://hl7.org/fhir/encounter-status' version '5.0.0'
```

Reported downstream in https://github.com/ahdis/matchbox/issues/538.

## Fix
- `BaseWorkerContext.copy()`: copy `packages`
- `CanonicalResourceManager.copy()`: also copy `masterDefinitions`, `listForId` and `supplements` (and clear all indexes first)

## Tests
- `CanonicalResourceManagerTests.testCopyKeepsMasterDefinitions`: fails on master (`expected: <4.0.1> but was: <5.0.0>`), passes with the fix
- New validator test case in FHIR/fhir-test-cases#283 (`xver-encounter-status-r5cs`, tag `context-copy`): fails on master with the error above, passes with the fix (run with `-DincludedValidationTags=context-copy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)